### PR TITLE
Agent guide + README documentation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ TASKS = {
 }
 ```
 
-Backend `OPTIONS` (all optional): `DATABASE` (the `DATABASES` alias to use, default
-`"default"`), `DEFAULT_MAX_ATTEMPTS` (default `5`), and `QUEUES` (a map of queue name →
-`absurd_sdk.CreateQueueOptions` for per-queue config).
+Backend `OPTIONS` (all optional):
+
+- `DATABASE` — the `DATABASES` alias to use (default `"default"`).
+- `DEFAULT_MAX_ATTEMPTS` — retry ceiling per task (default `5`).
+- `QUEUES` — a map of queue name → `absurd_sdk.CreateQueueOptions`, for per-queue
+  customization. Use this _instead of_ the top-level `QUEUES` list (which only names
+  queues) — declare queues in one place or the other, never both (setting both is a
+  configuration error).
 
 ## Setup
 
@@ -102,12 +107,19 @@ transaction — a task spawned inside `atomic()` is rolled back if the block fai
 
 ## Adopting an existing Absurd database
 
-If the target database already runs Absurd (its schema managed outside Django), fake the
-initial migration so Django records it without re-running the DDL:
+If the target database already runs Absurd (its schema managed outside Django), you can
+fake django-absurd's migration so Django records it as applied without re-running the
+DDL:
 
 ```console
-python manage.py migrate --fake django_absurd 0001
+python manage.py migrate --fake django_absurd
 ```
+
+> **Use extreme caution.** Faking tells Django the schema is already present without
+> checking it. Only do this when the existing `absurd` schema exactly matches the
+> version django-absurd targets (`django_absurd.ABSURD_SCHEMA_VERSION`) — a mismatch
+> causes runtime failures Django cannot detect. Verify the versions line up before
+> faking.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,88 @@ skips unless you pass `--pre`:
 pip install --pre django-absurd
 ```
 
+## Configuration
+
+Add the app, register the router, and point Django's `TASKS` setting at the backend:
+
+```python
+INSTALLED_APPS = [
+    # ...
+    "django_absurd",
+]
+
+DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
+
+TASKS = {
+    "default": {
+        "BACKEND": "django_absurd.backends.AbsurdBackend",
+        "QUEUES": ["default"],  # queue names this app enqueues to
+    },
+}
+```
+
+Backend `OPTIONS` (all optional): `DATABASE` (the `DATABASES` alias to use, default
+`"default"`), `DEFAULT_MAX_ATTEMPTS` (default `5`), and `QUEUES` (a map of queue name →
+`absurd_sdk.CreateQueueOptions` for per-queue config).
+
+## Setup
+
+```console
+python manage.py migrate              # create Absurd's schema (offline, shipped SQL)
+python manage.py absurd_sync_queues   # create/update the configured queues
+python manage.py absurd_worker        # run a worker
+```
+
+`migrate` does not create any queues — run `absurd_sync_queues` after configuring
+`QUEUES`. Validate configuration at any time with
+`python manage.py check django_absurd`.
+
+## Defining and enqueuing tasks
+
+Use Django's Tasks API. Attach Absurd options per task (a decorator, applied _below_
+`@task`) or per call:
+
+```python
+from django.tasks import task
+from django_absurd.params import AbsurdSpawnParams, absurd_default_params
+
+@task
+@absurd_default_params(max_attempts=3)
+def send_report(user_id): ...
+
+send_report.enqueue(42)
+send_report.enqueue(42, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="report-42"))
+```
+
+Parameters: `max_attempts`, `retry_strategy`, `cancellation` (defaults and per call),
+plus `headers` and `idempotency_key` (per call). Enqueuing rides the surrounding Django
+transaction — a task spawned inside `atomic()` is rolled back if the block fails
+(enqueue-on-commit, automatic).
+
+## Deployment notes
+
+- **Database privileges.** `migrate` runs `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`
+  and `CREATE SCHEMA IF NOT EXISTS absurd`, so the migrating role needs rights to create
+  extensions and schemas (a superuser, or a role granted those — with `uuid-ossp`
+  allow-listed on managed Postgres). The schema name `absurd` is fixed.
+- **At-least-once delivery.** A task may run more than once (e.g. a crash between the
+  handler committing and Absurd's bookkeeping). Keep handlers idempotent; use
+  `idempotency_key` where it helps.
+- **Queue sync is additive.** `absurd_sync_queues` creates/updates configured queues but
+  never drops queues removed from config. A queue's `storage_mode` is immutable after
+  creation (a change is reported as a warning, not applied).
+- **Teardown is destructive.** `migrate django_absurd zero` drops the `absurd` schema
+  and all data in it.
+
+## Adopting an existing Absurd database
+
+If the target database already runs Absurd (its schema managed outside Django), fake the
+initial migration so Django records it without re-running the DDL:
+
+```console
+python manage.py migrate --fake django_absurd 0001
+```
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -4,40 +4,91 @@ Guidance for coding agents integrating **django-absurd** into a Django project. 
 file ships inside the installed package (`site-packages/django_absurd/AGENTS.md`) so it
 is discoverable from a project's virtualenv.
 
-django-absurd is a Django integration for
-[Absurd](https://earendil-works.github.io/absurd/), a Postgres-native workflow engine.
-It reuses Django's database connection, ships Absurd's schema as Django migrations, and
-surfaces queues/tasks through Django settings, management commands, and system checks.
+django-absurd plugs [Absurd](https://earendil-works.github.io/absurd/), a
+Postgres-native workflow engine, into Django's Tasks framework. It reuses Django's
+database connection and ships Absurd's schema as Django migrations.
 
 ## Hard requirements
 
 - **Python 3.12+**, **Django 6.0+**.
-- **PostgreSQL via the psycopg (v3) Django backend.** The Absurd SDK reuses Django's
-  connection and requires psycopg3 — `django.db.backends.postgresql` with psycopg3
-  installed. A psycopg2 setup will not work. The app asserts this; do not work around
-  it.
-- Targets `DATABASES['default']`.
+- **PostgreSQL via the psycopg (v3) Django backend** — `django.db.backends.postgresql`
+  with psycopg3 installed. The Absurd SDK reuses Django's connection; psycopg2 will not
+  work. The package asserts this at runtime; do not work around it.
 
-## Setup checklist
+## Configure
 
-1. Install: `pip install django-absurd` (pre-releases: add `--pre`).
-2. Add `django_absurd` to `INSTALLED_APPS`.
-3. Configure Django's `TASKS` setting to use the Absurd backend (see the project README
-   and the upstream Absurd docs for backend path and `OPTIONS`).
-4. Run `python manage.py migrate` — Absurd's schema is applied via shipped SQL
-   migrations (no network access needed at migrate time).
-5. Sync declared queues: `python manage.py absurd_sync_queues`.
-6. Run a worker: `python manage.py absurd_worker`.
+Add the app, register the router, and point Django's `TASKS` setting at the backend:
 
-## Validation
+```python
+INSTALLED_APPS = [
+    # ...
+    "django_absurd",
+]
 
-- Run `python manage.py check django_absurd` — system checks flag misconfiguration
-  (wrong DB backend, queues declared but not synced, missing router, etc.). Treat check
-  failures as blocking; fix configuration rather than silencing them.
+DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
+
+TASKS = {
+    "default": {
+        "BACKEND": "django_absurd.backends.AbsurdBackend",
+        "QUEUES": ["default"],  # queue names this app enqueues to
+    },
+}
+```
+
+Backend `OPTIONS` (all optional):
+
+- `DATABASE` — which `DATABASES` alias to use (default: `"default"`).
+- `DEFAULT_MAX_ATTEMPTS` — retry ceiling per task (default: `5`).
+- `QUEUES` — map of queue name → `absurd_sdk.CreateQueueOptions` for per-queue config.
+
+## Run
+
+```bash
+python manage.py migrate              # apply Absurd's schema (offline, shipped SQL)
+python manage.py absurd_sync_queues   # create/update declared queues
+python manage.py absurd_worker        # run a worker
+```
+
+## Validate
+
+Run `python manage.py check django_absurd` and resolve everything it reports before
+relying on the setup. Fix the configuration it points at rather than silencing the
+check.
+
+## Enqueue
+
+Use Django's Tasks API. Absurd parameters attach two ways — both live in
+`django_absurd.params`:
+
+- **Per-task defaults** — the `@absurd_default_params(...)` decorator, applied _below_
+  `@task` (applying it above a `Task` raises `TypeError`):
+
+  ```python
+  from django.tasks import task
+  from django_absurd.params import absurd_default_params
+
+  @task
+  @absurd_default_params(max_attempts=3)
+  def send_report(...): ...
+  ```
+
+- **Per-invocation** — pass an `AbsurdSpawnParams` as the `absurd_spawn_params` kwarg to
+  `.enqueue()`:
+
+  ```python
+  from django_absurd.params import AbsurdSpawnParams
+
+  send_report.enqueue(..., absurd_spawn_params=AbsurdSpawnParams(idempotency_key="abc"))
+  ```
+
+Parameter fields (see `django_absurd.params`): `max_attempts`, `retry_strategy`,
+`cancellation` (defaults and per-call), plus `headers` and `idempotency_key` (per-call
+only). Field types come from `absurd_sdk` (`RetryStrategy`, `CancellationPolicy`,
+`JsonObject`). Backend capabilities: result retrieval is supported; async enqueue,
+defer, and priority are not.
 
 ## Notes
 
-- Migrations are offline and sourced only from the pinned Absurd schema — never fetch at
-  migrate time.
-- This is alpha software; confirm behavior against the installed version's README rather
-  than assuming API stability.
+- Migrations are offline — the schema comes only from the pinned Absurd version shipped
+  with this package; never fetch at migrate time.
+- Alpha software; APIs may change between versions.

--- a/django_absurd/__init__.py
+++ b/django_absurd/__init__.py
@@ -1,1 +1,13 @@
+"""Django integration for Absurd, the Postgres-native workflow engine.
+
+Coding agents: this package ships an integration guide, ``AGENTS.md``, alongside this
+module. Read it with::
+
+    from importlib.resources import files
+    print(files("django_absurd").joinpath("AGENTS.md").read_text())
+
+It covers requirements, the ``TASKS`` setting, migrations, the ``absurd_sync_queues`` /
+``absurd_worker`` management commands, system checks, and enqueue params/decorators.
+"""
+
 ABSURD_SCHEMA_VERSION = "0.4.0"

--- a/examples/uv.lock
+++ b/examples/uv.lock
@@ -39,7 +39,6 @@ wheels = [
 
 [[package]]
 name = "django-absurd"
-version = "0.1.0"
 source = { editable = "../" }
 dependencies = [
     { name = "absurd-sdk" },
@@ -58,14 +57,15 @@ dev = [
     { name = "build", specifier = ">=1.2.0" },
     { name = "django-coverage-plugin", specifier = ">=3.2.0" },
     { name = "django-stubs", specifier = ">=6.0.5" },
-    { name = "mypy", specifier = ">=1.20.2" },
+    { name = "mypy", specifier = ">=2.1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=9.1.0" },
-    { name = "pytest-cov", specifier = ">=6.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-django", specifier = ">=4.12.0" },
     { name = "pytest-socket", specifier = ">=0.8.0" },
     { name = "ruff", specifier = ">=0.9.0" },
-    { name = "setuptools", specifier = ">=68" },
+    { name = "setuptools", specifier = ">=77" },
+    { name = "setuptools-scm", specifier = ">=8" },
     { name = "wheel", specifier = ">=0.43.0" },
 ]
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,9 +1,13 @@
+import pydoc
 import shutil
 import subprocess
 import sys
 import tarfile
 import zipfile
+from importlib.resources import files
 from pathlib import Path
+
+import django_absurd
 
 # Top-level entries allowed in the sdist. setuptools-scm's git file-finder would
 # otherwise sweep the whole repo in; MANIFEST.in prunes it back to these. Anything
@@ -59,3 +63,12 @@ def test_dist_ships_only_django_absurd(tmp_path):
         f"unexpected files in sdist: {sdist_top - EXPECTED_SDIST_TOP}"
     )
     assert {"django_absurd", "pyproject.toml", "README.md", "LICENSE"} <= sdist_top
+
+
+def test_agents_guide_discoverable_via_help():
+    # help(django_absurd) renders the module docstring via pydoc; it must point an
+    # agent at AGENTS.md...
+    assert "AGENTS.md" in pydoc.render_doc(django_absurd)
+    # ...and the guide the docstring promises must actually be readable from the package.
+    guide = files("django_absurd").joinpath("AGENTS.md").read_text()
+    assert guide.strip()


### PR DESCRIPTION
Docs pass for agents + users.

- AGENTS.md: self-contained integration guide (config, backend OPTIONS, commands, enqueue params/decorator).
- `__init__.py`: module docstring points agents to AGENTS.md + an `importlib.resources` read snippet (surfaces via `help()`).
- `tests/test_packaging.py`: asserts AGENTS.md is discoverable via `help()` and readable.
- README: Configuration / Setup / Defining-and-enqueuing / Deployment notes / Adopting-an-existing-DB sections.
- examples/uv.lock: synced with the dynamic-version + dev-dep changes.
