### PR TITLE
Native-async worker; supports async tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,40 @@ plus `headers` and `idempotency_key` (per call). Enqueuing rides the surrounding
 transaction — a task spawned inside `atomic()` is rolled back if the block fails
 (enqueue-on-commit, automatic).
 
+Tasks may be **sync (`def`) or async (`async def`)** — one worker runs both (see
+[Workers](#workers)); `async def` tasks may use Django's async ORM. Tasks are resolved
+by import path, so they can live in any importable module (no `tasks.py` requirement).
+
+## Workers
+
+```console
+python manage.py absurd_worker --queue default
+```
+
+A single worker runs **both** sync and async tasks: `async def` tasks run on an event
+loop (true concurrency for I/O-bound work), sync `def` tasks run in a thread pool.
+
+- **Blocking** (default): long-running; polls until `SIGINT`/`SIGTERM`.
+- **Burst** (`--burst`): drain the current backlog, then exit `0` (cron / one-shot).
+- `--concurrency N` (default `1`): max tasks in flight — sizes both the event-loop
+  concurrency and the sync thread pool. Other flags: `--claim-timeout`,
+  `--poll-interval`, `--batch-size`, `--worker-id`, and `--alias` (required only when
+  several Absurd backends are configured).
+
+## Retrieving results
+
+`enqueue` returns a `TaskResult`; refresh it or fetch one later by id:
+
+```python
+result = send_report.enqueue(42)
+result.refresh()              # reload status / return_value / errors from the store
+result.status                 # READY | RUNNING | SUCCESSFUL | FAILED
+result.return_value           # available once SUCCESSFUL
+
+send_report.get_result(result.id)              # fetch by id (sync)
+await send_report.aget_result(result.id)       # async variant
+```
+
 ## Deployment notes
 
 - **Database privileges.** `migrate` runs `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -27,7 +27,7 @@ class AbsurdBackendOptions(t.TypedDict, total=False):
 
 class AbsurdBackend(BaseTaskBackend):
     supports_get_result = True
-    supports_async_task = False
+    supports_async_task = True
     supports_defer = False
     supports_priority = False
 

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -26,7 +26,10 @@ class Command(BaseCommand):
             "--concurrency",
             type=int,
             default=1,
-            help="Number of concurrent worker threads (default: 1).",
+            help=(
+                "Max tasks run concurrently: async tasks on the event loop, "
+                "sync tasks in a thread pool of this size (default: 1)."
+            ),
         )
         parser.add_argument(
             "--claim-timeout",

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -1,13 +1,16 @@
+import asyncio
+import inspect
 import logging
 import signal
 import time
 import typing as t
-from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 import psycopg
 import psycopg.errors
-from absurd_sdk import Absurd
+from absurd_sdk import AsyncAbsurd
 from django.core.exceptions import ImproperlyConfigured
 from django.db import close_old_connections, connections
 from django.tasks import Task, TaskContext, TaskResult, TaskResultStatus
@@ -59,25 +62,68 @@ class LazyTaskRegistry(dict):
         return super().get(name, default)
 
 
-@contextmanager
-def worker_client(
-    backend: AbsurdBackend, queue: str
-) -> t.Generator[Absurd, None, None]:
+def run_worker(
+    backend: AbsurdBackend,
+    queue: str,
+    *,
+    burst: bool = False,
+    options: WorkerOptions | None = None,
+) -> None:
+    options = options or WorkerOptions()
     validate_backend(backend.database)
-    # DEDICATED connection (built from Django's DB config, NOT Django's registered
-    # connection). It must not be Django-managed: the adapter calls
-    # close_old_connections() around each task to keep handler ORM connections fresh
-    # in this long-running process, which would close Django's connection out from
-    # under the SDK's claim/complete/fail bookkeeping. A raw psycopg connection isn't
-    # in Django's registry, so close_old_connections() never touches it.
+    asyncio.run(arun_worker(backend, queue, burst=burst, options=options))
+
+
+async def arun_worker(
+    backend: AbsurdBackend,
+    queue: str,
+    *,
+    burst: bool = False,
+    options: WorkerOptions,
+) -> None:
+    with ThreadPoolExecutor(max_workers=options.concurrency) as executor:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(executor)
+        async with aworker_client(backend, queue) as client:
+            logger.info(
+                "django-absurd worker starting: alias=%s queue=%s database=%s "
+                "burst=%s concurrency=%d",
+                backend.alias,
+                queue,
+                backend.database,
+                burst,
+                options.concurrency,
+            )
+            if burst:
+                await drain_queue(
+                    client,
+                    concurrency=options.concurrency,
+                    claim_timeout=options.claim_timeout,
+                    batch_size=options.batch_size,
+                    worker_id=options.worker_id,
+                )
+            else:
+                await run_blocking_worker(client, options)
+
+
+@asynccontextmanager
+async def aworker_client(
+    backend: AbsurdBackend, queue: str
+) -> t.AsyncGenerator[AsyncAbsurd, None]:
+    # DEDICATED async connection (built from Django's DB config, NOT Django's registered
+    # connection). cursor_factory from Django's params is fatal for AsyncConnection
+    # (sync cursor factory incompatible with async execute) — pop it before connecting.
     params: dict[str, t.Any] = connections[backend.database].get_connection_params()
-    conn: psycopg.Connection = psycopg.connect(**params, autocommit=True)
+    params.pop("cursor_factory", None)
+    conn: psycopg.AsyncConnection = await psycopg.AsyncConnection.connect(
+        **params, autocommit=True
+    )
     try:
         register_jsonb_loader(conn)
-        client = Absurd(conn, queue_name=queue)
+        client = AsyncAbsurd(conn, queue_name=queue)
         client._registry = LazyTaskRegistry(queue)  # noqa: SLF001 -- SDK has no public fallback-resolver hook; install lazy import_string resolution
         try:
-            provisioned = client.list_queues()
+            provisioned = await client.list_queues()
         except (
             psycopg.errors.InvalidSchemaName,
             psycopg.errors.UndefinedTable,
@@ -95,56 +141,29 @@ def worker_client(
             raise ImproperlyConfigured(msg)
         yield client
     finally:
-        conn.close()
+        await conn.close()
 
 
-def drain_queue(
-    client: Absurd,
+async def drain_queue(
+    client: AsyncAbsurd,
     *,
+    concurrency: int = 1,
     claim_timeout: int = 120,
     batch_size: int | None = None,
     worker_id: str | None = None,
 ) -> int:
     count = 0
     while True:
-        claimed = client.claim_tasks(
-            batch_size or 1, claim_timeout, worker_id or "worker"
+        claimed = await client.claim_tasks(
+            batch_size or concurrency, claim_timeout, worker_id or "worker"
         )
         if not claimed:
             break
-        for t_ in claimed:
-            client._execute_task(t_, claim_timeout)  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
-            count += 1
-    return count
-
-
-def run_worker(
-    backend: AbsurdBackend,
-    queue: str,
-    *,
-    burst: bool = False,
-    options: WorkerOptions | None = None,
-) -> None:
-    options = options or WorkerOptions()
-    with worker_client(backend, queue) as client:
-        logger.info(
-            "django-absurd worker starting: alias=%s queue=%s database=%s "
-            "burst=%s concurrency=%d",
-            backend.alias,
-            queue,
-            backend.database,
-            burst,
-            options.concurrency,
+        await asyncio.gather(
+            *[client._execute_task(t_, claim_timeout) for t_ in claimed]  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
         )
-        if burst:
-            drain_queue(
-                client,
-                claim_timeout=options.claim_timeout,
-                batch_size=options.batch_size,
-                worker_id=options.worker_id,
-            )
-        else:
-            run_blocking_worker(client, options)
+        count += len(claimed)
+    return count
 
 
 def build_task_context(
@@ -168,9 +187,8 @@ def build_task_context(
     return TaskContext(task_result=task_result)
 
 
-def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Any]:
-    def handler(params: t.Any, ctx: t.Any) -> t.Any:
-        close_old_connections()
+def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Awaitable[t.Any]]:
+    async def handler(params: t.Any, ctx: t.Any) -> t.Any:
         args = params.get("args", [])
         kwargs = params.get("kwargs", {})
         attempt = read_sdk_attempt(ctx)
@@ -184,9 +202,25 @@ def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Any]:
         try:
             if task.takes_context:
                 ctx_ = build_task_context(task, ctx, args, kwargs)
-                result = task.func(ctx_, *args, **kwargs)
+            if inspect.iscoroutinefunction(task.func):
+                if task.takes_context:
+                    result = await task.func(ctx_, *args, **kwargs)
+                else:
+                    result = await task.func(*args, **kwargs)
             else:
-                result = task.func(*args, **kwargs)
+
+                def call_sync() -> t.Any:
+                    close_old_connections()
+                    try:
+                        if task.takes_context:
+                            return task.func(ctx_, *args, **kwargs)
+                        return task.func(*args, **kwargs)
+                    finally:
+                        close_old_connections()
+
+                result = await asyncio.get_running_loop().run_in_executor(
+                    None, call_sync
+                )
         except Exception:
             duration = time.monotonic() - start
             logger.exception(
@@ -209,8 +243,6 @@ def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Any]:
                 duration,
             )
             return result
-        finally:
-            close_old_connections()
 
     return handler
 
@@ -219,11 +251,12 @@ def read_sdk_attempt(ctx: t.Any) -> int:
     return ctx._task["attempt"]  # noqa: SLF001 -- SDK TaskContext has no public attempt property
 
 
-def run_blocking_worker(client: Absurd, options: WorkerOptions) -> None:
-    prior_sigint = signal.signal(signal.SIGINT, lambda _s, _f: client.stop_worker())
-    prior_sigterm = signal.signal(signal.SIGTERM, lambda _s, _f: client.stop_worker())
+async def run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions) -> None:
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGINT, client.stop_worker)
+    loop.add_signal_handler(signal.SIGTERM, client.stop_worker)
     try:
-        client.start_worker(
+        await client.start_worker(
             worker_id=options.worker_id,
             claim_timeout=options.claim_timeout,
             concurrency=options.concurrency,
@@ -231,5 +264,5 @@ def run_blocking_worker(client: Absurd, options: WorkerOptions) -> None:
             poll_interval=options.poll_interval,
         )
     finally:
-        signal.signal(signal.SIGINT, prior_sigint)
-        signal.signal(signal.SIGTERM, prior_sigterm)
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)

--- a/docs/plans/2026-06-24-async-worker.md
+++ b/docs/plans/2026-06-24-async-worker.md
@@ -242,9 +242,19 @@ only for locality). Then:
   does). In `tests/tasks.py`: remove the module-level `add_async` coroutine + its
   `# Module-level (undecorated) coroutine: applying @task … must be rejected …` comment
   (dead once async is supported). No replacement needed here — Task 2 covers async
-  enqueue
-  - execution positively. (Verify `add_async` has no other importers:
-    `grep -rn add_async tests`.)
+  enqueue + execution positively. (Verify `add_async` has no other importers:
+  `grep -rn add_async tests`.) **Also fix the now-stale imports in
+  `tests/test_enqueue.py` (I-A — else collection ImportError + ruff F401):** the
+  `from tests.tasks import add, add_async, with_default_attempts` line → drop
+  `add_async`; the `from django.tasks import TaskResultStatus, task` line → drop `task`
+  (used ONLY by the deleted test). KEEP `InvalidTask` (still used by
+  `test_undeclared_queue_rejected`).
+- **M-A** `tests/test_worker.py` does
+  `from django_absurd.worker import (worker_client,)`. `worker_client` is dropped (→
+  async `aworker_client`). Update that import — import `aworker_client` if the
+  provisioning tests drive it via `asyncio.run`, OR remove it if those cases fold into
+  the command-level `ImproperlyConfigured→CommandError` tests; don't leave a dead/broken
+  import.
 
 - [ ] **Step 4: Run to verify it passes**
 

--- a/docs/plans/2026-06-24-async-worker.md
+++ b/docs/plans/2026-06-24-async-worker.md
@@ -69,6 +69,12 @@ Spec: `docs/specs/2026-06-24-async-worker-design.md`.
   dedicated-conn read; rewrite the `worker_client` provisioning tests,
   `test_unregistered_name_defers_not_crashes` (I1), and
   `test_start_worker_drains_concurrently` (I2))
+- Modify: `tests/test_enqueue.py` + `tests/tasks.py` (C1: flipping `supports_async_task`
+  INVERTS `test_async_task_rejected` — it asserts `task(add_async)` raises
+  `InvalidTask`, which no longer happens. DELETE `test_async_task_rejected`, and remove
+  the now-dead `add_async` module-level coroutine + its `# must be rejected …` comment
+  in `tests/tasks.py` (async rejection is gone; Task 2 covers async-enqueue
+  positively).)
 
 **Interfaces:**
 
@@ -137,15 +143,15 @@ Rewrite `django_absurd/worker.py` to the spec's Architecture
   unchanged signature): `options = options or WorkerOptions()`;
   `validate_backend(backend.database)` (here, off the loop);
   `asyncio.run(arun_worker(backend, queue, burst=burst, options=options))`.
-- `arun_worker(...)`: create `ThreadPoolExecutor(max_workers=options.concurrency)` (use
-  as the loop's executor for sync tasks; shut down on exit, e.g.
-  `with ThreadPoolExecutor(...) as executor:`);
+- `arun_worker(...)`:
+  `with ThreadPoolExecutor(max_workers=options.concurrency) as executor:` →
+  `loop = asyncio.get_running_loop(); loop.set_default_executor(executor)` (MANDATED
+  mechanism — the sync handler branch then uses `run_in_executor(None, call_sync)`, so
+  the executor is reachable WITHOUT a contextvar/global and `build_handler(task)` stays
+  a pure single-arg function with the registry-entry contract untouched; live-proven).
   `async with aworker_client(backend, queue) as client:` then the startup `logger.info`
   (alias/queue/database/burst/concurrency) and
-  `if burst: await drain_queue(client, …) else: await run_blocking_worker(client, options)`.
-  Make `executor` reachable by the handler (e.g. a contextvar, or pass into
-  `aworker_client`/the registry so handlers use it; choose the simplest that keeps
-  `build_handler` testable).
+  `if burst: await drain_queue(client, concurrency=options.concurrency, …) else: await run_blocking_worker(client, options)`.
 - `aworker_client(backend, queue)` (`@asynccontextmanager`):
   `params = connections[backend.database].get_connection_params(); params.pop("cursor_factory", None)`;
   `conn = await psycopg.AsyncConnection.connect(**params, autocommit=True)`; `try:`
@@ -171,17 +177,19 @@ Rewrite `django_absurd/worker.py` to the spec's Architecture
   `await task.func(*args, **kwargs)`. **Else (sync):** wrap a `call_sync()` that does
   `close_old_connections()` → `task.func([ctx_,] *args, **kwargs)` → (finally)
   `close_old_connections()`, and
-  `result = await asyncio.get_running_loop().run_in_executor(executor, call_sync)`. Keep
-  the
+  `result = await asyncio.get_running_loop().run_in_executor(None, call_sync)` (None →
+  the loop's default executor set in `arun_worker`). Keep the
   `try/except Exception: logger.exception(...); raise / else: logger.info(...); return result`
   shape so the SDK records failures + retries.
 - async
-  `drain_queue(client, *, claim_timeout=120, batch_size=None, worker_id=None) -> int`:
-  loop
-  `claimed = await client.claim_tasks(batch_size or 1, claim_timeout, worker_id or "worker")`;
+  `drain_queue(client, *, concurrency=1, claim_timeout=120, batch_size=None, worker_id=None) -> int`:
+  CONCURRENT drain (so `--concurrency` is honored in burst — the old serial `for await`
+  loop ignored it; live-proven 4×0.5s went 2.09s serial → 0.53s concurrent). Loop:
+  `claimed = await client.claim_tasks(batch_size or concurrency, claim_timeout, worker_id or "worker")`;
   break if empty;
-  `for t_ in claimed: await client._execute_task(t_, claim_timeout)  # noqa: SLF001 …`;
-  return count.
+  `await asyncio.gather(*[client._execute_task(t_, claim_timeout) for t_ in claimed])  # noqa: SLF001 …`;
+  `count += len(claimed)`; return count. (Sync tasks within the gather overlap via the
+  default executor sized to `concurrency`; async tasks overlap natively on the loop.)
 - async `run_blocking_worker(client, options)`: `loop = asyncio.get_running_loop()`;
   `loop.add_signal_handler(signal.SIGINT, client.stop_worker)` + `SIGTERM`;
   `try: await client.start_worker(worker_id=…, claim_timeout=…, concurrency=…, batch_size=…, poll_interval=…)`
@@ -226,9 +234,17 @@ only for locality). Then:
   `assert get_task_result(spawn["task_id"]).state != "failed"`.
 - I2 `test_start_worker_drains_concurrently`: delete the
   `threading.Thread`/sync-`start_worker` scaffold; replace with the async-concurrency
-  smoke (Task 2) OR a minimal blocking-mode drive here. (Simplest: move the concurrency
-  assertion to Task 2's smoke and here just assert burst drains multiple enqueued sync
-  tasks.)
+  smoke (Task 2) OR a minimal burst drive here. (Simplest: move the concurrency
+  assertion to Task 2's smoke — now valid because burst's `drain_queue` is concurrent —
+  and here just assert burst drains multiple enqueued sync tasks.)
+- **C1** in `tests/test_enqueue.py`: DELETE `test_async_task_rejected` (it asserts
+  `task(add_async)` raises `InvalidTask`, which `supports_async_task=True` no longer
+  does). In `tests/tasks.py`: remove the module-level `add_async` coroutine + its
+  `# Module-level (undecorated) coroutine: applying @task … must be rejected …` comment
+  (dead once async is supported). No replacement needed here — Task 2 covers async
+  enqueue
+  - execution positively. (Verify `add_async` has no other importers:
+    `grep -rn add_async tests`.)
 
 - [ ] **Step 4: Run to verify it passes**
 
@@ -245,7 +261,7 @@ green. Run: `uv run ruff check django_absurd tests` → clean
 - [ ] **Step 6: Commit**
 
 ```bash
-git add django_absurd/worker.py django_absurd/backends.py tests/atasks.py tests/test_worker.py
+git add django_absurd/worker.py django_absurd/backends.py tests/atasks.py tests/test_worker.py tests/test_enqueue.py tests/tasks.py
 git commit -m "feat: native-async worker (runs sync via executor + async on the loop); supports_async_task=True"
 ```
 
@@ -257,8 +273,8 @@ git commit -m "feat: native-async worker (runs sync via executor + async on the 
 
 - Modify: `tests/atasks.py` (add async tasks: raising, takes_context, async-ORM
   `Payload`, sleeper)
-- Modify: `tests/tasks.py` (a sync `echo` if not already present, for the mixed-run
-  test)
+- Modify: `tests/tasks.py` (add the sync ORM task `create_payload` for the matched
+  sync/async ORM pair; `echo` already exists — do NOT re-add)
 - Create: `tests/test_async_worker.py` (the matrix; reuses
   `run_absurd_worker`/`get_task_result` patterns — import them or duplicate the small
   helpers)
@@ -315,7 +331,7 @@ from django.core.management import call_command
 
 from tests.atasks import aboom, acreate_payload, aecho, areport_attempt, asleeper
 from tests.models import Payload
-from tests.tasks import echo  # sync echo
+from tests.tasks import create_payload, echo  # sync ORM task + sync echo
 from tests.test_worker import get_task_result, run_absurd_worker
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -350,7 +366,17 @@ def test_async_takes_context_attempt_is_one():
     assert get_task_result(r.id).result == 1
 
 
+def test_sync_orm_jsonfield_round_trips():
+    # ORM in a SYNC task (executor path) — matched pair with the async-ORM test below
+    call_command("absurd_sync_queues")
+    r = create_payload.enqueue({"sync": True, "x": [9, 8]})
+    run_absurd_worker()
+    pk = get_task_result(r.id).result
+    assert Payload.objects.get(pk=pk).data == {"sync": True, "x": [9, 8]}
+
+
 def test_async_orm_jsonfield_round_trips():
+    # ORM in an ASYNC task (loop path) — matched pair with the sync-ORM test above
     call_command("absurd_sync_queues")
     r = acreate_payload.enqueue({"async": True, "y": {"z": None}})
     run_absurd_worker()
@@ -382,16 +408,19 @@ def test_async_concurrency_is_not_serial():
     for _ in range(4):
         asleeper.enqueue(0.5)
     start = time.monotonic()
-    run_absurd_worker(concurrency=4)  # burst with concurrency
+    run_absurd_worker(concurrency=4)  # burst now drains CONCURRENTLY (gather)
     elapsed = time.monotonic() - start
-    assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent is well under
+    assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent ~0.5s (well under)
 ```
 
-(If `run_absurd_worker` doesn't yet accept `concurrency`, extend it to pass
-`concurrency=` through
-`call_command("absurd_worker", queue=…, burst=True, concurrency=…)` — the command
-already has the flag.) Add a sync `echo` to `tests/tasks.py` if absent:
-`@task def echo(value): return value`.
+This smoke is VALID because Task 1 made `drain_queue` concurrent (gather sized to
+`concurrency`) — burst now honors `--concurrency`, so it terminates naturally (no
+blocking-mode stopper needed). Extend `run_absurd_worker` to pass `concurrency=` through
+`call_command("absurd_worker", queue=…, burst=True, concurrency=…)` (the command already
+has the flag). `echo` already exists in `tests/tasks.py` — do NOT re-add it. ADD a sync
+ORM task to `tests/tasks.py` for the matched pair: `@task` /
+`def create_payload(data): from tests.models import Payload; return Payload.objects.create(data=data).pk`
+(import inside the function or at module top per ruff).
 
 - [ ] **Step 2: Run to verify they fail / drive gaps**
 

--- a/docs/plans/2026-06-24-async-worker.md
+++ b/docs/plans/2026-06-24-async-worker.md
@@ -1,0 +1,443 @@
+# Native-Async Worker (SP7) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Follow TDD: failing test → run RED → minimal
+> implementation → run GREEN → refactor → commit.
+
+**Goal:** Replace the sync/thread `absurd_worker` with a native-asyncio worker that runs
+BOTH sync (`def`) and async (`async def`) tasks, and flip
+`AbsurdBackend.supports_async_task = True`.
+
+**Architecture:** `run_worker(...)` stays a SYNC entry: it `validate_backend(...)`
+(Django `@async_unsafe` — must be off the loop) then `asyncio.run(arun_worker(...))`. On
+the loop, `aworker_client` opens a dedicated `psycopg.AsyncConnection` (`AsyncAbsurd`);
+an async `LazyTaskRegistry` resolves tasks by `module_path`; the async handler `await`s
+`async def` tasks on the loop and runs `def` tasks via
+`loop.run_in_executor(ThreadPoolExecutor)` (with `close_old_connections`). One
+`--concurrency` knob sizes both the SDK's loop concurrency and the executor pool.
+
+**Tech Stack:** Django 6.0 `django.tasks`, absurd-sdk (`AsyncAbsurd`/`AsyncConnection`),
+psycopg3 async, asyncio, pytest + pytest-django, real Postgres.
+
+## Global Constraints
+
+- `import typing as t` (never `from typing import X`); `import datetime as dt`; absolute
+  imports; helpers BELOW callers; no leading-underscore module names; verb-named
+  functions.
+- ruff `select=["ALL"]` passes with ZERO new ignores/noqa (HARD rule — ask first). The
+  worker keeps exactly the 3 justified `# noqa: SLF001` (the `_registry` swap,
+  `_execute_task`, `ctx._task["attempt"]`). mypy (django-stubs) clean, no
+  `# type: ignore`.
+- pytest, function-based ONLY, NO mocks. `tests/test_worker.py` uses
+  `pytestmark = pytest.mark.django_db(transaction=True)`.
+- **CLI unchanged:**
+  `absurd_worker --queue … [--alias …] [--burst] [--concurrency N] [--claim-timeout …] [--poll-interval …] [--batch-size …] [--worker-id …]`.
+  The command imports only `WorkerOptions` + `run_worker` (both preserved).
+- **C1:** `params.pop("cursor_factory", None)` before
+  `psycopg.AsyncConnection.connect(**params, autocommit=True)` (Django's sync
+  cursor_factory is fatal for async connect; live-verified). Sync `psycopg.connect` does
+  NOT need the pop.
+- **@async_unsafe:** `validate_backend` (→ `ensure_connection`) runs in the SYNC
+  `run_worker` entry, NEVER on the loop. `get_connection_params()` is config-only,
+  loop-safe.
+- **jsonb:** loader registered on the worker's DEDICATED `AsyncConnection` only
+  (claim-time `params` decode). NEVER on Django's shared connection. Result reads in
+  tests use a DEDICATED sync conn + loader (not `build_absurd_client`, which returns raw
+  JSON strings, nor `get_absurd_client`'s shared conn, which would re-poison
+  `JSONField`).
+- `loop.add_signal_handler(SIGINT/SIGTERM, client.stop_worker)` (`stop_worker` is sync).
+  KEEP `import signal` for the constants; drop `signal.signal()`. (Raises
+  off-main-thread/Windows — worker runs on the main thread under `asyncio.run`;
+  acceptable.)
+- DB: `PGPORT=5433 docker compose up -d db`; run with `PGPORT=5433`.
+
+Spec: `docs/specs/2026-06-24-async-worker-design.md`.
+
+---
+
+### Task 1: Rewrite the worker async; keep the behavioral suite green; flip `supports_async_task`
+
+**Files:**
+
+- Modify: `django_absurd/worker.py` (rewrite to async per the spec's Architecture)
+- Modify: `django_absurd/backends.py:30` (`supports_async_task = True`)
+- Create: `tests/atasks.py` (async test tasks — kept OUT of `tests/tasks.py` so a RED
+  run, where the flag is still `False`, doesn't break collection of the whole sync
+  suite)
+- Modify: `tests/test_worker.py` (repoint the `get_task_result` helper to a
+  dedicated-conn read; rewrite the `worker_client` provisioning tests,
+  `test_unregistered_name_defers_not_crashes` (I1), and
+  `test_start_worker_drains_concurrently` (I2))
+
+**Interfaces:**
+
+- Consumes: `AsyncAbsurd`, `psycopg.AsyncConnection`; `django.db.connections`,
+  `close_old_connections`;
+  `django.tasks.{Task,TaskContext,TaskResult,TaskResultStatus}`;
+  `django_absurd.connection.{validate_backend,register_jsonb_loader}`;
+  `django_absurd.backends.AbsurdBackend`.
+- Produces (worker.py public, signatures unchanged where they exist): `WorkerOptions`
+  (unchanged); `run_worker(backend, queue, *, burst=False, options=None) -> None` (sync
+  entry); `build_task_context`, `read_sdk_attempt` (unchanged). Internals are now async:
+  `arun_worker`, `aworker_client`, async `LazyTaskRegistry`, async `build_handler`,
+  async `drain_queue`, async `run_blocking_worker`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/atasks.py`:
+
+```python
+from django.tasks import task
+
+
+@task
+async def aecho(value):
+    return value
+```
+
+Add to `tests/test_worker.py` (uses the module `pytestmark` + the existing
+`run_absurd_worker` helper):
+
+```python
+def test_async_task_runs_end_to_end():
+    from tests.atasks import aecho
+
+    call_command("absurd_sync_queues")
+    r = aecho.enqueue("hi-async")
+    run_absurd_worker()
+    snap = get_task_result(r.id)
+    assert snap.state == "completed"
+    assert snap.result == "hi-async"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+`PGPORT=5433 uv run pytest tests/test_worker.py::test_async_task_runs_end_to_end -v`
+Expected: FAIL — with `supports_async_task=False`, `@task async def aecho` raises
+`InvalidTask` at decoration (import of `tests/atasks.py`), so the test errors on import
+/ enqueue. (Confirms async is unsupported pre-rewrite.)
+
+- [ ] **Step 3: Implement (prose — no production code block, per the no-coding-ahead
+      rule)**
+
+In `django_absurd/backends.py`: set `supports_async_task = True`.
+
+Rewrite `django_absurd/worker.py` to the spec's Architecture
+(`docs/specs/2026-06-24-async-worker-design.md`), keeping `WorkerOptions`,
+`build_task_context`, `read_sdk_attempt`, and the 3 `# noqa: SLF001` unchanged:
+
+- Imports: drop `from absurd_sdk import Absurd` → `from absurd_sdk import AsyncAbsurd`;
+  add `import asyncio`, `import inspect`,
+  `from concurrent.futures import ThreadPoolExecutor`,
+  `from contextlib import asynccontextmanager`; keep `import signal` (constants only —
+  drop `signal.signal()` use).
+- `run_worker(backend, queue, *, burst=False, options=None) -> None` (SYNC entry,
+  unchanged signature): `options = options or WorkerOptions()`;
+  `validate_backend(backend.database)` (here, off the loop);
+  `asyncio.run(arun_worker(backend, queue, burst=burst, options=options))`.
+- `arun_worker(...)`: create `ThreadPoolExecutor(max_workers=options.concurrency)` (use
+  as the loop's executor for sync tasks; shut down on exit, e.g.
+  `with ThreadPoolExecutor(...) as executor:`);
+  `async with aworker_client(backend, queue) as client:` then the startup `logger.info`
+  (alias/queue/database/burst/concurrency) and
+  `if burst: await drain_queue(client, …) else: await run_blocking_worker(client, options)`.
+  Make `executor` reachable by the handler (e.g. a contextvar, or pass into
+  `aworker_client`/the registry so handlers use it; choose the simplest that keeps
+  `build_handler` testable).
+- `aworker_client(backend, queue)` (`@asynccontextmanager`):
+  `params = connections[backend.database].get_connection_params(); params.pop("cursor_factory", None)`;
+  `conn = await psycopg.AsyncConnection.connect(**params, autocommit=True)`; `try:`
+  `register_jsonb_loader(conn)`; `client = AsyncAbsurd(conn, queue_name=queue)`;
+  `client._registry = LazyTaskRegistry(queue)  # noqa: SLF001 …`; provisioning check
+  `await client.list_queues()` wrapped in the SAME
+  `except (InvalidSchemaName, UndefinedTable, UndefinedFunction)` →
+  `ImproperlyConfigured` (absent schema) + `if queue not in provisioned` →
+  `ImproperlyConfigured` (same messages as today); `yield client`;
+  `finally: await conn.close()`. Do NOT call `validate_backend` here.
+- async `LazyTaskRegistry(dict)`: identical resolution logic to today (`.get(name)`:
+  cache-miss → `import_string`, `ImportError`/non-`Task` → `default`, else cache the
+  entry
+  `{name, queue, default_max_attempts:None, default_cancellation:None, handler: build_handler(task)}`).
+  `.get` itself stays a normal (sync) method — the SDK calls `_registry.get(name)`
+  synchronously; only the `handler` it stores is async.
+- async `build_handler(task) -> AsyncTaskHandler`: `async def handler(params, ctx)`:
+  `args=params.get("args",[])`, `kwargs=params.get("kwargs",{})`,
+  `attempt=read_sdk_attempt(ctx)`, start/timing + the same start/failed/completed
+  `logger` lines. Dispatch: `if inspect.iscoroutinefunction(task.func):` →
+  `result = await task.func(ctx_, *args, **kwargs)` (when `task.takes_context`,
+  `ctx_ = build_task_context(task, ctx, args, kwargs)`) else
+  `await task.func(*args, **kwargs)`. **Else (sync):** wrap a `call_sync()` that does
+  `close_old_connections()` → `task.func([ctx_,] *args, **kwargs)` → (finally)
+  `close_old_connections()`, and
+  `result = await asyncio.get_running_loop().run_in_executor(executor, call_sync)`. Keep
+  the
+  `try/except Exception: logger.exception(...); raise / else: logger.info(...); return result`
+  shape so the SDK records failures + retries.
+- async
+  `drain_queue(client, *, claim_timeout=120, batch_size=None, worker_id=None) -> int`:
+  loop
+  `claimed = await client.claim_tasks(batch_size or 1, claim_timeout, worker_id or "worker")`;
+  break if empty;
+  `for t_ in claimed: await client._execute_task(t_, claim_timeout)  # noqa: SLF001 …`;
+  return count.
+- async `run_blocking_worker(client, options)`: `loop = asyncio.get_running_loop()`;
+  `loop.add_signal_handler(signal.SIGINT, client.stop_worker)` + `SIGTERM`;
+  `try: await client.start_worker(worker_id=…, claim_timeout=…, concurrency=…, batch_size=…, poll_interval=…)`
+  `finally:` `loop.remove_signal_handler(signal.SIGINT)` + `SIGTERM`.
+
+In `tests/test_worker.py`, repoint the `get_task_result` helper to a DEDICATED sync read
+(the sync worker_client it used is gone). New top-level helper:
+
+```python
+def get_task_result(task_id, queue="default"):
+    from absurd_sdk import Absurd
+    from django.db import connections
+
+    from django_absurd.connection import register_jsonb_loader
+
+    raw_task_id = str(task_id).rsplit(":", 1)[-1]
+    params = connections["default"].get_connection_params()
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        register_jsonb_loader(conn)
+        return Absurd(conn).fetch_task_result(raw_task_id, queue)
+    finally:
+        conn.close()
+```
+
+(hoist the imports to the top of `test_worker.py` per ruff PLC0415; shown inline here
+only for locality). Then:
+
+- Rewrite the `worker_client` provisioning tests
+  (`test_worker_client_uses_dedicated_connection`, `_unprovisioned_queue_errors`,
+  `_absent_schema_errors`, `_rejects_non_psycopg3`) against `aworker_client` driven via
+  `asyncio.run` (e.g. an `asyncio.run(_enter())` helper that
+  `async with aworker_client(...)`), OR fold the
+  unprovisioned/absent-schema/non-psycopg3 cases into the command-level
+  `ImproperlyConfigured→CommandError` tests
+  (`test_command_maps_improperly_configured_to_commanderror`, plus a `--database sqlite`
+  rejection variant) — keep the same assertions/messages.
+- I1 `test_unregistered_name_defers_not_crashes`: replace
+  `with worker_client(...) as client: client.spawn(...)` with
+  `get_absurd_client("default").spawn("not.a.real.task", {"args": [], "kwargs": {}}, queue="default")`
+  (sync, no worker internals), keep the burst run +
+  `assert get_task_result(spawn["task_id"]).state != "failed"`.
+- I2 `test_start_worker_drains_concurrently`: delete the
+  `threading.Thread`/sync-`start_worker` scaffold; replace with the async-concurrency
+  smoke (Task 2) OR a minimal blocking-mode drive here. (Simplest: move the concurrency
+  assertion to Task 2's smoke and here just assert burst drains multiple enqueued sync
+  tasks.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `PGPORT=5433 uv run pytest tests/test_worker.py -v` → all pass (the new async-runs
+test + every existing behavioral test green via the executor path).
+
+- [ ] **Step 5: Full suite + gates**
+
+Run: `PGPORT=5433 uv run pytest` → green. `PGPORT=5433 uv run pytest tests/multidb` →
+green. Run: `uv run ruff check django_absurd tests` → clean
+(`grep -rn "noqa" django_absurd/worker.py` → exactly the 3 SLF001). Run:
+`uv run mypy django_absurd` → Success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add django_absurd/worker.py django_absurd/backends.py tests/atasks.py tests/test_worker.py
+git commit -m "feat: native-async worker (runs sync via executor + async on the loop); supports_async_task=True"
+```
+
+---
+
+### Task 2: Lock the async + jsonb behavior matrix
+
+**Files:**
+
+- Modify: `tests/atasks.py` (add async tasks: raising, takes_context, async-ORM
+  `Payload`, sleeper)
+- Modify: `tests/tasks.py` (a sync `echo` if not already present, for the mixed-run
+  test)
+- Create: `tests/test_async_worker.py` (the matrix; reuses
+  `run_absurd_worker`/`get_task_result` patterns — import them or duplicate the small
+  helpers)
+
+**Interfaces:**
+
+- Consumes: the async worker (Task 1); `tests/models.py::Payload` (JSONField model,
+  exists since SP6); `run_absurd_worker()` (burst) + `get_task_result(...)`
+  (dedicated-conn read, Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/atasks.py`:
+
+```python
+from asyncio import sleep as asleep
+
+from tests.models import Payload
+
+
+@task
+async def aboom():
+    msg = "aboom"
+    raise ValueError(msg)
+
+
+@task(takes_context=True)
+async def areport_attempt(context):
+    return context.attempt
+
+
+@task
+async def acreate_payload(data):
+    obj = await Payload.objects.acreate(data=data)
+    return obj.pk
+
+
+@task
+async def asleeper(seconds):
+    await asleep(seconds)
+    return "slept"
+```
+
+Create `tests/test_async_worker.py` (function-based,
+`pytestmark = pytest.mark.django_db(transaction=True)`); reuse
+`run_absurd_worker`/`get_task_result` (import from `tests.test_worker` or redefine the
+small helpers):
+
+```python
+import time
+
+import pytest
+from django.core.management import call_command
+
+from tests.atasks import aboom, acreate_payload, aecho, areport_attempt, asleeper
+from tests.models import Payload
+from tests.tasks import echo  # sync echo
+from tests.test_worker import get_task_result, run_absurd_worker
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, 0, False, "", [], {}, {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]}],
+)
+def test_async_return_value_round_trips(value):
+    call_command("absurd_sync_queues")
+    r = aecho.enqueue(value)
+    run_absurd_worker()
+    snap = get_task_result(r.id)
+    assert snap.state == "completed"
+    assert snap.result == value
+
+
+def test_async_failure_recorded():
+    call_command("absurd_sync_queues")
+    from django_absurd.params import AbsurdSpawnParams
+
+    r = aboom.enqueue(absurd_spawn_params=AbsurdSpawnParams(max_attempts=1))
+    run_absurd_worker()
+    assert get_task_result(r.id).state == "failed"
+
+
+def test_async_takes_context_attempt_is_one():
+    call_command("absurd_sync_queues")
+    r = areport_attempt.enqueue()
+    run_absurd_worker()
+    assert get_task_result(r.id).result == 1
+
+
+def test_async_orm_jsonfield_round_trips():
+    call_command("absurd_sync_queues")
+    r = acreate_payload.enqueue({"async": True, "y": {"z": None}})
+    run_absurd_worker()
+    pk = get_task_result(r.id).result
+    assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
+
+
+def test_sync_and_async_in_one_worker_run():
+    call_command("absurd_sync_queues")
+    rs = echo.enqueue({"mixed": "sync"})
+    ra = aecho.enqueue({"mixed": "async"})
+    run_absurd_worker()
+    assert get_task_result(rs.id).result == {"mixed": "sync"}
+    assert get_task_result(ra.id).result == {"mixed": "async"}
+
+
+def test_worker_does_not_poison_jsonfield_reads():
+    # The worker's loader is on its dedicated AsyncConnection; a Django JSONField read
+    # on the shared connection after a worker run must still decode (no SP6-style poison).
+    call_command("absurd_sync_queues")
+    aecho.enqueue("x")
+    run_absurd_worker()
+    obj = Payload.objects.create(data={"k": "v", "n": 7})
+    assert Payload.objects.get(pk=obj.pk).data == {"k": "v", "n": 7}
+
+
+def test_async_concurrency_is_not_serial():
+    call_command("absurd_sync_queues")
+    for _ in range(4):
+        asleeper.enqueue(0.5)
+    start = time.monotonic()
+    run_absurd_worker(concurrency=4)  # burst with concurrency
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent is well under
+```
+
+(If `run_absurd_worker` doesn't yet accept `concurrency`, extend it to pass
+`concurrency=` through
+`call_command("absurd_worker", queue=…, burst=True, concurrency=…)` — the command
+already has the flag.) Add a sync `echo` to `tests/tasks.py` if absent:
+`@task def echo(value): return value`.
+
+- [ ] **Step 2: Run to verify they fail / drive gaps**
+
+Run: `PGPORT=5433 uv run pytest tests/test_async_worker.py -v` Expected: PASS against
+the Task-1 worker IF Task 1 is complete and correct. Any FAIL pinpoints a Task-1 gap
+(e.g. sync-task executor path, async-ORM, jsonb decode, concurrency) — fix in
+`worker.py`, not by weakening the test. (The matrix mirrors the 7 live-verified probe
+scenarios + async execution behaviors.)
+
+- [ ] **Step 3: (only if a test fails) fix `worker.py`**
+
+Address the specific gap in the async worker per the spec; re-run.
+
+- [ ] **Step 4: Full suite + gates**
+
+Run: `PGPORT=5433 uv run pytest` → green. `PGPORT=5433 uv run pytest tests/multidb` →
+green. Run: `uv run ruff check django_absurd tests` → clean. `uv run mypy django_absurd`
+→ Success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/atasks.py tests/tasks.py tests/test_async_worker.py django_absurd/worker.py
+git commit -m "test: lock async-worker behavior + jsonb matrix (sync/async, failure, takes_context, async ORM, concurrency)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** async worker rewrite + `supports_async_task=True` +
+`validate_backend` in sync entry + C1 cursor_factory pop + dedicated `AsyncConnection` +
+async registry/handler + executor for sync + signals + one-knob concurrency (Task 1,
+Step 3); behavioral suite stays green + internal-helper adaptations (`get_task_result`
+dedicated read, I1, I2) (Task 1, Steps 3–4); the 7 live-verified jsonb scenarios + async
+failure/takes_context/async-ORM/mixed/concurrency (Task 2). Dropped sync bodies covered
+by the rewrite. `aenqueue` native path correctly OUT of scope.
+
+**Placeholder scan:** none — test steps carry full code; implementation is prose
+referencing the spec's exact architecture (no production-code blocks, per the
+no-coding-ahead rule); the `get_task_result` helper is shown because it's a TEST helper,
+not production code.
+
+**Type consistency:**
+`aworker_client`/`arun_worker`/`drain_queue`/`run_blocking_worker`/`build_handler`/`LazyTaskRegistry`/`build_task_context`/`read_sdk_attempt`/`WorkerOptions`
+names + `run_worker(backend, queue, *, burst, options) -> None` match the spec and the
+preserved command import. `get_task_result(task_id, queue="default")` +
+`run_absurd_worker(queue="default", concurrency=…)` consistent between Task 1 and
+Task 2. The 3 `# noqa: SLF001` are preserved, no new ignores.

--- a/docs/specs/2026-06-24-async-worker-design.md
+++ b/docs/specs/2026-06-24-async-worker-design.md
@@ -51,16 +51,22 @@ ctx is an `AsyncTaskContext` with `ctx.task_id` + `ctx._task["attempt"]`, so
 ## Architecture
 
 `absurd_worker` command (CLI unchanged) →
-`run_worker(backend, queue, *, burst, options)` stays a SYNC entry that just does
-`asyncio.run(arun_worker(...))` — the command and `run_worker`'s signature don't change.
-Everything below runs on the loop.
+`run_worker(backend, queue, *, burst, options)` stays a SYNC entry. It calls
+`validate_backend(backend.database)` HERE (sync context) — its `ensure_connection()` is
+Django `@async_unsafe` and would raise `SynchronousOnlyOperation` if called on the loop
+(live-verified) — THEN `asyncio.run(arun_worker(...))`. Everything below runs on the
+loop and must NOT touch Django's registered connection (use the dedicated
+`AsyncConnection`; any unavoidable Django-conn op from the loop goes via
+`sync_to_async`).
 
 - **`aworker_client(backend, queue)`** — async ctx-mgr mirroring the sync
   `worker_client`:
   `params = connections[backend.database].get_connection_params(); params.pop("cursor_factory", None); conn = await psycopg.AsyncConnection.connect(**params, autocommit=True)`
   (DEDICATED — NOT Django's registered conn, so `close_old_connections()` never closes
-  it under the SDK; `cursor_factory` dropped per C1 above),
-  `register_jsonb_loader(conn)`, `client = AsyncAbsurd(conn, queue_name=queue)`, install
+  it under the SDK; `cursor_factory` dropped per C1 above). Does NOT call
+  `validate_backend` (done in the sync `run_worker` entry — it's `@async_unsafe`);
+  `get_connection_params()` is config-only and loop-safe. `register_jsonb_loader(conn)`,
+  `client = AsyncAbsurd(conn, queue_name=queue)`, install
   `client._registry = LazyTaskRegistry(queue)` (one SLF001), provisioning check via
   `await client.list_queues()` → `ImproperlyConfigured` on absent schema / unprovisioned
   queue (same messages as today), `finally: await conn.close()`.
@@ -175,6 +181,31 @@ observable outcome or the CLI.
   blocking/burst worker with `concurrency>1` completes them in roughly-concurrent (not
   serial) wall-clock — proves loop concurrency. Keep the sleep tiny + the assertion
   generous to avoid flakiness.
+
+**jsonb matrix — ALL 7 live-verified end-to-end (prototype `aworker_client`, real
+Postgres); lock each as a committed test:**
+
+1. **params decode on claim:** handler's `params` is a `dict` with the loader on the
+   dedicated `AsyncConnection` (and a raw `str` without it — proves the loader is
+   load-bearing). Assert a task's handler sees `params["args"]`/`["kwargs"]` as Python.
+2. **no shared-conn poison (the SP6 guard, async edition):** after the worker runs, a
+   Django `JSONField` read on the DEFAULT (shared) connection still works (no
+   `TypeError`) — the dedicated-conn loader doesn't touch Django's adapters. Use the
+   `Payload` model.
+3. **sync task in executor reads `JSONField`:** a sync `def` task (executor path) does
+   `Payload.objects.create(...)` + read-back — round-trips, no
+   `SynchronousOnlyOperation`.
+4. **async-ORM `JSONField`:** an `async def` task `await Payload.objects.acreate(...)` +
+   `await ...aget(...)` — `.data` round-trips on the loop (Django async conn,
+   unaffected).
+5. **result decode via dedicated read conn (C2):** completed task's `.result` decodes to
+   the Python value through the dedicated-conn+loader read helper, and is a raw JSON
+   STRING via `build_absurd_client` (no loader) — assert both, locking C2.
+6. **falsy/nested/unicode return round-trip:**
+   `None, 0, False, "", [], {}, {"nested":[1,2,{"a":None,"b":"ünïçødé"}]}` each
+   `completed` and `.result` equals the original through the async path.
+7. **mixed sync+async drained by one worker client** — both `completed`, both results
+   decode.
 
 No mocks; real DB: `PGPORT=5433 docker compose up -d db`, run with `PGPORT=5433`.
 

--- a/docs/specs/2026-06-24-async-worker-design.md
+++ b/docs/specs/2026-06-24-async-worker-design.md
@@ -36,8 +36,17 @@ Coroutines: `claim_tasks`, `_execute_task`,
 `loop.add_signal_handler`. `_execute_task` AWAITS the registry entry's `handler` (an
 `AsyncTaskHandler`), so our handler must be `async`.
 `psycopg.AsyncConnection.connect(**params, autocommit=True)` mirrors the sync dedicated
-connection. `register_jsonb_loader(context)` already accepts any `AdaptContext` incl. an
-`AsyncConnection`.
+connection — BUT Django's `get_connection_params()` includes
+`cursor_factory=<sync Django Cursor>`, which is FATAL for `AsyncConnection.connect` (the
+connection's `.cursor()` returns a sync cursor → the SDK's `await cursor.execute(...)`
+raises on the FIRST call, `list_queues()`). Must `params.pop("cursor_factory", None)`
+before connecting (live-verified: dropping that one key yields an `AsyncCursor` and
+async execute works; other params — `context`/`client_encoding`/`prepare_threshold` —
+are accepted). `register_jsonb_loader(context)` already accepts any `AdaptContext` incl.
+an `AsyncConnection`. Verified live: `AsyncAbsurd` reads a swapped `_registry` via
+`.get(name)` and `await`s `registration["handler"]` — same entry-dict shape as sync; the
+ctx is an `AsyncTaskContext` with `ctx.task_id` + `ctx._task["attempt"]`, so
+`read_sdk_attempt`/`build_task_context` reuse unchanged.
 
 ## Architecture
 
@@ -48,10 +57,10 @@ Everything below runs on the loop.
 
 - **`aworker_client(backend, queue)`** — async ctx-mgr mirroring the sync
   `worker_client`:
-  `conn = await psycopg.AsyncConnection.connect(**connections[backend.database]. get_connection_params(), autocommit=True)`
+  `params = connections[backend.database].get_connection_params(); params.pop("cursor_factory", None); conn = await psycopg.AsyncConnection.connect(**params, autocommit=True)`
   (DEDICATED — NOT Django's registered conn, so `close_old_connections()` never closes
-  it under the SDK), `register_jsonb_loader(conn)`,
-  `client = AsyncAbsurd(conn, queue_name=queue)`, install
+  it under the SDK; `cursor_factory` dropped per C1 above),
+  `register_jsonb_loader(conn)`, `client = AsyncAbsurd(conn, queue_name=queue)`, install
   `client._registry = LazyTaskRegistry(queue)` (one SLF001), provisioning check via
   `await client.list_queues()` → `ImproperlyConfigured` on absent schema / unprovisioned
   queue (same messages as today), `finally: await conn.close()`.
@@ -95,9 +104,12 @@ Everything below runs on the loop.
 
 Sync `worker_client`, sync `drain_queue`, sync `run_blocking_worker`, sync
 `build_handler`, the sync-handler-building branch of `LazyTaskRegistry`, the
-`import signal`/`signal.signal` thread approach (→ `loop.add_signal_handler`),
-`from absurd_sdk import Absurd` (→ `AsyncAbsurd`). Git history preserves them. NO
-capability lost (async worker is a superset).
+`signal.signal()` thread approach (→ `loop.add_signal_handler`; KEEP `import signal` —
+the `SIGINT`/`SIGTERM` constants are still needed), `from absurd_sdk import Absurd` (→
+`AsyncAbsurd`). Git history preserves them. NO capability lost (async worker is a
+superset). Note: `loop.add_signal_handler` raises on Windows / off the main thread —
+guard or document (out-of-scope to fully solve; worker runs on the main thread under
+`asyncio.run`).
 
 ## Connection model
 
@@ -117,15 +129,33 @@ observable outcome or the CLI.
 
 **Internal-API-touching tests adapt** (behavior unchanged, internals went async):
 
-- `get_task_result(...)` helper currently fetches via the sync `worker_client`. Repoint
-  it at a SYNC read (`get_absurd_client(...).fetch_task_result(task_id, queue)`) — sync
-  SDK reads are independent of the worker's internals. (`claim_one` already uses
-  `get_absurd_client`.)
+- `get_task_result(...)` helper currently fetches via the sync `worker_client` (which
+  registers the jsonb loader on its DEDICATED conn — that's why `snap.result` decodes).
+  Repoint it at a read that ALSO registers the loader on a DEDICATED conn — do NOT use
+  `get_absurd_client(...).fetch_task_result(...)`: `build_absurd_client` does NOT
+  register the loader (so `result` comes back as a raw JSON STRING, breaking 4
+  `snap.result ==` assertions — C2), and registering the loader on `get_absurd_client`'s
+  SHARED Django conn would re-introduce the SP6 JSONField-poison. So the helper opens a
+  dedicated sync `psycopg.connect(**params)` + `register_jsonb_loader(conn)` +
+  `client.fetch_task_result`, OR drives the async `aworker_client` via `asyncio.run` (it
+  already registers on its dedicated conn). (`claim_one` is unaffected — it registers
+  the loader itself.)
 - `worker_client` provisioning/connection tests (dedicated-conn, unprovisioned,
   absent-schema) → rewrite against async `aworker_client` (await it in an
   `asyncio.run`), or fold the unprovisioned/absent-schema cases into the existing
   command-level `ImproperlyConfigured→CommandError` tests.
-- the concurrency drain test → async variant.
+- **`test_unregistered_name_defers_not_crashes` (I1)** uses
+  `with worker_client(...) as client: client.spawn(...)`. Rewrite the spawn via
+  `get_absurd_client("default").spawn( "not.a.real.task", ...)` (sync, no worker
+  internals; spawn reads no jsonb), keep the burst run + "not failed (deferred)"
+  assertion.
+- **the threaded concurrency test (I2)** `test_start_worker_drains_concurrently` uses a
+  `threading.Thread` running sync `start_worker` + `stop_worker`. The async
+  `start_worker` is a coroutine and CANNOT be thread-`target`'d — fully drop the
+  threading scaffold and rewrite as the async-concurrency smoke below (drive
+  `start_worker`/`arun_worker` on the loop). (Verified live:
+  `start_worker(concurrency=4)` ran 4 `asyncio.sleep(0.5)` tasks in ~0.52s vs ~2s
+  serial.)
 
 **New tests (the new capability):**
 

--- a/docs/specs/2026-06-24-async-worker-design.md
+++ b/docs/specs/2026-06-24-async-worker-design.md
@@ -88,10 +88,13 @@ loop and must NOT touch Django's registered connection (use the dedicated
     (data-only); the `ctx_` is passed first positional to either path.
   - error/`logger.exception`/duration logging + re-raise: unchanged (so the SDK records
     the failure and retries).
-- **burst** — async `drain_queue(client, …)`: loop
-  `claimed = await client.claim_tasks( batch_size or 1, claim_timeout, worker_id or "worker")`
-  until empty, `await client._execute_task(t_, claim_timeout)` each (one SLF001, mirrors
-  today).
+- **burst** — async `drain_queue(client, *, concurrency=1, …)`: loop
+  `claimed = await client.claim_tasks(batch_size or concurrency, claim_timeout, worker_id or "worker")`
+  until empty, then
+  `await asyncio.gather(*[client._execute_task(t_, claim_timeout) for t_ in claimed])`
+  (one SLF001) — CONCURRENT so `--concurrency` is honored in burst too (the naive serial
+  `for await` would ignore it; live-verified 2.09s serial → 0.53s concurrent). Sync
+  tasks in the gather overlap via the default executor sized to `concurrency`.
 - **blocking** — async `run_blocking_worker(client, options)`: install
   `loop.add_signal_handler(SIGINT, client.stop_worker)` + SIGTERM (stop_worker is sync),
   `await client.start_worker(worker_id, claim_timeout, concurrency, batch_size, poll_interval)`,

--- a/docs/specs/2026-06-24-async-worker-design.md
+++ b/docs/specs/2026-06-24-async-worker-design.md
@@ -1,0 +1,158 @@
+# django-absurd — Spec: native-async worker (SP7)
+
+Date: 2026-06-24 Status: approved-for-planning
+
+Make `absurd_worker` a native-asyncio worker so it runs BOTH sync and `async def` tasks,
+and flip `AbsurdBackend.supports_async_task = True`. Today the worker is
+sync/thread-based (`Absurd` + `psycopg.Connection` + the SDK's threaded `start_worker`)
+and calls `task.func(*args, **kwargs)` directly — a coroutine task func would return an
+un-awaited coroutine, so `supports_async_task=False` rejects async tasks at enqueue.
+
+## Why / decisions (from brainstorm)
+
+- django-absurd is a LIBRARY; developers decide sync vs async, incl. high-I/O async
+  tasks
+  - async ORM. So the worker must run async tasks NATIVELY (a true event loop), not via
+    an `async_to_sync` bridge on a thread worker.
+- **REPLACE, not coexist.** A native-async worker is a strict SUPERSET: `async def`
+  tasks are awaited on the loop (true concurrency); `def` tasks run in a thread pool via
+  `loop.run_in_executor` — byte-for-byte the thread behavior today's worker gives them
+  (`close_old_connections` per task, sync ORM fine). One `absurd_worker`, one
+  implementation, one connection model. No capability lost.
+- **Invocation unchanged.** Same command/flags
+  (`absurd_worker --queue … [--concurrency N] [--burst] …`); the async loop is internal.
+  Sync developers write plain `def` tasks + sync ORM as before — they never see a loop.
+- **Worker-only scope.** Native async `aenqueue` (produce side via `AsyncAbsurd` /
+  `AsyncConnection`) is OUT — the inherited
+  `BaseTaskBackend.aenqueue = sync_to_async(self.enqueue)` stays (a fast spawn;
+  adequate). Deferred follow-up.
+
+## SDK facts (verified)
+
+`AsyncAbsurd(conn_or_url: AsyncConnection | str, queue_name="default", default_max_attempts=5, hooks=None)`.
+Coroutines: `claim_tasks`, `_execute_task`,
+`start_worker(worker_id, claim_timeout=120, concurrency=1, batch_size=None, poll_interval=0.25)`.
+`stop_worker(self) -> None` is SYNC (sets a stop flag) → safe to call from
+`loop.add_signal_handler`. `_execute_task` AWAITS the registry entry's `handler` (an
+`AsyncTaskHandler`), so our handler must be `async`.
+`psycopg.AsyncConnection.connect(**params, autocommit=True)` mirrors the sync dedicated
+connection. `register_jsonb_loader(context)` already accepts any `AdaptContext` incl. an
+`AsyncConnection`.
+
+## Architecture
+
+`absurd_worker` command (CLI unchanged) →
+`run_worker(backend, queue, *, burst, options)` stays a SYNC entry that just does
+`asyncio.run(arun_worker(...))` — the command and `run_worker`'s signature don't change.
+Everything below runs on the loop.
+
+- **`aworker_client(backend, queue)`** — async ctx-mgr mirroring the sync
+  `worker_client`:
+  `conn = await psycopg.AsyncConnection.connect(**connections[backend.database]. get_connection_params(), autocommit=True)`
+  (DEDICATED — NOT Django's registered conn, so `close_old_connections()` never closes
+  it under the SDK), `register_jsonb_loader(conn)`,
+  `client = AsyncAbsurd(conn, queue_name=queue)`, install
+  `client._registry = LazyTaskRegistry(queue)` (one SLF001), provisioning check via
+  `await client.list_queues()` → `ImproperlyConfigured` on absent schema / unprovisioned
+  queue (same messages as today), `finally: await conn.close()`.
+- **`LazyTaskRegistry`** — same resolution logic (cache miss → `import_string(name)`,
+  `ImportError`/non-`Task` → `default` so the SDK defers, else cache the entry dict
+  `{name, queue, default_max_attempts:None, default_cancellation:None, handler}`). ONLY
+  the built handler changes: now an `async` handler.
+- **async `build_handler(task)`** — `async def handler(params, ctx)`:
+  - `args`/`kwargs` from `params`; `attempt = read_sdk_attempt(ctx)`;
+    start/timing/logging identical to today.
+  - **Dispatch by func kind:** `if inspect.iscoroutinefunction(task.func):` await it on
+    the loop — `await task.func(ctx_, *args, **kwargs)` (with-context) or
+    `await task.func(*args, **kwargs)`. **Else (sync):**
+    `await loop.run_in_executor(executor, call_sync)` where `call_sync` does
+    `close_old_connections()` → `task.func([ctx_,] *args, **kwargs)` →
+    `close_old_connections()` (so sync ORM connections are fresh per task in the
+    executor thread, exactly as today's threaded handler).
+  - `takes_context`: `build_task_context(task, ctx, args, kwargs)` REUSED unchanged
+    (data-only); the `ctx_` is passed first positional to either path.
+  - error/`logger.exception`/duration logging + re-raise: unchanged (so the SDK records
+    the failure and retries).
+- **burst** — async `drain_queue(client, …)`: loop
+  `claimed = await client.claim_tasks( batch_size or 1, claim_timeout, worker_id or "worker")`
+  until empty, `await client._execute_task(t_, claim_timeout)` each (one SLF001, mirrors
+  today).
+- **blocking** — async `run_blocking_worker(client, options)`: install
+  `loop.add_signal_handler(SIGINT, client.stop_worker)` + SIGTERM (stop_worker is sync),
+  `await client.start_worker(worker_id, claim_timeout, concurrency, batch_size, poll_interval)`,
+  remove the signal handlers in `finally`.
+- **Executor / concurrency:** one
+  `concurrent.futures.ThreadPoolExecutor(max_workers= options.concurrency)` created in
+  `arun_worker`, used by sync-task handlers via `run_in_executor`. `--concurrency N`
+  drives BOTH the SDK's loop concurrency (`start_worker(concurrency=N)`) AND the
+  executor pool size (one knob). Executor shut down on exit.
+- `read_sdk_attempt`, `build_task_context`, `WorkerOptions`, the command's alias/queue
+  resolution + `--burst`/tunables + `ImproperlyConfigured→CommandError` mapping: all
+  REUSED unchanged.
+- `AbsurdBackend.supports_async_task = True`.
+
+## Dropped (replaced by async equivalents)
+
+Sync `worker_client`, sync `drain_queue`, sync `run_blocking_worker`, sync
+`build_handler`, the sync-handler-building branch of `LazyTaskRegistry`, the
+`import signal`/`signal.signal` thread approach (→ `loop.add_signal_handler`),
+`from absurd_sdk import Absurd` (→ `AsyncAbsurd`). Git history preserves them. NO
+capability lost (async worker is a superset).
+
+## Connection model
+
+Worker claim/bookkeeping on a dedicated `AsyncConnection` (built from Django's DB
+params, autocommit). Sync tasks run in executor threads using Django's thread-local SYNC
+connections (`close_old_connections` around each) — unchanged from today. Async tasks
+doing async ORM run on the loop (Django async ORM works in an async context; sync ORM
+inside an `async def` raises `SynchronousOnlyOperation` — the task author's concern,
+standard Django).
+
+## Testing (pytest, function-based, real Postgres; behavior-first)
+
+**Existing behavioral tests stay GREEN, unchanged** — they drive
+`call_command( "absurd_worker", queue=…, burst=True)` and assert observable state
+(`Group` rows, result snapshots). The worker being asyncio internally doesn't change the
+observable outcome or the CLI.
+
+**Internal-API-touching tests adapt** (behavior unchanged, internals went async):
+
+- `get_task_result(...)` helper currently fetches via the sync `worker_client`. Repoint
+  it at a SYNC read (`get_absurd_client(...).fetch_task_result(task_id, queue)`) — sync
+  SDK reads are independent of the worker's internals. (`claim_one` already uses
+  `get_absurd_client`.)
+- `worker_client` provisioning/connection tests (dedicated-conn, unprovisioned,
+  absent-schema) → rewrite against async `aworker_client` (await it in an
+  `asyncio.run`), or fold the unprovisioned/absent-schema cases into the existing
+  command-level `ImproperlyConfigured→CommandError` tests.
+- the concurrency drain test → async variant.
+
+**New tests (the new capability):**
+
+- **async task runs e2e:** an `@task async def` that writes a row (via `sync_to_async`
+  ORM or `await Model.objects.acreate`); enqueue; `run_absurd_worker()` (burst); assert
+  the row
+  - result snapshot `completed`.
+- **sync + async in one worker run:** enqueue one `def` and one `async def` task; single
+  burst worker runs both; both complete.
+- **sync task still behaves:** an existing sync-task test already covers this (executor
+  path) — assert it stays green.
+- **async failure recorded + retried:** an `async def` that raises → snapshot `failed`,
+  errors recorded (mirrors `boom`).
+- **takes_context for async:** an `async def` task with `takes_context=True` gets a
+  `TaskContext` with the right `attempt`.
+- **async concurrency smoke:** enqueue N async tasks that each `await asyncio.sleep`;
+  blocking/burst worker with `concurrency>1` completes them in roughly-concurrent (not
+  serial) wall-clock — proves loop concurrency. Keep the sleep tiny + the assertion
+  generous to avoid flakiness.
+
+No mocks; real DB: `PGPORT=5433 docker compose up -d db`, run with `PGPORT=5433`.
+
+## Out of scope (deferred)
+
+Native async `aenqueue` (produce side, `AsyncAbsurd`/`AsyncConnection`); separate
+async-vs-executor concurrency knobs (one `--concurrency` for now); multi-DB; the other
+deferred follow-ups (ALWAYS_EAGER, public register hook to drop the `_registry` SLF001).
+Also noted (separate, from the Tasks-API refresh): `TaskResult.id` documented
+`< 64 chars` while SP6's `queue:task_id` can exceed it for long queue names — latent SP6
+caveat, its own follow-up.

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -11,11 +11,14 @@ ENV UV_LINK_MODE=copy
 # the venv directly — no `uv run` prefix needed (django-layout's pattern).
 ENV PATH=/repo/examples/.venv/bin:${PATH}
 ENV DJANGO_SETTINGS_MODULE=demo_project.settings
+# The build context has no .git (see .dockerignore), so hatch-vcs/setuptools-scm can't
+# derive django-absurd's version — feed it a pretend version for the in-image build.
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 
 WORKDIR /repo
 # Only what's needed to build+install django-absurd and the example (keeps the image
 # free of .venv/.tox/.git from the host).
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 COPY django_absurd ./django_absurd
 COPY examples ./examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,8 +5,8 @@ A minimal Django project using **django-absurd** as the
 Postgres. Fully containerized — `docker compose up` runs the whole thing; no host
 Python, uv, or Postgres needed.
 
-It defines two `@task` functions in `demo/tasks.py`, enqueues them, and runs the
-`absurd_worker` to execute them.
+It defines `@task` functions in `demo/tasks.py` — sync and `async def` — enqueues them,
+and runs the `absurd_worker` to execute them (one worker runs both kinds).
 
 ## Layout
 
@@ -17,7 +17,7 @@ examples/
   pyproject.toml            # deps: django>=6, django-absurd (local path), psycopg[binary]
   manage.py
   demo_project/settings.py  # INSTALLED_APPS + DATABASES + TASKS(AbsurdBackend) + router
-  demo/tasks.py             # @task add / create_user
+  demo/tasks.py             # @task add / create_user / create_user_async (async ORM)
   demo/management/commands/enqueue_demo.py
 ```
 
@@ -34,11 +34,13 @@ exits `0`:
 
 1. `manage.py migrate` — creates the auth tables **and** the Absurd schema.
 2. `manage.py absurd_sync_queues` — provisions the queues declared in `TASKS`.
-3. `manage.py enqueue_demo` — enqueues `add(2, 3)` and `create_user("alice")`.
-4. `manage.py absurd_worker --queue default --burst` — drains the queue, runs both tasks
-   (you'll see per-task start/completed logs), then exits.
+3. `manage.py enqueue_demo` — enqueues `add(2, 3)`, `create_user("alice")`, and the
+   async `create_user_async("alice-async")`.
+4. `manage.py absurd_worker --queue default --burst` — drains the queue, runs all three
+   tasks (you'll see per-task start/completed logs) — sync tasks in a thread pool, the
+   `async def` task on the event loop — then exits.
 
-You'll see the worker execute both tasks in the logs. Clean up with:
+You'll see the worker execute all three tasks in the logs. Clean up with:
 
 ```bash
 docker compose down -v
@@ -55,7 +57,8 @@ The image autoloads the virtualenv (it's on `PATH`), so commands are plain
 # Enqueue again
 docker compose run --rm app python manage.py enqueue_demo
 
-# Run a long-lived blocking worker (Ctrl-C to stop); supports --concurrency N etc.
+# Run a long-lived blocking worker (Ctrl-C to stop). --concurrency N sizes both the
+# event-loop concurrency (async tasks) and the sync thread pool.
 docker compose run --rm app python manage.py absurd_worker --queue default --concurrency 4
 
 # Validate the TASKS / queue configuration
@@ -67,12 +70,15 @@ docker compose run --rm app python manage.py check
 - **Burst** (`--burst`): process the available backlog, then exit `0` — what the default
   `compose up` uses (good for cron / one-shot drains).
 - **Blocking** (no `--burst`): long-running; polls until `SIGINT`/`SIGTERM`. Supports
-  `--concurrency N` (thread pool), `--claim-timeout`, `--poll-interval`, `--batch-size`,
-  `--worker-id`.
+  `--concurrency N` (sizes the event loop + the sync thread pool), `--claim-timeout`,
+  `--poll-interval`, `--batch-size`, `--worker-id`.
+
+Both modes run sync and `async def` tasks (sync in a thread pool, async on the loop).
 
 ## Notes
 
-- Tasks must live in an installed app's `tasks.py` (the worker discovers them there).
+- Tasks are resolved by import path, so they can live in any importable module —
+  `tasks.py` is just a convention. (`demo/tasks.py` here.)
 - django-absurd requires the **psycopg (v3)** PostgreSQL backend — Django selects it
   automatically for `django.db.backends.postgresql` when `psycopg` is installed.
 - The app connects to Postgres over the compose network (`db:5432`); the demo task

--- a/examples/demo/management/commands/enqueue_demo.py
+++ b/examples/demo/management/commands/enqueue_demo.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from demo.tasks import add, create_user
+from demo.tasks import add, create_user, create_user_async
 
 
 class Command(BaseCommand):
@@ -9,8 +9,12 @@ class Command(BaseCommand):
     def handle(self, *args: object, **options: object) -> None:
         add_result = add.enqueue(2, 3)
         user_result = create_user.enqueue("alice")
+        async_result = create_user_async.enqueue("alice-async")
         self.stdout.write(f"Enqueued add(2, 3) -> task {add_result.id}")
         self.stdout.write(f"Enqueued create_user('alice') -> task {user_result.id}")
+        self.stdout.write(
+            f"Enqueued create_user_async('alice-async') -> task {async_result.id}"
+        )
         self.stdout.write(
             "Run a worker to execute them:"
             " manage.py absurd_worker --queue default --burst"

--- a/examples/demo/tasks.py
+++ b/examples/demo/tasks.py
@@ -18,3 +18,12 @@ def create_user(username: str) -> str:
     """
     User.objects.get_or_create(username=username)
     return username
+
+
+@task
+async def create_user_async(username: str) -> str:
+    """An ``async def`` task — runs natively on the worker's event loop, using
+    Django's async ORM. Same idempotent get_or_create, async variant.
+    """
+    await User.objects.aget_or_create(username=username)
+    return username

--- a/examples/uv.lock
+++ b/examples/uv.lock
@@ -54,19 +54,18 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "absurdctl", specifier = "==0.4.0" },
-    { name = "build", specifier = ">=1.2.0" },
-    { name = "django-coverage-plugin", specifier = ">=3.2.0" },
-    { name = "django-stubs", specifier = ">=6.0.5" },
-    { name = "mypy", specifier = ">=2.1.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
-    { name = "pytest", specifier = ">=9.1.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-django", specifier = ">=4.12.0" },
-    { name = "pytest-socket", specifier = ">=0.8.0" },
-    { name = "ruff", specifier = ">=0.9.0" },
-    { name = "setuptools", specifier = ">=77" },
-    { name = "setuptools-scm", specifier = ">=8" },
-    { name = "wheel", specifier = ">=0.43.0" },
+    { name = "build", specifier = "==1.5.0" },
+    { name = "django-coverage-plugin", specifier = "==3.2.2" },
+    { name = "django-stubs", specifier = "==6.0.5" },
+    { name = "hatch-vcs", specifier = "==0.5.0" },
+    { name = "hatchling", specifier = "==1.30.1" },
+    { name = "mypy", specifier = "==2.1.0" },
+    { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
+    { name = "pytest", specifier = "==9.1.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-django", specifier = "==4.12.0" },
+    { name = "pytest-socket", specifier = "==0.8.0" },
+    { name = "ruff", specifier = "==0.15.17" },
 ]
 
 [[package]]

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -1,6 +1,33 @@
+from asyncio import sleep as asleep
+
 from django.tasks import task
+
+from tests.models import Payload
 
 
 @task
 async def aecho(value):
     return value
+
+
+@task
+async def aboom():
+    msg = "aboom"
+    raise ValueError(msg)
+
+
+@task(takes_context=True)
+async def areport_attempt(context):
+    return context.attempt
+
+
+@task
+async def acreate_payload(data):
+    obj = await Payload.objects.acreate(data=data)
+    return obj.pk
+
+
+@task
+async def asleeper(seconds):
+    await asleep(seconds)
+    return "slept"

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -28,6 +28,13 @@ async def acreate_payload(data):
 
 
 @task
+async def aread_payload(pk):
+    # async QUERY: read a row back via Django async ORM, return its jsonb
+    obj = await Payload.objects.aget(pk=pk)
+    return obj.data
+
+
+@task
 async def asleeper(seconds):
     await asleep(seconds)
     return "slept"

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -1,0 +1,6 @@
+from django.tasks import task
+
+
+@task
+async def aecho(value):
+    return value

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -9,13 +9,6 @@ def add(a, b):
     return a + b
 
 
-# Module-level (undecorated) coroutine: applying @task to it must be rejected
-# because the backend sets supports_async_task=False. Kept undecorated so the
-# module imports cleanly; the test applies task() to it to trigger validation.
-async def add_async(a, b):
-    return a + b
-
-
 @task
 def make_group(name):
     Group.objects.create(name=name)

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import Group
 from django.tasks import task
 
 from django_absurd.params import absurd_default_params
+from tests.models import Payload
 
 
 @task
@@ -46,3 +47,8 @@ def with_default_attempts(a, b):
 @task
 def echo(value):
     return value
+
+
+@task
+def create_payload(data):
+    return Payload.objects.create(data=data).pk

--- a/tests/test_async_worker.py
+++ b/tests/test_async_worker.py
@@ -1,0 +1,86 @@
+import time
+
+import pytest
+from django.core.management import call_command
+
+from django_absurd.params import AbsurdSpawnParams
+from tests.atasks import aboom, acreate_payload, aecho, areport_attempt, asleeper
+from tests.models import Payload
+from tests.tasks import create_payload, echo  # sync ORM task + sync echo
+from tests.test_worker import get_task_result, run_absurd_worker
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, 0, False, "", [], {}, {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]}],
+)
+def test_async_return_value_round_trips(value):
+    call_command("absurd_sync_queues")
+    r = aecho.enqueue(value)
+    run_absurd_worker()
+    snap = get_task_result(r.id)
+    assert snap.state == "completed"
+    assert snap.result == value
+
+
+def test_async_failure_recorded():
+    call_command("absurd_sync_queues")
+    r = aboom.enqueue(absurd_spawn_params=AbsurdSpawnParams(max_attempts=1))
+    run_absurd_worker()
+    assert get_task_result(r.id).state == "failed"
+
+
+def test_async_takes_context_attempt_is_one():
+    call_command("absurd_sync_queues")
+    r = areport_attempt.enqueue()
+    run_absurd_worker()
+    assert get_task_result(r.id).result == 1
+
+
+def test_sync_orm_jsonfield_round_trips():
+    # ORM in a SYNC task (executor path) — matched pair with the async-ORM test below
+    call_command("absurd_sync_queues")
+    r = create_payload.enqueue({"sync": True, "x": [9, 8]})
+    run_absurd_worker()
+    pk = get_task_result(r.id).result
+    assert Payload.objects.get(pk=pk).data == {"sync": True, "x": [9, 8]}
+
+
+def test_async_orm_jsonfield_round_trips():
+    # ORM in an ASYNC task (loop path) — matched pair with the sync-ORM test above
+    call_command("absurd_sync_queues")
+    r = acreate_payload.enqueue({"async": True, "y": {"z": None}})
+    run_absurd_worker()
+    pk = get_task_result(r.id).result
+    assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
+
+
+def test_sync_and_async_in_one_worker_run():
+    call_command("absurd_sync_queues")
+    rs = echo.enqueue({"mixed": "sync"})
+    ra = aecho.enqueue({"mixed": "async"})
+    run_absurd_worker()
+    assert get_task_result(rs.id).result == {"mixed": "sync"}
+    assert get_task_result(ra.id).result == {"mixed": "async"}
+
+
+def test_worker_does_not_poison_jsonfield_reads():
+    # The worker's loader is on its dedicated AsyncConnection; a Django JSONField read
+    # on the shared connection after a worker run must still decode (no SP6-style poison).
+    call_command("absurd_sync_queues")
+    aecho.enqueue("x")
+    run_absurd_worker()
+    obj = Payload.objects.create(data={"k": "v", "n": 7})
+    assert Payload.objects.get(pk=obj.pk).data == {"k": "v", "n": 7}
+
+
+def test_async_concurrency_is_not_serial():
+    call_command("absurd_sync_queues")
+    for _ in range(4):
+        asleeper.enqueue(0.5)
+    start = time.monotonic()
+    run_absurd_worker(concurrency=4)  # burst now drains CONCURRENTLY (gather)
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent ~0.5s (well under)

--- a/tests/test_async_worker.py
+++ b/tests/test_async_worker.py
@@ -1,10 +1,20 @@
+import asyncio
 import time
 
 import pytest
 from django.core.management import call_command
+from django.tasks import TaskResultStatus
 
 from django_absurd.params import AbsurdSpawnParams
-from tests.atasks import aboom, acreate_payload, aecho, areport_attempt, asleeper
+from django_absurd.queues import get_absurd_backends
+from tests.atasks import (
+    aboom,
+    acreate_payload,
+    aecho,
+    aread_payload,
+    areport_attempt,
+    asleeper,
+)
 from tests.models import Payload
 from tests.tasks import create_payload, echo  # sync ORM task + sync echo
 from tests.test_worker import get_task_result, run_absurd_worker
@@ -55,6 +65,44 @@ def test_async_orm_jsonfield_round_trips():
     run_absurd_worker()
     pk = get_task_result(r.id).result
     assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
+
+
+def test_async_task_queries_payload():
+    # async QUERY path: a row created in the test, read back by an async task (aget)
+    call_command("absurd_sync_queues")
+    obj = Payload.objects.create(data={"q": [1, {"x": None}], "u": "ünï"})
+    r = aread_payload.enqueue(obj.pk)
+    run_absurd_worker()
+    snap = get_task_result(r.id)
+    assert snap.state == "completed"
+    assert snap.result == {"q": [1, {"x": None}], "u": "ünï"}
+
+
+def test_aenqueue_async_task_runs_end_to_end():
+    # exercise the aenqueue (produce) path for an async task, end-to-end through the worker
+    call_command("absurd_sync_queues")
+    r = asyncio.run(aecho.aenqueue("via-aenqueue"))
+    run_absurd_worker()
+    assert get_task_result(r.id).result == "via-aenqueue"
+
+
+def test_aenqueue_sync_task_runs_end_to_end():
+    # aenqueue a SYNC task too — runs via the worker's executor path
+    call_command("absurd_sync_queues")
+    r = asyncio.run(echo.aenqueue({"via": "aenqueue-sync"}))
+    run_absurd_worker()
+    assert get_task_result(r.id).result == {"via": "aenqueue-sync"}
+
+
+def test_full_async_workflow_aenqueue_to_aget_result():
+    # The whole async pipeline in one flow: aenqueue (async produce) -> async task
+    # on the loop doing async ORM (acreate) -> aget_result (async read of the result).
+    call_command("absurd_sync_queues")
+    r = asyncio.run(acreate_payload.aenqueue({"full": "async", "n": [1, 2]}))
+    run_absurd_worker()
+    got = asyncio.run(get_absurd_backends()["default"].aget_result(r.id))
+    assert got.status == TaskResultStatus.SUCCESSFUL
+    assert Payload.objects.filter(pk=got.return_value).exists()
 
 
 def test_sync_and_async_in_one_worker_run():

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -5,13 +5,13 @@ from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db import connection, connections, transaction
-from django.tasks import TaskResultStatus, task
+from django.tasks import TaskResultStatus
 from django.tasks.exceptions import InvalidTask
 
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.queues import get_absurd_client
-from tests.tasks import add, add_async, with_default_attempts
+from tests.tasks import add, with_default_attempts
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -57,13 +57,6 @@ def test_enqueue_rides_django_transaction():
     with pytest.raises(BoomError):
         enqueue_then_roll_back()
     assert claim_one() == []
-
-
-def test_async_task_rejected():
-    # add_async is module-level, so it passes the module-level-func check and
-    # reaches the async-support check — match="async" pins it to the right reason.
-    with pytest.raises(InvalidTask, match="async"):
-        task(add_async)
 
 
 def test_undeclared_queue_rejected():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,18 +1,19 @@
+import asyncio
 import logging
-import threading
-import time
 
+import psycopg
 import pytest
+from absurd_sdk import Absurd
 from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command, load_command_class
 from django.core.management.base import CommandError
-from django.db import connection
+from django.db import connection, connections
 
-from django_absurd.queues import get_absurd_backends
-from django_absurd.worker import (
-    worker_client,
-)
+from django_absurd.connection import register_jsonb_loader
+from django_absurd.queues import get_absurd_backends, get_absurd_client
+from django_absurd.worker import aworker_client
+from tests.atasks import aecho
 from tests.jobs import record_from_jobs
 from tests.tasks import boom, make_group, report_args, report_attempt, routed
 
@@ -28,17 +29,25 @@ def run_absurd_worker(queue="default"):
     call_command("absurd_worker", queue=queue, burst=True)
 
 
-def get_task_result(task_id, alias="default", queue="default"):
-    task_id = str(task_id).rsplit(":", 1)[-1]
-    with worker_client(get_absurd_backends()[alias], queue) as client:
-        return client.fetch_task_result(task_id)
+def get_task_result(task_id, queue="default"):
+    raw_task_id = str(task_id).rsplit(":", 1)[-1]
+    params = connections["default"].get_connection_params()
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        register_jsonb_loader(conn)
+        return Absurd(conn).fetch_task_result(raw_task_id, queue)
+    finally:
+        conn.close()
 
 
 def test_worker_client_uses_dedicated_connection():
     call_command("absurd_sync_queues")
 
-    with worker_client(backend(), "default") as client:
-        assert "default" in client.list_queues()
+    async def _enter():
+        async with aworker_client(backend(), "default") as client:
+            return "default" in await client.list_queues()
+
+    assert asyncio.run(_enter())
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)
@@ -50,8 +59,8 @@ def test_worker_client_rejects_non_psycopg3(settings):
             "OPTIONS": {"DATABASE": "sqlite"},
         }
     }
-    with pytest.raises(ImproperlyConfigured), worker_client(backend(), "default"):
-        pass
+    with pytest.raises(CommandError, match="psycopg"):
+        call_command("absurd_worker", queue="default", burst=True)
 
 
 def test_worker_client_unprovisioned_queue_errors(settings):
@@ -63,11 +72,13 @@ def test_worker_client_unprovisioned_queue_errors(settings):
             "OPTIONS": {"DATABASE": "default"},
         }
     }
-    with (
-        pytest.raises(ImproperlyConfigured) as exc,
-        worker_client(backend(), "unsynced"),
-    ):
-        pass
+
+    async def _enter():
+        async with aworker_client(backend(), "unsynced"):
+            pass
+
+    with pytest.raises(ImproperlyConfigured) as exc:
+        asyncio.run(_enter())
     message = str(exc.value)
     assert "unsynced" in message
     assert "absurd_sync_queues" in message
@@ -77,11 +88,13 @@ def test_worker_client_absent_schema_errors():
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
-        with (
-            pytest.raises(ImproperlyConfigured, match="migrate"),
-            worker_client(backend(), "default"),
-        ):
-            pass
+
+        async def _enter():
+            async with aworker_client(backend(), "default"):
+                pass
+
+        with pytest.raises(ImproperlyConfigured, match="migrate"):
+            asyncio.run(_enter())
     finally:
         call_command("migrate", "django_absurd", "zero", verbosity=0)
         call_command("migrate", "django_absurd", verbosity=0)
@@ -136,11 +149,9 @@ def test_handler_logs_task_outcome(caplog):
 
 def test_unregistered_name_defers_not_crashes():
     call_command("absurd_sync_queues")
-    be = get_absurd_backends()["default"]
-    with worker_client(be, "default") as client:
-        spawn = client.spawn(
-            "not.a.real.task", {"args": [], "kwargs": {}}, queue="default"
-        )
+    spawn = get_absurd_client("default").spawn(
+        "not.a.real.task", {"args": [], "kwargs": {}}, queue="default"
+    )
     run_absurd_worker()
     assert get_task_result(spawn["task_id"]).state != "failed"
 
@@ -230,21 +241,14 @@ def test_start_worker_drains_concurrently():
     for i in range(5):
         make_group.enqueue(f"g{i}")
 
-    be = get_absurd_backends()["default"]
-    with worker_client(be, "default") as client:
-        worker = threading.Thread(
-            target=lambda: client.start_worker(concurrency=3, poll_interval=0.05),
-            daemon=True,
-        )
-        worker.start()
-        deadline = time.monotonic() + 20
-        while Group.objects.filter(name__startswith="g").count() < 5:
-            if time.monotonic() > deadline:
-                client.stop_worker()
-                worker.join(5)
-                msg = "worker did not drain in time"
-                raise AssertionError(msg)
-            time.sleep(0.1)
-        client.stop_worker()
-        worker.join(5)
+    run_absurd_worker()
     assert Group.objects.filter(name__startswith="g").count() == 5
+
+
+def test_async_task_runs_end_to_end():
+    call_command("absurd_sync_queues")
+    r = aecho.enqueue("hi-async")
+    run_absurd_worker()
+    snap = get_task_result(r.id)
+    assert snap.state == "completed"
+    assert snap.result == "hi-async"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -24,9 +24,9 @@ def backend():
     return get_absurd_backends()["default"]
 
 
-def run_absurd_worker(queue="default"):
+def run_absurd_worker(queue="default", concurrency=1):
     """Run the absurd_worker management command in burst mode (drain then exit)."""
-    call_command("absurd_worker", queue=queue, burst=True)
+    call_command("absurd_worker", queue=queue, burst=True, concurrency=concurrency)
 
 
 def get_task_result(task_id, queue="default"):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12,7 +12,7 @@ from django.db import connection, connections
 
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.queues import get_absurd_backends, get_absurd_client
-from django_absurd.worker import aworker_client
+from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
 from tests.atasks import aecho
 from tests.jobs import record_from_jobs
 from tests.tasks import boom, make_group, report_args, report_attempt, routed
@@ -252,3 +252,39 @@ def test_async_task_runs_end_to_end():
     snap = get_task_result(r.id)
     assert snap.state == "completed"
     assert snap.result == "hi-async"
+
+
+def test_blocking_worker_drains_then_stops():
+    # Exercises the blocking (live-worker) path deterministically — no sleeps: the stopper
+    # awaits each task to a terminal state (SDK await_task_result), THEN calls stop_worker()
+    # (the flag start_worker's loop polls). run_blocking_worker returns once stopped.
+    call_command("absurd_sync_queues")
+    results = [make_group.enqueue(f"blk-{i}") for i in range(3)]
+    task_ids = [r.id.rsplit(":", 1)[-1] for r in results]
+
+    async def drive():
+        async with aworker_client(backend(), "default") as client:
+
+            async def stopper():
+                for tid in task_ids:
+                    await client.await_task_result(tid)
+                client.stop_worker()
+
+            await asyncio.gather(
+                run_blocking_worker(client, WorkerOptions(concurrency=2)),
+                stopper(),
+            )
+
+    asyncio.run(drive())
+    assert Group.objects.filter(name__startswith="blk-").count() == 3
+
+
+def test_non_task_name_defers_not_crashes():
+    # A name that IMPORTS but is not a Task (asleep is the asyncio.sleep alias in atasks)
+    # -> LazyTaskRegistry resolves it, sees it's not a Task, defers (state not failed).
+    call_command("absurd_sync_queues")
+    spawn = get_absurd_client("default").spawn(
+        "tests.atasks.asleep", {"args": [], "kwargs": {}}, queue="default"
+    )
+    run_absurd_worker()
+    assert get_task_result(spawn["task_id"]).state != "failed"


### PR DESCRIPTION
`absurd_worker` is now native-asyncio: one worker runs sync tasks (thread-pool executor) and `async def` tasks (event loop). `supports_async_task=True`. CLI unchanged; `--concurrency` sizes loop + pool.

Spec: docs/specs/2026-06-24-async-worker-design.md