### PR TITLE
Docs quickstart tidy + --queue default + fix PG18 example

### DIFF
--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -3,8 +3,8 @@ name: sync-docs
 description:
   Use when a change touches user-facing behavior — management commands or their flags,
   TASKS / OPTIONS settings, the enqueue or params API, defaults, the setup flow, or
-  system checks. Keeps the project's docs in sync with the code so updates don't get
-  lost in context.
+  system checks. Keeps README.md, the AGENTS.md integration guide, AND the runnable
+  example (examples/) in sync with the code so updates don't get lost in context.
 ---
 
 # sync-docs
@@ -48,9 +48,12 @@ A change triggers a doc pass if it touches any of:
    it in AGENTS.md and link instead.
 2. **AGENTS.md** — update the relevant section (Configure / Run / Validate / Enqueue /
    Workers / Results / Deployment / Adopting). This is where completeness lives.
-3. **examples/** — if the change alters the run flow or a demonstrated capability,
-   update `examples/README.md` and the runnable bits (`Dockerfile` CMD, `demo/tasks.py`,
-   `enqueue_demo`). Prefer demonstrating the simplest happy path.
+3. **examples/** — always check the example when the run flow or a demonstrated
+   capability changes. Update `examples/README.md` AND the runnable bits it documents
+   (`Dockerfile` CMD, `compose.yaml`, `demo/tasks.py`, `enqueue_demo`), kept to the
+   simplest happy path. If the flow changed, re-run it
+   (`docker compose up --build --abort-on-container-exit`) to confirm it still exits
+   `0`.
 4. **Cross-check copy** — exact command names, flag names, message text, and defaults
    must match the code verbatim across all three files.
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ separate broker — reusing Django's own database connection.
 ## Install
 
 ```console
-pip install django-absurd          # add --pre for alpha (pre-release) versions
+pip install django-absurd
 ```
 
 ## Quickstart
 
-Add the app, register the router, and point Django's `TASKS` setting at the backend:
+Add the app and point Django's `TASKS` setting at the backend:
 
 ```python
 # settings.py
-INSTALLED_APPS = [..., "django_absurd"]
-DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
+INSTALLED_APPS = [
+    # ...
+    "django_absurd",
+]
 
 TASKS = {
     "default": {
@@ -37,20 +39,23 @@ TASKS = {
 ```
 
 ```console
-python manage.py migrate          # install Absurd's schema (shipped, offline)
-python manage.py absurd_worker    # run a worker
+python manage.py migrate                       # create the Absurd schema
+python manage.py absurd_worker --queue default # run a worker
 ```
 
-Define tasks with Django's Tasks API and enqueue them — the declared queue is **created
-automatically** on first use, so there's no provisioning step:
+Define a task with Django's Tasks API and enqueue it — the declared queue is **created
+automatically** on first use:
 
 ```python
 from django.tasks import task
 
-@task
-def send_report(user_id): ...
 
-send_report.enqueue(42)
+@task
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+result = add.enqueue(2, 3)  # returns a TaskResult; the worker runs it
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -33,18 +33,17 @@ INSTALLED_APPS = [
 TASKS = {
     "default": {
         "BACKEND": "django_absurd.backends.AbsurdBackend",
-        "QUEUES": ["default"],  # queue names this app enqueues to
     },
 }
 ```
 
 ```console
-python manage.py migrate                       # create the Absurd schema
-python manage.py absurd_worker --queue default # run a worker
+python manage.py migrate          # create the Absurd schema
+python manage.py absurd_worker    # run a worker (consumes the "default" queue)
 ```
 
-Define a task with Django's Tasks API and enqueue it — the declared queue is **created
-automatically** on first use:
+Define a task with Django's Tasks API and enqueue it — the `"default"` queue is
+**created automatically** on first use:
 
 ```python
 from django.tasks import task

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -28,10 +28,13 @@ INSTALLED_APPS = [
 TASKS = {
     "default": {
         "BACKEND": "django_absurd.backends.AbsurdBackend",
-        "QUEUES": ["default"],  # queue names this app enqueues to
+        "QUEUES": ["default"],  # optional — defaults to ["default"]
     },
 }
 ```
+
+`QUEUES` is optional: omit it to use just the `"default"` queue. List names here for
+additional queues, or use `OPTIONS["QUEUES"]` (below) to set per-queue policy.
 
 Backend `OPTIONS` (all optional):
 
@@ -107,7 +110,8 @@ defer, and priority are not.
 ## Workers
 
 ```bash
-python manage.py absurd_worker --queue default
+python manage.py absurd_worker            # consumes the "default" queue
+python manage.py absurd_worker --queue reports
 ```
 
 A single worker runs **both** sync and async tasks: `async def` tasks run on an event
@@ -117,6 +121,7 @@ changes) and reports to stdout.
 
 - **Blocking** (default): long-running; polls until `SIGINT`/`SIGTERM`.
 - **Burst** (`--burst`): drain the current backlog, then exit `0` (cron / one-shot).
+- `--queue` (default `"default"`): which queue to consume.
 - `--concurrency N` (default `1`): max tasks in flight — sizes both the event-loop
   concurrency and the sync thread pool. Other flags: `--claim-timeout`,
   `--poll-interval`, `--batch-size`, `--worker-id`, and `--alias` (required only when

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -17,15 +17,13 @@ database connection and ships Absurd's schema as Django migrations — no separa
 
 ## Configure
 
-Add the app, register the router, and point Django's `TASKS` setting at the backend:
+Add the app and point Django's `TASKS` setting at the backend:
 
 ```python
 INSTALLED_APPS = [
     # ...
     "django_absurd",
 ]
-
-DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
 
 TASKS = {
     "default": {
@@ -42,6 +40,13 @@ Backend `OPTIONS` (all optional):
 - `QUEUES` — a map of queue name → `absurd_sdk.CreateQueueOptions` for per-queue config.
   Use this _instead of_ the top-level `QUEUES` list (which only names queues) — declare
   queues in one place or the other, never both (setting both is a configuration error).
+
+Only when you point `DATABASE` at a **non-default** alias, also register the router so
+django-absurd's schema and queries route to that database:
+
+```python
+DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
+```
 
 ## Run
 

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -13,7 +13,11 @@ class Command(AbsurdReportCommand):
     help = "Start the Absurd task worker."
 
     def add_arguments(self, parser: t.Any) -> None:
-        parser.add_argument("--queue", required=True, help="Queue name to consume.")
+        parser.add_argument(
+            "--queue",
+            default="default",
+            help="Queue name to consume (default: 'default').",
+        )
         parser.add_argument(
             "--alias",
             default=None,

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -30,4 +30,4 @@ RUN uv sync --locked
 CMD ["sh", "-c", "\
   python manage.py migrate && \
   python manage.py enqueue_demo && \
-  python manage.py absurd_worker --queue default --burst"]
+  python manage.py absurd_worker --burst"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,10 +37,10 @@ exits `0`:
    async `create_user_async("alice-async")`. The first enqueue **auto-creates** the
    `default` queue — no `absurd_sync_queues` step is needed (it stays available for
    eager provisioning / policy reconciliation).
-3. `manage.py absurd_worker --queue default --burst` — reconciles the queue on start
-   (reporting to stdout), drains it, runs all three tasks (per-task start/completed
-   logs) — sync tasks in a thread pool, the `async def` task on the event loop — then
-   exits.
+3. `manage.py absurd_worker --burst` — consumes the `"default"` queue (the default);
+   reconciles it on start (reporting to stdout), drains it, runs all three tasks
+   (per-task start/completed logs) — sync tasks in a thread pool, the `async def` task
+   on the event loop — then exits.
 
 You'll see the worker execute all three tasks in the logs. Clean up with:
 
@@ -61,7 +61,7 @@ docker compose run --rm app python manage.py enqueue_demo
 
 # Run a long-lived blocking worker (Ctrl-C to stop). --concurrency N sizes both the
 # event-loop concurrency (async tasks) and the sync thread pool.
-docker compose run --rm app python manage.py absurd_worker --queue default --concurrency 4
+docker compose run --rm app python manage.py absurd_worker --concurrency 4
 
 # Validate the TASKS / queue configuration
 docker compose run --rm app python manage.py check

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -11,7 +11,8 @@ services:
     image: postgres:18-alpine
     # No host port published — the app connects over the compose network (db:5432).
     volumes:
-      - pgdata:/var/lib/postgresql/data/
+      # PG18+ stores data under /var/lib/postgresql (a major-version subdir), not /data.
+      - pgdata:/var/lib/postgresql
 
   app:
     build:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -158,9 +158,12 @@ def test_task_outside_tasks_py_runs():
     assert get_task_result(result.id).result == "from-jobs"
 
 
-def test_queue_is_required():
-    with pytest.raises(CommandError):
-        call_command("absurd_worker")
+def test_queue_defaults_to_default(capsys):
+    make_group.enqueue("dflt")  # auto-creates the default queue
+    call_command("absurd_worker", burst=True)  # no --queue -> "default"
+    out = capsys.readouterr().out
+    assert out == "Started worker on queue 'default'.\n"
+    assert Group.objects.filter(name="dflt").exists()
 
 
 def test_unknown_queue_errors_listing_valid(settings):
@@ -195,8 +198,8 @@ def test_ambiguous_alias_requires_flag(settings):
 def test_command_parses_all_flags_with_defaults():
     cmd = load_command_class("django_absurd", "absurd_worker")
     parser = cmd.create_parser("manage.py", "absurd_worker")
-    opts = vars(parser.parse_args(["--queue", "default"]))
-    assert opts["queue"] == "default"
+    opts = vars(parser.parse_args([]))
+    assert opts["queue"] == "default"  # --queue defaults to "default"
     assert opts["alias"] is None
     assert opts["burst"] is False
     assert opts["concurrency"] == 1


### PR DESCRIPTION
Follow-up doc/ergonomics tidy after the auto-create-queues merge.

- **README** trimmed to the happy path: drop the router line (only needed for a non-default `DATABASE`), `--pre`, "shipped/offline" and "provisioning step" wording; wrap `INSTALLED_APPS`; a complete `add(a, b)` task example. `QUEUES` no longer shown (it defaults to `["default"]`).
- **`--queue` is now optional**, defaulting to `"default"` — `absurd_worker` runs bare.
- **AGENTS.md** marks the router non-default-only and `QUEUES`/`--queue` optional.
- **`/sync-docs` skill** now explicitly maintains `examples/`.
- **Fix:** PG18 (Renovate bump #14) changed the data dir — mount `pgdata` at `/var/lib/postgresql`; the dockerized example was broken on main.

## How tested
138 single-DB + 6 multi-DB; ruff + mypy clean. Dockerized example re-run end-to-end, exits 0.
