### PR TITLE
Auto-create declared queues on first use

### DIFF
--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: sync-docs
+description:
+  Use when a change touches user-facing behavior — management commands or their flags,
+  TASKS / OPTIONS settings, the enqueue or params API, defaults, the setup flow, or
+  system checks. Keeps the project's docs in sync with the code so updates don't get
+  lost in context.
+---
+
+# sync-docs
+
+## Overview
+
+The project has several docs with **distinct audiences and a single canonical home
+each**. When code changes user-facing behavior, the right doc(s) must be updated — and
+updated in the _right_ place, at the _right_ altitude. This skill is the checklist so
+that never gets dropped.
+
+There is no doc site yet (planned). Until then, **AGENTS.md is the canonical full
+reference**.
+
+## Audience map — where each fact lives
+
+| File                               | Audience                                     | Role / altitude                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`                        | repo landing                                 | **Trim.** The tl;dr happy path only: one-liner + alpha note, `pip install`, a ~10-line quickstart (TASKS snippet → `migrate` → `absurd_worker`, "queues auto-create"), then a short **Documentation** section linking out. **Never grow it** — new detail goes to AGENTS.md, not here.                              |
+| `django_absurd/AGENTS.md`          | **end users** (devs integrating the package) | The **full reference**: requirements, configuration + every `OPTIONS` key, run, validate (`check`), workers, enqueue + params, retrieving results, deployment notes, adopting an existing DB. Ships inside the installed package, so it is discoverable from a project's venv. Canonical until the doc site exists. |
+| `examples/README.md` + `examples/` | runnable demo                                | A working dockerized project. Keep the **flow accurate**: `Dockerfile` CMD, `compose.yaml`, `demo/tasks.py`, `enqueue_demo`, and the "Run it" steps must match real behavior.                                                                                                                                       |
+| `docs/specs/`, `docs/plans/`       | design history                               | NOT user docs. Design intent / decisions. Leave to `capture-why` / `archive-specs`; don't treat as the place to document features.                                                                                                                                                                                  |
+
+## When to act
+
+A change triggers a doc pass if it touches any of:
+
+- a **management command** or one of its flags (`absurd_worker`, `absurd_sync_queues`,
+  …)
+- **settings**: `TASKS`, backend `OPTIONS`, defaults (e.g. `DEFAULT_MAX_ATTEMPTS`)
+- the **enqueue / params API** (`AbsurdSpawnParams`, `@absurd_default_params`, reserved
+  kwargs)
+- the **setup / run flow** (what a user must run, and in what order)
+- **system checks** (which fire, their messages/hints)
+- backend **capabilities** (`supports_*`)
+
+## Checklist
+
+1. **README.md** — does the quickstart still reflect the happy path? If a step changed
+   (e.g. a command became optional), fix it. If you're tempted to _add_ explanation, put
+   it in AGENTS.md and link instead.
+2. **AGENTS.md** — update the relevant section (Configure / Run / Validate / Enqueue /
+   Workers / Results / Deployment / Adopting). This is where completeness lives.
+3. **examples/** — if the change alters the run flow or a demonstrated capability,
+   update `examples/README.md` and the runnable bits (`Dockerfile` CMD, `demo/tasks.py`,
+   `enqueue_demo`). Prefer demonstrating the simplest happy path.
+4. **Cross-check copy** — exact command names, flag names, message text, and defaults
+   must match the code verbatim across all three files.
+
+## Conventions
+
+- Keep README trim; AGENTS complete; examples runnable. Don't duplicate full reference
+  prose into README.
+- Don't narrate history in docs ("previously…", "this used to…") — document current
+  behavior.
+- After editing, skim the changed docs once with fresh eyes for stale
+  command/flag/default references the change made obsolete.

--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ Backend `OPTIONS` (all optional):
 
 ```console
 python manage.py migrate              # create Absurd's schema (offline, shipped SQL)
-python manage.py absurd_sync_queues   # create/update the configured queues
-python manage.py absurd_worker        # run a worker
+python manage.py absurd_worker        # run a worker (auto-creates its queue)
 ```
 
-`migrate` does not create any queues — run `absurd_sync_queues` after configuring
-`QUEUES`. Validate configuration at any time with
+Declared queues are **created automatically** on first use — the first `enqueue` to a
+queue, or worker start — so no provisioning step is required. `absurd_sync_queues`
+remains available for eager/explicit provisioning and for reconciling per-queue policy
+changes, but it is no longer a prerequisite. Validate configuration at any time with
 `python manage.py check django_absurd`.
 
 ## Defining and enqueuing tasks
@@ -133,9 +134,12 @@ await send_report.aget_result(result.id)       # async variant
 - **At-least-once delivery.** A task may run more than once (e.g. a crash between the
   handler committing and Absurd's bookkeeping). Keep handlers idempotent; use
   `idempotency_key` where it helps.
-- **Queue sync is additive.** `absurd_sync_queues` creates/updates configured queues but
-  never drops queues removed from config. A queue's `storage_mode` is immutable after
-  creation (a change is reported as a warning, not applied).
+- **Queue creation is automatic and additive.** Declared queues are created on first use
+  (enqueue / worker start); worker start also reconciles a served queue's mutable
+  policy. Neither auto-create nor `absurd_sync_queues` ever drops queues removed from
+  config. A queue's `storage_mode` is immutable after creation (a declared change is
+  reported as a warning, not applied). Only queues **declared in `QUEUES`** are
+  auto-created — an undeclared queue name is rejected, not silently created.
 - **Teardown is destructive.** `migrate django_absurd zero` drops the `absurd` schema
   and all data in it.
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,31 @@
 # django-absurd
 
 Django integration for [Absurd](https://earendil-works.github.io/absurd/), the
-Postgres-native workflow engine. Wraps Absurd's SDK so it reuses Django's database
-connection, ships its schema as Django migrations, and exposes its queues and tasks
-through Django settings, management commands, and system checks.
+Postgres-native workflow engine. Runs Django's
+[Tasks](https://docs.djangoproject.com/en/6.0/topics/tasks/) framework on Postgres — no
+separate broker — reusing Django's own database connection.
 
 > **Alpha.** APIs and behavior may change between releases.
 
 ## Requirements
 
-- Python 3.12+
-- Django 6.0+
+- Python 3.12+, Django 6.0+
 - PostgreSQL with the **psycopg (v3)** Django backend (the Absurd SDK reuses Django's
   connection and requires psycopg3)
 
-## Installation
+## Install
 
 ```console
-pip install django-absurd
+pip install django-absurd          # add --pre for alpha (pre-release) versions
 ```
 
-Pre-release tags (e.g. `v0.1.0a1`) upload as PyPI pre-releases, which `pip install`
-skips unless you pass `--pre`:
-
-```console
-pip install --pre django-absurd
-```
-
-## Configuration
+## Quickstart
 
 Add the app, register the router, and point Django's `TASKS` setting at the backend:
 
 ```python
-INSTALLED_APPS = [
-    # ...
-    "django_absurd",
-]
-
+# settings.py
+INSTALLED_APPS = [..., "django_absurd"]
 DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
 
 TASKS = {
@@ -47,117 +36,30 @@ TASKS = {
 }
 ```
 
-Backend `OPTIONS` (all optional):
-
-- `DATABASE` — the `DATABASES` alias to use (default `"default"`).
-- `DEFAULT_MAX_ATTEMPTS` — retry ceiling per task (default `5`).
-- `QUEUES` — a map of queue name → `absurd_sdk.CreateQueueOptions`, for per-queue
-  customization. Use this _instead of_ the top-level `QUEUES` list (which only names
-  queues) — declare queues in one place or the other, never both (setting both is a
-  configuration error).
-
-## Setup
-
 ```console
-python manage.py migrate              # create Absurd's schema (offline, shipped SQL)
-python manage.py absurd_worker        # run a worker (auto-creates its queue)
+python manage.py migrate          # install Absurd's schema (shipped, offline)
+python manage.py absurd_worker    # run a worker
 ```
 
-Declared queues are **created automatically** on first use — the first `enqueue` to a
-queue, or worker start — so no provisioning step is required. `absurd_sync_queues`
-remains available for eager/explicit provisioning and for reconciling per-queue policy
-changes, but it is no longer a prerequisite. Validate configuration at any time with
-`python manage.py check django_absurd`.
-
-## Defining and enqueuing tasks
-
-Use Django's Tasks API. Attach Absurd options per task (a decorator, applied _below_
-`@task`) or per call:
+Define tasks with Django's Tasks API and enqueue them — the declared queue is **created
+automatically** on first use, so there's no provisioning step:
 
 ```python
 from django.tasks import task
-from django_absurd.params import AbsurdSpawnParams, absurd_default_params
 
 @task
-@absurd_default_params(max_attempts=3)
 def send_report(user_id): ...
 
 send_report.enqueue(42)
-send_report.enqueue(42, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="report-42"))
 ```
 
-Parameters: `max_attempts`, `retry_strategy`, `cancellation` (defaults and per call),
-plus `headers` and `idempotency_key` (per call). Enqueuing rides the surrounding Django
-transaction — a task spawned inside `atomic()` is rolled back if the block fails
-(enqueue-on-commit, automatic).
+## Documentation
 
-Tasks may be **sync (`def`) or async (`async def`)** — one worker runs both (see
-[Workers](#workers)); `async def` tasks may use Django's async ORM. Tasks are resolved
-by import path, so they can live in any importable module (no `tasks.py` requirement).
-
-## Workers
-
-```console
-python manage.py absurd_worker --queue default
-```
-
-A single worker runs **both** sync and async tasks: `async def` tasks run on an event
-loop (true concurrency for I/O-bound work), sync `def` tasks run in a thread pool.
-
-- **Blocking** (default): long-running; polls until `SIGINT`/`SIGTERM`.
-- **Burst** (`--burst`): drain the current backlog, then exit `0` (cron / one-shot).
-- `--concurrency N` (default `1`): max tasks in flight — sizes both the event-loop
-  concurrency and the sync thread pool. Other flags: `--claim-timeout`,
-  `--poll-interval`, `--batch-size`, `--worker-id`, and `--alias` (required only when
-  several Absurd backends are configured).
-
-## Retrieving results
-
-`enqueue` returns a `TaskResult`; refresh it or fetch one later by id:
-
-```python
-result = send_report.enqueue(42)
-result.refresh()              # reload status / return_value / errors from the store
-result.status                 # READY | RUNNING | SUCCESSFUL | FAILED
-result.return_value           # available once SUCCESSFUL
-
-send_report.get_result(result.id)              # fetch by id (sync)
-await send_report.aget_result(result.id)       # async variant
-```
-
-## Deployment notes
-
-- **Database privileges.** `migrate` runs `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`
-  and `CREATE SCHEMA IF NOT EXISTS absurd`, so the migrating role needs rights to create
-  extensions and schemas (a superuser, or a role granted those — with `uuid-ossp`
-  allow-listed on managed Postgres). The schema name `absurd` is fixed.
-- **At-least-once delivery.** A task may run more than once (e.g. a crash between the
-  handler committing and Absurd's bookkeeping). Keep handlers idempotent; use
-  `idempotency_key` where it helps.
-- **Queue creation is automatic and additive.** Declared queues are created on first use
-  (enqueue / worker start); worker start also reconciles a served queue's mutable
-  policy. Neither auto-create nor `absurd_sync_queues` ever drops queues removed from
-  config. A queue's `storage_mode` is immutable after creation (a declared change is
-  reported as a warning, not applied). Only queues **declared in `QUEUES`** are
-  auto-created — an undeclared queue name is rejected, not silently created.
-- **Teardown is destructive.** `migrate django_absurd zero` drops the `absurd` schema
-  and all data in it.
-
-## Adopting an existing Absurd database
-
-If the target database already runs Absurd (its schema managed outside Django), you can
-fake django-absurd's migration so Django records it as applied without re-running the
-DDL:
-
-```console
-python manage.py migrate --fake django_absurd
-```
-
-> **Use extreme caution.** Faking tells Django the schema is already present without
-> checking it. Only do this when the existing `absurd` schema exactly matches the
-> version django-absurd targets (`django_absurd.ABSURD_SCHEMA_VERSION`) — a mismatch
-> causes runtime failures Django cannot detect. Verify the versions line up before
-> faking.
+- **[Integration guide](django_absurd/AGENTS.md)** — full configuration and `OPTIONS`,
+  workers, task parameters, retrieving results, deployment notes, and adopting an
+  existing Absurd database.
+- **[Runnable example](examples/)** — a dockerized Django project demonstrating the
+  whole flow end to end.
 
 ## License
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -45,9 +45,13 @@ Backend `OPTIONS` (all optional):
 
 ```bash
 python manage.py migrate              # apply Absurd's schema (offline, shipped SQL)
-python manage.py absurd_sync_queues   # create/update declared queues
-python manage.py absurd_worker        # run a worker
+python manage.py absurd_worker        # run a worker (auto-creates its queue)
 ```
+
+Declared queues are created automatically on first use (first enqueue to a queue, or
+worker start), so no provisioning step is required. `absurd_sync_queues` still exists
+for eager provisioning and for reconciling per-queue policy changes, but it is optional.
+Only queues declared in `QUEUES` are auto-created; an undeclared queue name is rejected.
 
 ## Validate
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1,12 +1,12 @@
-# django-absurd — agent guide
+# django-absurd — integration guide
 
-Guidance for coding agents integrating **django-absurd** into a Django project. This
-file ships inside the installed package (`site-packages/django_absurd/AGENTS.md`) so it
-is discoverable from a project's virtualenv.
+A guide for developers integrating **django-absurd** into a Django project. This file
+ships inside the installed package (`site-packages/django_absurd/AGENTS.md`), so it
+stays discoverable from a project's virtualenv (and by coding agents working there).
 
 django-absurd plugs [Absurd](https://earendil-works.github.io/absurd/), a
 Postgres-native workflow engine, into Django's Tasks framework. It reuses Django's
-database connection and ships Absurd's schema as Django migrations.
+database connection and ships Absurd's schema as Django migrations — no separate broker.
 
 ## Hard requirements
 
@@ -39,7 +39,9 @@ Backend `OPTIONS` (all optional):
 
 - `DATABASE` — which `DATABASES` alias to use (default: `"default"`).
 - `DEFAULT_MAX_ATTEMPTS` — retry ceiling per task (default: `5`).
-- `QUEUES` — map of queue name → `absurd_sdk.CreateQueueOptions` for per-queue config.
+- `QUEUES` — a map of queue name → `absurd_sdk.CreateQueueOptions` for per-queue config.
+  Use this _instead of_ the top-level `QUEUES` list (which only names queues) — declare
+  queues in one place or the other, never both (setting both is a configuration error).
 
 ## Run
 
@@ -59,10 +61,16 @@ Run `python manage.py check django_absurd` and resolve everything it reports bef
 relying on the setup. Fix the configuration it points at rather than silencing the
 check.
 
-## Enqueue
+## Defining and enqueuing tasks
 
-Use Django's Tasks API. Absurd parameters attach two ways — both live in
-`django_absurd.params`:
+Use Django's Tasks API. Tasks may be **sync (`def`) or async (`async def`)** — one
+worker runs both, and `async def` tasks may use Django's async ORM. Tasks are resolved
+by import path, so they can live in any importable module (no `tasks.py` requirement).
+
+Enqueuing rides the surrounding Django transaction — a task spawned inside `atomic()` is
+rolled back if the block fails (enqueue-on-commit, automatic).
+
+Absurd parameters attach two ways — both live in `django_absurd.params`:
 
 - **Per-task defaults** — the `@absurd_default_params(...)` decorator, applied _below_
   `@task` (applying it above a `Task` raises `TypeError`):
@@ -90,6 +98,71 @@ Parameter fields (see `django_absurd.params`): `max_attempts`, `retry_strategy`,
 only). Field types come from `absurd_sdk` (`RetryStrategy`, `CancellationPolicy`,
 `JsonObject`). Backend capabilities: result retrieval is supported; async enqueue,
 defer, and priority are not.
+
+## Workers
+
+```bash
+python manage.py absurd_worker --queue default
+```
+
+A single worker runs **both** sync and async tasks: `async def` tasks run on an event
+loop (true concurrency for I/O-bound work), sync `def` tasks run in a thread pool. On
+start it reconciles the served queue (creating it if missing, applying declared policy
+changes) and reports to stdout.
+
+- **Blocking** (default): long-running; polls until `SIGINT`/`SIGTERM`.
+- **Burst** (`--burst`): drain the current backlog, then exit `0` (cron / one-shot).
+- `--concurrency N` (default `1`): max tasks in flight — sizes both the event-loop
+  concurrency and the sync thread pool. Other flags: `--claim-timeout`,
+  `--poll-interval`, `--batch-size`, `--worker-id`, and `--alias` (required only when
+  several Absurd backends are configured).
+
+## Retrieving results
+
+`enqueue` returns a `TaskResult`; refresh it or fetch one later by id:
+
+```python
+result = send_report.enqueue(42)
+result.refresh()              # reload status / return_value / errors from the store
+result.status                 # READY | RUNNING | SUCCESSFUL | FAILED
+result.return_value           # available once SUCCESSFUL
+
+send_report.get_result(result.id)              # fetch by id (sync)
+await send_report.aget_result(result.id)       # async variant
+```
+
+## Deployment notes
+
+- **Database privileges.** `migrate` runs `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`
+  and `CREATE SCHEMA IF NOT EXISTS absurd`, so the migrating role needs rights to create
+  extensions and schemas (a superuser, or a role granted those — with `uuid-ossp`
+  allow-listed on managed Postgres). The schema name `absurd` is fixed.
+- **At-least-once delivery.** A task may run more than once (e.g. a crash between the
+  handler committing and Absurd's bookkeeping). Keep handlers idempotent; use
+  `idempotency_key` where it helps.
+- **Queue creation is automatic and additive.** Declared queues are created on first use
+  (enqueue / worker start); worker start also reconciles a served queue's mutable
+  policy. Neither auto-create nor `absurd_sync_queues` ever drops queues removed from
+  config. A queue's `storage_mode` is immutable after creation (a declared change is
+  reported as a warning, not applied). Only queues declared in `QUEUES` are auto-created
+  — an undeclared queue name is rejected, not silently created.
+- **Teardown is destructive.** `migrate django_absurd zero` drops the `absurd` schema
+  and all data in it.
+
+## Adopting an existing Absurd database
+
+If the target database already runs Absurd (its schema managed outside Django), you can
+fake django-absurd's migration so Django records it as applied without re-running the
+DDL:
+
+```bash
+python manage.py migrate --fake django_absurd
+```
+
+**Use extreme caution.** Faking tells Django the schema is already present without
+checking it. Only do this when the existing `absurd` schema exactly matches the version
+django-absurd targets (`django_absurd.ABSURD_SCHEMA_VERSION`) — a mismatch causes
+runtime failures Django cannot detect. Verify the versions line up before faking.
 
 ## Notes
 

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -6,7 +6,7 @@ from absurd_sdk import CreateQueueOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections, transaction
 from django.db.utils import ProgrammingError
-from django.tasks import TaskResult, TaskResultStatus
+from django.tasks import TaskResult, TaskResultStatus, task_backends
 from django.tasks.backends.base import BaseTaskBackend
 from django.tasks.base import TaskError
 from django.tasks.exceptions import TaskResultDoesNotExist
@@ -225,6 +225,14 @@ def get_declared_queues(backend: "AbsurdBackend") -> dict[str, dict]:
     if "QUEUES" in backend.options:
         return dict(backend.options["QUEUES"])
     return {name: {} for name in backend.queues}
+
+
+def get_absurd_backends() -> dict[str, "AbsurdBackend"]:
+    return {
+        alias: be
+        for alias in task_backends
+        if isinstance((be := task_backends[alias]), AbsurdBackend)
+    }
 
 
 def build_merged_spawn_options(defaults: t.Any, per_call: t.Any) -> dict[str, t.Any]:

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -65,6 +65,9 @@ class AbsurdBackend(BaseTaskBackend):
             psycopg.errors.InvalidSchemaName,
         ):
             declared = get_declared_queues(self)
+            # validate_task() rejects an undeclared queue (InvalidTask) when the
+            # backend declares queues. This guards the empty-QUEUES config (where
+            # that check is skipped) and the declared[...] access below from KeyError.
             if task.queue_name not in declared:
                 msg = (
                     f"Queue '{task.queue_name}' is not declared in TASKS QUEUES. "

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -64,12 +64,29 @@ class AbsurdBackend(BaseTaskBackend):
             psycopg.errors.UndefinedFunction,
             psycopg.errors.InvalidSchemaName,
         ):
-            msg = (
-                f"Queue '{task.queue_name}' is not provisioned in Absurd. "
-                "Run manage.py absurd_sync_queues (and manage.py migrate if the "
-                "absurd schema is absent)."
-            )
-            raise ImproperlyConfigured(msg) from None
+            declared = get_declared_queues(self)
+            if task.queue_name not in declared:
+                msg = (
+                    f"Queue '{task.queue_name}' is not declared in TASKS QUEUES. "
+                    "Add it to the QUEUES list in your TASKS backend settings."
+                )
+                raise ImproperlyConfigured(msg) from None
+            try:
+                client.create_queue(task.queue_name, **declared[task.queue_name])
+            except (
+                psycopg.errors.UndefinedFunction,
+                psycopg.errors.InvalidSchemaName,
+            ):
+                msg = "Absurd schema is not installed. Run: manage.py migrate"
+                raise ImproperlyConfigured(msg) from None
+            with transaction.atomic(using=self.database, savepoint=True):
+                spawn_result = client.spawn(
+                    task.module_path,
+                    {"args": list(args), "kwargs": dict(kwargs)},
+                    queue=task.queue_name,
+                    max_attempts=max_attempts,
+                    **merged,
+                )
         return TaskResult(
             task=task,
             id=f"{task.queue_name}:{spawn_result['task_id']}",
@@ -199,6 +216,12 @@ def build_task_result(
     if state == "completed":
         object.__setattr__(result, "_return_value", completed_payload)
     return result
+
+
+def get_declared_queues(backend: "AbsurdBackend") -> dict[str, dict]:
+    if "QUEUES" in backend.options:
+        return dict(backend.options["QUEUES"])
+    return {name: {} for name in backend.queues}
 
 
 def build_merged_spawn_options(defaults: t.Any, per_call: t.Any) -> dict[str, t.Any]:

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -10,13 +10,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.connection import ConnectionDoesNotExist
 
-from django_absurd.backends import get_declared_queues
+from django_absurd.backends import get_absurd_backends, get_declared_queues
 from django_absurd.connection import BACKEND_ERROR_MESSAGE, validate_backend
 from django_absurd.models import Queue
-from django_absurd.queues import (
-    get_absurd_backends,
-    get_absurd_database,
-)
+from django_absurd.queues import get_absurd_database
 from django_absurd.routers import AbsurdRouter
 
 W002_MSG = (

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -10,12 +10,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.connection import ConnectionDoesNotExist
 
+from django_absurd.backends import get_declared_queues
 from django_absurd.connection import BACKEND_ERROR_MESSAGE, validate_backend
 from django_absurd.models import Queue
 from django_absurd.queues import (
     get_absurd_backends,
     get_absurd_database,
-    get_declared_queues,
 )
 from django_absurd.routers import AbsurdRouter
 

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -1,6 +1,5 @@
 import typing as t
 from collections.abc import Sequence
-from datetime import timedelta
 
 from absurd_sdk import CreateQueueOptions, QueueDetachMode, QueueStorageMode
 from django.apps import AppConfig
@@ -8,7 +7,6 @@ from django.conf import settings
 from django.core.checks import CheckMessage, Error, Tags, register
 from django.core.checks import Warning as DjangoWarning
 from django.core.exceptions import ImproperlyConfigured
-from django.db import connections
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.connection import ConnectionDoesNotExist
 
@@ -21,13 +19,11 @@ from django_absurd.queues import (
 )
 from django_absurd.routers import AbsurdRouter
 
-W001_MSG = (
-    "django-absurd: the absurd schema is not migrated;"
-    " declared queues cannot be provisioned."
+W002_MSG = (
+    "django-absurd: a queue's declared storage_mode differs from the database"
+    " (storage_mode is immutable)."
 )
-W001_HINT = "Run 'manage.py migrate', then 'manage.py absurd_sync_queues'."
-W002_MSG = "django-absurd: declared queues are out of sync with the database."
-W002_HINT = "Run 'manage.py absurd_sync_queues'."
+W002_HINT = "Recreate the queue, or revert the declared storage_mode."
 E005_MSG = (
     "django-absurd: a non-default DATABASE is configured but AbsurdRouter is not in"
     " DATABASE_ROUTERS."
@@ -49,11 +45,6 @@ E004_MSG = (
     " DATABASE values."
 )
 E004_HINT = "Use a single DATABASE across all Absurd backends."
-
-DURATION_OPTION_KEYS = frozenset(
-    ("partition_lookahead", "partition_lookback", "cleanup_ttl", "detach_min_age")
-)
-SCALAR_OPTION_KEYS = frozenset(("cleanup_limit", "detach_mode", "storage_mode"))
 
 VALID_QUEUE_OPTION_KEYS = set(CreateQueueOptions.__annotations__)
 VALID_STORAGE_MODES = set(t.get_args(QueueStorageMode))
@@ -177,41 +168,22 @@ def query_queue_state(alias: str, declared: dict[str, dict]) -> list[CheckMessag
             q.queue_name: q
             for q in Queue.objects.using(alias).filter(queue_name__in=declared)
         }
-    except OperationalError:
+    except (OperationalError, ProgrammingError):
         return []
-    except ProgrammingError:
-        return [DjangoWarning(W001_MSG, hint=W001_HINT, id="absurd.W001")]
 
     drift = [
         name
-        for name, opts in declared.items()
-        if name not in actual or has_option_drifted(alias, opts, actual[name])
+        for name in declared
+        if name in actual
+        and declared[name].get("storage_mode")
+        and declared[name]["storage_mode"] != actual[name].storage_mode
     ]
     if drift:
         return [
             DjangoWarning(
                 W002_MSG,
-                hint=f"{W002_HINT} Out of sync: {', '.join(drift)}",
+                hint=f"{W002_HINT} Affected: {', '.join(drift)}",
                 id="absurd.W002",
             )
         ]
     return []
-
-
-def has_option_drifted(alias: str, opts: dict, queue: Queue) -> bool:
-    for key, declared_val in opts.items():
-        if key in DURATION_OPTION_KEYS:
-            actual_val = getattr(queue, key)
-            if parse_interval(alias, declared_val) != actual_val:
-                return True
-        elif key in SCALAR_OPTION_KEYS:
-            actual_val = getattr(queue, key)
-            if declared_val != actual_val:
-                return True
-    return False
-
-
-def parse_interval(alias: str, interval_str: str) -> timedelta:
-    with connections[alias].cursor() as cur:
-        cur.execute("SELECT %s::interval", [interval_str])
-        return cur.fetchone()[0]

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -6,12 +6,14 @@ from django_absurd.queues import SyncResult
 class AbsurdReportCommand(BaseCommand):
     """Base for commands that report a queue SyncResult to stdout/stderr."""
 
-    def report_sync_result(self, result: SyncResult, prefix: str = "") -> None:
+    def report_sync_result(
+        self, result: SyncResult, prefix: str = "", empty_message: str | None = None
+    ) -> None:
         if result.created:
             self.stdout.write(f"{prefix}Created: {', '.join(result.created)}")
         if result.reconciled:
             self.stdout.write(f"{prefix}Reconciled: {', '.join(result.reconciled)}")
-        if not result.created and not result.reconciled:
-            self.stdout.write(f"{prefix}No queues to sync.")
+        if empty_message and not result.created and not result.reconciled:
+            self.stdout.write(f"{prefix}{empty_message}")
         for warning in result.storage_warnings:
             self.stderr.write(self.style.WARNING(f"{prefix}{warning}"))

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+
+from django_absurd.queues import SyncResult
+
+
+class AbsurdReportCommand(BaseCommand):
+    """Base for commands that report a queue SyncResult to stdout/stderr."""
+
+    def report_sync_result(self, result: SyncResult, prefix: str = "") -> None:
+        if result.created:
+            self.stdout.write(f"{prefix}Created: {', '.join(result.created)}")
+        if result.reconciled:
+            self.stdout.write(f"{prefix}Reconciled: {', '.join(result.reconciled)}")
+        if not result.created and not result.reconciled:
+            self.stdout.write(f"{prefix}No queues to sync.")
+        for warning in result.storage_warnings:
+            self.stderr.write(self.style.WARNING(f"{prefix}{warning}"))

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -1,14 +1,8 @@
-from django.core.management.base import BaseCommand
-
-from django_absurd.queues import (
-    SyncResult,
-    get_absurd_backends,
-    sync_queues,
-    write_sync_report,
-)
+from django_absurd.management.base import AbsurdReportCommand
+from django_absurd.queues import get_absurd_backends, sync_queues
 
 
-class Command(BaseCommand):
+class Command(AbsurdReportCommand):
     help = "Create and reconcile queues declared on each Absurd task backend."
 
     def handle(self, *args: object, **options: object) -> None:
@@ -18,7 +12,4 @@ class Command(BaseCommand):
             return
         for alias, backend in backends.items():
             prefix = f"[{alias}] " if len(backends) > 1 else ""
-            self.report_result(prefix, sync_queues(backend))
-
-    def report_result(self, prefix: str, result: SyncResult) -> None:
-        write_sync_report(self, result, prefix)
+            self.report_sync_result(sync_queues(backend), prefix)

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -1,5 +1,6 @@
+from django_absurd.backends import get_absurd_backends
 from django_absurd.management.base import AbsurdReportCommand
-from django_absurd.queues import get_absurd_backends, sync_queues
+from django_absurd.queues import sync_queues
 
 
 class Command(AbsurdReportCommand):

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -1,6 +1,11 @@
 from django.core.management.base import BaseCommand
 
-from django_absurd.queues import SyncResult, get_absurd_backends, sync_queues
+from django_absurd.queues import (
+    SyncResult,
+    get_absurd_backends,
+    sync_queues,
+    write_sync_report,
+)
 
 
 class Command(BaseCommand):
@@ -16,11 +21,4 @@ class Command(BaseCommand):
             self.report_result(prefix, sync_queues(backend))
 
     def report_result(self, prefix: str, result: SyncResult) -> None:
-        if result.created:
-            self.stdout.write(f"{prefix}Created: {', '.join(result.created)}")
-        if result.reconciled:
-            self.stdout.write(f"{prefix}Reconciled: {', '.join(result.reconciled)}")
-        if not result.created and not result.reconciled:
-            self.stdout.write(f"{prefix}No queues to sync.")
-        for warning in result.storage_warnings:
-            self.stderr.write(self.style.WARNING(f"{prefix}{warning}"))
+        write_sync_report(self, result, prefix)

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -13,4 +13,6 @@ class Command(AbsurdReportCommand):
             return
         for alias, backend in backends.items():
             prefix = f"[{alias}] " if len(backends) > 1 else ""
-            self.report_sync_result(sync_queues(backend), prefix)
+            self.report_sync_result(
+                sync_queues(backend), prefix, empty_message="No queues to sync."
+            )

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -3,7 +3,7 @@ import typing as t
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand, CommandError
 
-from django_absurd.queues import get_absurd_backends
+from django_absurd.queues import get_absurd_backends, reconcile_queue, write_sync_report
 from django_absurd.worker import WorkerOptions, run_worker
 
 
@@ -84,6 +84,12 @@ class Command(BaseCommand):
                 f" Valid queues: {valid}"
             )
             raise CommandError(msg)
+
+        try:
+            result = reconcile_queue(backend, queue)
+        except ImproperlyConfigured as exc:
+            raise CommandError(str(exc)) from exc
+        write_sync_report(self, result)
 
         worker_options = WorkerOptions(
             concurrency=options["concurrency"],

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -3,8 +3,9 @@ import typing as t
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import CommandError
 
+from django_absurd.backends import get_absurd_backends
 from django_absurd.management.base import AbsurdReportCommand
-from django_absurd.queues import get_absurd_backends, reconcile_queue
+from django_absurd.queues import reconcile_queue
 from django_absurd.worker import WorkerOptions, run_worker
 
 

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -1,13 +1,14 @@
 import typing as t
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import CommandError
 
-from django_absurd.queues import get_absurd_backends, reconcile_queue, write_sync_report
+from django_absurd.management.base import AbsurdReportCommand
+from django_absurd.queues import get_absurd_backends, reconcile_queue
 from django_absurd.worker import WorkerOptions, run_worker
 
 
-class Command(BaseCommand):
+class Command(AbsurdReportCommand):
     help = "Start the Absurd task worker."
 
     def add_arguments(self, parser: t.Any) -> None:
@@ -89,7 +90,7 @@ class Command(BaseCommand):
             result = reconcile_queue(backend, queue)
         except ImproperlyConfigured as exc:
             raise CommandError(str(exc)) from exc
-        write_sync_report(self, result)
+        self.report_sync_result(result)
 
         worker_options = WorkerOptions(
             concurrency=options["concurrency"],

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -100,7 +100,4 @@ class Command(AbsurdReportCommand):
             batch_size=options["batch_size"],
             worker_id=options["worker_id"],
         )
-        try:
-            run_worker(backend, queue, burst=options["burst"], options=worker_options)
-        except ImproperlyConfigured as exc:
-            raise CommandError(str(exc)) from exc
+        run_worker(backend, queue, burst=options["burst"], options=worker_options)

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -100,4 +100,5 @@ class Command(AbsurdReportCommand):
             batch_size=options["batch_size"],
             worker_id=options["worker_id"],
         )
+        self.stdout.write(f"Started worker on queue '{queue}'.")
         run_worker(backend, queue, burst=options["burst"], options=worker_options)

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -93,17 +93,6 @@ def sync_queues(backend: AbsurdBackend) -> SyncResult:
     return result
 
 
-def write_sync_report(command: t.Any, result: SyncResult, prefix: str = "") -> None:
-    if result.created:
-        command.stdout.write(f"{prefix}Created: {', '.join(result.created)}")
-    if result.reconciled:
-        command.stdout.write(f"{prefix}Reconciled: {', '.join(result.reconciled)}")
-    if not result.created and not result.reconciled:
-        command.stdout.write(f"{prefix}No queues to sync.")
-    for warning in result.storage_warnings:
-        command.stderr.write(command.style.WARNING(f"{prefix}{warning}"))
-
-
 def get_absurd_backends() -> dict[str, AbsurdBackend]:
     return {
         alias: be

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -93,6 +93,17 @@ def sync_queues(backend: AbsurdBackend) -> SyncResult:
     return result
 
 
+def write_sync_report(command: t.Any, result: SyncResult, prefix: str = "") -> None:
+    if result.created:
+        command.stdout.write(f"{prefix}Created: {', '.join(result.created)}")
+    if result.reconciled:
+        command.stdout.write(f"{prefix}Reconciled: {', '.join(result.reconciled)}")
+    if not result.created and not result.reconciled:
+        command.stdout.write(f"{prefix}No queues to sync.")
+    for warning in result.storage_warnings:
+        command.stderr.write(command.style.WARNING(f"{prefix}{warning}"))
+
+
 def get_absurd_backends() -> dict[str, AbsurdBackend]:
     return {
         alias: be

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -53,11 +53,7 @@ def get_absurd_client(using: str | None = None) -> Absurd:
 def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncResult:
     db = backend.database
     validate_backend(db)
-    declared = backends.get_declared_queues(backend)
-    if queue_name not in declared:
-        msg = f"Queue {queue_name!r} is not declared in TASKS QUEUES."
-        raise ImproperlyConfigured(msg)
-    opts = declared[queue_name]
+    opts = backends.get_declared_queues(backend)[queue_name]
     result = SyncResult()
     client = build_absurd_client(db)
     try:

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -1,11 +1,16 @@
+import typing as t
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import timedelta
 
 from absurd_sdk import Absurd, CreateQueueOptions
+from django.core.exceptions import ImproperlyConfigured
+from django.db import connections
+from django.db.utils import ProgrammingError
 from django.tasks import task_backends
 
 from django_absurd.backends import AbsurdBackend
-from django_absurd.connection import build_absurd_client
+from django_absurd.connection import build_absurd_client, validate_backend
 from django_absurd.models import Queue
 
 AbsurdQueues = Mapping[str, CreateQueueOptions]
@@ -17,6 +22,10 @@ MUTABLE_OPTION_KEYS = (
     "cleanup_limit",
     "detach_mode",
     "detach_min_age",
+)
+
+INTERVAL_OPTION_KEYS = frozenset(
+    ("partition_lookahead", "partition_lookback", "cleanup_ttl", "detach_min_age")
 )
 
 
@@ -48,27 +57,45 @@ def get_absurd_client(using: str | None = None) -> Absurd:
     return build_absurd_client(using or resolve_absurd_database())
 
 
-def sync_queues(backend: AbsurdBackend) -> SyncResult:
-    using = backend.database
+def reconcile_queue(backend: AbsurdBackend, queue_name: str) -> SyncResult:
+    db = backend.database
+    validate_backend(db)
+    declared = get_declared_queues(backend)
+    if queue_name not in declared:
+        msg = f"Queue {queue_name!r} is not declared in TASKS QUEUES."
+        raise ImproperlyConfigured(msg)
+    opts = declared[queue_name]
     result = SyncResult()
-    client = get_absurd_client(using)
-    existing = {q.queue_name: q for q in Queue.objects.using(using)}
-    for name, opts in get_declared_queues(backend).items():
-        if name not in existing:
-            client.create_queue(name, **opts)
-            result.created.append(name)
-        else:
-            mutable_opts = {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS}
-            if mutable_opts:
-                client.set_queue_policy(name, **mutable_opts)
-            result.reconciled.append(name)
-            existing_mode = existing[name].storage_mode
-            if "storage_mode" in opts and opts["storage_mode"] != existing_mode:
-                result.storage_warnings.append(
-                    f"Queue '{name}': storage_mode cannot be changed "
-                    f"(existing: {existing[name].storage_mode!r}, "
-                    f"declared: {opts['storage_mode']!r}); skipping."
-                )
+    client = build_absurd_client(db)
+    try:
+        row = Queue.objects.using(db).filter(queue_name=queue_name).first()
+    except ProgrammingError as exc:
+        msg = "Absurd schema is not installed. Run: manage.py migrate"
+        raise ImproperlyConfigured(msg) from exc
+    if row is None:
+        client.create_queue(queue_name, **opts)
+        result.created.append(queue_name)
+    else:
+        mutable_opts = {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS}
+        if mutable_opts and check_mutable_options_drifted(db, mutable_opts, row):
+            client.set_queue_policy(queue_name, **mutable_opts)
+            result.reconciled.append(queue_name)
+        if "storage_mode" in opts and opts["storage_mode"] != row.storage_mode:
+            result.storage_warnings.append(
+                f"Queue '{queue_name}': storage_mode cannot be changed "
+                f"(existing: {row.storage_mode!r}, "
+                f"declared: {opts['storage_mode']!r}); skipping."
+            )
+    return result
+
+
+def sync_queues(backend: AbsurdBackend) -> SyncResult:
+    result = SyncResult()
+    for name in get_declared_queues(backend):
+        r = reconcile_queue(backend, name)
+        result.created.extend(r.created)
+        result.reconciled.extend(r.reconciled)
+        result.storage_warnings.extend(r.storage_warnings)
     return result
 
 
@@ -78,3 +105,22 @@ def get_absurd_backends() -> dict[str, AbsurdBackend]:
         for alias in task_backends
         if isinstance((be := task_backends[alias]), AbsurdBackend)
     }
+
+
+def parse_interval(using: str, interval_str: str) -> timedelta:
+    with connections[using].cursor() as cur:
+        cur.execute("SELECT %s::interval", [interval_str])
+        return cur.fetchone()[0]
+
+
+def check_mutable_options_drifted(
+    using: str, opts: dict[str, t.Any], row: Queue
+) -> bool:
+    for key, declared_value in opts.items():
+        db_value = getattr(row, key)
+        if key in INTERVAL_OPTION_KEYS:
+            if parse_interval(using, declared_value) != db_value:
+                return True
+        elif declared_value != db_value:
+            return True
+    return False

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -8,11 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.utils import ProgrammingError
 
-from django_absurd.backends import (
-    AbsurdBackend,
-    get_absurd_backends,
-    get_declared_queues,
-)
+from django_absurd import backends
 from django_absurd.connection import build_absurd_client, validate_backend
 from django_absurd.models import Queue
 
@@ -39,12 +35,12 @@ class SyncResult:
     storage_warnings: list[str] = field(default_factory=list)
 
 
-def get_absurd_database(backend: AbsurdBackend) -> str:
+def get_absurd_database(backend: backends.AbsurdBackend) -> str:
     return backend.database
 
 
 def resolve_absurd_database() -> str:
-    databases = {be.database for be in get_absurd_backends().values()}
+    databases = {be.database for be in backends.get_absurd_backends().values()}
     if len(databases) == 1:
         return next(iter(databases))
     return "default"
@@ -54,10 +50,10 @@ def get_absurd_client(using: str | None = None) -> Absurd:
     return build_absurd_client(using or resolve_absurd_database())
 
 
-def reconcile_queue(backend: AbsurdBackend, queue_name: str) -> SyncResult:
+def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncResult:
     db = backend.database
     validate_backend(db)
-    declared = get_declared_queues(backend)
+    declared = backends.get_declared_queues(backend)
     if queue_name not in declared:
         msg = f"Queue {queue_name!r} is not declared in TASKS QUEUES."
         raise ImproperlyConfigured(msg)
@@ -86,9 +82,9 @@ def reconcile_queue(backend: AbsurdBackend, queue_name: str) -> SyncResult:
     return result
 
 
-def sync_queues(backend: AbsurdBackend) -> SyncResult:
+def sync_queues(backend: backends.AbsurdBackend) -> SyncResult:
     result = SyncResult()
-    for name in get_declared_queues(backend):
+    for name in backends.get_declared_queues(backend):
         r = reconcile_queue(backend, name)
         result.created.extend(r.created)
         result.reconciled.extend(r.reconciled)

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -9,7 +9,7 @@ from django.db import connections
 from django.db.utils import ProgrammingError
 from django.tasks import task_backends
 
-from django_absurd.backends import AbsurdBackend
+from django_absurd.backends import AbsurdBackend, get_declared_queues
 from django_absurd.connection import build_absurd_client, validate_backend
 from django_absurd.models import Queue
 
@@ -34,12 +34,6 @@ class SyncResult:
     created: list[str] = field(default_factory=list)
     reconciled: list[str] = field(default_factory=list)
     storage_warnings: list[str] = field(default_factory=list)
-
-
-def get_declared_queues(backend: AbsurdBackend) -> dict[str, dict]:
-    if "QUEUES" in backend.options:
-        return dict(backend.options["QUEUES"])
-    return {name: {} for name in backend.queues}
 
 
 def get_absurd_database(backend: AbsurdBackend) -> str:

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -7,9 +7,12 @@ from absurd_sdk import Absurd, CreateQueueOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.utils import ProgrammingError
-from django.tasks import task_backends
 
-from django_absurd.backends import AbsurdBackend, get_declared_queues
+from django_absurd.backends import (
+    AbsurdBackend,
+    get_absurd_backends,
+    get_declared_queues,
+)
 from django_absurd.connection import build_absurd_client, validate_backend
 from django_absurd.models import Queue
 
@@ -91,14 +94,6 @@ def sync_queues(backend: AbsurdBackend) -> SyncResult:
         result.reconciled.extend(r.reconciled)
         result.storage_warnings.extend(r.storage_warnings)
     return result
-
-
-def get_absurd_backends() -> dict[str, AbsurdBackend]:
-    return {
-        alias: be
-        for alias in task_backends
-        if isinstance((be := task_backends[alias]), AbsurdBackend)
-    }
 
 
 def parse_interval(using: str, interval_str: str) -> timedelta:

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -86,7 +86,7 @@ async def arun_worker(
         loop.set_default_executor(executor)
         async with aworker_client(backend, queue) as client:
             logger.info(
-                "django-absurd worker starting: alias=%s queue=%s database=%s "
+                "django-absurd worker started: alias=%s queue=%s database=%s "
                 "burst=%s concurrency=%d",
                 backend.alias,
                 queue,

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -123,7 +123,8 @@ async def aworker_client(
         client = AsyncAbsurd(conn, queue_name=queue)
         client._registry = LazyTaskRegistry(queue)  # noqa: SLF001 -- SDK has no public fallback-resolver hook; install lazy import_string resolution
         try:
-            provisioned = await client.list_queues()
+            # Probes for the schema-absent guard; raises if Absurd is not migrated.
+            await client.list_queues()
         except (
             psycopg.errors.InvalidSchemaName,
             psycopg.errors.UndefinedTable,
@@ -134,11 +135,6 @@ async def aworker_client(
                 " Run: manage.py migrate then manage.py absurd_sync_queues"
             )
             raise ImproperlyConfigured(msg) from err
-        if queue not in provisioned:
-            msg = (
-                f"Queue '{queue}' is not provisioned. Run: manage.py absurd_sync_queues"
-            )
-            raise ImproperlyConfigured(msg)
         yield client
     finally:
         await conn.close()

--- a/docs/plans/2026-06-24-auto-create-queues.md
+++ b/docs/plans/2026-06-24-auto-create-queues.md
@@ -1,0 +1,562 @@
+# Auto-create queues — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) tracking.
+> Project CLAUDE.md OVERRIDES the writing-plans skill: plans show TESTS in full (RED
+> first) and describe implementation in PROSE — never finished implementation blocks
+> (coding-ahead = TDD violation). Each impl step: prose only.
+
+**Goal:** Declared queues materialize automatically on first use (enqueue + worker
+start); the `absurd_sync_queues` command is no longer required, and obsolete
+system-check warnings are removed.
+
+**Architecture:** A new `reconcile_queue(backend, queue_name)` factors `sync_queues`'
+per- queue create/reconcile into a reusable unit. Worker start reconciles via the
+`absurd_worker` command (reports to stdout/stderr). Enqueue create is failure-driven
+(spawn → on missing-queue error, create declared queue → retry once). System checks
+shrink: W001 dropped, W002 narrowed to storage_mode-drift only.
+
+**Tech Stack:** Django 6 Tasks, absurd_sdk, psycopg3, pytest (function-based), Postgres.
+
+## Global Constraints
+
+- Floor Django 6.0 / Python 3.12; psycopg (v3) backend only.
+- `import typing as t` (never `from typing import X`). Absolute imports only.
+- Functions contain a verb; no leading-underscore module constants/helpers; helpers
+  BELOW their public callers.
+- pytest function-based only; autouse `_enable_db` gives DB access (no
+  `@pytest.mark. django_db` unless transactional — these tests use
+  `@pytest.mark.django_db(transaction= True)`, already the module default in the touched
+  files). No mocks / no `unittest.mock.patch`. Drive states with real DB conditions.
+  Assert on emitted text.
+- ruff `select=ALL`; NO new ignores/noqa without asking.
+- System-check `msg` = PROBLEM only; `hint` = RESOLUTION only.
+- Settings = source of truth: only queues in `TASKS[...]['QUEUES']` auto-create.
+- Enqueue hot path: zero added cost when queue exists (auto-create only in `except`).
+- Test env fact: `_reset_absurd_queues` (conftest) leaves the `absurd` schema present
+  with ZERO queues before each test — so a declared queue is unprovisioned until
+  created. Default `tests/settings.py` declares queues `["default", "other"]`; any other
+  name (e.g. `"ghost"`) is UNDECLARED.
+
+---
+
+### Task 1: `reconcile_queue` + `sync_queues` refactor
+
+**Files:**
+
+- Modify: `django_absurd/queues.py` (add `reconcile_queue`; refactor `sync_queues` to
+  loop it)
+- Test: `tests/test_queue_sync.py`
+
+**Interfaces:**
+
+- Consumes: `get_declared_queues(backend)`, `get_absurd_client(using)`,
+  `validate_backend(using)` (from `django_absurd.connection`), `SyncResult`, `Queue`,
+  `MUTABLE_OPTION_KEYS`.
+- Produces: `reconcile_queue(backend: AbsurdBackend, queue_name: str) -> SyncResult` —
+  validates backend, raises `ImproperlyConfigured` if `queue_name` undeclared, creates
+  the queue (declared opts) if absent else reconciles mutable policy + appends
+  storage_mode warning, maps schema-absent DB errors →
+  `ImproperlyConfigured("...Run: manage.py migrate")`. Returns a one-queue `SyncResult`.
+
+- [ ] **Step 1: Write failing tests** in `tests/test_queue_sync.py` (append). Uses
+      existing `build_tasks_setting`, `table_exists`, `Queue`. Add imports:
+      `from     django_absurd.queues import reconcile_queue, get_absurd_backends` and
+      `from     django.db import connection` (already imported).
+
+```python
+def get_backend():
+    from django_absurd.queues import get_absurd_backends
+
+    return get_absurd_backends()["default"]
+
+
+def test_reconcile_queue_creates_when_absent(settings):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    result = reconcile_queue(get_backend(), "q")
+    assert result.created == ["q"]
+    assert Queue.objects.filter(queue_name="q").exists()
+    assert table_exists("t_q")
+
+
+def test_reconcile_queue_is_idempotent(settings):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    reconcile_queue(get_backend(), "q")
+    second = reconcile_queue(get_backend(), "q")
+    assert second.created == []
+    assert second.reconciled == ["q"]
+    assert Queue.objects.filter(queue_name="q").count() == 1
+
+
+def test_reconcile_queue_applies_mutable_policy(settings):
+    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
+    reconcile_queue(get_backend(), "q")
+    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
+    reconcile_queue(get_backend(), "q")
+    assert Queue.objects.get(queue_name="q").cleanup_limit == 250
+
+
+def test_reconcile_queue_warns_on_storage_mode_drift(settings):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    reconcile_queue(get_backend(), "q")
+    settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
+    result = reconcile_queue(get_backend(), "q")
+    assert result.storage_warnings
+    assert "storage_mode" in result.storage_warnings[0]
+
+
+def test_reconcile_queue_undeclared_raises(settings):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    with pytest.raises(ImproperlyConfigured, match="ghost"):
+        reconcile_queue(get_backend(), "ghost")
+
+
+def test_reconcile_queue_schema_absent_raises_migrate(settings):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    with connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
+    try:
+        with pytest.raises(ImproperlyConfigured, match="migrate"):
+            reconcile_queue(get_backend(), "q")
+    finally:
+        call_command("migrate", "django_absurd", "zero", verbosity=0)
+        call_command("migrate", "django_absurd", verbosity=0)
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+      `uv run pytest tests/test_queue_sync.py -k reconcile -v` Expected: FAIL
+      (ImportError: cannot import name `reconcile_queue`).
+
+- [ ] **Step 3: Implement (prose).** In `queues.py`, add
+      `reconcile_queue(backend,     queue_name)` placed BELOW `sync_queues` (or above —
+      keep public funcs grouped; it is public). Body, minimal: call
+      `validate_backend(backend.database)`; read
+      `declared =     get_declared_queues(backend)`; if `queue_name not in declared`,
+      raise `ImproperlyConfigured` whose message NAMES the queue and points at
+      `TASKS QUEUES` (problem+pointer, one string). Build a fresh `SyncResult`. Get
+      `client =     get_absurd_client(backend.database)`. Wrap the DB work in
+      `try/except ProgrammingError` (`from django.db.utils import ProgrammingError`,
+      already used elsewhere) → re-raise
+      `ImproperlyConfigured("Absurd schema is not installed. Run: manage.py migrate")`.
+      Inside: query `Queue.objects.using(db).filter(queue_name=queue_name)`; if not
+      present → `client.create_queue(queue_name, **declared[queue_name])` and append to
+      `result.created`; else → apply mutable opts
+      (`{k: v ... if k in MUTABLE_OPTION_KEYS}` via `client.set_queue_policy`), append
+      to `result.reconciled`, and if `"storage_mode"     in opts` and it differs from
+      the existing row's `storage_mode`, append the existing storage_mode warning string
+      (reuse the exact wording currently in `sync_queues`). Return `result`. Refactor
+      `sync_queues(backend)` to: build `SyncResult()`, loop
+      `for name in get_declared_queues(backend)`, call `reconcile_queue(backend, name)`,
+      and extend the three result lists from each. Keep the existing
+      `MUTABLE_OPTION_KEYS` constant; move its drift/warning logic into
+      `reconcile_queue`.
+
+- [ ] **Step 4: Run reconcile tests + full sync regression.**
+      `uv run pytest tests/test_queue_sync.py -v` Expected: PASS (new + all existing —
+      `test_sync_creates_with_options_and_model_maps`,
+      `_reconciles_changed_option_     idempotent`, `_non_destructive`,
+      `_list_shorthand`, `_screams_on_non_postgres_backend`,
+      `_reports_nothing_when_no_absurd_backend`).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add django_absurd/queues.py tests/test_queue_sync.py
+git commit -m "feat: reconcile_queue (per-queue create+reconcile); sync_queues loops it"
+```
+
+---
+
+### Task 2: Enqueue auto-create (failure-driven, retry once)
+
+**Files:**
+
+- Modify: `django_absurd/backends.py` (`AbsurdBackend.enqueue`, ~lines 42-86)
+- Test: `tests/test_enqueue.py`
+
+**Interfaces:**
+
+- Consumes: `get_declared_queues`
+  (`from django_absurd.queues import get_declared_queues`), existing
+  `build_absurd_client`, `client.create_queue`, `psycopg.errors`.
+- Produces: enqueue auto-creates a declared-but-missing queue then retries spawn once;
+  undeclared queue → `ImproperlyConfigured`; schema absent →
+  `ImproperlyConfigured(migrate)`.
+
+- [ ] **Step 1: Repoint + add failing tests** in `tests/test_enqueue.py`. REPLACE
+      `test_enqueue_to_unprovisioned_queue_raises_clear_error` (it used declared
+      `default`, which now auto-creates) and REFRAME
+      `test_enqueue_error_does_not_poison_atomic_block`. Keep
+      `test_enqueue_with_absent_schema_raises_clear_error` (still green). New/updated
+      tests (use existing imports: `add`, `Group`, `transaction`, `connection`,
+      `ImproperlyConfigured`; add `from tests.tasks import make_group` if not present —
+      check file; `make_group` creates a Group named by its arg and is in
+      `tests/tasks.py`):
+
+```python
+def test_enqueue_auto_creates_declared_queue_and_runs():
+    # 'default' is declared but unprovisioned (no absurd_sync_queues). Enqueue must
+    # auto-create it, then the worker runs the task end-to-end.
+    result = make_group.enqueue("auto")
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="auto").exists()
+
+
+def test_enqueue_to_undeclared_queue_raises():
+    with pytest.raises(ImproperlyConfigured, match="ghost"):
+        add.using(queue_name="ghost").enqueue(1, 2)
+
+
+def test_enqueue_auto_create_survives_outer_atomic():
+    # Auto-create + retry happens inside the savepoint; the surrounding atomic() stays
+    # usable and the task persists after commit.
+    with transaction.atomic():
+        make_group.enqueue("inatomic")
+        assert Group.objects.count() == 0  # nothing committed yet
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="inatomic").exists()
+```
+
+      Add `from django.core.management import call_command` if absent. Delete the old
+      `test_enqueue_to_unprovisioned_queue_raises_clear_error` body and the
+      `test_enqueue_error_does_not_poison_atomic_block` body, replaced by the above.
+
+- [ ] **Step 2: Run, verify FAIL.**
+      `uv run pytest tests/test_enqueue.py -k "auto_create or     undeclared" -v`
+      Expected: FAIL — `test_enqueue_to_undeclared_queue_raises` currently raises with
+      the old "absurd_sync_queues" message (no queue-name match guaranteed) and the
+      auto-create tests fail (spawn raises, no retry).
+
+- [ ] **Step 3: Implement (prose).** In `enqueue`, wrap the existing
+      `with transaction.atomic(savepoint=True): spawn` in the current `try`. CHANGE the
+      `except (UndefinedTable, UndefinedFunction, InvalidSchemaName)` handler: instead
+      of raising the old "run absurd_sync_queues" message, (a) read
+      `declared =     get_declared_queues(self)`; if `task.queue_name not in declared`,
+      raise `ImproperlyConfigured` naming the queue + telling the user to declare it in
+      `TASKS QUEUES`; (b) else attempt
+      `client.create_queue(task.queue_name,     **declared[task.queue_name])` inside an
+      inner `try/except (UndefinedFunction,     InvalidSchemaName)` that re-raises
+      `ImproperlyConfigured("Absurd schema is not     installed. Run: manage.py migrate")`
+      (schema absent → create can't help); (c) then RETRY the spawn ONCE inside a fresh
+      `with transaction.atomic(savepoint=True):`, assigning `spawn_result`. A second
+      failure propagates unchanged. The happy-path spawn and the `TaskResult(...)`
+      construction below are untouched. Import `get_declared_queues` at module top
+      (absolute import).
+
+- [ ] **Step 4: Run enqueue suite.** `uv run pytest tests/test_enqueue.py -v` Expected:
+      PASS (new auto-create tests, undeclared-raises, atomic-survives, kept
+      schema-absent test, and all other existing enqueue tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add django_absurd/backends.py tests/test_enqueue.py
+git commit -m "feat: enqueue auto-creates a declared queue on missing-table, retries once"
+```
+
+---
+
+### Task 3: Worker `aworker_client` — drop the not-provisioned block
+
+**Files:**
+
+- Modify: `django_absurd/worker.py` (`aworker_client`, ~lines 125-141: remove the
+  `if queue not in provisioned: raise ImproperlyConfigured` block; keep the
+  schema-absent `except` that maps `list_queues` errors →
+  `ImproperlyConfigured(migrate)`)
+- Test: `tests/test_worker.py`
+
+**Interfaces:**
+
+- Consumes: existing `aworker_client(backend, queue)`, `backend()` helper, `asyncio`.
+- Produces: `aworker_client` no longer raises for an unprovisioned (but schema-present)
+  queue; schema-absent still raises `ImproperlyConfigured(migrate)`.
+
+- [ ] **Step 1: Repoint failing test** in `tests/test_worker.py`. REMOVE
+      `test_worker_client_unprovisioned_queue_errors` (its premise — aworker_client
+      raises on unprovisioned — is deleted). Keep
+      `test_worker_client_absent_schema_errors` (still valid). Add a positive test that
+      aworker_client opens against a schema-present queue WITHOUT a prior raise (it need
+      not be provisioned — list_queues just returns without that queue):
+
+```python
+def test_worker_client_opens_without_provisioning_check():
+    # No absurd_sync_queues, queue 'default' not provisioned: aworker_client must NOT
+    # raise (the provisioned-or-die check is gone). Schema is present.
+    async def _enter():
+        async with aworker_client(backend(), "default") as client:
+            return await client.list_queues()
+
+    queues = asyncio.run(_enter())
+    assert "default" not in queues  # unprovisioned, yet no error
+```
+
+- [ ] **Step 2: Run, verify state.**
+      `uv run pytest tests/test_worker.py -k     "worker_client" -v` Expected: the new
+      test FAILS (current code raises ImproperlyConfigured "not provisioned");
+      `test_worker_client_absent_schema_errors` passes.
+
+- [ ] **Step 3: Implement (prose).** In `aworker_client`, delete the
+      `if queue not in provisioned:` block and its `ImproperlyConfigured` raise. Keep
+      the `provisioned = await client.list_queues()` call wrapped in the schema-absent
+      `except     (InvalidSchemaName, UndefinedTable, UndefinedFunction)` →
+      `ImproperlyConfigured(migrate)` (still the schema guard). `provisioned` is now
+      only used by that guard's success path; if it becomes unused, replace the
+      assignment with a bare `await client.list_queues()` (kept solely to trigger the
+      schema-absent error) — keep a short comment explaining it probes the schema.
+
+- [ ] **Step 4: Run.** `uv run pytest tests/test_worker.py -k "worker_client" -v`
+      Expected: PASS (new positive test + schema-absent test).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add django_absurd/worker.py tests/test_worker.py
+git commit -m "refactor: aworker_client drops provisioned-or-die check (queues auto-create)"
+```
+
+---
+
+### Task 4: `absurd_worker` command — reconcile + report; shared report helper
+
+**Files:**
+
+- Modify: `django_absurd/management/commands/absurd_worker.py` (`handle`: reconcile +
+  report before `run_worker`)
+- Modify: `django_absurd/management/commands/absurd_sync_queues.py` (use the shared
+  report helper)
+- Modify: `django_absurd/queues.py` (add shared `write_sync_report` helper)
+- Test: `tests/test_worker.py`
+
+**Interfaces:**
+
+- Consumes: `reconcile_queue(backend, queue_name)` (Task 1), `SyncResult`, the command's
+  `self.stdout`/`self.stderr`/`self.style`.
+- Produces: `write_sync_report(command, result, prefix="")` in `queues.py` — writes
+  `Created: ...` / `Reconciled: ...` to `command.stdout`, `No queues to sync.` when both
+  empty (sync_queues path keeps that wording via prefix), and storage_warnings to
+  `command.stderr` (`command.style.WARNING`). `absurd_worker.handle` calls
+  `reconcile_queue` (wrapped → `CommandError`), then `write_sync_report(self, result)`,
+  then `run_worker(...)`.
+
+- [ ] **Step 1: Write failing tests** in `tests/test_worker.py` (uses existing
+      `run_absurd_worker`/`call_command`, `capsys`, `backend`, `make_group`,
+      `get_task_     result`, `connection`, `CommandError`). REPOINT
+      `test_command_maps_improperly_configured_to_commanderror` (its old trigger —
+      declared- but-unsynced queue → error — now auto-creates) to a schema-absent
+      trigger. New tests:
+
+```python
+def test_worker_command_reports_created_on_unprovisioned_queue(capsys):
+    make_group.enqueue("rep")
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Created: default" in out
+
+
+def test_worker_command_reports_reconciled_when_already_provisioned(capsys):
+    call_command("absurd_sync_queues")
+    capsys.readouterr()  # drop sync output
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Reconciled: default" in out
+
+
+def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {}}},
+        }
+    }
+    call_command("absurd_sync_queues")  # create 'default' unpartitioned
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"storage_mode": "partitioned"}}},
+        }
+    }
+    capsys.readouterr()
+    call_command("absurd_worker", queue="default", burst=True)
+    err = capsys.readouterr().err
+    assert "storage_mode" in err
+
+
+def test_worker_command_schema_absent_errors_migrate():
+    with connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
+    try:
+        with pytest.raises(CommandError, match="migrate"):
+            call_command("absurd_worker", queue="default", burst=True)
+    finally:
+        call_command("migrate", "django_absurd", "zero", verbosity=0)
+        call_command("migrate", "django_absurd", verbosity=0)
+```
+
+      Then REPLACE `test_command_maps_improperly_configured_to_commanderror`'s body so it
+      asserts the schema-absent → CommandError path (or delete it as redundant with
+      `test_worker_command_schema_absent_errors_migrate` — note in the commit which).
+
+- [ ] **Step 2: Run, verify FAIL.**
+      `uv run pytest tests/test_worker.py -k     "worker_command" -v` Expected: FAIL (no
+      reconcile/report yet; no `write_sync_report`).
+
+- [ ] **Step 3: Implement (prose).** (a) In `queues.py`, add
+      `write_sync_report(command,     result, prefix="")`: mirror the current
+      `absurd_sync_queues.Command.report_result` logic but write via
+      `command.stdout.write` / `command.stderr.write` / `command.style.WARNING` (problem
+      text lives in `SyncResult`). (b) Refactor
+      `absurd_sync_queues.Command.report_result` to delegate to
+      `write_sync_report(self,     result, prefix)` (behavior identical — its existing
+      tests must stay green). (c) In `absurd_worker.Command.handle`, after the existing
+      backend/queue resolution and BEFORE building `WorkerOptions`/calling `run_worker`:
+      call `reconcile_queue(backend, queue)` inside
+      `try/except ImproperlyConfigured → CommandError` (reuse/extend the existing
+      mapping at the bottom), then `write_sync_report(self, result)`. Import
+      `reconcile_queue` and `write_sync_report` (absolute imports). Leave `run_worker`
+      untouched. Keep `report_result`'s "No queues to sync." wording in the helper for
+      the sync command; the worker passes one queue so it always reports Created or
+      Reconciled.
+
+- [ ] **Step 4: Run worker + sync suites.**
+      `uv run pytest tests/test_worker.py     tests/test_queue_sync.py -v` Expected:
+      PASS (new worker-command tests + unchanged sync command reporting tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add django_absurd/management/commands/absurd_worker.py \
+  django_absurd/management/commands/absurd_sync_queues.py django_absurd/queues.py \
+  tests/test_worker.py
+git commit -m "feat: absurd_worker reconciles served queue on boot, reports to stdout/stderr"
+```
+
+---
+
+### Task 5: System checks cleanup (drop W001, narrow W002 to storage_mode)
+
+**Files:**
+
+- Modify: `django_absurd/checks.py` (drop W001 + `W001_MSG`/`W001_HINT`; narrow W002 to
+  storage_mode-drift; delete `has_option_drifted`, `parse_interval`,
+  `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`; reword `W002_MSG`/`W002_HINT`)
+- Test: `tests/test_checks.py`
+
+**Interfaces:**
+
+- Consumes: existing `query_queue_state(alias, declared)`, `Queue`,
+  `get_declared_queues`.
+- Produces: `query_queue_state` returns `[]` for unreachable / schema-absent / missing /
+  mutable-drift; returns `[W002]` ONLY when an existing queue's declared `storage_mode`
+  differs from the DB.
+
+- [ ] **Step 1: Repoint + add failing tests** in `tests/test_checks.py`. Changes:
+  - DELETE `test_schema_absent_warns_migrate_first` (W001 gone). Optionally replace with
+    a silence assertion (below).
+  - REPOINT `test_drift_warns_run_sync` (missing queue → was W002) to assert NO W002.
+  - REPOINT `test_option_drift_warns` and `test_duration_drift_warns` (mutable drift) to
+    assert NO W002.
+  - REPOINT/REMOVE `test_mixed_missing_and_drifted_hint_names_both` (missing + mutable;
+    now neither) → assert NO W002.
+  - `test_db_unreachable_is_silent`: remove its now-dead reference to the W001 message
+    string; assert only that W002 is absent.
+  - ADD `test_storage_mode_drift_warns`.
+
+```python
+def test_missing_declared_queue_no_longer_warns(settings, capsys):
+    settings.TASKS = build_tasks_setting({"synced": {}})
+    call_command("absurd_sync_queues")
+    settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" not in out
+
+
+def test_mutable_option_drift_no_longer_warns(settings, capsys):
+    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
+    call_command("absurd_sync_queues")
+    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" not in out
+
+
+def test_schema_absent_is_silent(settings, capsys):
+    settings.TASKS = build_tasks_setting({"a": {}})
+    with connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
+    try:
+        out = run_absurd_check(capsys, databases=["default"])
+        assert "absurd.W001" not in out
+        assert "absurd.W002" not in out
+    finally:
+        call_command("migrate", "django_absurd", "zero", verbosity=0)
+        call_command("migrate", "django_absurd", verbosity=0)
+
+
+def test_storage_mode_drift_warns(settings, capsys):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    call_command("absurd_sync_queues")  # 'q' created unpartitioned
+    settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" in out
+    assert "storage_mode" in out
+    assert "q" in out
+```
+
+      Delete the bodies of the four repointed tests and replace with the equivalents above
+      (rename as shown). `test_in_sync_no_warning` (top of file) references the W001 message
+      string — drop that W001 assertion line, keep the W002 one.
+
+- [ ] **Step 2: Run, verify FAIL.** `uv run pytest tests/test_checks.py -v` Expected:
+      the new/repointed tests FAIL (current code still warns on missing/mutable drift
+      and emits W001).
+
+- [ ] **Step 3: Implement (prose).** In `checks.py`: remove `W001_MSG`, `W001_HINT`,
+      `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`, `has_option_drifted`,
+      `parse_interval`. Rewrite `query_queue_state(alias, declared)`: wrap the
+      `Queue.objects` read in `except (OperationalError, ProgrammingError): return []`
+      (schema-absent now silent, folded with unreachable — no W001). Compute
+      `drift = [name for name in declared if     name in actual and declared[name].get("storage_mode") and declared[name]["storage_mode"]     != actual[name].storage_mode]`.
+      If `drift`, return one
+      `DjangoWarning(W002_MSG, hint=     f"{W002_HINT} Affected: {', '.join(drift)}", id="absurd.W002")`.
+      Reword the constants:
+      `W002_MSG = "django-absurd: a queue's declared storage_mode differs from the database     (storage_mode is immutable)."`
+      (problem only);
+      `W002_HINT = "Recreate the queue, or     revert the declared storage_mode."`
+      (resolution only — the affected names are appended at call site). Drop the
+      now-unused imports (`timedelta`, `connections` if only used by `parse_interval`;
+      verify with ruff). `check_absurd_config` (E001-E005) untouched.
+
+- [ ] **Step 4: Run check suite + full suite.** `uv run pytest tests/test_checks.py -v`
+      then `uv run pytest` Expected: PASS. Confirm ruff clean:
+      `uv run ruff check     django_absurd/checks.py` (no unused imports/dead code).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add django_absurd/checks.py tests/test_checks.py
+git commit -m "refactor: drop W001, narrow W002 to storage_mode drift (queues auto-create)"
+```
+
+---
+
+## Docs (fold into the final review task or a trailing commit)
+
+- `README.md`: Setup section currently lists `absurd_sync_queues` as a required step —
+  reword to "declared queues are created automatically on first enqueue / worker start;
+  `absurd_sync_queues` remains for explicit/eager provisioning and policy
+  reconciliation."
+- `examples/README.md`: the `compose up` flow runs `absurd_sync_queues` explicitly —
+  leave the example as-is (still valid) but note it's now optional.
+
+## Self-review notes (coverage vs spec)
+
+- Both seams: Task 2 (enqueue) + Tasks 1/3/4 (worker start). ✓
+- Always-on, declared-bounded, settings source of truth: enqueue + reconcile read
+  `get_declared_queues`. ✓
+- `absurd_sync_queues` unchanged externally: Task 1 refactor is behavior-neutral
+  (regression tests retained); Task 4 only reuses its report helper. ✓
+- Worker reports to stdout/stderr: Task 4. ✓
+- Schema-absent → `ImproperlyConfigured(migrate)` at both seams: Task 1 (reconcile) +
+  Task 2 (enqueue). ✓
+- Checks: W001 dropped, W002 storage_mode-only, dead code removed: Task 5. ✓
+- Test inversions enumerated in spec all assigned to a task. ✓

--- a/docs/plans/2026-06-24-auto-create-queues.md
+++ b/docs/plans/2026-06-24-auto-create-queues.md
@@ -11,10 +11,11 @@ start); the `absurd_sync_queues` command is no longer required, and obsolete
 system-check warnings are removed.
 
 **Architecture:** A new `reconcile_queue(backend, queue_name)` factors `sync_queues`'
-per- queue create/reconcile into a reusable unit. Worker start reconciles via the
-`absurd_worker` command (reports to stdout/stderr). Enqueue create is failure-driven
-(spawn → on missing-queue error, create declared queue → retry once). System checks
-shrink: W001 dropped, W002 narrowed to storage_mode-drift only.
+per- queue create/reconcile into a reusable, DRIFT-GATED unit (only writes policy when
+declared opts actually differ). Worker start reconciles via the `absurd_worker` command
+(reports to stdout/stderr). Enqueue create is failure-driven (spawn → on missing-queue
+error, create declared queue → retry once). System checks shrink: W001 dropped, W002
+narrowed to storage_mode-drift only.
 
 **Tech Stack:** Django 6 Tasks, absurd_sdk, psycopg3, pytest (function-based), Postgres.
 
@@ -24,150 +25,222 @@ shrink: W001 dropped, W002 narrowed to storage_mode-drift only.
 - `import typing as t` (never `from typing import X`). Absolute imports only.
 - Functions contain a verb; no leading-underscore module constants/helpers; helpers
   BELOW their public callers.
-- pytest function-based only; autouse `_enable_db` gives DB access (no
-  `@pytest.mark. django_db` unless transactional — these tests use
-  `@pytest.mark.django_db(transaction= True)`, already the module default in the touched
-  files). No mocks / no `unittest.mock.patch`. Drive states with real DB conditions.
-  Assert on emitted text.
+- pytest function-based only; autouse `_enable_db` gives DB access. Touched test modules
+  already set `pytestmark = pytest.mark.django_db(transaction=True)`. No mocks / no
+  `unittest.mock.patch`. Drive states with REAL DB conditions.
+- **Test at the ENTRYPOINTS** (the `enqueue` API + management commands + system checks
+  run via `call_command`) — NOT by calling `reconcile_queue`/internal helpers directly.
+  Assert on emitted text AND, for reconciliation, on the DB `Queue` row VALUES (prove
+  the write happened). PARAMETRIZE when multiple cases share structure.
 - ruff `select=ALL`; NO new ignores/noqa without asking.
 - System-check `msg` = PROBLEM only; `hint` = RESOLUTION only.
 - Settings = source of truth: only queues in `TASKS[...]['QUEUES']` auto-create.
 - Enqueue hot path: zero added cost when queue exists (auto-create only in `except`).
-- Test env fact: `_reset_absurd_queues` (conftest) leaves the `absurd` schema present
-  with ZERO queues before each test — so a declared queue is unprovisioned until
-  created. Default `tests/settings.py` declares queues `["default", "other"]`; any other
-  name (e.g. `"ghost"`) is UNDECLARED.
+- Test env facts: `_reset_absurd_queues` (conftest) leaves the `absurd` schema present
+  with ZERO queues before each test (declared queue is unprovisioned until created).
+  Default `tests/settings.py` declares queues `["default", "other"]`; any other name
+  (e.g. `"ghost"`) is UNDECLARED. `tests/tasks.py` has `make_group(name)` (creates a
+  `Group`).
+
+**Task order rationale:** checks cleanup (Task 1) removes `parse_interval`/
+`has_option_drifted` from `checks.py` FIRST, so Task 2 can add fresh drift-gating to
+`queues.py` with no duplication window.
 
 ---
 
-### Task 1: `reconcile_queue` + `sync_queues` refactor
+### Task 1: System checks cleanup (drop W001, narrow W002 to storage_mode)
 
 **Files:**
 
-- Modify: `django_absurd/queues.py` (add `reconcile_queue`; refactor `sync_queues` to
-  loop it)
-- Test: `tests/test_queue_sync.py`
+- Modify: `django_absurd/checks.py` (drop W001 + `W001_MSG`/`W001_HINT`; narrow W002 to
+  storage_mode-drift; remove `has_option_drifted`, `parse_interval`,
+  `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`; reword `W002_MSG`/`W002_HINT`)
+- Test: `tests/test_checks.py`
 
 **Interfaces:**
 
-- Consumes: `get_declared_queues(backend)`, `get_absurd_client(using)`,
-  `validate_backend(using)` (from `django_absurd.connection`), `SyncResult`, `Queue`,
-  `MUTABLE_OPTION_KEYS`.
-- Produces: `reconcile_queue(backend: AbsurdBackend, queue_name: str) -> SyncResult` —
-  validates backend, raises `ImproperlyConfigured` if `queue_name` undeclared, creates
-  the queue (declared opts) if absent else reconciles mutable policy + appends
-  storage_mode warning, maps schema-absent DB errors →
-  `ImproperlyConfigured("...Run: manage.py migrate")`. Returns a one-queue `SyncResult`.
+- Produces: `query_queue_state(alias, declared)` returns `[]` for unreachable / schema-
+  absent / missing / mutable-drift; returns one `absurd.W002` `Warning` ONLY when an
+  EXISTING queue's declared `storage_mode` differs from the DB.
 
-- [ ] **Step 1: Write failing tests** in `tests/test_queue_sync.py` (append). Uses
-      existing `build_tasks_setting`, `table_exists`, `Queue`. Add imports:
-      `from     django_absurd.queues import reconcile_queue, get_absurd_backends` and
-      `from     django.db import connection` (already imported).
+- [ ] **Step 1: Repoint + add failing tests** in `tests/test_checks.py`. Uses existing
+      `build_tasks_setting`, `run_absurd_check`, `connection`, `call_command`. Changes:
+  - DELETE `test_schema_absent_warns_migrate_first`; replace with the silence test
+    below.
+  - DELETE the bodies of `test_drift_warns_run_sync`, `test_option_drift_warns`,
+    `test_duration_drift_warns`, `test_mixed_missing_and_drifted_hint_names_both` —
+    folded into the parametrized `test_self_healing_drift_no_longer_warns` below.
+  - In `test_in_sync_no_warning`: DROP the W001-message assertion line (keep the W002
+    one).
+  - In `test_db_unreachable_is_silent`: DROP the W001-message assertion line (keep
+    W002).
+  - ADD:
 
 ```python
-def get_backend():
-    from django_absurd.queues import get_absurd_backends
-
-    return get_absurd_backends()["default"]
+import pytest
 
 
-def test_reconcile_queue_creates_when_absent(settings):
+@pytest.mark.parametrize(
+    "after",
+    [
+        {"synced": {}, "missing": {}},
+        {"synced": {"cleanup_limit": 250}},
+        {"synced": {"cleanup_ttl": "60 days"}},
+    ],
+    ids=["missing-queue", "mutable-scalar", "mutable-duration"],
+)
+def test_self_healing_drift_no_longer_warns(settings, capsys, after):
+    settings.TASKS = build_tasks_setting({"synced": {}})
+    call_command("absurd_sync_queues")
+    settings.TASKS = build_tasks_setting(after)
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" not in out
+
+
+def test_storage_mode_drift_warns(settings, capsys):
     settings.TASKS = build_tasks_setting({"q": {}})
-    result = reconcile_queue(get_backend(), "q")
-    assert result.created == ["q"]
-    assert Queue.objects.filter(queue_name="q").exists()
-    assert table_exists("t_q")
-
-
-def test_reconcile_queue_is_idempotent(settings):
-    settings.TASKS = build_tasks_setting({"q": {}})
-    reconcile_queue(get_backend(), "q")
-    second = reconcile_queue(get_backend(), "q")
-    assert second.created == []
-    assert second.reconciled == ["q"]
-    assert Queue.objects.filter(queue_name="q").count() == 1
-
-
-def test_reconcile_queue_applies_mutable_policy(settings):
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
-    reconcile_queue(get_backend(), "q")
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
-    reconcile_queue(get_backend(), "q")
-    assert Queue.objects.get(queue_name="q").cleanup_limit == 250
-
-
-def test_reconcile_queue_warns_on_storage_mode_drift(settings):
-    settings.TASKS = build_tasks_setting({"q": {}})
-    reconcile_queue(get_backend(), "q")
+    call_command("absurd_sync_queues")  # 'q' created unpartitioned
     settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
-    result = reconcile_queue(get_backend(), "q")
-    assert result.storage_warnings
-    assert "storage_mode" in result.storage_warnings[0]
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" in out
+    assert "storage_mode" in out
+    assert "q" in out
 
 
-def test_reconcile_queue_undeclared_raises(settings):
-    settings.TASKS = build_tasks_setting({"q": {}})
-    with pytest.raises(ImproperlyConfigured, match="ghost"):
-        reconcile_queue(get_backend(), "ghost")
-
-
-def test_reconcile_queue_schema_absent_raises_migrate(settings):
-    settings.TASKS = build_tasks_setting({"q": {}})
+def test_schema_absent_check_is_silent(settings, capsys):
+    settings.TASKS = build_tasks_setting({"a": {}})
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
-        with pytest.raises(ImproperlyConfigured, match="migrate"):
-            reconcile_queue(get_backend(), "q")
+        out = run_absurd_check(capsys, databases=["default"])
+        assert "absurd.W001" not in out
+        assert "absurd.W002" not in out
     finally:
         call_command("migrate", "django_absurd", "zero", verbosity=0)
         call_command("migrate", "django_absurd", verbosity=0)
 ```
 
-- [ ] **Step 2: Run, verify FAIL.**
-      `uv run pytest tests/test_queue_sync.py -k reconcile -v` Expected: FAIL
-      (ImportError: cannot import name `reconcile_queue`).
+- [ ] **Step 2: Run, verify FAIL.** `uv run pytest tests/test_checks.py -v` Expected:
+      the new/parametrized tests FAIL (current code still emits W001 and warns on
+      missing / mutable drift).
 
-- [ ] **Step 3: Implement (prose).** In `queues.py`, add
-      `reconcile_queue(backend,     queue_name)` placed BELOW `sync_queues` (or above —
-      keep public funcs grouped; it is public). Body, minimal: call
-      `validate_backend(backend.database)`; read
-      `declared =     get_declared_queues(backend)`; if `queue_name not in declared`,
-      raise `ImproperlyConfigured` whose message NAMES the queue and points at
-      `TASKS QUEUES` (problem+pointer, one string). Build a fresh `SyncResult`. Get
-      `client =     get_absurd_client(backend.database)`. Wrap the DB work in
-      `try/except ProgrammingError` (`from django.db.utils import ProgrammingError`,
-      already used elsewhere) → re-raise
-      `ImproperlyConfigured("Absurd schema is not installed. Run: manage.py migrate")`.
-      Inside: query `Queue.objects.using(db).filter(queue_name=queue_name)`; if not
-      present → `client.create_queue(queue_name, **declared[queue_name])` and append to
-      `result.created`; else → apply mutable opts
-      (`{k: v ... if k in MUTABLE_OPTION_KEYS}` via `client.set_queue_policy`), append
-      to `result.reconciled`, and if `"storage_mode"     in opts` and it differs from
-      the existing row's `storage_mode`, append the existing storage_mode warning string
-      (reuse the exact wording currently in `sync_queues`). Return `result`. Refactor
-      `sync_queues(backend)` to: build `SyncResult()`, loop
-      `for name in get_declared_queues(backend)`, call `reconcile_queue(backend, name)`,
-      and extend the three result lists from each. Keep the existing
-      `MUTABLE_OPTION_KEYS` constant; move its drift/warning logic into
-      `reconcile_queue`.
+- [ ] **Step 3: Implement (prose).** In `checks.py`: remove `W001_MSG`, `W001_HINT`,
+      `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`, `has_option_drifted`,
+      `parse_interval`. Rewrite `query_queue_state(alias, declared)`: read
+      `actual = {q.queue_name: q for q in     Queue.objects.using(alias).filter(queue_name__in=declared)}`
+      inside `try/except     (OperationalError, ProgrammingError): return []`
+      (schema-absent now silent, folded with unreachable — W001 gone). Compute
+      `drift = [name for name in declared if name in     actual and declared[name].get("storage_mode") and declared[name]["storage_mode"] !=     actual[name].storage_mode]`.
+      If `drift`, return one
+      `DjangoWarning(W002_MSG,     hint=f"{W002_HINT} Affected: {', '.join(drift)}", id="absurd.W002")`
+      else `[]`. Reword constants:
+      `W002_MSG = "django-absurd: a queue's declared storage_mode differs from     the database (storage_mode is immutable)."`
+      (problem only);
+      `W002_HINT = "Recreate the     queue, or revert the declared storage_mode."`
+      (resolution only — names appended at call site). Remove now-unused imports
+      (`timedelta`; `connections` only if nothing else uses it — verify with ruff).
+      `check_absurd_config` (E001–E005) untouched.
 
-- [ ] **Step 4: Run reconcile tests + full sync regression.**
-      `uv run pytest tests/test_queue_sync.py -v` Expected: PASS (new + all existing —
-      `test_sync_creates_with_options_and_model_maps`,
-      `_reconciles_changed_option_     idempotent`, `_non_destructive`,
-      `_list_shorthand`, `_screams_on_non_postgres_backend`,
-      `_reports_nothing_when_no_absurd_backend`).
+- [ ] **Step 4: Run + ruff.** `uv run pytest tests/test_checks.py -v` (PASS) then
+      `uv run ruff check django_absurd/checks.py` (clean — no unused imports / dead
+      code).
 
 - [ ] **Step 5: Commit.**
 
 ```bash
-git add django_absurd/queues.py tests/test_queue_sync.py
-git commit -m "feat: reconcile_queue (per-queue create+reconcile); sync_queues loops it"
+git add django_absurd/checks.py tests/test_checks.py
+git commit -m "refactor: drop W001, narrow W002 to storage_mode drift (queues auto-create)"
 ```
 
 ---
 
-### Task 2: Enqueue auto-create (failure-driven, retry once)
+### Task 2: `reconcile_queue` (drift-gated) + `sync_queues` refactor
+
+**Files:**
+
+- Modify: `django_absurd/queues.py` (add `reconcile_queue` + a drift helper +
+  `parse_interval`; refactor `sync_queues` to loop `reconcile_queue`)
+- Test: `tests/test_queue_sync.py` (regression only — no new unit tests; entrypoint =
+  `absurd_sync_queues` command)
+
+**Interfaces:**
+
+- Consumes: `get_declared_queues(backend)`, `get_absurd_client(using)`,
+  `validate_backend` (`django_absurd.connection`), `SyncResult`, `Queue`,
+  `MUTABLE_OPTION_KEYS`.
+- Produces: `reconcile_queue(backend: AbsurdBackend, queue_name: str) -> SyncResult` —
+  validates backend; raises `ImproperlyConfigured` if `queue_name` undeclared (message
+  names it); maps schema-absent DB errors →
+  `ImproperlyConfigured("...Run: manage.py migrate")`; creates the queue (declared opts)
+  if absent (→ `created`); else DRIFT-GATES: only `set_queue_policy` + record
+  `reconciled` if a declared MUTABLE opt differs from the DB row, else no-op;
+  storage_mode drift → `storage_warnings` regardless. Unchanged existing queue → empty
+  `SyncResult`.
+
+- [ ] **Step 1: Confirm the regression net.** No new tests authored here
+      (entrypoint-only rule: `reconcile_queue` is exercised through the
+      `absurd_sync_queues` command, already covered, and through the `absurd_worker`
+      command in Task 5). The existing `tests/test_queue_sync.py` tests are the gate —
+      especially these, which assert DB VALUES and thus prove create + drift-gated
+      reconcile:
+  - `test_sync_creates_with_options_and_model_maps` (create →
+    `storage_mode`/`cleanup_ttl` in DB; `t_x` table exists),
+  - `test_sync_reconciles_changed_option_idempotent` (change `cleanup_limit` 100→250 →
+    DB == 250; re-sync → still 250),
+  - `test_non_destructive`, `test_list_shorthand`,
+    `test_sync_command_screams_on_non_postgres_backend`,
+    `test_sync_command_reports_nothing_when_no_absurd_backend`. Run them now to capture
+    the green baseline: `uv run pytest tests/test_queue_sync.py   -v` (all PASS on
+    current code).
+
+- [ ] **Step 2: Implement (prose).** In `queues.py`:
+  - Add `parse_interval(alias, interval_str) -> timedelta` (relocated from the
+    now-cleaned `checks.py`; runs `SELECT %s::interval`) and a drift helper
+    `mutable_options_drifted(alias, opts, queue_row) -> bool` that iterates
+    `MUTABLE_OPTION_KEYS`, comparing declared values to `getattr(queue_row, key)` —
+    parsing interval-typed keys via `parse_interval`, comparing the rest directly.
+    (`storage_mode` is NOT in `MUTABLE_OPTION_KEYS`, so it's excluded — handled
+    separately as a warning.) Place helpers BELOW `reconcile_queue`.
+  - Add `reconcile_queue(backend, queue_name)`: `validate_backend(backend.database)`;
+    read `declared = get_declared_queues(backend)`; if `queue_name not in declared`
+    raise `ImproperlyConfigured` naming the queue + pointing at `TASKS QUEUES`.
+    `opts = declared[queue_name]`; `result = SyncResult()`;
+    `client = get_absurd_client(backend.database)`. Wrap DB work in
+    `try/except ProgrammingError` (`from django.db.utils import ProgrammingError`) →
+    raise
+    `ImproperlyConfigured("Absurd schema is not installed. Run: manage.py migrate")`.
+    Inside: fetch the row via
+    `Queue.objects.using(db).filter(queue_name=queue_name).first()`. If `None`:
+    `client.create_queue(queue_name, **opts)`; `result.created.append(queue_name)`.
+    Else: build
+    `mutable_opts = {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS}`; if
+    `mutable_opts and mutable_options_drifted(db, mutable_opts, row)`:
+    `client. set_queue_policy(queue_name, **mutable_opts)`;
+    `result.reconciled.append(queue_name)`. In all existing-row cases, if
+    `"storage_mode" in opts and opts["storage_mode"] != row.storage_mode`: append the
+    existing storage_mode warning string (reuse current wording from `sync_queues`).
+    Return `result`.
+  - Refactor `sync_queues(backend)`: `result = SyncResult()`;
+    `for name in get_declared_queues(backend): r = reconcile_queue(backend, name)`;
+    extend `result.created/reconciled/storage_warnings` from `r`. Return `result`. (Drop
+    the inline create/reconcile loop body now living in `reconcile_queue`. Keep
+    `MUTABLE_OPTION_KEYS`.)
+
+- [ ] **Step 3: Run regression.** `uv run pytest tests/test_queue_sync.py -v` Expected:
+      PASS (drift-gating keeps the idempotent test green: first change writes 250,
+      re-run is a no-op, value stays 250). Then
+      `uv run ruff check django_absurd/queues.py`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add django_absurd/queues.py tests/test_queue_sync.py
+git commit -m "feat: reconcile_queue (drift-gated per-queue create+reconcile); sync_queues loops it"
+```
+
+---
+
+### Task 3: Enqueue auto-create (failure-driven, retry once)
 
 **Files:**
 
@@ -180,24 +253,22 @@ git commit -m "feat: reconcile_queue (per-queue create+reconcile); sync_queues l
   (`from django_absurd.queues import get_declared_queues`), existing
   `build_absurd_client`, `client.create_queue`, `psycopg.errors`.
 - Produces: enqueue auto-creates a declared-but-missing queue then retries spawn once;
-  undeclared queue → `ImproperlyConfigured`; schema absent →
+  undeclared queue → `ImproperlyConfigured` naming it; schema absent →
   `ImproperlyConfigured(migrate)`.
 
-- [ ] **Step 1: Repoint + add failing tests** in `tests/test_enqueue.py`. REPLACE
-      `test_enqueue_to_unprovisioned_queue_raises_clear_error` (it used declared
-      `default`, which now auto-creates) and REFRAME
-      `test_enqueue_error_does_not_poison_atomic_block`. Keep
-      `test_enqueue_with_absent_schema_raises_clear_error` (still green). New/updated
-      tests (use existing imports: `add`, `Group`, `transaction`, `connection`,
-      `ImproperlyConfigured`; add `from tests.tasks import make_group` if not present —
-      check file; `make_group` creates a Group named by its arg and is in
-      `tests/tasks.py`):
+- [ ] **Step 1: Repoint + add failing tests** in `tests/test_enqueue.py`. REPLACE the
+      body of `test_enqueue_to_unprovisioned_queue_raises_clear_error` (used declared
+      `default`, now auto-creates) and REFRAME
+      `test_enqueue_error_does_not_poison_atomic_block`. KEEP
+      `test_enqueue_with_absent_schema_raises_clear_error` (still green — new code
+      path). Use existing imports; add `from django.core.management import call_command`
+      and `from     tests.tasks import make_group` if absent.
 
 ```python
 def test_enqueue_auto_creates_declared_queue_and_runs():
-    # 'default' is declared but unprovisioned (no absurd_sync_queues). Enqueue must
-    # auto-create it, then the worker runs the task end-to-end.
-    result = make_group.enqueue("auto")
+    # 'default' declared but unprovisioned (no absurd_sync_queues). Enqueue auto-creates
+    # it; the worker then runs the task end-to-end.
+    make_group.enqueue("auto")
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="auto").exists()
 
@@ -208,8 +279,6 @@ def test_enqueue_to_undeclared_queue_raises():
 
 
 def test_enqueue_auto_create_survives_outer_atomic():
-    # Auto-create + retry happens inside the savepoint; the surrounding atomic() stays
-    # usable and the task persists after commit.
     with transaction.atomic():
         make_group.enqueue("inatomic")
         assert Group.objects.count() == 0  # nothing committed yet
@@ -217,35 +286,28 @@ def test_enqueue_auto_create_survives_outer_atomic():
     assert Group.objects.filter(name="inatomic").exists()
 ```
 
-      Add `from django.core.management import call_command` if absent. Delete the old
-      `test_enqueue_to_unprovisioned_queue_raises_clear_error` body and the
-      `test_enqueue_error_does_not_poison_atomic_block` body, replaced by the above.
+      Delete the old `test_enqueue_to_unprovisioned_queue_raises_clear_error` and
+      `test_enqueue_error_does_not_poison_atomic_block` bodies (replaced above).
 
 - [ ] **Step 2: Run, verify FAIL.**
       `uv run pytest tests/test_enqueue.py -k "auto_create or     undeclared" -v`
-      Expected: FAIL — `test_enqueue_to_undeclared_queue_raises` currently raises with
-      the old "absurd_sync_queues" message (no queue-name match guaranteed) and the
-      auto-create tests fail (spawn raises, no retry).
+      Expected: FAIL (spawn raises with the old "absurd_sync_queues" message; no
+      auto-create/retry).
 
-- [ ] **Step 3: Implement (prose).** In `enqueue`, wrap the existing
-      `with transaction.atomic(savepoint=True): spawn` in the current `try`. CHANGE the
-      `except (UndefinedTable, UndefinedFunction, InvalidSchemaName)` handler: instead
-      of raising the old "run absurd_sync_queues" message, (a) read
-      `declared =     get_declared_queues(self)`; if `task.queue_name not in declared`,
+- [ ] **Step 3: Implement (prose).** In `enqueue`, keep the existing
+      `try: with     transaction.atomic(savepoint=True): spawn`. CHANGE the
+      `except (UndefinedTable,     UndefinedFunction, InvalidSchemaName)` handler: (a)
+      `declared =     get_declared_queues(self)`; if `task.queue_name not in declared`
       raise `ImproperlyConfigured` naming the queue + telling the user to declare it in
-      `TASKS QUEUES`; (b) else attempt
-      `client.create_queue(task.queue_name,     **declared[task.queue_name])` inside an
-      inner `try/except (UndefinedFunction,     InvalidSchemaName)` that re-raises
-      `ImproperlyConfigured("Absurd schema is not     installed. Run: manage.py migrate")`
-      (schema absent → create can't help); (c) then RETRY the spawn ONCE inside a fresh
-      `with transaction.atomic(savepoint=True):`, assigning `spawn_result`. A second
-      failure propagates unchanged. The happy-path spawn and the `TaskResult(...)`
-      construction below are untouched. Import `get_declared_queues` at module top
-      (absolute import).
+      `TASKS     QUEUES`; (b) else
+      `try: client.create_queue(task.queue_name,     **declared[task.queue_name]) except (UndefinedFunction, InvalidSchemaName): raise     ImproperlyConfigured("Absurd schema is not installed. Run: manage.py migrate") from     None`;
+      (c) RETRY spawn ONCE inside a fresh `with transaction.atomic(savepoint=True):`,
+      reassigning `spawn_result`. Second failure propagates. The happy-path spawn and
+      the `TaskResult(...)` construction are untouched. Import `get_declared_queues` at
+      module top (absolute).
 
 - [ ] **Step 4: Run enqueue suite.** `uv run pytest tests/test_enqueue.py -v` Expected:
-      PASS (new auto-create tests, undeclared-raises, atomic-survives, kept
-      schema-absent test, and all other existing enqueue tests).
+      PASS (new + kept schema-absent test + all other existing enqueue tests).
 
 - [ ] **Step 5: Commit.**
 
@@ -256,57 +318,49 @@ git commit -m "feat: enqueue auto-creates a declared queue on missing-table, ret
 
 ---
 
-### Task 3: Worker `aworker_client` — drop the not-provisioned block
+### Task 4: Worker `aworker_client` — drop the not-provisioned block
 
 **Files:**
 
-- Modify: `django_absurd/worker.py` (`aworker_client`, ~lines 125-141: remove the
-  `if queue not in provisioned: raise ImproperlyConfigured` block; keep the
-  schema-absent `except` that maps `list_queues` errors →
-  `ImproperlyConfigured(migrate)`)
+- Modify: `django_absurd/worker.py` (`aworker_client`, ~lines 125-141)
 - Test: `tests/test_worker.py`
 
 **Interfaces:**
 
 - Consumes: existing `aworker_client(backend, queue)`, `backend()` helper, `asyncio`.
-- Produces: `aworker_client` no longer raises for an unprovisioned (but schema-present)
+- Produces: `aworker_client` no longer raises for an unprovisioned (schema-present)
   queue; schema-absent still raises `ImproperlyConfigured(migrate)`.
 
-- [ ] **Step 1: Repoint failing test** in `tests/test_worker.py`. REMOVE
-      `test_worker_client_unprovisioned_queue_errors` (its premise — aworker_client
-      raises on unprovisioned — is deleted). Keep
-      `test_worker_client_absent_schema_errors` (still valid). Add a positive test that
-      aworker_client opens against a schema-present queue WITHOUT a prior raise (it need
-      not be provisioned — list_queues just returns without that queue):
+- [ ] **Step 1: Repoint test** in `tests/test_worker.py`. REMOVE
+      `test_worker_client_unprovisioned_queue_errors` (premise deleted). KEEP
+      `test_worker_client_absent_schema_errors`. ADD:
 
 ```python
 def test_worker_client_opens_without_provisioning_check():
-    # No absurd_sync_queues, queue 'default' not provisioned: aworker_client must NOT
-    # raise (the provisioned-or-die check is gone). Schema is present.
+    # No absurd_sync_queues; 'default' unprovisioned (schema present). aworker_client must
+    # NOT raise — the provisioned-or-die check is gone.
     async def _enter():
         async with aworker_client(backend(), "default") as client:
             return await client.list_queues()
 
-    queues = asyncio.run(_enter())
-    assert "default" not in queues  # unprovisioned, yet no error
+    assert "default" not in asyncio.run(_enter())  # unprovisioned, yet no error
 ```
 
 - [ ] **Step 2: Run, verify state.**
-      `uv run pytest tests/test_worker.py -k     "worker_client" -v` Expected: the new
-      test FAILS (current code raises ImproperlyConfigured "not provisioned");
+      `uv run pytest tests/test_worker.py -k "worker_client"     -v` Expected: the new
+      test FAILS (current code raises "not provisioned");
       `test_worker_client_absent_schema_errors` passes.
 
 - [ ] **Step 3: Implement (prose).** In `aworker_client`, delete the
-      `if queue not in provisioned:` block and its `ImproperlyConfigured` raise. Keep
-      the `provisioned = await client.list_queues()` call wrapped in the schema-absent
-      `except     (InvalidSchemaName, UndefinedTable, UndefinedFunction)` →
-      `ImproperlyConfigured(migrate)` (still the schema guard). `provisioned` is now
-      only used by that guard's success path; if it becomes unused, replace the
-      assignment with a bare `await client.list_queues()` (kept solely to trigger the
-      schema-absent error) — keep a short comment explaining it probes the schema.
+      `if queue not in     provisioned:` block and its raise. Keep
+      `await client.list_queues()` wrapped in the schema-absent
+      `except (InvalidSchemaName, UndefinedTable, UndefinedFunction) →     ImproperlyConfigured(migrate)`
+      (it now only probes the schema). If `provisioned` becomes unused, drop the
+      assignment and call `await client.list_queues()` bare, with a short comment that
+      it probes for the schema-absent guard.
 
 - [ ] **Step 4: Run.** `uv run pytest tests/test_worker.py -k "worker_client" -v`
-      Expected: PASS (new positive test + schema-absent test).
+      Expected: PASS.
 
 - [ ] **Step 5: Commit.**
 
@@ -317,34 +371,32 @@ git commit -m "refactor: aworker_client drops provisioned-or-die check (queues a
 
 ---
 
-### Task 4: `absurd_worker` command — reconcile + report; shared report helper
+### Task 5: `absurd_worker` command — reconcile + report; shared report helper
 
 **Files:**
 
 - Modify: `django_absurd/management/commands/absurd_worker.py` (`handle`: reconcile +
   report before `run_worker`)
-- Modify: `django_absurd/management/commands/absurd_sync_queues.py` (use the shared
-  report helper)
-- Modify: `django_absurd/queues.py` (add shared `write_sync_report` helper)
+- Modify: `django_absurd/management/commands/absurd_sync_queues.py` (delegate to shared
+  helper)
+- Modify: `django_absurd/queues.py` (add `write_sync_report`)
 - Test: `tests/test_worker.py`
 
 **Interfaces:**
 
-- Consumes: `reconcile_queue(backend, queue_name)` (Task 1), `SyncResult`, the command's
-  `self.stdout`/`self.stderr`/`self.style`.
+- Consumes: `reconcile_queue` (Task 2), `SyncResult`, `self.stdout`/`self.stderr`/
+  `self.style`.
 - Produces: `write_sync_report(command, result, prefix="")` in `queues.py` — writes
   `Created: ...` / `Reconciled: ...` to `command.stdout`, `No queues to sync.` when both
-  empty (sync_queues path keeps that wording via prefix), and storage_warnings to
-  `command.stderr` (`command.style.WARNING`). `absurd_worker.handle` calls
-  `reconcile_queue` (wrapped → `CommandError`), then `write_sync_report(self, result)`,
-  then `run_worker(...)`.
+  empty, storage_warnings to `command.stderr` (`command.style.WARNING`).
+  `absurd_worker.handle` calls `reconcile_queue` (wrapped → `CommandError`), then
+  `write_sync_report(self, result)`, then `run_worker(...)`.
 
 - [ ] **Step 1: Write failing tests** in `tests/test_worker.py` (uses existing
-      `run_absurd_worker`/`call_command`, `capsys`, `backend`, `make_group`,
-      `get_task_     result`, `connection`, `CommandError`). REPOINT
-      `test_command_maps_improperly_configured_to_commanderror` (its old trigger —
-      declared- but-unsynced queue → error — now auto-creates) to a schema-absent
-      trigger. New tests:
+      `call_command`, `capsys`, `backend`, `make_group`, `connection`, `CommandError`,
+      and `Queue` — add `from django_absurd.models import Queue` if absent). Also DELETE
+      `test_command_maps_improperly_configured_to_commanderror` (its old trigger now
+      auto- creates; the mapping is covered by the schema-absent test below). New tests:
 
 ```python
 def test_worker_command_reports_created_on_unprovisioned_queue(capsys):
@@ -352,14 +404,44 @@ def test_worker_command_reports_created_on_unprovisioned_queue(capsys):
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
     assert "Created: default" in out
+    assert Queue.objects.filter(queue_name="default").exists()
 
 
-def test_worker_command_reports_reconciled_when_already_provisioned(capsys):
+def test_worker_command_reconciles_changed_mutable_option(settings, capsys):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 100}}},
+        }
+    }
     call_command("absurd_sync_queues")
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 250}}},
+        }
+    }
     capsys.readouterr()  # drop sync output
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
     assert "Reconciled: default" in out
+    assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
+
+
+def test_worker_command_no_reconcile_when_unchanged(settings, capsys):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 100}}},
+        }
+    }
+    call_command("absurd_sync_queues")
+    before = Queue.objects.get(queue_name="default").cleanup_limit
+    capsys.readouterr()
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Reconciled: default" not in out  # drift-gated: nothing changed
+    assert Queue.objects.get(queue_name="default").cleanup_limit == before
 
 
 def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
@@ -378,8 +460,7 @@ def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
     }
     capsys.readouterr()
     call_command("absurd_worker", queue="default", burst=True)
-    err = capsys.readouterr().err
-    assert "storage_mode" in err
+    assert "storage_mode" in capsys.readouterr().err
 
 
 def test_worker_command_schema_absent_errors_migrate():
@@ -393,34 +474,28 @@ def test_worker_command_schema_absent_errors_migrate():
         call_command("migrate", "django_absurd", verbosity=0)
 ```
 
-      Then REPLACE `test_command_maps_improperly_configured_to_commanderror`'s body so it
-      asserts the schema-absent → CommandError path (or delete it as redundant with
-      `test_worker_command_schema_absent_errors_migrate` — note in the commit which).
-
 - [ ] **Step 2: Run, verify FAIL.**
-      `uv run pytest tests/test_worker.py -k     "worker_command" -v` Expected: FAIL (no
-      reconcile/report yet; no `write_sync_report`).
+      `uv run pytest tests/test_worker.py -k "worker_command"     -v` Expected: FAIL (no
+      reconcile/report; no `write_sync_report`).
 
 - [ ] **Step 3: Implement (prose).** (a) In `queues.py`, add
-      `write_sync_report(command,     result, prefix="")`: mirror the current
-      `absurd_sync_queues.Command.report_result` logic but write via
-      `command.stdout.write` / `command.stderr.write` / `command.style.WARNING` (problem
-      text lives in `SyncResult`). (b) Refactor
-      `absurd_sync_queues.Command.report_result` to delegate to
+      `write_sync_report(command,     result, prefix="")` mirroring the current
+      `absurd_sync_queues.Command.report_result`: write `Created: ...`/`Reconciled: ...`
+      (and `No queues to sync.` when both empty) via `command.stdout.write`, and each
+      `storage_warnings` entry via `command.stderr.write(command.style.WARNING(...))`.
+      (b) Refactor `absurd_sync_queues.Command.report_result` to delegate to
       `write_sync_report(self,     result, prefix)` (behavior identical — its existing
-      tests must stay green). (c) In `absurd_worker.Command.handle`, after the existing
-      backend/queue resolution and BEFORE building `WorkerOptions`/calling `run_worker`:
-      call `reconcile_queue(backend, queue)` inside
-      `try/except ImproperlyConfigured → CommandError` (reuse/extend the existing
-      mapping at the bottom), then `write_sync_report(self, result)`. Import
-      `reconcile_queue` and `write_sync_report` (absolute imports). Leave `run_worker`
-      untouched. Keep `report_result`'s "No queues to sync." wording in the helper for
-      the sync command; the worker passes one queue so it always reports Created or
-      Reconciled.
+      tests stay green). (c) In `absurd_worker.Command.handle`, AFTER the existing
+      backend/queue resolution and BEFORE building `WorkerOptions`:
+      `result = reconcile_queue(backend, queue)` inside
+      `try/except     ImproperlyConfigured → CommandError` (reuse/extend the existing
+      mapping), then `write_sync_report(self, result)`. Import `reconcile_queue` and
+      `write_sync_report` (absolute). `run_worker` untouched.
 
 - [ ] **Step 4: Run worker + sync suites.**
       `uv run pytest tests/test_worker.py     tests/test_queue_sync.py -v` Expected:
-      PASS (new worker-command tests + unchanged sync command reporting tests).
+      PASS (new worker-command tests + unchanged sync reporting tests). Then
+      `uv run ruff check django_absurd`.
 
 - [ ] **Step 5: Commit.**
 
@@ -433,130 +508,31 @@ git commit -m "feat: absurd_worker reconciles served queue on boot, reports to s
 
 ---
 
-### Task 5: System checks cleanup (drop W001, narrow W002 to storage_mode)
+## Docs (trailing commit after Task 5, or fold into final review)
 
-**Files:**
-
-- Modify: `django_absurd/checks.py` (drop W001 + `W001_MSG`/`W001_HINT`; narrow W002 to
-  storage_mode-drift; delete `has_option_drifted`, `parse_interval`,
-  `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`; reword `W002_MSG`/`W002_HINT`)
-- Test: `tests/test_checks.py`
-
-**Interfaces:**
-
-- Consumes: existing `query_queue_state(alias, declared)`, `Queue`,
-  `get_declared_queues`.
-- Produces: `query_queue_state` returns `[]` for unreachable / schema-absent / missing /
-  mutable-drift; returns `[W002]` ONLY when an existing queue's declared `storage_mode`
-  differs from the DB.
-
-- [ ] **Step 1: Repoint + add failing tests** in `tests/test_checks.py`. Changes:
-  - DELETE `test_schema_absent_warns_migrate_first` (W001 gone). Optionally replace with
-    a silence assertion (below).
-  - REPOINT `test_drift_warns_run_sync` (missing queue → was W002) to assert NO W002.
-  - REPOINT `test_option_drift_warns` and `test_duration_drift_warns` (mutable drift) to
-    assert NO W002.
-  - REPOINT/REMOVE `test_mixed_missing_and_drifted_hint_names_both` (missing + mutable;
-    now neither) → assert NO W002.
-  - `test_db_unreachable_is_silent`: remove its now-dead reference to the W001 message
-    string; assert only that W002 is absent.
-  - ADD `test_storage_mode_drift_warns`.
-
-```python
-def test_missing_declared_queue_no_longer_warns(settings, capsys):
-    settings.TASKS = build_tasks_setting({"synced": {}})
-    call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "absurd.W002" not in out
-
-
-def test_mutable_option_drift_no_longer_warns(settings, capsys):
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
-    call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "absurd.W002" not in out
-
-
-def test_schema_absent_is_silent(settings, capsys):
-    settings.TASKS = build_tasks_setting({"a": {}})
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
-        out = run_absurd_check(capsys, databases=["default"])
-        assert "absurd.W001" not in out
-        assert "absurd.W002" not in out
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", "django_absurd", verbosity=0)
-
-
-def test_storage_mode_drift_warns(settings, capsys):
-    settings.TASKS = build_tasks_setting({"q": {}})
-    call_command("absurd_sync_queues")  # 'q' created unpartitioned
-    settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "absurd.W002" in out
-    assert "storage_mode" in out
-    assert "q" in out
-```
-
-      Delete the bodies of the four repointed tests and replace with the equivalents above
-      (rename as shown). `test_in_sync_no_warning` (top of file) references the W001 message
-      string — drop that W001 assertion line, keep the W002 one.
-
-- [ ] **Step 2: Run, verify FAIL.** `uv run pytest tests/test_checks.py -v` Expected:
-      the new/repointed tests FAIL (current code still warns on missing/mutable drift
-      and emits W001).
-
-- [ ] **Step 3: Implement (prose).** In `checks.py`: remove `W001_MSG`, `W001_HINT`,
-      `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`, `has_option_drifted`,
-      `parse_interval`. Rewrite `query_queue_state(alias, declared)`: wrap the
-      `Queue.objects` read in `except (OperationalError, ProgrammingError): return []`
-      (schema-absent now silent, folded with unreachable — no W001). Compute
-      `drift = [name for name in declared if     name in actual and declared[name].get("storage_mode") and declared[name]["storage_mode"]     != actual[name].storage_mode]`.
-      If `drift`, return one
-      `DjangoWarning(W002_MSG, hint=     f"{W002_HINT} Affected: {', '.join(drift)}", id="absurd.W002")`.
-      Reword the constants:
-      `W002_MSG = "django-absurd: a queue's declared storage_mode differs from the database     (storage_mode is immutable)."`
-      (problem only);
-      `W002_HINT = "Recreate the queue, or     revert the declared storage_mode."`
-      (resolution only — the affected names are appended at call site). Drop the
-      now-unused imports (`timedelta`, `connections` if only used by `parse_interval`;
-      verify with ruff). `check_absurd_config` (E001-E005) untouched.
-
-- [ ] **Step 4: Run check suite + full suite.** `uv run pytest tests/test_checks.py -v`
-      then `uv run pytest` Expected: PASS. Confirm ruff clean:
-      `uv run ruff check     django_absurd/checks.py` (no unused imports/dead code).
-
-- [ ] **Step 5: Commit.**
-
-```bash
-git add django_absurd/checks.py tests/test_checks.py
-git commit -m "refactor: drop W001, narrow W002 to storage_mode drift (queues auto-create)"
-```
-
----
-
-## Docs (fold into the final review task or a trailing commit)
-
-- `README.md`: Setup section currently lists `absurd_sync_queues` as a required step —
-  reword to "declared queues are created automatically on first enqueue / worker start;
+- `README.md`: the Setup section lists `absurd_sync_queues` as a required step — reword
+  to "declared queues are created automatically on first enqueue / worker start;
   `absurd_sync_queues` remains for explicit/eager provisioning and policy
   reconciliation."
 - `examples/README.md`: the `compose up` flow runs `absurd_sync_queues` explicitly —
-  leave the example as-is (still valid) but note it's now optional.
+  leave it (still valid) but note it's now optional.
 
-## Self-review notes (coverage vs spec)
+## Self-review (coverage vs spec)
 
-- Both seams: Task 2 (enqueue) + Tasks 1/3/4 (worker start). ✓
+- Both seams: Task 3 (enqueue) + Tasks 2/4/5 (worker start). ✓
 - Always-on, declared-bounded, settings source of truth: enqueue + reconcile read
   `get_declared_queues`. ✓
-- `absurd_sync_queues` unchanged externally: Task 1 refactor is behavior-neutral
-  (regression tests retained); Task 4 only reuses its report helper. ✓
-- Worker reports to stdout/stderr: Task 4. ✓
-- Schema-absent → `ImproperlyConfigured(migrate)` at both seams: Task 1 (reconcile) +
-  Task 2 (enqueue). ✓
-- Checks: W001 dropped, W002 storage_mode-only, dead code removed: Task 5. ✓
-- Test inversions enumerated in spec all assigned to a task. ✓
+- Drift-gated reconcile ("don't reconcile if unchanged"; prove via DB value): Task 2
+  logic + Task 5 entrypoint tests (`reconciles_changed_mutable_option` asserts DB ==
+  250; `no_reconcile_when_unchanged` asserts no write). ✓
+- Entrypoint-only testing, no `reconcile_queue` unit tests, parametrized where shared
+  (Task 1 self-healing-drift). ✓
+- `absurd_sync_queues` unchanged externally: Task 2 refactor regression-tested; Task 5
+  only reuses its report helper. ✓
+- Worker reports to stdout/stderr: Task 5. ✓
+- Schema-absent → `ImproperlyConfigured(migrate)` at both seams: Task 2 (reconcile,
+  surfaced via Task 5 worker command) + Task 3 (enqueue). ✓
+- Checks: W001 dropped, W002 storage_mode-only, helpers relocated to `queues.py`: Tasks
+  1 + 2. ✓
+- Deletions: `test_command_maps_improperly_configured_to_commanderror` (Task 5),
+  `test_worker_client_unprovisioned_queue_errors` (Task 4). ✓

--- a/docs/specs/2026-06-24-auto-create-queues-design.md
+++ b/docs/specs/2026-06-24-auto-create-queues-design.md
@@ -55,9 +55,14 @@ In `queues.py`. Does for ONE queue what `sync_queues` loop body does today:
 - opts = `declared[queue_name]`.
 - if queue absent in DB (`Queue.objects.using(db)`): `client.create_queue(name, **opts)`
   → record created.
-- else: apply mutable opts via `set_queue_policy`; storage_mode drift → warning. (same
-  as today.)
+- else: **drift-gate** — only call `set_queue_policy` (and record `reconciled`) if a
+  declared MUTABLE opt actually differs from the DB row. If nothing changed, NO write
+  and NO `reconciled` entry (idempotent no-op — don't churn on every worker boot).
+  storage_mode drift → warning regardless (immutable; can't apply). Drift detection
+  reuses the interval-aware comparison (`has_option_drifted` / `parse_interval`) —
+  RELOCATED here from `checks.py` (see System checks cleanup).
 - returns `SyncResult` (created / reconciled / storage_warnings) scoped to one queue.
+  Unchanged existing queue → all three empty.
 
 `sync_queues(backend)` refactors to loop `reconcile_queue` over declared queues, merging
 results. External behavior identical — command output unchanged.
@@ -164,10 +169,12 @@ Why now: auto-create makes two of the queue-state warnings obsolete.
     `"django-absurd: a queue's declared storage_mode differs from the database (storage_mode is immutable)."`;
     hint `"Recreate the queue, or revert the declared storage_mode. Affected: <names>"`.
     id stays `absurd.W002`.
-  - **Dead code to DELETE** (now unused): `has_option_drifted()`, `parse_interval()`
-    (removes a per-interval DB round-trip), `DURATION_OPTION_KEYS`,
-    `SCALAR_OPTION_KEYS`. NOTE: `MUTABLE_OPTION_KEYS` in `queues.py` STAYS — that's
-    `set_queue_policy`'s reconcile list, unrelated to the check.
+  - **Removed from `checks.py`** (storage_mode is a plain string compare): drop
+    `DURATION_OPTION_KEYS`, `SCALAR_OPTION_KEYS`, and the use of
+    `has_option_drifted`/`parse_interval`. Those two helpers are NOT globally deleted —
+    they RELOCATE to `queues.py` to power `reconcile_queue`'s drift-gating (restricted
+    to `MUTABLE_OPTION_KEYS`, which excludes immutable storage_mode).
+    `MUTABLE_OPTION_KEYS` already lives in `queues.py`.
   - `query_queue_state` collapses:
     `except (OperationalError, ProgrammingError): return []` (schema-absent now silent,
     folded with unreachable); compute storage_mode drift; W002 if any.
@@ -178,35 +185,47 @@ exists + storage_mode drift → W002; all match → `[]`.
 
 ## Testing (real DB, no mocks)
 
-- Enqueue to declared-but-unprovisioned queue → task runs end-to-end (auto-created).
-- Enqueue to UNDECLARED queue → `ImproperlyConfigured`, message names queue.
-- Enqueue with schema absent (drop schema) → schema-absent error (`migrate`), not
-  silent.
-- Enqueue inside outer `atomic()` that auto-creates then retries → outer txn survives,
-  task persists.
-- Worker start on declared-but-unprovisioned queue → drains end-to-end (no command run).
-- Worker command on unprovisioned queue → stdout reports `Created: <queue>` (capsys); on
-  already-provisioned queue → stdout reports `Reconciled: <queue>`.
-- Worker command, storage_mode drift on existing queue → stderr emits the storage
-  warning (capsys), worker still starts.
-- Worker command schema-absent (drop schema) → `CommandError` mentioning migrate.
-- Worker start, undeclared `--queue` → `CommandError`.
-- `reconcile_queue` idempotency: call twice → second is no-op (created once).
-- `reconcile_queue` policy reconcile: change mutable opt → applied; change storage_mode
-  on existing queue → storage_warning surfaced (worker logs it).
-- `sync_queues` regression: existing command tests still pass (refactor
-  behavior-neutral).
-- Enqueue happy path (queue exists) makes NO extra queue-existence query — assert via
-  existing fast-path tests still green (no new round-trip added).
+Test at the ENTRYPOINTS (enqueue API + management commands), never `reconcile_queue`
+directly. Prove reconciliation by asserting the DB `Queue` row VALUES, not just emitted
+text. Parametrize when cases share structure.
+
+Enqueue (entrypoint = `Task.enqueue`):
+
+- Declared-but-unprovisioned queue → task runs end-to-end (auto-created); assert the
+  side-effect (e.g. `Group` row) AND the queue now exists.
+- UNDECLARED queue → `ImproperlyConfigured`, message names the queue.
+- Schema absent (drop schema) → schema-absent error (`migrate`), not silent.
+- Inside outer `atomic()` that auto-creates then retries → outer txn survives, task
+  persists after commit.
+- Happy path (queue exists) makes NO extra queue-existence query — covered by existing
+  fast-path tests staying green (auto-create lives only in `except`).
+
+Worker (entrypoint = `absurd_worker` command, capsys):
+
+- Unprovisioned declared queue → stdout `Created: <queue>`, DB row created, task drains.
+- Provisioned queue, a MUTABLE opt changed in settings → stdout `Reconciled: <queue>`
+  AND the DB `Queue` row reflects the new value (assert e.g. `cleanup_limit == 250`).
+- Provisioned queue, NOTHING changed → drift-gated no-op: NO `Reconciled` line, DB row
+  unchanged.
+- storage_mode drift on existing queue → stderr storage warning (capsys), worker still
+  starts.
+- Schema absent (drop schema) → `CommandError` mentioning migrate.
+- Undeclared `--queue` → `CommandError` (existing command guard).
+
+Refactor regression:
+
+- `sync_queues` / `absurd_sync_queues` existing command tests still pass (Task 1
+  refactor + drift-gating must keep their DB-value assertions green — e.g.
+  `test_sync_reconciles_changed_option_idempotent`).
 
 ### Existing tests that INVERT or change (audit + repoint)
 
 Auto-create flips current "unprovisioned → error" assertions. Plan must address:
 
 - `test_worker.py::test_command_maps_improperly_configured_to_commanderror` — premise
-  (declared-but-unsynced queue → CommandError) now AUTO-CREATES → drains. Repoint the
-  ImproperlyConfigured→CommandError mapping test to a SCHEMA-ABSENT trigger (drop
-  schema, declared queue → CommandError mentioning migrate).
+  (declared-but-unsynced queue → CommandError) now AUTO-CREATES → drains. DELETE it —
+  the `ImproperlyConfigured → CommandError` mapping is covered by the new schema-absent
+  worker command test.
 - `test_worker.py::test_worker_client_unprovisioned_queue_errors` — asserts
   `aworker_client` raises on an unprovisioned queue; that block is deleted. Remove or
   repoint (e.g. fold into the run_worker auto-create-drains test).

--- a/docs/specs/2026-06-24-auto-create-queues-design.md
+++ b/docs/specs/2026-06-24-auto-create-queues-design.md
@@ -1,0 +1,257 @@
+# Auto-create queues — design
+
+## Problem
+
+Queues only exist after running `absurd_sync_queues`. Mandatory manual step before
+enqueue or worker works. Clumsy. Forgetting it → `ImproperlyConfigured` /
+`UndefinedTable`. Goal: declared queues materialize automatically on first use. Command
+no longer required.
+
+## Goal
+
+Declared queues auto-create on demand at two seams (enqueue, worker start). No manual
+command needed for normal use. Settings stays source of truth — only queues declared in
+`TASKS[...]['QUEUES']` auto-create. Always on, no opt-out.
+
+## Constraints
+
+- Floor Django 6.0 / Python 3.12; psycopg3 backend.
+- `absurd.create_queue` already idempotent:
+  `INSERT ... ON CONFLICT (queue_name) DO NOTHING` + `ensure_queue_tables`
+  (`CREATE TABLE IF NOT EXISTS`). Calling on existing queue = no-op. Concurrent creators
+  race harmlessly.
+- Enqueue hot path MUST stay fast — zero added cost when queue exists.
+- Single source of truth for "declared queues + opts": `get_declared_queues(backend)`.
+  Both seams read it. No duplicated validity notion.
+
+## Decisions (locked)
+
+- Both seams auto-create. Always on, no setting.
+- Bounded to declared queues. Undeclared queue name → error (typo protection).
+- `absurd_sync_queues` command: UNCHANGED. No longer required; optional/explicit.
+- Worker start: create + reconcile (mutable policy + storage_mode warning), served queue
+  only. Reconcile runs in the `absurd_worker` COMMAND and REPORTS to stdout/stderr
+  (Created/Reconciled + warnings), like `absurd_sync_queues`.
+- Enqueue: create-only, failure-driven, retry spawn once. NO reconcile (would add DB
+  hits + Python on hot path for no gain — create path only ever sees a missing queue).
+- System checks: CLEANED UP (see below). W001 dropped (schema-absent is a runtime error,
+  not a deploy warning). W002 narrowed to STORAGE_MODE-drift-only (the one condition
+  that never self-heals); missing queues + mutable-option drift no longer warn.
+
+## Architecture
+
+Shared knowledge already centralized: `get_declared_queues(backend)`. New work factors
+the per-queue create+reconcile out of `sync_queues`'s loop body into a reusable
+function.
+
+### New: `reconcile_queue(backend, queue_name) -> SyncResult`
+
+In `queues.py`. Does for ONE queue what `sync_queues` loop body does today:
+
+- `validate_backend(backend.database)` first (clean psycopg3 error standalone;
+  schema-absent DB errors below map to `ImproperlyConfigured("run migrate")`).
+- `declared = get_declared_queues(backend)`; if `queue_name not in declared` → raise
+  `ImproperlyConfigured` (undeclared). Message names queue + points at `TASKS QUEUES`.
+- opts = `declared[queue_name]`.
+- if queue absent in DB (`Queue.objects.using(db)`): `client.create_queue(name, **opts)`
+  → record created.
+- else: apply mutable opts via `set_queue_policy`; storage_mode drift → warning. (same
+  as today.)
+- returns `SyncResult` (created / reconciled / storage_warnings) scoped to one queue.
+
+`sync_queues(backend)` refactors to loop `reconcile_queue` over declared queues, merging
+results. External behavior identical — command output unchanged.
+
+### Seam 1 — worker start (create + reconcile, served queue only)
+
+Reconcile lives in the `absurd_worker` COMMAND (not `run_worker`) so it can REPORT to
+stdout/stderr. `run_worker` blocks on the event loop and never returns in blocking mode,
+so it can't hand a result back — the command must own reconcile + reporting. Bonus:
+`run_worker` stays exactly as today (`validate_backend` + `asyncio.run`), so worker.py
+barely changes.
+
+Command `handle()` flow (after existing backend/queue resolution at `absurd_worker.py`):
+
+- `reconcile_queue(backend, queue)` wrapped in
+  `except ImproperlyConfigured → CommandError` (mapping already in place at
+  `absurd_worker.py:97`).
+- Report the returned `SyncResult` to stdout (`Created: q` / `Reconciled: q`) and stderr
+  (storage_warnings, `style.WARNING`) — REUSE `sync_queues`'s reporting. Extract the
+  command's `report_result(prefix, result)` into a shared helper both commands call
+  (DRY).
+- Then `run_worker(backend, queue, burst=..., options=...)` — UNCHANGED.
+
+`reconcile_queue` itself: calls `validate_backend(backend.database)` first (clean
+psycopg3 error standalone), then create-or-reconcile per the Architecture section.
+
+- `aworker_client`: DELETE the `if queue not in provisioned: raise ImproperlyConfigured`
+  block. Queue guaranteed to exist by the time the async client runs (command reconciled
+  first). Keep aworker_client's schema-absent path as harmless defense — but the
+  command's `reconcile_queue` now hits schema-absent first (see below), so it's no
+  longer the primary guard.
+- **Schema-absent (gap fix):** `reconcile_queue` reads `Queue.objects` + calls
+  `create_queue`, both touching the `absurd` schema. Absent schema → Django
+  `ProgrammingError` (UndefinedTable/UndefinedFunction). `reconcile_queue` MUST catch
+  this and raise
+  `ImproperlyConfigured("Absurd schema is not installed. Run: manage.py migrate")`.
+  Command maps it → `CommandError`.
+- **Undeclared `--queue`:** already rejected by the command at `absurd_worker.py:80`
+  (`queue not in backend.queues` → `CommandError` listing valid queues), BEFORE
+  reconcile. UNCHANGED. `reconcile_queue`'s own undeclared-raise is defense-in-depth /
+  for programmatic callers; not the worker UX path.
+
+### Seam 2 — enqueue (create-only, failure-driven, retry once)
+
+`backends.py` `enqueue`. Happy path untouched — auto-create lives only in `except`.
+
+```
+try:
+    with atomic(savepoint=True):
+        spawn_result = client.spawn(...)
+except (UndefinedTable, UndefinedFunction, InvalidSchemaName):
+    declared = get_declared_queues(self)            # NB self is the backend
+    if task.queue_name not in declared:
+        # "Queue 'X' is not declared in this backend's TASKS QUEUES. Add it to QUEUES
+        #  (or fix the queue name) — only declared queues are auto-created."
+        raise ImproperlyConfigured(undeclared_msg) from None
+    try:
+        client.create_queue(task.queue_name, **declared[task.queue_name])
+    except (UndefinedFunction, InvalidSchemaName):  # schema absent — create can't help
+        # "Absurd schema is not installed. Run: manage.py migrate"
+        raise ImproperlyConfigured(schema_absent_msg) from None
+    with atomic(savepoint=True):                    # retry ONCE
+        spawn_result = client.spawn(...)
+```
+
+- Failed `spawn` inside savepoint → savepoint rollback on except → outer `atomic()`
+  still usable. Then create (DDL; participates in current txn — fine, transactional DDL,
+  idempotent). Then retry spawn in fresh savepoint.
+- Create uses declared opts → `storage_mode` correct from birth.
+- Retry once only. Second failure propagates (not swallowed).
+- `create_queue` uses the existing sync client (`build_absurd_client(self.database)`,
+  Django connection). No new connection.
+
+Note: `get_declared_queues` takes a backend; in `enqueue`, `self` is the backend.
+
+## Errors removed / changed
+
+- Enqueue old `ImproperlyConfigured("... run absurd_sync_queues ...")` → REPLACED by:
+  undeclared-queue error, OR schema-absent error (`run migrate`). No "run sync_queues".
+- Worker `ImproperlyConfigured("Queue X not provisioned. Run absurd_sync_queues")` →
+  GONE (auto-reconciled).
+
+## System checks cleanup
+
+`check_absurd_config` (E001–E005) — UNTOUCHED. Only the DB-level
+`check_absurd_queue_state` → `query_queue_state` changes.
+
+Why now: auto-create makes two of the queue-state warnings obsolete.
+
+- **W001 (schema not migrated) — DROP entirely.** Remove the check branch + `W001_MSG`/
+  `W001_HINT`. Rationale: schema-absent is an ERROR, not a warning — it's now surfaced
+  loudly at runtime (enqueue + worker → `ImproperlyConfigured("run migrate")`). The
+  warning's only non-noisy surface was `check --database`; during `migrate` it nagged
+  you to run the command in progress. `query_queue_state` folds `ProgrammingError`
+  (schema-absent) into the SAME silent path as `OperationalError` → returns `[]`.
+- **W002 — NARROW to STORAGE_MODE-drift-only.** The only condition that never self-heals
+  (storage_mode is immutable; reconcile/worker/command can only warn). Drop the
+  missing-queue trigger (self-heals) AND the mutable-option-drift trigger (self-heals on
+  next worker boot / command). W002 now fires ONLY when an EXISTING queue's declared
+  `storage_mode` differs from the DB.
+  - New `drift` computation:
+    `[name for name in declared if name in actual and declared[name].get("storage_mode") and declared[name]["storage_mode"] != actual[name].storage_mode]`.
+  - **Reword** msg/hint (the W002 tests get rewritten anyway, so favor clarity): msg
+    `"django-absurd: a queue's declared storage_mode differs from the database (storage_mode is immutable)."`;
+    hint `"Recreate the queue, or revert the declared storage_mode. Affected: <names>"`.
+    id stays `absurd.W002`.
+  - **Dead code to DELETE** (now unused): `has_option_drifted()`, `parse_interval()`
+    (removes a per-interval DB round-trip), `DURATION_OPTION_KEYS`,
+    `SCALAR_OPTION_KEYS`. NOTE: `MUTABLE_OPTION_KEYS` in `queues.py` STAYS — that's
+    `set_queue_policy`'s reconcile list, unrelated to the check.
+  - `query_queue_state` collapses:
+    `except (OperationalError, ProgrammingError): return []` (schema-absent now silent,
+    folded with unreachable); compute storage_mode drift; W002 if any.
+
+Resulting `query_queue_state` cases: DB unreachable → `[]`; schema absent → `[]`; queue
+missing → `[]` (was W002); queue exists + mutable drift → `[]` (was W002); queue
+exists + storage_mode drift → W002; all match → `[]`.
+
+## Testing (real DB, no mocks)
+
+- Enqueue to declared-but-unprovisioned queue → task runs end-to-end (auto-created).
+- Enqueue to UNDECLARED queue → `ImproperlyConfigured`, message names queue.
+- Enqueue with schema absent (drop schema) → schema-absent error (`migrate`), not
+  silent.
+- Enqueue inside outer `atomic()` that auto-creates then retries → outer txn survives,
+  task persists.
+- Worker start on declared-but-unprovisioned queue → drains end-to-end (no command run).
+- Worker command on unprovisioned queue → stdout reports `Created: <queue>` (capsys); on
+  already-provisioned queue → stdout reports `Reconciled: <queue>`.
+- Worker command, storage_mode drift on existing queue → stderr emits the storage
+  warning (capsys), worker still starts.
+- Worker command schema-absent (drop schema) → `CommandError` mentioning migrate.
+- Worker start, undeclared `--queue` → `CommandError`.
+- `reconcile_queue` idempotency: call twice → second is no-op (created once).
+- `reconcile_queue` policy reconcile: change mutable opt → applied; change storage_mode
+  on existing queue → storage_warning surfaced (worker logs it).
+- `sync_queues` regression: existing command tests still pass (refactor
+  behavior-neutral).
+- Enqueue happy path (queue exists) makes NO extra queue-existence query — assert via
+  existing fast-path tests still green (no new round-trip added).
+
+### Existing tests that INVERT or change (audit + repoint)
+
+Auto-create flips current "unprovisioned → error" assertions. Plan must address:
+
+- `test_worker.py::test_command_maps_improperly_configured_to_commanderror` — premise
+  (declared-but-unsynced queue → CommandError) now AUTO-CREATES → drains. Repoint the
+  ImproperlyConfigured→CommandError mapping test to a SCHEMA-ABSENT trigger (drop
+  schema, declared queue → CommandError mentioning migrate).
+- `test_worker.py::test_worker_client_unprovisioned_queue_errors` — asserts
+  `aworker_client` raises on an unprovisioned queue; that block is deleted. Remove or
+  repoint (e.g. fold into the run_worker auto-create-drains test).
+- `test_worker.py::test_worker_client_absent_schema_errors` — calls `aworker_client`
+  directly; STAYS valid (aworker_client defense block kept). Add a parallel run_worker /
+  command-level schema-absent test for the reconcile_queue path.
+- `test_enqueue.py::test_enqueue_to_unprovisioned_queue_raises_clear_error` — uses
+  declared `default` → now auto-creates → INVERTS. Repoint to an UNDECLARED queue (e.g.
+  `add.using(queue_name="ghost").enqueue(...)` where ghost ∉ QUEUES) →
+  ImproperlyConfigured naming the queue. Add a sibling: declared-unprovisioned `default`
+  → enqueue succeeds.
+- `test_enqueue.py::test_enqueue_error_does_not_poison_atomic_block` — premise (spawn
+  raises on unprovisioned declared queue) no longer holds; REFRAME to: enqueue inside
+  `atomic()` that auto-creates-then-retries → outer txn usable + task persists
+  (savepoint still the thing under test, now guarding the retry path).
+- `test_enqueue.py::test_enqueue_with_absent_schema_raises_clear_error` — STAYS GREEN:
+  spawn fails → declared → `create_queue` also fails (schema absent) → mapped to
+  `ImproperlyConfigured("migrate")`. Same assertion, new code path. Keep.
+
+Check tests (`tests/test_checks.py`) — W002 is now STORAGE_MODE-drift-only:
+
+- `test_schema_absent_warns_migrate_first` — W001 dropped → REMOVE (or repoint to assert
+  the check is SILENT on schema-absent: no W001/W002 emitted).
+- `test_drift_warns_run_sync` — misnamed; declares a MISSING queue, expects W002.
+  Missing no longer warns → INVERTS. Repoint to assert a declared-but-missing queue
+  emits NO W002 (rename, e.g. `test_missing_declared_queue_no_longer_warns`).
+- `test_option_drift_warns` (cleanup_limit) — mutable drift no longer warns → INVERTS.
+  Repoint to assert NO W002 on mutable drift.
+- `test_duration_drift_warns` (cleanup_ttl) — mutable drift no longer warns → INVERTS.
+  Repoint to assert NO W002 on mutable drift.
+- `test_mixed_missing_and_drifted_hint_names_both` — missing + mutable drift; NEITHER
+  fires now → INVERTS fully. Remove or repoint to NO-W002.
+- **NEW** `test_storage_mode_drift_warns` — create queue unpartitioned, then declare
+  `storage_mode="partitioned"` → W002 with the new storage_mode message + queue name.
+- `test_db_unreachable_is_silent` — STAYS; drop its now-dead reference to the W001
+  message string (assert no W002 only).
+- config-check tests (E001/E002/E003/E004/E005) — UNTOUCHED.
+
+Task-type note: auto-create is task-type-AGNOSTIC (create fires on missing queue tables
+/ worker boot, never sees sync-vs-async). Do NOT parametrize auto-create tests
+sync×async — use a sync task. One async task through a worker-start test is optional
+belt-and-braces, not required.
+
+## Out of scope
+
+- Auto-create for undeclared queues.
+- Per-backend opt-out setting.
+- Reconcile at enqueue.

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -29,6 +29,5 @@ RUN uv sync --locked
 # run a long-lived blocking worker instead.)
 CMD ["sh", "-c", "\
   python manage.py migrate && \
-  python manage.py absurd_sync_queues && \
   python manage.py enqueue_demo && \
   python manage.py absurd_worker --queue default --burst"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,9 @@ That brings up Postgres, waits for it, then the `app` service runs the full flow
 exits `0`:
 
 1. `manage.py migrate` — creates the auth tables **and** the Absurd schema.
-2. `manage.py absurd_sync_queues` — provisions the queues declared in `TASKS`.
+2. `manage.py absurd_sync_queues` — provisions the queues declared in `TASKS`. _Optional
+   now: declared queues auto-create on first enqueue / worker start; kept here to show
+   eager provisioning._
 3. `manage.py enqueue_demo` — enqueues `add(2, 3)`, `create_user("alice")`, and the
    async `create_user_async("alice-async")`.
 4. `manage.py absurd_worker --queue default --burst` — drains the queue, runs all three

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,14 +33,14 @@ That brings up Postgres, waits for it, then the `app` service runs the full flow
 exits `0`:
 
 1. `manage.py migrate` — creates the auth tables **and** the Absurd schema.
-2. `manage.py absurd_sync_queues` — provisions the queues declared in `TASKS`. _Optional
-   now: declared queues auto-create on first enqueue / worker start; kept here to show
-   eager provisioning._
-3. `manage.py enqueue_demo` — enqueues `add(2, 3)`, `create_user("alice")`, and the
-   async `create_user_async("alice-async")`.
-4. `manage.py absurd_worker --queue default --burst` — drains the queue, runs all three
-   tasks (you'll see per-task start/completed logs) — sync tasks in a thread pool, the
-   `async def` task on the event loop — then exits.
+2. `manage.py enqueue_demo` — enqueues `add(2, 3)`, `create_user("alice")`, and the
+   async `create_user_async("alice-async")`. The first enqueue **auto-creates** the
+   `default` queue — no `absurd_sync_queues` step is needed (it stays available for
+   eager provisioning / policy reconciliation).
+3. `manage.py absurd_worker --queue default --burst` — reconciles the queue on start
+   (reporting to stdout), drains it, runs all three tasks (per-task start/completed
+   logs) — sync tasks in a thread pool, the `async def` task on the event loop — then
+   exits.
 
 You'll see the worker execute all three tasks in the logs. Clean up with:
 

--- a/tests/multidb/test_check.py
+++ b/tests/multidb/test_check.py
@@ -17,25 +17,25 @@ def run_absurd_check(capsys, *args, **kwargs):
     return cap.out + cap.err
 
 
-def test_duration_drift_detected_on_non_default_alias(settings, capsys):
+def test_storage_mode_drift_detected_on_non_default_alias(settings, capsys):
+    # W002 now fires only on storage_mode drift (immutable; never self-heals). This
+    # locks the alias threading through query_queue_state on a non-default database.
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
-            "OPTIONS": {
-                "DATABASE": "absurd",
-                "QUEUES": {"d": {"cleanup_ttl": "90 days"}},
-            },
+            "OPTIONS": {"DATABASE": "absurd", "QUEUES": {"d": {}}},
         }
     }
-    call_command("absurd_sync_queues")
+    call_command("absurd_sync_queues")  # 'd' created unpartitioned on alias 'absurd'
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
             "OPTIONS": {
                 "DATABASE": "absurd",
-                "QUEUES": {"d": {"cleanup_ttl": "30 days"}},
+                "QUEUES": {"d": {"storage_mode": "partitioned"}},
             },
         }
     }
     out = run_absurd_check(capsys, databases=["absurd"])
     assert "absurd.W002" in out
+    assert "storage_mode" in out

--- a/tests/multidb/test_check.py
+++ b/tests/multidb/test_check.py
@@ -38,4 +38,8 @@ def test_storage_mode_drift_detected_on_non_default_alias(settings, capsys):
     }
     out = run_absurd_check(capsys, databases=["absurd"])
     assert "absurd.W002" in out
-    assert "storage_mode" in out
+    assert (
+        "django-absurd: a queue's declared storage_mode differs from the database"
+        " (storage_mode is immutable)." in out
+    )
+    assert "Affected: d" in out

--- a/tests/test_async_worker.py
+++ b/tests/test_async_worker.py
@@ -5,8 +5,8 @@ import pytest
 from django.core.management import call_command
 from django.tasks import TaskResultStatus
 
+from django_absurd.backends import get_absurd_backends
 from django_absurd.params import AbsurdSpawnParams
-from django_absurd.queues import get_absurd_backends
 from tests.atasks import (
     aboom,
     acreate_payload,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,11 +1,11 @@
 from django.tasks import task_backends
 
-from django_absurd.backends import AbsurdBackend
-from django_absurd.queues import (
+from django_absurd.backends import (
+    AbsurdBackend,
     get_absurd_backends,
     get_declared_queues,
-    resolve_absurd_database,
 )
+from django_absurd.queues import resolve_absurd_database
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
 EXTENDED = "tests.backends.ExtendedAbsurdBackend"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -32,68 +32,8 @@ def test_in_sync_no_warning(settings, capsys):
     call_command("absurd_sync_queues")
     out = run_absurd_check(capsys, databases=["default"])
     assert (
-        "django-absurd: the absurd schema is not migrated; declared queues cannot be provisioned."
-        not in out
-    )
-    assert (
         "django-absurd: declared queues are out of sync with the database." not in out
     )
-
-
-def test_drift_warns_run_sync(settings, capsys):
-    settings.TASKS = build_tasks_setting({"synced": {}})
-    call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "absurd.W002" in out
-    assert "django-absurd: declared queues are out of sync with the database." in out
-
-
-def test_schema_absent_warns_migrate_first(settings, capsys):
-    settings.TASKS = build_tasks_setting({"a": {}})
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
-        out = run_absurd_check(capsys, databases=["default"])
-        assert "absurd.W001" in out
-        assert (
-            "django-absurd: the absurd schema is not migrated; declared queues cannot be provisioned."
-            in out
-        )
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", "django_absurd", verbosity=0)
-
-
-def test_option_drift_warns(settings, capsys):
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
-    call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "django-absurd: declared queues are out of sync with the database." in out
-
-
-def test_duration_drift_warns(settings, capsys):
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_ttl": "30 days"}})
-    call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_ttl": "60 days"}})
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "django-absurd: declared queues are out of sync with the database." in out
-
-
-def test_mixed_missing_and_drifted_hint_names_both(settings, capsys):
-    settings.TASKS = build_tasks_setting({"present": {"cleanup_limit": 100}})
-    call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting(
-        {
-            "present": {"cleanup_limit": 250},
-            "absent": {},
-        }
-    )
-    out = run_absurd_check(capsys, databases=["default"])
-    assert "django-absurd: declared queues are out of sync with the database." in out
-    assert "present" in out
-    assert "absent" in out
 
 
 def test_db_unreachable_is_silent(settings, capsys):
@@ -104,16 +44,52 @@ def test_db_unreachable_is_silent(settings, capsys):
     try:
         out = run_absurd_check(capsys, databases=["default"])
         assert (
-            "django-absurd: the absurd schema is not migrated; declared queues cannot be provisioned."
-            not in out
-        )
-        assert (
             "django-absurd: declared queues are out of sync with the database."
             not in out
         )
     finally:
         settings.DATABASES["default"]["NAME"] = real_name
         connections["default"].close()
+
+
+@pytest.mark.parametrize(
+    "after",
+    [
+        {"synced": {}, "missing": {}},
+        {"synced": {"cleanup_limit": 250}},
+        {"synced": {"cleanup_ttl": "60 days"}},
+    ],
+    ids=["missing-queue", "mutable-scalar", "mutable-duration"],
+)
+def test_self_healing_drift_no_longer_warns(settings, capsys, after):
+    settings.TASKS = build_tasks_setting({"synced": {}})
+    call_command("absurd_sync_queues")
+    settings.TASKS = build_tasks_setting(after)
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" not in out
+
+
+def test_storage_mode_drift_warns(settings, capsys):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    call_command("absurd_sync_queues")  # 'q' created unpartitioned
+    settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
+    out = run_absurd_check(capsys, databases=["default"])
+    assert "absurd.W002" in out
+    assert "storage_mode" in out
+    assert "q" in out
+
+
+def test_schema_absent_check_is_silent(settings, capsys):
+    settings.TASKS = build_tasks_setting({"a": {}})
+    with connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
+    try:
+        out = run_absurd_check(capsys, databases=["default"])
+        assert "absurd.W001" not in out
+        assert "absurd.W002" not in out
+    finally:
+        call_command("migrate", "django_absurd", "zero", verbosity=0)
+        call_command("migrate", "django_absurd", verbosity=0)
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"])
@@ -201,7 +177,6 @@ def test_multiple_backends_distinct_db_errors(settings, capsys):
 
 
 def test_plain_check_skips_db_state(settings, capsys):
-    # Declared-but-unsynced queue would be W002 drift IF the DB check ran.
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
@@ -214,4 +189,4 @@ def test_check_with_database_runs_db_state(settings, capsys):
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
     out = run_absurd_check(capsys, databases=["default"])
-    assert "absurd.W002" in out
+    assert "absurd.W002" not in out

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -85,6 +85,18 @@ def test_enqueue_to_undeclared_queue_raises():
         add.using(queue_name="ghost").enqueue(1, 2)
 
 
+def test_enqueue_with_empty_queues_reports_undeclared(settings):
+    # Empty QUEUES makes validate_task skip its queue check, reaching the backend guard.
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {}},
+        }
+    }
+    with pytest.raises(ImproperlyConfigured, match="not declared"):
+        add.enqueue(1, 2)
+
+
 def test_enqueue_auto_create_survives_outer_atomic():
     with transaction.atomic():
         make_group.enqueue("inatomic")

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -11,7 +11,7 @@ from django.tasks.exceptions import InvalidTask
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.queues import get_absurd_client
-from tests.tasks import add, with_default_attempts
+from tests.tasks import add, make_group, with_default_attempts
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -71,22 +71,26 @@ def test_aenqueue_lands():
     assert len(claim_one()) == 1
 
 
-def test_enqueue_to_unprovisioned_queue_raises_clear_error():
-    with pytest.raises(ImproperlyConfigured) as exc:
-        add.enqueue(1, 2)
-    message = str(exc.value)
-    assert "default" in message
-    assert "absurd_sync_queues" in message
+def test_enqueue_auto_creates_declared_queue_and_runs():
+    # 'default' declared but unprovisioned (no absurd_sync_queues). Enqueue auto-creates
+    # it; the worker then runs the task end-to-end.
+    make_group.enqueue("auto")
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="auto").exists()
 
 
-def test_enqueue_error_does_not_poison_atomic_block():
-    # Unprovisioned queue -> spawn raises UndefinedTable, aborting the DB transaction.
-    # A savepoint must contain that abort so the surrounding atomic() stays usable.
+def test_enqueue_to_undeclared_queue_raises():
+    # 'ghost' is not in TASKS QUEUES; validate_task raises InvalidTask naming the queue.
+    with pytest.raises(InvalidTask, match="ghost"):
+        add.using(queue_name="ghost").enqueue(1, 2)
+
+
+def test_enqueue_auto_create_survives_outer_atomic():
     with transaction.atomic():
-        with pytest.raises(ImproperlyConfigured):
-            add.enqueue(1, 2)  # no absurd_sync_queues -> t_default missing
-        # outer transaction must still be usable after the caught error
-        assert Group.objects.count() == 0
+        make_group.enqueue("inatomic")
+        assert Group.objects.count() == 0  # nothing committed yet
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="inatomic").exists()
 
 
 def test_enqueue_with_absent_schema_raises_clear_error():

--- a/tests/test_queue_sync.py
+++ b/tests/test_queue_sync.py
@@ -89,6 +89,14 @@ def test_non_destructive(settings):
     assert Queue.objects.filter(queue_name="keep").exists()
 
 
+def test_sync_reports_no_queues_when_all_in_sync(settings, capsys):
+    settings.TASKS = build_tasks_setting({"q": {}})
+    call_command("absurd_sync_queues")  # creates q
+    capsys.readouterr()
+    call_command("absurd_sync_queues")  # q exists, no drift -> empty result
+    assert "No queues to sync." in capsys.readouterr().out
+
+
 def test_get_absurd_database_resolves_from_backend(settings):
     settings.TASKS = build_tasks_setting({}, database="default")
     assert resolve_absurd_database() == "default"

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -9,8 +9,9 @@ from django.db import connections, transaction
 from django.tasks import TaskResultStatus
 from django.tasks.exceptions import TaskResultDoesNotExist
 
+from django_absurd.backends import get_absurd_backends
 from django_absurd.params import AbsurdSpawnParams
-from django_absurd.queues import get_absurd_backends, get_absurd_client
+from django_absurd.queues import get_absurd_client
 from tests.models import Payload
 from tests.tasks import add, boom, echo
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10,9 +10,10 @@ from django.core.management import call_command, load_command_class
 from django.core.management.base import CommandError
 from django.db import connection, connections
 
+from django_absurd.backends import get_absurd_backends
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.models import Queue
-from django_absurd.queues import get_absurd_backends, get_absurd_client
+from django_absurd.queues import get_absurd_client
 from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
 from tests.atasks import aecho
 from tests.jobs import record_from_jobs

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -217,7 +217,7 @@ def test_command_burst_runs_task_end_to_end():
 def test_worker_command_reports_created_on_unprovisioned_queue(capsys):
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
-    assert "Created: default" in out
+    assert out == "Created: default\nStarted worker on queue 'default'.\n"
     assert Queue.objects.filter(queue_name="default").exists()
 
 
@@ -238,7 +238,7 @@ def test_worker_command_reconciles_changed_mutable_option(settings, capsys):
     capsys.readouterr()  # drop sync output
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
-    assert "Reconciled: default" in out
+    assert out == "Reconciled: default\nStarted worker on queue 'default'.\n"
     assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
 
 
@@ -265,7 +265,7 @@ def test_worker_command_reconciles_changed_interval_option(settings, capsys):
     capsys.readouterr()
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
-    assert "Reconciled: default" in out
+    assert out == "Reconciled: default\nStarted worker on queue 'default'.\n"
     assert Queue.objects.get(queue_name="default").cleanup_ttl == timedelta(days=60)
 
 
@@ -281,7 +281,8 @@ def test_worker_command_no_reconcile_when_unchanged(settings, capsys):
     capsys.readouterr()
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
-    assert "Reconciled: default" not in out  # drift-gated: nothing changed
+    # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just the start line.
+    assert out == "Started worker on queue 'default'.\n"
     assert Queue.objects.get(queue_name="default").cleanup_ttl == before
 
 
@@ -301,7 +302,12 @@ def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
     }
     capsys.readouterr()
     call_command("absurd_worker", queue="default", burst=True)
-    assert "storage_mode" in capsys.readouterr().err
+    cap = capsys.readouterr()
+    assert cap.out == "Started worker on queue 'default'.\n"
+    assert cap.err == (
+        "Queue 'default': storage_mode cannot be changed "
+        "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
+    )
 
 
 def test_worker_command_schema_absent_errors_migrate():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,6 +11,7 @@ from django.core.management.base import CommandError
 from django.db import connection, connections
 
 from django_absurd.connection import register_jsonb_loader
+from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_backends, get_absurd_client
 from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
 from tests.atasks import aecho
@@ -211,7 +212,70 @@ def test_command_burst_runs_task_end_to_end():
     assert get_task_result(result.id).state == "completed"
 
 
-def test_command_maps_improperly_configured_to_commanderror():
+def test_worker_command_reports_created_on_unprovisioned_queue(capsys):
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Created: default" in out
+    assert Queue.objects.filter(queue_name="default").exists()
+
+
+def test_worker_command_reconciles_changed_mutable_option(settings, capsys):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 100}}},
+        }
+    }
+    call_command("absurd_sync_queues")
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 250}}},
+        }
+    }
+    capsys.readouterr()  # drop sync output
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Reconciled: default" in out
+    assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
+
+
+def test_worker_command_no_reconcile_when_unchanged(settings, capsys):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 100}}},
+        }
+    }
+    call_command("absurd_sync_queues")
+    before = Queue.objects.get(queue_name="default").cleanup_limit
+    capsys.readouterr()
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Reconciled: default" not in out  # drift-gated: nothing changed
+    assert Queue.objects.get(queue_name="default").cleanup_limit == before
+
+
+def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {}}},
+        }
+    }
+    call_command("absurd_sync_queues")  # create 'default' unpartitioned
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {"storage_mode": "partitioned"}}},
+        }
+    }
+    capsys.readouterr()
+    call_command("absurd_worker", queue="default", burst=True)
+    assert "storage_mode" in capsys.readouterr().err
+
+
+def test_worker_command_schema_absent_errors_migrate():
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -63,25 +63,14 @@ def test_worker_client_rejects_non_psycopg3(settings):
         call_command("absurd_worker", queue="default", burst=True)
 
 
-def test_worker_client_unprovisioned_queue_errors(settings):
-    call_command("absurd_sync_queues")
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "QUEUES": ["default", "unsynced"],
-            "OPTIONS": {"DATABASE": "default"},
-        }
-    }
-
+def test_worker_client_opens_without_provisioning_check():
+    # No absurd_sync_queues; 'default' unprovisioned (schema present). aworker_client must
+    # NOT raise — the provisioned-or-die check is gone.
     async def _enter():
-        async with aworker_client(backend(), "unsynced"):
-            pass
+        async with aworker_client(backend(), "default") as client:
+            return await client.list_queues()
 
-    with pytest.raises(ImproperlyConfigured) as exc:
-        asyncio.run(_enter())
-    message = str(exc.value)
-    assert "unsynced" in message
-    assert "absurd_sync_queues" in message
+    assert "default" not in asyncio.run(_enter())  # unprovisioned, yet no error
 
 
 def test_worker_client_absent_schema_errors():
@@ -222,18 +211,15 @@ def test_command_burst_runs_task_end_to_end():
     assert get_task_result(result.id).state == "completed"
 
 
-def test_command_maps_improperly_configured_to_commanderror(settings):
-    call_command("absurd_sync_queues")
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "QUEUES": ["default", "unsynced"],
-            "OPTIONS": {"DATABASE": "default"},
-        }
-    }
-    with pytest.raises(CommandError) as exc:
-        call_command("absurd_worker", queue="unsynced", burst=True)
-    assert "unsynced" in str(exc.value)
+def test_command_maps_improperly_configured_to_commanderror():
+    with connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
+    try:
+        with pytest.raises(CommandError, match="migrate"):
+            call_command("absurd_worker", queue="default", burst=True)
+    finally:
+        call_command("migrate", "django_absurd", "zero", verbosity=0)
+        call_command("migrate", "django_absurd", verbosity=0)
 
 
 def test_start_worker_drains_concurrently():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from datetime import timedelta
 
 import psycopg
 import pytest
@@ -241,20 +242,47 @@ def test_worker_command_reconciles_changed_mutable_option(settings, capsys):
     assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
 
 
+def test_worker_command_reconciles_changed_interval_option(settings, capsys):
+    # Two mutable opts: cleanup_limit unchanged (loop continues), cleanup_ttl changed
+    # (interval drift via parse_interval).
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {
+                "QUEUES": {"default": {"cleanup_limit": 100, "cleanup_ttl": "30 days"}}
+            },
+        }
+    }
+    call_command("absurd_sync_queues")
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {
+                "QUEUES": {"default": {"cleanup_limit": 100, "cleanup_ttl": "60 days"}}
+            },
+        }
+    }
+    capsys.readouterr()
+    call_command("absurd_worker", queue="default", burst=True)
+    out = capsys.readouterr().out
+    assert "Reconciled: default" in out
+    assert Queue.objects.get(queue_name="default").cleanup_ttl == timedelta(days=60)
+
+
 def test_worker_command_no_reconcile_when_unchanged(settings, capsys):
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 100}}},
+            "OPTIONS": {"QUEUES": {"default": {"cleanup_ttl": "30 days"}}},
         }
     }
     call_command("absurd_sync_queues")
-    before = Queue.objects.get(queue_name="default").cleanup_limit
+    before = Queue.objects.get(queue_name="default").cleanup_ttl
     capsys.readouterr()
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
     assert "Reconciled: default" not in out  # drift-gated: nothing changed
-    assert Queue.objects.get(queue_name="default").cleanup_limit == before
+    assert Queue.objects.get(queue_name="default").cleanup_ttl == before
 
 
 def test_worker_command_warns_on_storage_mode_drift(settings, capsys):


### PR DESCRIPTION
Declared queues auto-create on first use — `absurd_sync_queues` no longer required.

- **Enqueue**: on missing-queue `spawn` failure, create the declared queue, retry once (savepoint-isolated).
- **Worker start**: `absurd_worker` reconciles the served queue (drift-gated) and reports Created/Reconciled to stdout, storage warnings to stderr.
- **Checks**: drop W001 (schema-absent is a runtime error); narrow W002 to immutable `storage_mode` drift.
- Bounded to queues declared in `TASKS[...]['QUEUES']`; undeclared queues still rejected.

## How tested
135 single-DB + 6 multi-DB; ruff + mypy clean. Per-task + final + adversarial review.
