### PR TITLE
Add PyPI publish workflow (tag-triggered, trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,77 @@
+---
+name: Publish to PyPI
+
+# Publishes on version tags only. Use a PEP 440 pre-release tag (e.g. v0.1.0a1,
+# v0.2.0rc1) to ship an alpha/beta/rc: PyPI marks it a pre-release and
+# `pip install` skips it unless `--pre` is passed. The per-PR packaging gate
+# lives in test.yml; this workflow never runs on pull requests.
+"on":
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # full history + tags so setuptools-scm derives the version
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-absurd
+    permissions:
+      id-token: write # mandatory for Trusted Publishing (OIDC)
+    steps:
+      - name: Download the distribution packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        # Tokenless Trusted Publishing; emits PEP 740 attestations by default.
+        # yamllint disable-line rule:line-length
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+
+  github-release:
+    name: GitHub Release
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # mandatory for creating a GitHub Release
+    steps:
+      - name: Download the distribution packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Mark a/b/rc/dev tags as pre-releases so the "Latest" badge skips them.
+        run: |
+          case "${{ github.ref_name }}" in
+            *a[0-9]*|*b[0-9]*|*rc[0-9]*|*.dev*) PRERELEASE=--prerelease ;;
+            *) PRERELEASE= ;;
+          esac
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --generate-notes $PRERELEASE \
+            dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,4 +75,4 @@ jobs:
       - name: Build sdist + wheel
         run: uv build
       - name: Check distribution metadata
-        run: uvx twine check dist/*
+        run: uvx twine check --strict dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,17 @@ jobs:
           report_type: test_results
           flags: ${{ matrix.env }}
           fail_ci_if_error: true
+
+  build:
+    name: build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # full history + tags so setuptools-scm can derive the version
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Check distribution metadata
+        run: uvx twine check dist/*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lincoln Loop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune examples

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,10 @@
+# setuptools-scm's git file-finder sweeps every tracked file into the sdist.
+# Prune dev/internal files so only django_absurd (plus the standard packaging
+# files: pyproject.toml, README, LICENSE) ships.
+prune docs
 prune examples
+prune tests
+prune .github
+exclude CLAUDE.md compose.yaml renovate.json tox.ini uv.lock
+exclude .dockerignore .editorconfig .envrc .gitignore .python-version
+exclude .pre-commit-config.yaml .prettierrc.toml .yamllint.yml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# django-absurd
+
+Django integration for [Absurd](https://earendil-works.github.io/absurd/), the
+Postgres-native workflow engine. Wraps Absurd's SDK so it reuses Django's database
+connection, ships its schema as Django migrations, and exposes its queues and tasks
+through Django settings, management commands, and system checks.
+
+> **Alpha.** APIs and behavior may change between releases.
+
+## Requirements
+
+- Python 3.12+
+- Django 6.0+
+- PostgreSQL with the **psycopg (v3)** Django backend (the Absurd SDK reuses Django's
+  connection and requires psycopg3)
+
+## Installation
+
+```console
+pip install django-absurd
+```
+
+Pre-releases are published to PyPI but skipped by default; opt in with:
+
+```console
+pip install --pre django-absurd
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ through Django settings, management commands, and system checks.
 pip install django-absurd
 ```
 
-Pre-releases are published to PyPI but skipped by default; opt in with:
+Pre-release tags (e.g. `v0.1.0a1`) upload as PyPI pre-releases, which `pip install`
+skips unless you pass `--pre`:
 
 ```console
 pip install --pre django-absurd

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1,0 +1,43 @@
+# django-absurd — agent guide
+
+Guidance for coding agents integrating **django-absurd** into a Django project. This
+file ships inside the installed package (`site-packages/django_absurd/AGENTS.md`) so it
+is discoverable from a project's virtualenv.
+
+django-absurd is a Django integration for
+[Absurd](https://earendil-works.github.io/absurd/), a Postgres-native workflow engine.
+It reuses Django's database connection, ships Absurd's schema as Django migrations, and
+surfaces queues/tasks through Django settings, management commands, and system checks.
+
+## Hard requirements
+
+- **Python 3.12+**, **Django 6.0+**.
+- **PostgreSQL via the psycopg (v3) Django backend.** The Absurd SDK reuses Django's
+  connection and requires psycopg3 — `django.db.backends.postgresql` with psycopg3
+  installed. A psycopg2 setup will not work. The app asserts this; do not work around
+  it.
+- Targets `DATABASES['default']`.
+
+## Setup checklist
+
+1. Install: `pip install django-absurd` (pre-releases: add `--pre`).
+2. Add `django_absurd` to `INSTALLED_APPS`.
+3. Configure Django's `TASKS` setting to use the Absurd backend (see the project README
+   and the upstream Absurd docs for backend path and `OPTIONS`).
+4. Run `python manage.py migrate` — Absurd's schema is applied via shipped SQL
+   migrations (no network access needed at migrate time).
+5. Sync declared queues: `python manage.py absurd_sync_queues`.
+6. Run a worker: `python manage.py absurd_worker`.
+
+## Validation
+
+- Run `python manage.py check django_absurd` — system checks flag misconfiguration
+  (wrong DB backend, queues declared but not synced, missing router, etc.). Treat check
+  failures as blocking; fix configuration rather than silencing them.
+
+## Notes
+
+- Migrations are offline and sourced only from the pinned Absurd schema — never fetch at
+  migrate time.
+- This is alpha software; confirm behavior against the installed version's README rather
+  than assuming API stability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=68", "setuptools-scm>=8"]
+requires = ["setuptools>=77", "setuptools-scm>=8"]
 
 [dependency-groups]
 dev = [
@@ -15,18 +15,58 @@ dev = [
   "pytest-socket>=0.7.0",
   "pytest>=9.0.0",
   "ruff>=0.9.0",
-  "setuptools>=68",
+  "setuptools-scm>=8",
+  "setuptools>=77",
   "wheel>=0.43.0",
 ]
 
 [project]
+authors = [
+  {name = "Marc Gibbons", email = "marc@lincolnloop.com"},
+  {name = "Lincoln Loop", email = "info@lincolnloop.com"},
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Environment :: Web Environment",
+  "Framework :: Django",
+  "Framework :: Django :: 6.0",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: System :: Distributed Computing",
+  "Typing :: Typed",
+]
 dependencies = [
   "absurd-sdk>=0.4.0,<0.5.0",
   "Django>=6.0",
 ]
+description = "Django integration for Absurd, the Postgres-native workflow engine."
 dynamic = ["version"]
+keywords = [
+  "absurd",
+  "background-jobs",
+  "django",
+  "postgres",
+  "queue",
+  "tasks",
+  "workflow",
+  "workflow-engine",
+]
+license = "MIT"
+license-files = ["LICENSE"]
 name = "django-absurd"
+readme = "README.md"
 requires-python = ">=3.12"
+
+[project.urls]
+Homepage = "https://github.com/lincolnloop/django-absurd"
+Issues = "https://github.com/lincolnloop/django-absurd/issues"
+Repository = "https://github.com/lincolnloop/django-absurd"
 
 [tool.coverage.report]
 exclude_lines = [
@@ -108,17 +148,13 @@ select = ["ALL"]
 ban-relative-imports = "all"
 
 [tool.setuptools.package-data]
-django_absurd = ["migrations/*.sql"]
+django_absurd = ["AGENTS.md", "migrations/*.sql", "py.typed"]
 
 [tool.setuptools.packages.find]
-exclude = ["tests*"]
+include = ["django_absurd*"]
 where = ["."]
 
 [tool.setuptools_scm]
-# Version derives from git tags (e.g. tag v0.1.0a1 -> 0.1.0a1, published as a
-# PEP 440 pre-release). fallback_version keeps tag-less builds (PR gate, sdist
-# without .git) from failing.
-fallback_version = "0.0.0"
 
 [tool.uv]
 # Mirror Renovate's minimumReleaseAge cooloff for local/CI resolution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=68"]
+requires = ["setuptools>=68", "setuptools-scm>=8"]
 
 [dependency-groups]
 dev = [
@@ -24,9 +24,9 @@ dependencies = [
   "absurd-sdk>=0.4.0,<0.5.0",
   "Django>=6.0",
 ]
+dynamic = ["version"]
 name = "django-absurd"
 requires-python = ">=3.12"
-version = "0.1.0"
 
 [tool.coverage.report]
 exclude_lines = [
@@ -113,6 +113,12 @@ django_absurd = ["migrations/*.sql"]
 [tool.setuptools.packages.find]
 exclude = ["tests*"]
 where = ["."]
+
+[tool.setuptools_scm]
+# Version derives from git tags (e.g. tag v0.1.0a1 -> 0.1.0a1, published as a
+# PEP 440 pre-release). fallback_version keeps tag-less builds (PR gate, sdist
+# without .git) from failing.
+fallback_version = "0.0.0"
 
 [tool.uv]
 # Mirror Renovate's minimumReleaseAge cooloff for local/CI resolution.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,32 +1,61 @@
 import shutil
 import subprocess
 import sys
+import tarfile
 import zipfile
 from pathlib import Path
 
+# Top-level entries allowed in the sdist. setuptools-scm's git file-finder would
+# otherwise sweep the whole repo in; MANIFEST.in prunes it back to these. Anything
+# else (tests/, docs/, examples/, CLAUDE.md, .github/, dev configs) is a leak.
+EXPECTED_SDIST_TOP = {
+    "LICENSE",
+    "MANIFEST.in",
+    "PKG-INFO",
+    "README.md",
+    "django_absurd",
+    "django_absurd.egg-info",
+    "pyproject.toml",
+    "setup.cfg",
+}
 
-def test_wheel_ships_migration_sql_and_excludes_tests(tmp_path):
+
+def test_dist_ships_only_django_absurd(tmp_path):
     root = Path(__file__).resolve().parent.parent
     shutil.rmtree(root / "build", ignore_errors=True)
     shutil.rmtree(root / "django_absurd.egg-info", ignore_errors=True)
+    # --no-isolation builds with the dev venv (which has build + setuptools-scm),
+    # so the test reports packaging problems rather than a slow isolated install.
     subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "build",
-            "--wheel",
-            "--no-isolation",
-            "--outdir",
-            str(tmp_path),
-        ],
+        [sys.executable, "-m", "build", "--no-isolation", "--outdir", str(tmp_path)],
         check=True,
         cwd=root,
     )
-    names = zipfile.ZipFile(next(tmp_path.glob("*.whl"))).namelist()
+
+    # Wheel: only the importable package (+ its .dist-info), with the data files.
+    wheel_names = zipfile.ZipFile(next(tmp_path.glob("*.whl"))).namelist()
     assert any(
-        n.startswith("django_absurd/migrations/") and n.endswith(".sql") for n in names
+        n.startswith("django_absurd/migrations/") and n.endswith(".sql")
+        for n in wheel_names
     )
-    assert "django_absurd/py.typed" in names
-    assert "django_absurd/AGENTS.md" in names
-    assert not any(n.startswith("tests/") for n in names)
-    assert not any(n.startswith("examples/") for n in names)
+    assert "django_absurd/py.typed" in wheel_names
+    assert "django_absurd/AGENTS.md" in wheel_names
+    wheel_top = {n.split("/")[0] for n in wheel_names}
+    unexpected_wheel = {
+        t for t in wheel_top if t != "django_absurd" and not t.endswith(".dist-info")
+    }
+    assert not unexpected_wheel, f"unexpected top-level in wheel: {unexpected_wheel}"
+
+    # Sdist: walk every member, collapse to top-level entries, assert the allowlist.
+    with tarfile.open(next(tmp_path.glob("*.tar.gz"))) as tf:
+        members = [m.name for m in tf.getmembers()]
+    pkg_root = members[0].split("/")[0]
+    sdist_top = {
+        m[len(pkg_root) + 1 :].split("/")[0]
+        for m in members
+        if m != pkg_root and "/" in m
+    }
+    assert sdist_top <= EXPECTED_SDIST_TOP, (
+        f"unexpected files in sdist: {sdist_top - EXPECTED_SDIST_TOP}"
+    )
+    assert {"django_absurd", "pyproject.toml", "README.md", "LICENSE"} <= sdist_top

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -26,4 +26,7 @@ def test_wheel_ships_migration_sql_and_excludes_tests(tmp_path):
     assert any(
         n.startswith("django_absurd/migrations/") and n.endswith(".sql") for n in names
     )
+    assert "django_absurd/py.typed" in names
+    assert "django_absurd/AGENTS.md" in names
     assert not any(n.startswith("tests/") for n in names)
+    assert not any(n.startswith("examples/") for n in names)

--- a/uv.lock
+++ b/uv.lock
@@ -223,6 +223,7 @@ dev = [
     { name = "pytest-socket" },
     { name = "ruff" },
     { name = "setuptools" },
+    { name = "setuptools-scm" },
     { name = "wheel" },
 ]
 
@@ -245,7 +246,8 @@ dev = [
     { name = "pytest-django", specifier = ">=4.12.0" },
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "ruff", specifier = ">=0.9.0" },
-    { name = "setuptools", specifier = ">=68" },
+    { name = "setuptools", specifier = ">=77" },
+    { name = "setuptools-scm", specifier = ">=8" },
     { name = "wheel", specifier = ">=0.43.0" },
 ]
 
@@ -604,6 +606,20 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools-scm"
+version = "10.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "vcs-versioning" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e263754036a0b573360bdbd6873b595725e49e11139722041/setuptools_scm-10.0.5.tar.gz", hash = "sha256:bbba8fe754516cdefd017f4456721775e6ef9662bd7887fb52ae26813d4838c3", size = 56748, upload-time = "2026-03-27T15:57:05.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695, upload-time = "2026-03-27T15:57:03.969Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -637,6 +653,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz", hash = "sha256:fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc", size = 97575, upload-time = "2026-03-27T20:42:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl", hash = "sha256:b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4", size = 79851, upload-time = "2026-03-27T20:42:40.45Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,6 @@ wheels = [
 
 [[package]]
 name = "django-absurd"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "absurd-sdk" },


### PR DESCRIPTION
Adds tag-triggered PyPI publishing with Trusted Publishing (OIDC), plus a per-PR packaging gate.

## Summary
- `setuptools-scm`: version derives from git tags (`dynamic = ["version"]`); `fallback_version` for tag-less builds.
- `test.yml`: new `build` job (`uv build` + `twine check`) gates every PR.
- `publish.yml`: on `v*` tags → build → publish (env `pypi`, OIDC, PEP 740 attestations) → GitHub Release. Pre-release tags (`v0.1.0a1`) auto-marked pre-release.
- GitHub `pypi` environment created: required reviewer + `v*`-tag-only deployments.

## Follow-up (out of band)
- Register the PyPI Trusted Publisher (PyPI side) before the first tag.
- Add README + LICENSE before a stable release (PyPI page/long_description + license metadata).
