### PR TITLE
Add /release skill; sync-docs covers CLAUDE.md

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: release
+description:
+  Use when cutting a django-absurd release to PyPI — deciding the next version (with the
+  human), drafting notes, and creating the GitHub Release that triggers publish.yml.
+  Heavy human-in-the-loop: the human chooses the version and approves the cut; the pypi
+  environment reviewer is a second, built-in gate.
+---
+
+# release
+
+## Overview
+
+How django-absurd ships to PyPI. Releases are **driven from GitHub Releases**, not tag
+pushes: `.github/workflows/publish.yml` triggers on `release: published`, builds
+(`uv build`), publishes via **Trusted Publishing** (OIDC, no tokens), and attaches the
+wheel + sdist to the release. The version is derived from the `v*` tag by **hatch-vcs**
+— PEP 440, no file to bump.
+
+This is a **heavy human-in-the-loop** workflow. The assistant prepares and proposes; the
+**human decides and approves** at every consequential step. Three gates:
+
+1. **Version choice** — the human picks the version. NEVER auto-increment and proceed;
+   present options with reasoning and stop for an explicit choice.
+2. **Cut approval** — the human approves the exact version + notes before the release is
+   created.
+3. **PyPI deployment** — the `pypi` GitHub environment has a required reviewer; the
+   publish job pauses until a human approves the deployment in the Actions run (the
+   assistant cannot approve it).
+
+Never bypass a gate. Never `git tag && git push` a version tag directly — that creates
+no Release and won't publish.
+
+## Choosing the version — the human decides
+
+Do **not** mechanically bump the last tag. The version is a judgement call about what
+changed and how stable it is. The assistant's job is to **lay out the options and the
+reasoning, then ask** — present the change summary, map it to candidate versions, and
+let the human choose. Surface disagreement (e.g. "these look like breaking changes, so
+I'd lean beta over another alpha — your call").
+
+**Where we are:** pre-1.0, the `0.1.0` line, shipping **alpha** pre-releases (`v0.1.0a1`
+→ `a2` → `a3`). The history: `git tag --list 'v*' | sort -V`.
+
+**PEP 440 pre-release suffixes** (what `pip` does):
+
+- `aN` (alpha), `bN` (beta), `rcN` (release candidate) — all install only with
+  `pip install --pre`. Tag each with the GitHub **"pre-release"** flag.
+- no suffix (`v0.1.0`) — the real release; installs by default.
+
+**How to reason about the next number (present these, let the human pick):**
+
+- **Another alpha** (`a(N+1)`) — still iterating toward `0.1.0`; API/behavior still
+  moving. The default during this phase.
+- **Move to beta / rc** (`b1` / `rc1`) — feature-set for `0.1.0` is settling; you want
+  wider testing without more API churn. A deliberate phase change — confirm intent.
+- **Bump the target line** (`0.2.0aN`, etc.) — only if scope grew enough that `0.1.0` no
+  longer names it.
+- **Semantic versioning** governs the target line. Pre-1.0 (`0.x`): the API is unstable,
+  so a `0.MINOR` bump may include breaking changes; `0.x.PATCH` is for fixes. Post-1.0:
+  MAJOR = breaking, MINOR = backward-compatible features, PATCH = fixes. The first
+  stable cut is `v0.1.0` (no suffix) — a separate, explicit decision (see Guardrails).
+
+## Steps
+
+1. **Pre-flight.**
+   - Release is cut from up-to-date `main`:
+     `git fetch origin && git log --oneline origin/main -1`.
+   - CI is green on that commit (`gh run list --branch main --limit 5`). Don't release
+     red `main`.
+2. **Summarize what changed** since the last tag — merged PRs / commits
+   (`git log --oneline <last-tag>..origin/main`). This is the input to the version
+   decision and the notes.
+3. **GATE 1 — version choice (human decides).** Present the change summary and the
+   candidate versions from "Choosing the version" above, each with its reasoning and
+   your recommendation. STOP. Do not pick for them. Proceed only with an explicitly
+   chosen version string.
+4. **Draft notes** for the chosen version (user-facing). `gh release create` can
+   `--generate-notes`, or hand-write `--notes`.
+5. **GATE 2 — cut approval.** Show the final version + pre-release flag + notes. STOP
+   for an explicit "yes." Cutting is outward and effectively irreversible — a published
+   PyPI version can never be reused.
+6. **Create the release** (creates the tag AND triggers `publish.yml`):
+
+   ```bash
+   gh release create v0.1.0aN --target main --prerelease \
+     --title v0.1.0aN --generate-notes        # or --notes "..."
+   ```
+
+   Use `--prerelease` for any `a`/`b`/`rc`; omit it only for a final release.
+   `--target main` ties the tag to `main`'s HEAD.
+
+7. **GATE 3 — approve the PyPI deployment (human, in GitHub).** The publish job waits on
+   the `pypi` environment reviewer. Tell the human: **Actions → the running "Publish to
+   PyPI" run → Review deployments → approve `pypi`.** The assistant cannot approve it.
+8. **Verify.** The workflow attaches wheel + sdist to the release and PyPI shows the
+   version. Confirm `pip install --pre django-absurd==<version>` resolves (pre-releases
+   need `--pre`) and the release page has the two assets.
+
+## Guardrails
+
+- Trusted Publishing (OIDC) — no API tokens. Auth is the `pypi` environment + the
+  Publisher registered on pypi.org (a one-time manual PyPI setup, already done for this
+  project).
+- The `pypi` environment restricts deployments to `v*` tags and requires a reviewer
+  (`marcgibbons`).
+- **First stable (non-pre) `v0.1.0`** is its own deliberate decision — confirm the API
+  is ready, and first ensure README + LICENSE + license metadata are in place (twine
+  warns on a missing long_description for pre-releases today).
+- A mistaken release: you can delete the GitHub release + its tag, but a published PyPI
+  version is permanent — yank it, never reuse the number; cut the next pre-release
+  instead.
+- See `.github/workflows/publish.yml` for the authoritative pipeline.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -3,8 +3,9 @@ name: sync-docs
 description:
   Use when a change touches user-facing behavior — management commands or their flags,
   TASKS / OPTIONS settings, the enqueue or params API, defaults, the setup flow, or
-  system checks. Keeps README.md, the AGENTS.md integration guide, AND the runnable
-  example (examples/) in sync with the code so updates don't get lost in context.
+  system checks, or project conventions. Keeps README.md, the AGENTS.md integration
+  guide, the runnable example (examples/), and CLAUDE.md (maintenance) in sync with the
+  code so updates don't get lost in context.
 ---
 
 # sync-docs
@@ -21,12 +22,13 @@ reference**.
 
 ## Audience map — where each fact lives
 
-| File                               | Audience                                     | Role / altitude                                                                                                                                                                                                                                                                                                     |
-| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `README.md`                        | repo landing                                 | **Trim.** The tl;dr happy path only: one-liner + alpha note, `pip install`, a ~10-line quickstart (TASKS snippet → `migrate` → `absurd_worker`, "queues auto-create"), then a short **Documentation** section linking out. **Never grow it** — new detail goes to AGENTS.md, not here.                              |
-| `django_absurd/AGENTS.md`          | **end users** (devs integrating the package) | The **full reference**: requirements, configuration + every `OPTIONS` key, run, validate (`check`), workers, enqueue + params, retrieving results, deployment notes, adopting an existing DB. Ships inside the installed package, so it is discoverable from a project's venv. Canonical until the doc site exists. |
-| `examples/README.md` + `examples/` | runnable demo                                | A working dockerized project. Keep the **flow accurate**: `Dockerfile` CMD, `compose.yaml`, `demo/tasks.py`, `enqueue_demo`, and the "Run it" steps must match real behavior.                                                                                                                                       |
-| `docs/specs/`, `docs/plans/`       | design history                               | NOT user docs. Design intent / decisions. Leave to `capture-why` / `archive-specs`; don't treat as the place to document features.                                                                                                                                                                                  |
+| File                               | Audience                                     | Role / altitude                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`                        | repo landing                                 | **Trim.** The tl;dr happy path only: one-liner + alpha note, `pip install`, a ~10-line quickstart (TASKS snippet → `migrate` → `absurd_worker`, "queues auto-create"), then a short **Documentation** section linking out. **Never grow it** — new detail goes to AGENTS.md, not here.                                                                  |
+| `django_absurd/AGENTS.md`          | **end users** (devs integrating the package) | The **full reference**: requirements, configuration + every `OPTIONS` key, run, validate (`check`), workers, enqueue + params, retrieving results, deployment notes, adopting an existing DB. Ships inside the installed package, so it is discoverable from a project's venv. Canonical until the doc site exists.                                     |
+| `examples/README.md` + `examples/` | runnable demo                                | A working dockerized project. Keep the **flow accurate**: `Dockerfile` CMD, `compose.yaml`, `demo/tasks.py`, `enqueue_demo`, and the "Run it" steps must match real behavior.                                                                                                                                                                           |
+| `CLAUDE.md`                        | **contributors / coding agents**             | Project **maintenance** only: naming, imports, testing conventions, runtime floor (Django / Python), tooling. NOT how-to — it _references_ `AGENTS.md` for usage/integration and must not duplicate it. Changes on convention / tooling / test-setup / runtime shifts (a different trigger from the user docs above; only the runtime floor is shared). |
+| `docs/specs/`, `docs/plans/`       | design history                               | NOT user docs. Design intent / decisions. Leave to `capture-why` / `archive-specs`; don't treat as the place to document features.                                                                                                                                                                                                                      |
 
 ## When to act
 
@@ -40,6 +42,8 @@ A change triggers a doc pass if it touches any of:
 - the **setup / run flow** (what a user must run, and in what order)
 - **system checks** (which fire, their messages/hints)
 - backend **capabilities** (`supports_*`)
+- project **conventions / tooling / testing setup / runtime floor** — these live in
+  `CLAUDE.md` (maintenance), a separate trigger from user-facing behavior
 
 ## Checklist
 
@@ -54,13 +58,18 @@ A change triggers a doc pass if it touches any of:
    simplest happy path. If the flow changed, re-run it
    (`docker compose up --build --abort-on-container-exit`) to confirm it still exits
    `0`.
-4. **Cross-check copy** — exact command names, flag names, message text, and defaults
-   must match the code verbatim across all three files.
+4. **CLAUDE.md** — only if a convention, the runtime floor, testing setup, or tooling
+   changed. Keep it maintenance-only; route any how-to/usage into AGENTS.md and
+   reference it, don't duplicate.
+5. **Cross-check copy** — exact command names, flag names, message text, and defaults
+   must match the code verbatim across the user-facing docs; the runtime floor (Django /
+   Python) must agree between `CLAUDE.md`, README, and AGENTS.
 
 ## Conventions
 
-- Keep README trim; AGENTS complete; examples runnable. Don't duplicate full reference
-  prose into README.
+- Keep README trim; AGENTS complete; examples runnable; CLAUDE.md maintenance-only (it
+  references AGENTS for how-to). Don't duplicate full reference prose into README, and
+  don't put usage/how-to into CLAUDE.md.
 - Don't narrate history in docs ("previously…", "this used to…") — document current
   behavior.
 - After editing, skim the changed docs once with fresh eyes for stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,11 @@ Django app wrapping [Absurd](https://earendil-works.github.io/absurd/) (Postgres
 workflow engine). Package at repo root (`django_absurd/`, no `src/`). Specs live in
 `docs/specs/`, plans in `docs/plans/`.
 
+This file is about **maintaining** the project — conventions, testing, tooling. For
+how-to / integration / usage (configuring the backend, enqueuing, workers, releasing),
+see [`django_absurd/AGENTS.md`](django_absurd/AGENTS.md), the user-facing guide; don't
+duplicate that material here.
+
 ## Naming
 
 - **Functions must contain a verb** (`get_declared_queues`, `sync_queues`,


### PR DESCRIPTION
Project-skill + docs maintenance (no code changes).

- **`/release` skill** — heavy human-in-the-loop release flow: human chooses the version (semver/PEP 440 reasoning), approves the cut, and approves the `pypi` deployment. Captures the GitHub-Releases-driven + hatch-vcs pipeline.
- **`sync-docs` skill** now also covers **CLAUDE.md** (maintenance trigger).
- **CLAUDE.md** points to `AGENTS.md` for how-to/usage (CLAUDE.md = maintenance only).

## How tested
Docs/skills only; pre-commit (prettier) clean.
