### PR TITLE
feat: scheduled (recurring) tasks via a beat scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ result = add.enqueue(2, 3)  # returns a TaskResult; the worker runs it
 - **[Integration guide](django_absurd/AGENTS.md)** — full configuration and `OPTIONS`,
   workers, task parameters, retrieving results, admin introspection, querying queue
   state with the ORM, deployment notes, and adopting an existing Absurd database.
+  Includes
+  [scheduling recurring tasks](django_absurd/AGENTS.md#scheduling-recurring-tasks) via
+  `absurd_beat`.
 - **[Runnable example](examples/)** — a single-file nanodjango app (web form, worker,
   and the Absurd admin) that runs with one `docker compose up`.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "${PGPORT:-5432}:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data/
+      - pgdata:/var/lib/postgresql
 
 volumes:
   pgdata:

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -134,6 +134,9 @@ System check IDs:
 - `absurd.E005` — `AbsurdRouter` missing from `DATABASE_ROUTERS`.
 - `absurd.E006` — `ENABLE_ADMIN` is not a bool, or `ADMIN_SITE` paths don't resolve to
   `AdminSite` instances.
+- `absurd.E007` — invalid `SCHEDULE` entry (bad task path, bad cron expression, unknown
+  key, non-serializable args/kwargs, or undeclared queue). See
+  [Scheduling recurring tasks](#scheduling-recurring-tasks).
 
 ## Defining and enqueuing tasks
 
@@ -193,6 +196,98 @@ whole catalog, not just the served queue — and reports to stdout.
   concurrency and the sync thread pool. Other flags: `--claim-timeout`,
   `--poll-interval`, `--batch-size`, `--worker-id`, and `--alias` (required only when
   several Absurd backends are configured).
+
+## Scheduling recurring tasks
+
+django-absurd has a built-in beat scheduler that fires
+[Absurd cron tasks](https://earendil-works.github.io/absurd/patterns/cron/) from
+settings-declared schedules. Schedules are cron expressions interpreted in Django's
+[`TIME_ZONE`](https://docs.djangoproject.com/en/stable/ref/settings/#time-zone).
+
+### Declare schedules
+
+Add a `SCHEDULE` map to `OPTIONS`. Each entry is a schedule name (arbitrary, unique
+within the backend) mapped to a spec dict:
+
+```python
+TASKS = {
+    "default": {
+        "BACKEND": "django_absurd.backends.AbsurdBackend",
+        "OPTIONS": {
+            "SCHEDULE": {
+                "nightly-report": {
+                    "task": "myapp.tasks.generate_report",  # dotted import path
+                    "cron": "0 2 * * *",                   # 5-field cron expression
+                },
+                "hourly-cleanup": {
+                    "task": "myapp.tasks.cleanup",
+                    "cron": "0 * * * *",
+                    "queue": "low-priority",               # optional; defaults to backend default
+                    "args": [30],                          # optional positional args
+                    "kwargs": {"dry_run": False},          # optional keyword args
+                },
+            },
+        },
+    },
+}
+```
+
+**Spec keys:**
+
+| Key      | Required | Description                                                    |
+| -------- | -------- | -------------------------------------------------------------- |
+| `task`   | yes      | Dotted import path to a `@task`-decorated function             |
+| `cron`   | yes      | 5-field cron expression (e.g. `"0 2 * * *"`)                   |
+| `queue`  | no       | Queue name; omit to use the backend's default queue            |
+| `args`   | no       | List of positional arguments passed to the task on each firing |
+| `kwargs` | no       | Dict of keyword arguments passed to the task on each firing    |
+
+Cron expressions are evaluated in Django's configured
+[`TIME_ZONE`](https://docs.djangoproject.com/en/stable/ref/settings/#time-zone).
+
+### Run the beat
+
+Start the beat scheduler as a standalone process:
+
+```bash
+python manage.py absurd_beat
+```
+
+Or run it co-located with a worker (saves a process in simple deployments):
+
+```bash
+python manage.py absurd_worker --beat
+```
+
+**Per-slot idempotency.** Each scheduled spawn carries an idempotency key derived from
+the schedule name and slot time (UTC minute), following the
+[Absurd cron pattern](https://earendil-works.github.io/absurd/patterns/cron/). If two
+beat processes briefly overlap, or a beat restarts and re-fires a slot it already
+attempted, Absurd collapses the duplicate to one task — each slot fires **at most
+once**. Single-instance is still the recommendation (leader election is not built in),
+but brief overlap is now safe.
+
+**Run exactly one beat process.** Running two or more beat processes against the same
+schedule causes double-firing under normal conditions: both processes independently fire
+each task at the same time. Per-slot idempotency protects against brief overlaps; it
+does not replace proper single-instance supervision. Use process supervision or a
+container orchestrator to enforce a single instance.
+
+**Fire-forward only.** The beat does not backfill missed firings. If it is down when a
+scheduled time passes, that firing is skipped; the next firing proceeds on schedule.
+
+### Validate
+
+`python manage.py check django_absurd` validates every schedule entry and reports
+`absurd.E007` for:
+
+- an unimportable or non-`@task` `task` path
+- an invalid cron expression
+- unknown keys in the spec
+- `args`/`kwargs` values that are not JSON-serializable
+- a `queue` that is not declared in `OPTIONS["QUEUES"]`
+
+Fix everything `absurd.E007` reports before relying on the schedule in production.
 
 ## Retrieving results
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -217,7 +217,7 @@ TASKS = {
             "SCHEDULE": {
                 "nightly-report": {
                     "task": "myapp.tasks.generate_report",  # dotted import path
-                    "cron": "0 2 * * *",                   # 5-field cron expression
+                    "cron": "0 2 * * *",                   # cron expression (see table)
                 },
                 "hourly-cleanup": {
                     "task": "myapp.tasks.cleanup",
@@ -234,16 +234,18 @@ TASKS = {
 
 **Spec keys:**
 
-| Key      | Required | Description                                                    |
-| -------- | -------- | -------------------------------------------------------------- |
-| `task`   | yes      | Dotted import path to a `@task`-decorated function             |
-| `cron`   | yes      | 5-field cron expression (e.g. `"0 2 * * *"`)                   |
-| `queue`  | no       | Queue name; omit to use the backend's default queue            |
-| `args`   | no       | List of positional arguments passed to the task on each firing |
-| `kwargs` | no       | Dict of keyword arguments passed to the task on each firing    |
+| Key      | Required | Description                                                                                                                                                                                                                                             |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task`   | yes      | Dotted import path to a `@task`-decorated function                                                                                                                                                                                                      |
+| `cron`   | yes      | Cron expression, parsed by [croniter](https://pypi.org/project/croniter/): standard **5-field** `min hour dom mon dow` (e.g. `"0 2 * * *"`), or **6-field** with a leading seconds column for sub-minute cadences (e.g. `"*/30 * * * * *"` = every 30s) |
+| `queue`  | no       | Queue name; omit to use the backend's default queue                                                                                                                                                                                                     |
+| `args`   | no       | List of positional arguments passed to the task on each firing                                                                                                                                                                                          |
+| `kwargs` | no       | Dict of keyword arguments passed to the task on each firing                                                                                                                                                                                             |
 
 Cron expressions are evaluated in Django's configured
 [`TIME_ZONE`](https://docs.djangoproject.com/en/stable/ref/settings/#time-zone).
+Sub-minute (6-field) schedules are supported; each slot enqueues a task, so size the
+cadence to what your worker can keep up with.
 
 ### Run the beat
 
@@ -260,7 +262,7 @@ python manage.py absurd_worker --beat
 ```
 
 **Per-slot idempotency.** Each scheduled spawn carries an idempotency key derived from
-the schedule name and slot time (UTC minute), following the
+the schedule name and slot time (UTC, to the second), following the
 [Absurd cron pattern](https://earendil-works.github.io/absurd/patterns/cron/). If two
 beat processes briefly overlap, or a beat restarts and re-fires a slot it already
 attempted, Absurd collapses the duplicate to one task — each slot fires **at most

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -261,8 +261,9 @@ Or run it co-located with a worker (saves a process in simple deployments):
 python manage.py absurd_worker --beat
 ```
 
-**Per-slot idempotency.** Each scheduled spawn carries an idempotency key derived from
-the schedule name and slot time (UTC, to the second), following the
+**Per-slot idempotency.** Each scheduled spawn carries an idempotency key — a
+`cron:`-prefixed SHA-256 of the schedule name, cron, and slot time (UTC, second
+resolution) — following the
 [Absurd cron pattern](https://earendil-works.github.io/absurd/patterns/cron/). If two
 beat processes briefly overlap, or a beat restarts and re-fires a slot it already
 attempted, Absurd collapses the duplicate to one task — each slot fires **at most

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -1,6 +1,8 @@
+import json
 import typing as t
 from collections.abc import Sequence
 
+import croniter
 from absurd_sdk import CreateQueueOptions, QueueDetachMode, QueueStorageMode
 from django.apps import AppConfig
 from django.conf import settings
@@ -9,6 +11,7 @@ from django.core.checks import CheckMessage, Error, Tags, register
 from django.core.checks import Warning as DjangoWarning
 from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import OperationalError, ProgrammingError
+from django.tasks import Task
 from django.utils.connection import ConnectionDoesNotExist
 from django.utils.module_loading import import_string
 
@@ -58,6 +61,20 @@ E006_ADMIN_SITE_TYPE_MSG = (
 E006_ADMIN_SITE_HINT = (
     "Set ADMIN_SITE to a tuple of dotted paths to AdminSite instances."
 )
+
+E007_MSG = "django-absurd: invalid SCHEDULE entry."
+E007_HINT_IMPORT = (
+    "Ensure the task path is importable and points to a @task-decorated function."
+)
+E007_HINT_NOT_TASK = "The path must point to a Django @task-decorated callable."
+E007_HINT_CRON = "Provide a valid 5-field cron expression (e.g. '0 2 * * *')."
+E007_HINT_UNKNOWN_KEY = (
+    "Remove unknown keys; valid keys are: task, cron, queue, args, kwargs."
+)
+E007_HINT_SERIALIZE = "Ensure args and kwargs contain only JSON-serializable values."
+E007_HINT_QUEUE = "Declare the queue under OPTIONS['QUEUES'] or correct the queue name."
+
+VALID_SCHEDULE_KEYS = {"task", "cron", "queue", "args", "kwargs"}
 
 
 @register("absurd")
@@ -124,6 +141,99 @@ def validate_admin_site_option(value: t.Any) -> list[CheckMessage]:
                 )
             )
     return errors
+
+
+@register("absurd")
+def check_absurd_schedule_config(
+    *,
+    app_configs: Sequence[AppConfig] | None,
+    **kwargs: t.Any,
+) -> list[CheckMessage]:
+    errors: list[CheckMessage] = []
+    for backend in get_absurd_backends().values():
+        declared_queues = set(get_declared_queues(backend))
+        raw_schedule: dict[str, t.Any] = backend.options.get("SCHEDULE", {})
+        for name, spec in raw_schedule.items():
+            errors.extend(validate_schedule(name, spec, declared_queues))
+    return errors
+
+
+def validate_schedule(
+    name: str,
+    spec: dict[str, t.Any],
+    declared_queues: set[str],
+) -> list[CheckMessage]:
+    errors: list[CheckMessage] = [
+        Error(
+            f"{E007_MSG} Schedule {name!r}: unknown key {key!r}.",
+            hint=E007_HINT_UNKNOWN_KEY,
+            id="absurd.E007",
+        )
+        for key in spec
+        if key not in VALID_SCHEDULE_KEYS
+    ]
+
+    errors.extend(validate_schedule_task(name, spec.get("task", "")))
+
+    cron = spec.get("cron", "")
+    if not croniter.croniter.is_valid(cron):
+        errors.append(
+            Error(
+                f"{E007_MSG} Schedule {name!r}: invalid cron expression {cron!r}.",
+                hint=E007_HINT_CRON,
+                id="absurd.E007",
+            )
+        )
+
+    for field in ("args", "kwargs"):
+        value = spec.get(field)
+        if value is not None:
+            try:
+                json.dumps(value)
+            except (TypeError, ValueError):
+                errors.append(
+                    Error(
+                        f"{E007_MSG} Schedule {name!r}:"
+                        f" {field} is not JSON-serializable.",
+                        hint=E007_HINT_SERIALIZE,
+                        id="absurd.E007",
+                    )
+                )
+
+    queue = spec.get("queue")
+    if queue is not None and queue not in declared_queues:
+        errors.append(
+            Error(
+                f"{E007_MSG} Schedule {name!r}: queue {queue!r} is not declared.",
+                hint=E007_HINT_QUEUE,
+                id="absurd.E007",
+            )
+        )
+
+    return errors
+
+
+def validate_schedule_task(name: str, task_path: str) -> list[CheckMessage]:
+    try:
+        task_obj = import_string(task_path)
+    except ImportError:
+        return [
+            Error(
+                f"{E007_MSG} Schedule {name!r}: task {task_path!r}"
+                " could not be imported.",
+                hint=E007_HINT_IMPORT,
+                id="absurd.E007",
+            )
+        ]
+    if not isinstance(task_obj, Task):
+        return [
+            Error(
+                f"{E007_MSG} Schedule {name!r}: {task_path!r} is not a Django task.",
+                hint=E007_HINT_NOT_TASK,
+                id="absurd.E007",
+            )
+        ]
+    return []
 
 
 @register("absurd")

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -202,7 +202,7 @@ def validate_schedule(
     errors.extend(validate_schedule_task(name, spec.get("task", "")))
 
     cron = spec.get("cron", "")
-    if not croniter.croniter.is_valid(cron):
+    if not isinstance(cron, str) or not croniter.croniter.is_valid(cron):
         errors.append(
             Error(
                 f"{E007_MSG} Schedule {name!r}: invalid cron expression {cron!r}.",
@@ -227,7 +227,9 @@ def validate_schedule(
                 )
 
     queue = spec.get("queue")
-    if queue is not None and queue not in declared_queues:
+    if queue is not None and (
+        not isinstance(queue, str) or queue not in declared_queues
+    ):
         errors.append(
             Error(
                 f"{E007_MSG} Schedule {name!r}: queue {queue!r} is not declared.",

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -1,6 +1,8 @@
 import json
+import logging
+import sys
 import typing as t
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import croniter
 from absurd_sdk import CreateQueueOptions, QueueDetachMode, QueueStorageMode
@@ -20,6 +22,8 @@ from django_absurd.connection import BACKEND_ERROR_MESSAGE, validate_backend
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_backend, get_absurd_database
 from django_absurd.routers import AbsurdRouter
+
+logger = logging.getLogger(__name__)
 
 W002_MSG = (
     "django-absurd: a queue's declared storage_mode differs from the database"
@@ -152,7 +156,17 @@ def check_absurd_schedule_config(
     errors: list[CheckMessage] = []
     for backend in get_absurd_backends().values():
         declared_queues = set(get_declared_queues(backend))
-        raw_schedule: dict[str, t.Any] = backend.options.get("SCHEDULE", {})
+        raw_schedule = backend.options.get("SCHEDULE", {})
+        if not isinstance(raw_schedule, Mapping):
+            errors.append(
+                Error(
+                    f'{E007_MSG} OPTIONS["SCHEDULE"] must be a mapping'
+                    " of name -> spec.",
+                    hint="Set SCHEDULE to a dict mapping schedule names to spec dicts.",
+                    id="absurd.E007",
+                )
+            )
+            continue
         for name, spec in raw_schedule.items():
             errors.extend(validate_schedule(name, spec, declared_queues))
     return errors
@@ -160,9 +174,21 @@ def check_absurd_schedule_config(
 
 def validate_schedule(
     name: str,
-    spec: dict[str, t.Any],
+    spec: t.Any,
     declared_queues: set[str],
 ) -> list[CheckMessage]:
+    if not isinstance(spec, Mapping):
+        return [
+            Error(
+                f"{E007_MSG} Schedule {name!r} must be a mapping.",
+                hint=(
+                    "Set the schedule entry to a dict"
+                    " with task, cron, and optional queue/args/kwargs."
+                ),
+                id="absurd.E007",
+            )
+        ]
+
     errors: list[CheckMessage] = [
         Error(
             f"{E007_MSG} Schedule {name!r}: unknown key {key!r}.",
@@ -216,11 +242,13 @@ def validate_schedule(
 def validate_schedule_task(name: str, task_path: str) -> list[CheckMessage]:
     try:
         task_obj = import_string(task_path)
-    except ImportError:
+    except Exception:
+        logger.exception("absurd.E007: task %r could not be imported", task_path)
+        exc = sys.exc_info()[1]
         return [
             Error(
                 f"{E007_MSG} Schedule {name!r}: task {task_path!r}"
-                " could not be imported.",
+                f" could not be imported: {exc!r}",
                 hint=E007_HINT_IMPORT,
                 id="absurd.E007",
             )

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -1,6 +1,25 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
+from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.queues import SyncResult
+
+
+def resolve_backend(options: dict) -> tuple[str, AbsurdBackend]:
+    backends = get_absurd_backends()
+    alias = options["alias"]
+    if alias is not None:
+        if alias not in backends:
+            valid = ", ".join(sorted(backends))
+            msg = f"'{alias}' is not an Absurd backend alias. Valid aliases: {valid}"
+            raise CommandError(msg)
+        backend = backends[alias]
+    elif len(backends) == 1:
+        alias, backend = next(iter(backends.items()))
+    else:
+        aliases = ", ".join(sorted(backends))
+        msg = f"Multiple Absurd backends found: {aliases}. Use --alias to select one."
+        raise CommandError(msg)
+    return alias, backend
 
 
 class AbsurdReportCommand(BaseCommand):

--- a/django_absurd/management/commands/absurd_beat.py
+++ b/django_absurd/management/commands/absurd_beat.py
@@ -1,0 +1,34 @@
+import signal
+import threading
+import typing as t
+
+from django.core.management.base import BaseCommand
+
+from django_absurd.management.base import resolve_backend
+from django_absurd.scheduler import get_settings_schedules, run_beat
+
+
+class Command(BaseCommand):
+    help = "Start the Absurd beat scheduler."
+
+    def add_arguments(self, parser: t.Any) -> None:
+        parser.add_argument(
+            "--alias",
+            default=None,
+            help="Absurd backend alias (required when multiple Absurd backends exist).",
+        )
+
+    def handle(self, *args: t.Any, **options: t.Any) -> None:
+        _, backend = resolve_backend(options)
+
+        stop = threading.Event()
+
+        def handle_signal(signum: int, frame: t.Any) -> None:
+            stop.set()
+
+        signal.signal(signal.SIGINT, handle_signal)
+        signal.signal(signal.SIGTERM, handle_signal)
+
+        schedules = get_settings_schedules(backend)
+        self.stdout.write(f"Started beat with {len(schedules)} schedule(s).")
+        run_beat(backend, stop=stop)

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -3,8 +3,7 @@ import typing as t
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import CommandError
 
-from django_absurd.backends import get_absurd_backends
-from django_absurd.management.base import AbsurdReportCommand
+from django_absurd.management.base import AbsurdReportCommand, resolve_backend
 from django_absurd.queues import provision_backend
 from django_absurd.worker import WorkerOptions, run_worker
 
@@ -60,27 +59,21 @@ class Command(AbsurdReportCommand):
             default=None,
             help="Worker identifier; SDK synthesizes <host>:<pid> when omitted.",
         )
+        parser.add_argument(
+            "--beat",
+            action="store_true",
+            help=(
+                "Run the beat scheduler in the worker loop"
+                " (not compatible with --burst)."
+            ),
+        )
 
     def handle(self, *args: t.Any, **options: t.Any) -> None:
-        backends = get_absurd_backends()
-        alias = options["alias"]
+        alias, backend = resolve_backend(options)
         queue = options["queue"]
 
-        if alias is not None:
-            if alias not in backends:
-                valid = ", ".join(sorted(backends))
-                msg = (
-                    f"'{alias}' is not an Absurd backend alias. Valid aliases: {valid}"
-                )
-                raise CommandError(msg)
-            backend = backends[alias]
-        elif len(backends) == 1:
-            alias, backend = next(iter(backends.items()))
-        else:
-            aliases = ", ".join(sorted(backends))
-            msg = (
-                f"Multiple Absurd backends found: {aliases}. Use --alias to select one."
-            )
+        if options["burst"] and options["beat"]:
+            msg = "--beat is not compatible with --burst."
             raise CommandError(msg)
 
         if queue not in backend.queues:
@@ -107,4 +100,10 @@ class Command(AbsurdReportCommand):
             worker_id=options["worker_id"],
         )
         self.stdout.write(f"Started worker on queue '{queue}'.")
-        run_worker(backend, queue, burst=options["burst"], options=worker_options)
+        run_worker(
+            backend,
+            queue,
+            burst=options["burst"],
+            run_beat=options["beat"],
+            options=worker_options,
+        )

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -78,10 +78,10 @@ def run_beat(
     validate_backend(backend.database)
     schedules = get_settings_schedules(backend)
     if not schedules:
-        logger.info("no schedules declared")
+        logger.info("django-absurd beat: no schedules declared")
         return
 
-    logger.info("beat started: %d schedule(s)", len(schedules))
+    logger.info("django-absurd beat started: schedules=%d", len(schedules))
     stop = stop or threading.Event()
     wait = wait or stop.wait
 
@@ -106,10 +106,10 @@ def fire_schedule(schedule: Schedule, slot: datetime.datetime) -> None:
     try:
         spawn_scheduled(schedule, slot)
     except Exception:
-        logger.exception("failed to spawn schedule %r", schedule.name)
+        logger.exception("django-absurd schedule failed: name=%s", schedule.name)
     else:
         logger.info(
-            "enqueued scheduled task %r (slot %s)",
+            "django-absurd schedule enqueued: name=%s slot=%s",
             schedule.name,
             slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%MZ"),
         )

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -1,0 +1,108 @@
+import dataclasses
+import datetime
+import logging
+import threading
+import typing as t
+
+import croniter
+from django.db import close_old_connections
+from django.utils import timezone
+from django.utils.module_loading import import_string
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.connection import validate_backend
+from django_absurd.params import AbsurdSpawnParams
+
+logger = logging.getLogger("django_absurd")
+
+
+@dataclasses.dataclass(frozen=True)
+class Schedule:
+    name: str
+    task: str
+    cron: str
+    queue: str | None = None
+    args: list = dataclasses.field(default_factory=list)
+    kwargs: dict = dataclasses.field(default_factory=dict)
+
+
+def get_next_datetime(cron: str, after: datetime.datetime) -> datetime.datetime:
+    local_after = timezone.localtime(after)
+    return croniter.croniter(cron, local_after).get_next(datetime.datetime)
+
+
+def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:
+    schedule_map: dict[str, t.Any] = backend.options.get("SCHEDULE", {})
+    return [
+        Schedule(
+            name=name,
+            task=spec["task"],
+            cron=spec["cron"],
+            queue=spec.get("queue", None),
+            args=list(spec.get("args", [])),
+            kwargs=dict(spec.get("kwargs", {})),
+        )
+        for name, spec in schedule_map.items()
+    ]
+
+
+def derive_idempotency_key(schedule: Schedule, slot: datetime.datetime) -> str:
+    utc_slot = slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%MZ")
+    return f"{schedule.name}:{utc_slot}"
+
+
+def spawn_scheduled(schedule: Schedule, slot: datetime.datetime) -> None:
+    close_old_connections()
+    try:
+        task = import_string(schedule.task)
+        if schedule.queue is not None:
+            task = task.using(queue_name=schedule.queue)
+        task.enqueue(
+            *schedule.args,
+            **schedule.kwargs,
+            absurd_spawn_params=AbsurdSpawnParams(
+                idempotency_key=derive_idempotency_key(schedule, slot)
+            ),
+        )
+    finally:
+        close_old_connections()
+
+
+def run_beat(
+    backend: AbsurdBackend,
+    *,
+    now: t.Callable[[], datetime.datetime] = timezone.now,
+    stop: threading.Event | None = None,
+    wait: t.Callable[[float], bool] | None = None,
+) -> None:
+    validate_backend(backend.database)
+    schedules = get_settings_schedules(backend)
+    if not schedules:
+        logger.info("no schedules declared")
+        return
+
+    stop = stop or threading.Event()
+    wait = wait or stop.wait
+
+    upcoming: dict[str, datetime.datetime] = {
+        s.name: get_next_datetime(s.cron, now()) for s in schedules
+    }
+    by_name = {s.name: s for s in schedules}
+
+    while not stop.is_set():
+        earliest = min(upcoming.values())
+        delay = (earliest - now()).total_seconds()
+        if delay > 0 and wait(delay):
+            break
+        current = now()
+        for name, due in list(upcoming.items()):
+            if due <= current:
+                fire_schedule(by_name[name], due)
+                upcoming[name] = get_next_datetime(by_name[name].cron, current)
+
+
+def fire_schedule(schedule: Schedule, slot: datetime.datetime) -> None:
+    try:
+        spawn_scheduled(schedule, slot)
+    except Exception:
+        logger.exception("failed to spawn schedule %r", schedule.name)

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -81,6 +81,7 @@ def run_beat(
         logger.info("no schedules declared")
         return
 
+    logger.info("beat started: %d schedule(s)", len(schedules))
     stop = stop or threading.Event()
     wait = wait or stop.wait
 
@@ -106,3 +107,9 @@ def fire_schedule(schedule: Schedule, slot: datetime.datetime) -> None:
         spawn_scheduled(schedule, slot)
     except Exception:
         logger.exception("failed to spawn schedule %r", schedule.name)
+    else:
+        logger.info(
+            "enqueued scheduled task %r (slot %s)",
+            schedule.name,
+            slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%MZ"),
+        )

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -47,7 +47,7 @@ def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:
 
 
 def derive_idempotency_key(schedule: Schedule, slot: datetime.datetime) -> str:
-    utc_slot = slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%MZ")
+    utc_slot = slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     return f"{schedule.name}:{utc_slot}"
 
 
@@ -111,5 +111,5 @@ def fire_schedule(schedule: Schedule, slot: datetime.datetime) -> None:
         logger.info(
             "django-absurd schedule enqueued: name=%s slot=%s",
             schedule.name,
-            slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%MZ"),
+            slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         )

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import hashlib
 import logging
 import threading
 import typing as t
@@ -47,8 +48,11 @@ def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:
 
 
 def derive_idempotency_key(schedule: Schedule, slot: datetime.datetime) -> str:
-    utc_slot = slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return f"{schedule.name}:{utc_slot}"
+    # Dedup key, anchored on the schedule name (not task/cron) so args/queue-varying
+    # entries don't collide. https://earendil-works.github.io/absurd/patterns/cron/
+    utc_slot = slot.astimezone(datetime.UTC).isoformat(timespec="seconds")
+    raw = f"{schedule.name}|{schedule.cron}|{utc_slot}"
+    return "cron:" + hashlib.sha256(raw.encode()).hexdigest()[:24]
 
 
 def spawn_scheduled(schedule: Schedule, slot: datetime.datetime) -> None:

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -198,7 +198,7 @@ def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Awaitable[t.Any]]:
         attempt = read_sdk_attempt(ctx)
         start = time.monotonic()
         logger.info(
-            "django-absurd task starting: name=%s task_id=%s attempt=%d",
+            "django-absurd task started: name=%s task_id=%s attempt=%d",
             task.module_path,
             ctx.task_id,
             attempt,

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import logging
 import signal
+import threading
 import time
 import typing as t
 from concurrent.futures import ThreadPoolExecutor
@@ -19,6 +20,7 @@ from django.utils.module_loading import import_string
 
 from django_absurd.backends import AbsurdBackend
 from django_absurd.connection import register_jsonb_loader, validate_backend
+from django_absurd.scheduler import run_beat
 
 logger = logging.getLogger("django_absurd")
 
@@ -67,11 +69,14 @@ def run_worker(
     queue: str,
     *,
     burst: bool = False,
+    run_beat: bool = False,
     options: WorkerOptions | None = None,
 ) -> None:
     options = options or WorkerOptions()
     validate_backend(backend.database)
-    asyncio.run(arun_worker(backend, queue, burst=burst, options=options))
+    asyncio.run(
+        arun_worker(backend, queue, burst=burst, run_beat=run_beat, options=options)
+    )
 
 
 async def arun_worker(
@@ -79,6 +84,7 @@ async def arun_worker(
     queue: str,
     *,
     burst: bool = False,
+    run_beat: bool = False,
     options: WorkerOptions,
 ) -> None:
     with ThreadPoolExecutor(max_workers=options.concurrency) as executor:
@@ -102,6 +108,8 @@ async def arun_worker(
                     batch_size=options.batch_size,
                     worker_id=options.worker_id,
                 )
+            elif run_beat:
+                await run_worker_with_beat(client, options, backend)
             else:
                 await run_blocking_worker(client, options)
 
@@ -249,8 +257,12 @@ def read_sdk_attempt(ctx: t.Any) -> int:
 
 async def run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions) -> None:
     loop = asyncio.get_running_loop()
-    loop.add_signal_handler(signal.SIGINT, client.stop_worker)
-    loop.add_signal_handler(signal.SIGTERM, client.stop_worker)
+
+    def handle_stop() -> None:
+        client.stop_worker()
+
+    loop.add_signal_handler(signal.SIGINT, handle_stop)
+    loop.add_signal_handler(signal.SIGTERM, handle_stop)
     try:
         await client.start_worker(
             worker_id=options.worker_id,
@@ -262,3 +274,20 @@ async def run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions) -> No
     finally:
         loop.remove_signal_handler(signal.SIGINT)
         loop.remove_signal_handler(signal.SIGTERM)
+
+
+async def run_worker_with_beat(
+    client: AsyncAbsurd,
+    options: WorkerOptions,
+    backend: AbsurdBackend,
+) -> None:
+    beat_stop = threading.Event()
+    beat_thread = threading.Thread(
+        target=run_beat, args=(backend,), kwargs={"stop": beat_stop}, daemon=True
+    )
+    beat_thread.start()
+    try:
+        await run_blocking_worker(client, options)
+    finally:
+        beat_stop.set()
+        await asyncio.get_running_loop().run_in_executor(None, beat_thread.join, 5)

--- a/docs/plans/2026-06-29-scheduler-beat.md
+++ b/docs/plans/2026-06-29-scheduler-beat.md
@@ -1,0 +1,865 @@
+# Scheduler (beat) — SP1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Plan style (project override of the skill template):** Implementation steps are
+> described in **prose**, not finished code blocks — coding-ahead is banned. Only
+> **test** code is shown verbatim (RED first). Prose is caveman-compressed; code/tests
+> are normal.
+
+**Goal:** Declare recurring tasks in `TASKS` settings; an `absurd_beat` process enqueues
+them on a cron cadence through the existing enqueue path. No pg_cron, no new tables.
+
+**Architecture:** New `django_absurd/scheduler.py` holds the shared core (`Schedule`,
+settings provider, slot math, spawn) + the async `arun_beat` loop. An `absurd_beat`
+management command runs it; `absurd_worker --beat` runs it in the worker's event loop.
+Spec: `docs/specs/2026-06-29-scheduler-design.md`.
+
+**Tech Stack:** Django 6 Tasks framework, Absurd SDK, croniter, freezegun (tests).
+
+## Global Constraints
+
+- Floor: Django ≥6.0, Python ≥3.12. Postgres + psycopg3 only.
+- `import typing as t` (never `from typing import X`); absolute imports only; functions
+  contain a verb; no leading-underscore module-level names; helpers placed BELOW the
+  public fn that uses them.
+- Tests: pytest, function-based only. Autouse `_enable_db(db)` gives DB access — do NOT
+  add `@pytest.mark.django_db`. Add `pytest.mark.django_db(transaction=True)`
+  (module-level `pytestmark`) only when the test does DDL/commits (queue create,
+  enqueue, worker). No `unittest.mock` / monkeypatch — drive branches with real inputs
+  or dependency injection.
+- Checks/commands tested by RUNNING them and asserting full emitted text (capsys), per
+  project convention.
+- ruff `select = ["ALL"]` (minus configured ignores); mypy clean. No new ruff ignores
+  without asking.
+- 100% statement+branch coverage on lines this plan adds/changes.
+- Cron interpreted in **Django `TIME_ZONE`**. **Fire-forward-only** (never backfill).
+  **Single beat instance** is an operator contract (no idempotency guard). Logging:
+  logger `"django_absurd"`, past-tense after an action.
+- Beat is **async** (`arun_beat`); fires through the real `enqueue` path; no hand-built
+  params.
+
+---
+
+## Task 1: Dependencies + test settings
+
+**Files:**
+
+- Modify: `pyproject.toml`, `tests/settings.py`
+- Test: `tests/test_scheduler.py` (create)
+
+**Interfaces:**
+
+- Produces: `croniter` importable at runtime; `freezegun` in the dev group;
+  `tests/settings.py` pins `TIME_ZONE = "UTC"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_scheduler.py`:
+
+```python
+import croniter  # noqa: F401  -- runtime dep must be importable
+
+
+def test_croniter_available():
+    assert croniter.croniter.is_valid("*/5 * * * *")
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -v` Expected: collection/import error —
+`croniter` not installed.
+
+- [ ] **Step 3: Implement (prose)**
+
+Add `croniter` to `[project] dependencies` (permissive lower bound, `"croniter>=2.0"`).
+Add `freezegun` to `[dependency-groups] dev`, pinned `==<resolved>` to match the
+exact-pin style (run `uv add --group dev freezegun`, copy the resolved version from
+`uv.lock`, keep the list alphabetised). Add `TIME_ZONE = "UTC"` to `tests/settings.py`
+so cron/slot tests are deterministic without per-test overrides. Run `uv sync`.
+
+Not adding `pytest-asyncio`: SP1's scheduler tests are **sync** — they drive the async
+loop via `asyncio.run` internally and assert observable DB side effects (matching the
+repo's existing `asyncio.run`-wrapper style). Adopting `pytest-asyncio` suite-wide +
+converting existing async tests (e.g. `test_aenqueue_lands`, async-worker drain) is a
+separate future cleanup.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -v` Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock tests/settings.py tests/test_scheduler.py
+git commit -m "build: add croniter runtime dep + freezegun; pin test TIME_ZONE=UTC"
+```
+
+---
+
+## Task 2: `Schedule` + settings provider
+
+**Files:**
+
+- Create: `django_absurd/scheduler.py`
+- Test: `tests/test_scheduler.py`
+
+**Interfaces:**
+
+- Produces:
+  - `Schedule` — frozen dataclass: `name: str`, `task: str`, `cron: str`,
+    `queue: str | None = None`, `args: list = field(default_factory=list)`,
+    `kwargs: dict = field(default_factory=dict)`.
+  - `get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]` — reads
+    `backend.options.get("SCHEDULE", {})`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_scheduler.py`:
+
+```python
+from django_absurd.backends import get_absurd_backends
+from django_absurd.scheduler import Schedule, get_settings_schedules
+
+
+def schedule_tasks_setting(schedule):
+    return {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {}, "reports": {}}, "SCHEDULE": schedule},
+        }
+    }
+
+
+def test_settings_provider_reads_entries(settings):
+    settings.TASKS = schedule_tasks_setting(
+        {
+            "nightly": {
+                "task": "tests.tasks.add",
+                "cron": "0 2 * * *",
+                "args": [1, 2],
+                "queue": "reports",
+            }
+        }
+    )
+    backend = get_absurd_backends()["default"]
+    schedules = get_settings_schedules(backend)
+    assert schedules == [
+        Schedule(
+            name="nightly",
+            task="tests.tasks.add",
+            cron="0 2 * * *",
+            queue="reports",
+            args=[1, 2],
+            kwargs={},
+        )
+    ]
+
+
+def test_settings_provider_defaults_and_empty(settings):
+    settings.TASKS = schedule_tasks_setting(
+        {"ping": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
+    )
+    backend = get_absurd_backends()["default"]
+    (s,) = get_settings_schedules(backend)
+    assert s.queue is None and s.args == [] and s.kwargs == {}
+
+
+def test_settings_provider_no_schedule_key(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "QUEUES": ["default"],
+        }
+    }
+    backend = get_absurd_backends()["default"]
+    assert get_settings_schedules(backend) == []
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -v` Expected: ImportError (`scheduler` has
+no `Schedule`/`get_settings_schedules`).
+
+- [ ] **Step 3: Implement (prose)**
+
+Create `django_absurd/scheduler.py`. Define the frozen `Schedule` dataclass (mutable
+defaults via `dataclasses.field(default_factory=...)`). Define
+`get_settings_schedules(backend)`: read the `SCHEDULE` map from `backend.options`; for
+each `name → spec`, build a `Schedule` taking `task`/`cron` directly and
+`queue`/`args`/`kwargs` via `.get` with the documented defaults (coerce args→list,
+kwargs→dict). Return the list. `import typing as t`; import `AbsurdBackend` from
+`django_absurd.backends`.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/scheduler.py tests/test_scheduler.py
+git commit -m "feat: Schedule dataclass + settings schedule provider"
+```
+
+---
+
+## Task 3: `get_next_datetime` (croniter, Django timezone)
+
+**Files:**
+
+- Modify: `django_absurd/scheduler.py`
+- Test: `tests/test_scheduler.py`
+
+**Interfaces:**
+
+- Produces: `get_next_datetime(cron: str, after: datetime) -> datetime` — next fire
+  strictly after `after`, cron interpreted in Django current tz, returns an aware
+  datetime.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+import datetime as dt
+
+from django.utils import timezone
+from freezegun import freeze_time
+
+from django_absurd.scheduler import get_next_datetime
+
+
+@freeze_time("2026-01-01 01:59:00")
+def test_get_next_datetime_same_day():
+    expected = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.timezone.utc)
+    assert get_next_datetime("0 2 * * *", timezone.now()) == expected
+
+
+@freeze_time("2026-01-01 02:00:00")
+def test_get_next_datetime_rolls_forward():
+    expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.timezone.utc)
+    assert get_next_datetime("0 2 * * *", timezone.now()) == expected
+
+
+@freeze_time("2026-01-01 12:00:00")  # 06:00 in Chicago (UTC-6)
+def test_get_next_datetime_uses_django_timezone(settings):
+    # cron interpreted in Django TIME_ZONE: 02:00 Chicago already passed -> tomorrow
+    settings.TIME_ZONE = "America/Chicago"
+    expected = dt.datetime(2026, 1, 2, 8, 0, tzinfo=dt.timezone.utc)  # 02:00 CST = 08:00 UTC
+    result = get_next_datetime("0 2 * * *", timezone.now()).astimezone(dt.timezone.utc)
+    assert result == expected
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -k get_next_datetime -v` Expected:
+ImportError (`get_next_datetime` undefined).
+
+- [ ] **Step 3: Implement (prose)**
+
+Add `get_next_datetime(cron, after)`: convert `after` into the Django current timezone
+with `django.utils.timezone.localtime(after)`, build `croniter(cron, local_after)`,
+return `croniter.get_next(datetime)` (aware, in the local tz). No mutation of global
+state.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -k get_next_datetime -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/scheduler.py tests/test_scheduler.py
+git commit -m "feat: get_next_datetime cron slot computation in Django timezone"
+```
+
+---
+
+## Task 4: `spawn_scheduled`
+
+**Files:**
+
+- Modify: `django_absurd/scheduler.py`
+- Test: `tests/test_scheduler.py`
+
+**Interfaces:**
+
+- Produces: `spawn_scheduled(schedule: Schedule) -> None` — resolve `schedule.task`
+  (dotted path) to a Django Task, route to `schedule.queue` via `.using(queue_name=...)`
+  when set, enqueue with `*args, **kwargs`. Closes stale connections around the call
+  (safe to run in a worker thread).
+
+- [ ] **Step 1: Write the failing test**
+
+Append. (These do DDL/commits + enqueue → the module needs
+`pytestmark = pytest.mark.django_db(transaction=True)`; add it once near the top of the
+file when first required.)
+
+```python
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+
+from django_absurd.scheduler import spawn_scheduled
+
+
+def test_spawn_scheduled_runs_task_with_args():
+    call_command("absurd_sync_queues")
+    spawn_scheduled(
+        Schedule(name="n", task="tests.tasks.make_group", cron="* * * * *", args=["sched-args"])
+    )
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="sched-args").exists()
+
+
+def test_spawn_scheduled_passes_kwargs():
+    call_command("absurd_sync_queues")
+    spawn_scheduled(
+        Schedule(name="n", task="tests.tasks.make_group", cron="* * * * *", kwargs={"name": "sched-kwargs"})
+    )
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="sched-kwargs").exists()
+
+
+def test_spawn_scheduled_routes_to_queue():
+    # route make_group to "other": only a worker draining "other" runs it.
+    call_command("absurd_sync_queues")
+    spawn_scheduled(
+        Schedule(name="n", task="tests.tasks.make_group", cron="* * * * *", queue="other", args=["routed"])
+    )
+    call_command("absurd_worker", queue="default", burst=True)
+    assert not Group.objects.filter(name="routed").exists()  # not on default
+    call_command("absurd_worker", queue="other", burst=True)
+    assert Group.objects.filter(name="routed").exists()  # ran from "other"
+```
+
+(`tests/settings.py` declares queues `["default", "other"]`. Asserting via a real worker
+run keeps the test behavioral — no raw queue-row inspection.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -k spawn_scheduled -v` Expected: ImportError
+(`spawn_scheduled` undefined).
+
+- [ ] **Step 3: Implement (prose)**
+
+Add `spawn_scheduled(schedule)`: call `django.db.close_old_connections()`, then in a
+`try/finally` (finally also `close_old_connections()`):
+`task = import_string(schedule.task)`; if `schedule.queue is not None`,
+`task = task.using(queue_name=schedule.queue)`;
+`task.enqueue(*schedule.args, **schedule.kwargs)`. The connection bookkeeping mirrors
+`worker.build_handler`'s `call_sync` so the function is safe when invoked from the
+loop's executor thread.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -k spawn_scheduled -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/scheduler.py tests/test_scheduler.py
+git commit -m "feat: spawn_scheduled enqueues a scheduled task via the real enqueue path"
+```
+
+---
+
+## Task 5: `arun_beat` loop
+
+**Files:**
+
+- Modify: `django_absurd/scheduler.py`
+- Test: `tests/test_scheduler.py`
+
+**Interfaces:**
+
+- Produces:
+
+  ```python
+  async def arun_beat(
+      backend: AbsurdBackend,
+      *,
+      now: t.Callable[[], datetime] = timezone.now,
+      sleep: t.Callable[[float], t.Awaitable[None]] = asyncio.sleep,
+      stop: asyncio.Event | None = None,
+  ) -> None
+  ```
+
+  `now`/`sleep`/`stop` are runtime injection seams (clock, wait, shutdown) — tests use
+  them to drive time deterministically. Each due schedule is fired via `spawn_scheduled`
+  run in the loop's default executor (so the loop never blocks on sync DB I/O).
+  Fire-forward-only; a per-schedule spawn failure is logged and does not stop the loop.
+
+- [ ] **Step 1: Write the failing test**
+
+Behavioral + deterministic: drive the loop with a fake clock + `stop`, fire real
+enqueues, drain with a worker, assert observable rows. Sync tests (run the loop via
+`asyncio.run`). Append:
+
+```python
+import asyncio
+
+from tests.models import Payload
+
+
+def schedule_backend(settings, schedule):
+    settings.TASKS = schedule_tasks_setting(schedule)
+    return get_absurd_backends()["default"]
+
+
+def test_beat_fires_each_due_slot(settings):
+    backend = schedule_backend(
+        settings, {"p": {"task": "tests.tasks.create_payload", "cron": "*/1 * * * *", "args": ["tick"]}}
+    )
+    call_command("absurd_sync_queues")
+    stop = asyncio.Event()
+    cutoff = dt.datetime(2026, 1, 1, 0, 2, 30, tzinfo=dt.timezone.utc)
+
+    with freeze_time("2026-01-01 00:00:00") as frozen:
+        async def fake_sleep(seconds):
+            frozen.tick(dt.timedelta(seconds=seconds))
+            if timezone.now() >= cutoff:
+                stop.set()
+
+        asyncio.run(arun_beat(backend, sleep=fake_sleep, stop=stop))
+
+    call_command("absurd_worker", queue="default", burst=True)
+    expected_fires = 2  # slots 00:01 and 00:02
+    assert Payload.objects.count() == expected_fires
+
+
+def test_beat_no_schedules_returns(settings):
+    backend = schedule_backend(settings, {})
+    asyncio.run(arun_beat(backend, stop=asyncio.Event()))  # returns immediately, no hang
+
+
+def test_beat_isolates_failing_schedule(settings):
+    backend = schedule_backend(
+        settings,
+        {
+            "bad": {"task": "tests.tasks.does_not_exist", "cron": "*/1 * * * *"},
+            "good": {"task": "tests.tasks.create_payload", "cron": "*/1 * * * *", "args": ["ok"]},
+        },
+    )
+    call_command("absurd_sync_queues")
+    stop = asyncio.Event()
+    cutoff = dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.timezone.utc)
+
+    with freeze_time("2026-01-01 00:00:00") as frozen:
+        async def fake_sleep(seconds):
+            frozen.tick(dt.timedelta(seconds=seconds))
+            if timezone.now() >= cutoff:
+                stop.set()
+
+        asyncio.run(arun_beat(backend, sleep=fake_sleep, stop=stop))
+
+    call_command("absurd_worker", queue="default", burst=True)
+    expected_good = 1  # "bad" raised in spawn (unimportable, logged); "good" still ran
+    assert Payload.objects.count() == expected_good
+```
+
+(`TIME_ZONE` is pinned to UTC in `tests/settings.py`, so the frozen instants and slot
+assertions stay UTC-clean. The fake `sleep` advances the frozen clock and trips `stop`
+once the cutoff passes — time/shutdown seams, not observation hooks; the assertions are
+real enqueued rows.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -k test_beat -v` Expected: ImportError
+(`arun_beat` undefined).
+
+- [ ] **Step 3: Implement (prose)**
+
+Add `arun_beat`. Resolve schedules via `get_settings_schedules(backend)`; if empty, log
+"no schedules declared" and return. Build a
+`dict name → get_next_datetime(cron, now())`. Loop while `stop` is None-or-unset: pick
+the earliest upcoming time; `delay = (earliest - now()).total_seconds()`; if
+`delay > 0`, `await sleep(delay)`; if `stop` set, break; recompute `current = now()`;
+for every schedule whose upcoming time `<= current`, fire it and advance its upcoming
+time to `get_next_datetime(cron, current)`. Fire by awaiting
+`asyncio.get_running_loop().run_in_executor(None, spawn_scheduled, schedule)` inside its
+own `try/except` (log via `logger.exception`, continue) so one bad schedule never stops
+the loop. Extract a verb-named helper below `arun_beat` if the fire-one-schedule block
+needs it; keep names underscore-free.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -k test_beat -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/scheduler.py tests/test_scheduler.py
+git commit -m "feat: arun_beat scheduler loop (fire-forward, failure-isolated)"
+```
+
+---
+
+## Task 6: `absurd_beat` management command
+
+**Files:**
+
+- Create: `django_absurd/management/commands/absurd_beat.py`
+- Modify: `django_absurd/scheduler.py` (add `run_beat` sync wrapper)
+- Test: `tests/test_scheduler.py`
+
+**Interfaces:**
+
+- Produces:
+  - `run_beat(backend: AbsurdBackend, *, stop: asyncio.Event | None = None) -> None` —
+    sync wrapper: `validate_backend(backend.database)` then
+    `asyncio.run(arun_beat(backend, stop=stop))`.
+  - `absurd_beat` command: selects the backend exactly like `absurd_worker` (`--alias`;
+    auto-select when single; `CommandError` listing aliases otherwise), installs
+    SIGINT/SIGTERM → set a `stop` event, logs the declared-schedule count, calls
+    `run_beat`.
+
+- [ ] **Step 1: Write the failing test**
+
+The blocking loop is covered by Task 5; here test the command's own logic — backend
+selection. Append:
+
+```python
+from django.core.management.base import CommandError
+
+
+def test_absurd_beat_unknown_alias_errors(settings):
+    settings.TASKS = schedule_tasks_setting(
+        {"m": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
+    )
+    with pytest.raises(CommandError, match="not an Absurd backend alias"):
+        call_command("absurd_beat", alias="nope")
+
+
+def test_absurd_beat_multiple_backends_requires_alias(settings):
+    settings.TASKS = {
+        "default": {"BACKEND": "django_absurd.backends.AbsurdBackend", "QUEUES": ["default"]},
+        "second": {"BACKEND": "django_absurd.backends.AbsurdBackend", "OPTIONS": {"DATABASE": "default", "QUEUES": {"default": {}}}},
+    }
+    with pytest.raises(CommandError, match="Use --alias"):
+        call_command("absurd_beat")
+```
+
+(Mirror the exact `CommandError` wording from `absurd_worker.py` so the `match=` strings
+line up; adjust if the wording differs.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -k absurd_beat -v` Expected:
+`CommandError: Unknown command: 'absurd_beat'` (command not found).
+
+- [ ] **Step 3: Implement (prose)**
+
+Add `run_beat` to `scheduler.py` (sync wrapper as in Interfaces). Create the command
+subclassing `django.core.management.base.BaseCommand`. `add_arguments`: `--alias`
+(default None). `handle`: copy `absurd_worker`'s backend-selection block
+(get_absurd_backends, alias validation, single-auto-select, multi → CommandError) —
+extract that block into a shared helper only if trivial; otherwise duplicate the few
+lines (DRY is nice-to-have, not worth a risky refactor here). Build an `asyncio.Event`
+stop; register SIGINT/SIGTERM handlers that set it (guard for platforms without signal
+support is unnecessary — same assumptions as the worker). `self.stdout.write` the
+declared-schedule count (e.g. `f"Started beat with {n} schedule(s)."`). Call
+`run_beat(backend, stop=stop)`.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -k absurd_beat -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/scheduler.py django_absurd/management/commands/absurd_beat.py tests/test_scheduler.py
+git commit -m "feat: absurd_beat management command + run_beat wrapper"
+```
+
+---
+
+## Task 7: `absurd_worker --beat`
+
+**Files:**
+
+- Modify: `django_absurd/worker.py` (`arun_worker`, `run_worker` gain `run_beat`)
+- Modify: `django_absurd/management/commands/absurd_worker.py` (add `--beat` flag)
+- Test: `tests/test_scheduler.py`
+
+**Interfaces:**
+
+- Consumes: `arun_beat` (Task 5).
+- Produces: `run_worker(..., run_beat: bool = False)` /
+  `arun_worker(..., run_beat: bool = False)`. When `run_beat` and NOT burst, the worker
+  gathers the blocking worker with `arun_beat(backend, stop=<shared>)` on one event
+  loop; SIGINT/SIGTERM stop both. `--beat` flag on `absurd_worker` (store_true, blocking
+  mode only).
+
+- [ ] **Step 1: Write the failing test**
+
+End-to-end at the command level: run `absurd_worker --beat` (main thread — asyncio
+signal handlers require it); a watcher thread sends SIGTERM once the scheduled side
+effect lands. `freeze_time(tick=True)` near a minute boundary makes the schedule fire
+within ~1s of real time. Append:
+
+```python
+import os
+import signal
+import threading
+import time
+
+from django.contrib.auth.models import Group
+from django.core.management.base import CommandError
+
+
+def test_worker_beat_rejects_burst(settings):
+    settings.TASKS = schedule_tasks_setting(
+        {"g": {"task": "tests.tasks.make_group", "cron": "*/1 * * * *", "args": ["x"]}}
+    )
+    with pytest.raises(CommandError, match="--beat"):
+        call_command("absurd_worker", queue="default", burst=True, beat=True)
+
+
+def test_worker_with_beat_runs_scheduled_task(settings):
+    settings.TASKS = schedule_tasks_setting(
+        {"g": {"task": "tests.tasks.make_group", "cron": "*/1 * * * *", "args": ["beat-ran"]}}
+    )
+    call_command("absurd_sync_queues")
+
+    def watch():
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if Group.objects.filter(name="beat-ran").exists():
+                break
+            time.sleep(0.05)
+        os.kill(os.getpid(), signal.SIGTERM)  # stop worker + beat (main-thread handler)
+
+    watcher = threading.Thread(target=watch, daemon=True)
+    watcher.start()
+    # tick=True near a boundary: next "*/1" slot is ~1s away in real time, so beat fires
+    # almost immediately; the live worker (fast poll) drains it.
+    with freeze_time("2026-01-01 00:00:59", tick=True):
+        call_command("absurd_worker", queue="default", beat=True, poll_interval=0.05)
+    watcher.join(timeout=5)
+
+    assert Group.objects.filter(name="beat-ran").exists()
+```
+
+(Caveats: the worker runs in the **main thread** — asyncio signal handlers require it.
+The watcher thread polls via its own ORM connection — sees committed rows under
+`transaction=True` — and sends a single SIGTERM, which the command's handler turns into
+a clean stop of both worker and beat. The 15s deadline is a safety bound; on success the
+Group appears in ~1s.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler.py -k worker_beat -v` Expected: error —
+`absurd_worker` has no `--beat` option yet.
+
+- [ ] **Step 3: Implement (prose)**
+
+Extend `arun_worker` with `run_beat: bool = False` and an optional shared
+`stop: asyncio.Event | None = None` (create one when None). In the non-burst branch,
+when `run_beat`:
+`await asyncio.gather(run_blocking_worker(client, options), arun_beat(backend, stop=stop))`;
+otherwise behave exactly as today. Extend the SIGINT/SIGTERM handlers (set in
+`run_blocking_worker`) to also set the shared `stop` so beat exits on the same signal.
+Thread `run_beat` + `stop` through `run_worker`. No beat clock/sleep seams on
+`arun_worker` — the command runs real time; the test drives timing via
+`freeze_time(tick=True)`. Add `--beat` (store_true) to `absurd_worker`; pass
+`run_beat=options["beat"]` into `run_worker`. Burst + `--beat` is not supported — if
+both given, raise `CommandError`.
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler.py -k worker_with_beat -v` → PASS. Then full
+file: `uv run pytest tests/test_scheduler.py -v`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/worker.py django_absurd/management/commands/absurd_worker.py tests/test_scheduler.py
+git commit -m "feat: absurd_worker --beat runs the scheduler in the worker loop"
+```
+
+---
+
+## Task 8: `E007` schedule validation checks
+
+**Files:**
+
+- Modify: `django_absurd/checks.py`
+- Test: `tests/test_scheduler_checks.py` (create)
+
+**Interfaces:**
+
+- Consumes: `get_settings_schedules`, `Schedule` (Task 2); `get_absurd_backends`,
+  `get_declared_queues`.
+- Produces: a new `@register("absurd")` check `check_absurd_schedule_config` emitting
+  `absurd.E007` per invalid `SCHEDULE` entry. No DB access.
+
+Validation per entry: `task` imports (ImportError → E007) and is a `django.tasks.Task`
+(else E007); `cron` valid (`croniter.croniter.is_valid(cron)` False → E007); only known
+keys `{task, cron, queue, args, kwargs}` (unknown key → E007); `args`/`kwargs`
+JSON-serializable (`json.dumps` raises → E007); `queue` (when set) in
+`get_declared_queues(backend)` (else E007). `msg` states the problem; `hint` states the
+fix.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_scheduler_checks.py`:
+
+```python
+import pytest
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+ABSURD = "django_absurd.backends.AbsurdBackend"
+
+
+def run_check(capsys, settings, schedule):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": ABSURD,
+            "OPTIONS": {"QUEUES": {"default": {}}, "SCHEDULE": schedule},
+        }
+    }
+    try:
+        call_command("check", "django_absurd")
+    except SystemCheckError as exc:
+        cap = capsys.readouterr()
+        return cap.out + cap.err + str(exc)
+    cap = capsys.readouterr()
+    return cap.out + cap.err
+
+
+def test_valid_schedule_no_error(capsys, settings):
+    out = run_check(capsys, settings, {"ok": {"task": "tests.tasks.add", "cron": "0 2 * * *"}})
+    assert "absurd.E007" not in out
+
+
+def test_unimportable_task(capsys, settings):
+    out = run_check(capsys, settings, {"x": {"task": "tests.tasks.nope", "cron": "0 2 * * *"}})
+    assert "absurd.E007" in out
+    assert "could not be imported" in out
+
+
+def test_not_a_task(capsys, settings):
+    out = run_check(capsys, settings, {"x": {"task": "tests.tasks.Payload", "cron": "0 2 * * *"}})
+    assert "absurd.E007" in out
+    assert "is not a Django task" in out
+
+
+def test_bad_cron(capsys, settings):
+    out = run_check(capsys, settings, {"x": {"task": "tests.tasks.add", "cron": "not-cron"}})
+    assert "absurd.E007" in out
+    assert "invalid cron expression" in out
+
+
+def test_unknown_key(capsys, settings):
+    out = run_check(capsys, settings, {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "bogus": 1}})
+    assert "absurd.E007" in out
+    assert "unknown key 'bogus'" in out
+
+
+def test_non_serializable_args(capsys, settings):
+    out = run_check(capsys, settings, {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "args": [object()]}})
+    assert "absurd.E007" in out
+    assert "not JSON-serializable" in out
+
+
+def test_undeclared_queue(capsys, settings):
+    out = run_check(capsys, settings, {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": "ghost"}})
+    assert "absurd.E007" in out
+    assert "queue 'ghost' is not declared" in out
+```
+
+(`tests.tasks.Payload` import path: use any importable non-Task symbol; if `Payload`
+isn't importable there, point at `tests.models.Payload`. Confirm while implementing.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `uv run pytest tests/test_scheduler_checks.py -v` Expected: failures —
+`absurd.E007` never present (check not implemented).
+
+- [ ] **Step 3: Implement (prose)**
+
+Add `E007` message/hint constants to `checks.py` following the existing
+`Exxx_MSG`/`Exxx_HINT` style (prefix `"django-absurd: "`; the per-entry detail strings
+must contain the exact substrings the tests assert: `could not be imported`,
+`is not a Django task`, `invalid cron expression`, `unknown key '<k>'`,
+`not JSON-serializable`, `queue '<q>' is not declared`). Add
+`check_absurd_schedule_config(*, app_configs, **kwargs)` decorated
+`@register("absurd")`: iterate `get_absurd_backends().values()`; for each,
+`get_settings_schedules(backend)` and the declared-queue set
+`get_declared_queues(backend)`; validate each `Schedule` per the rules above, appending
+one `Error(..., id="absurd.E007")` per problem. Put a
+`validate_schedule(schedule, declared_queues) -> list[CheckMessage]` helper BELOW the
+check (verb name, no leading underscore). Reading settings only — no DB — so it runs
+pre-migrate. Import `json`, `croniter`, `Task` (`from django.tasks import Task`).
+
+- [ ] **Step 4: Run, verify it passes**
+
+Run: `uv run pytest tests/test_scheduler_checks.py -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/checks.py tests/test_scheduler_checks.py
+git commit -m "feat: absurd.E007 system checks for SCHEDULE entries"
+```
+
+---
+
+## Task 9: User docs (AGENTS.md + README)
+
+**Files:**
+
+- Modify: `django_absurd/AGENTS.md`
+- Modify: `README.md`
+
+**Interfaces:** none (docs).
+
+Use the `sync-docs` skill's audience map. The Zensical site lives on the unmerged
+`docs-site` branch (PR #30) — its scheduling page is a follow-up once that merges; do
+NOT create `docs/guide/` here.
+
+- [ ] **Step 1: AGENTS.md — add a "Scheduling recurring tasks" section**
+
+Document: `OPTIONS["SCHEDULE"]` entry shape (`task`, `cron`, `queue?`, `args?`,
+`kwargs?`); cron is 5-field, interpreted in Django `TIME_ZONE`; `OPTIONS["SCHEDULER"]`
+default `"beat"` (pg_cron is a future opt-in); run `python manage.py absurd_beat` (or
+`absurd_worker --beat`); **run exactly one beat process** (concurrent beats
+double-fire); fire-forward-only (no backfill); validation surfaces as `absurd.E007` from
+`manage.py check`. Link the Absurd cron pattern
+(`https://earendil-works.github.io/absurd/patterns/cron/`) and Django Tasks docs per the
+docs-cross-link convention.
+
+- [ ] **Step 2: README.md — one-line mention + link**
+
+In the existing Documentation/feature area, add a single line that recurring tasks are
+supported via `absurd_beat`, linking to the AGENTS.md section. Keep README trim — no
+expansion beyond the line.
+
+- [ ] **Step 3: Verify wording matches code**
+
+Cross-check command name (`absurd_beat`), flag (`--beat`), setting keys (`SCHEDULE`,
+`SCHEDULER`), and the check id (`absurd.E007`) against the implemented code verbatim.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add django_absurd/AGENTS.md README.md
+git commit -m "docs: document settings-declared scheduled tasks (beat)"
+```
+
+---
+
+## Notes for the executor
+
+- Run the suite with Postgres up: `docker compose up -d db` (host `PGPORT` per
+  `.envrc`). Single-DB suite: `uv run pytest`. Don't run `tests/multidb` for this work.
+- After all tasks: full `uv run pytest` green + `uvx --with tox-uv tox` (matrix + mypy)
+  before the branch wrap-up.
+- Branch: `scheduler` (already cut from `origin/main`). Avoid `git add -A` — the
+  untracked Zensical `site/` build is not gitignored on this branch.

--- a/docs/specs/2026-06-29-scheduler-design.md
+++ b/docs/specs/2026-06-29-scheduler-design.md
@@ -1,0 +1,179 @@
+# Scheduler (beat) — design
+
+Issue: [#20](https://github.com/lincolnloop/django-absurd/issues/20). Recurring/periodic
+tasks for django-absurd. This spec covers **SP1 only** (see Decomposition). Builds the
+shared scheduling core + settings-declared schedules + an in-process **beat** loop that
+enqueues tasks on a cron cadence. No pg_cron, no new tables — ships scheduling on any
+Postgres.
+
+## Goal
+
+Declare recurring tasks in settings. Long-running `absurd_beat` process wakes on
+cadence, enqueues task through existing enqueue path. Celery-beat shape, Absurd engine
+underneath.
+
+## Architecture: two axes (whole feature)
+
+Recurring tasks split on two independent axes. Naming both here so SP1 fits the larger
+picture; SP1 implements only the marked pieces.
+
+- **Declaration** (what schedules exist): **settings provider** (SP1). Model /
+  admin-managed schedules are **out of scope** — settings is the only declaration source
+  for the beat approach.
+- **Execution** (what fires enqueue on cadence): **beat / application-side loop** (SP1)
+  · pg_cron / database-side (SP2).
+
+Declaration feeds whichever execution backend active. SP1 = settings provider + beat.
+
+## Scope (SP1)
+
+In: shared core (`Schedule`, settings provider, `spawn_scheduled`), `arun_beat` loop,
+`absurd_beat` command, `absurd_worker --beat`, `OPTIONS["SCHEDULE"]` +
+`OPTIONS["SCHEDULER"]`, `E007` checks, `croniter` runtime dep.
+
+Out (own sub-project): pg_cron backend (SP2). Out of scope entirely (not pursued for the
+beat approach): Django-model / admin-managed schedules. Also out: idempotency keys (see
+Decisions), `--once`/burst mode, backfill/catch-up, per-entry timezone, HA/multi-beat.
+
+## Components / file structure
+
+`django_absurd/scheduler.py` — shared core + loop:
+
+- `Schedule` — frozen dataclass. Fields: `name: str`, `task: str` (dotted path),
+  `cron: str` (5-field), `queue: str | None`, `args: list`, `kwargs: dict`. No `enabled`
+  — delete the settings entry to disable.
+- `get_settings_schedules(backend) -> list[Schedule]` — settings provider. Reads
+  `OPTIONS["SCHEDULE"]`. Settings is the only declaration source.
+- `spawn_scheduled(schedule) -> None` — resolve dotted path via `import_string` to the
+  Task, enqueue through the real Django Tasks path, routing to the schedule's queue via
+  `.using(queue_name=...)` when set:
+  `task.using(queue_name=schedule.queue).enqueue( *schedule.args, **schedule.kwargs)`
+  (skip `.using` when queue is None). Reusing enqueue gives param serialization for free
+  — no hand-built params.
+- `arun_beat(backend, *, now=..., sleep=..., stop=...) -> None` — async loop. `now`,
+  `sleep`, `stop` injectable for tests (see Testing). Per iteration: compute each
+  schedule's next fire instant (croniter, **Django timezone**), `await sleep` to
+  earliest, fire every schedule due at that slot via `spawn_scheduled`, repeat until
+  `stop` set.
+
+`django_absurd/management/commands/absurd_beat.py` — wraps `arun_beat` (asyncio.run),
+SIGTERM/SIGINT → set `stop` for clean shutdown. Logs declared-schedule count on start.
+
+`absurd_worker --beat` — worker is already async (`arun_worker`); flag schedules
+`arun_beat` as a concurrent task on the same loop. One process runs both.
+
+`django_absurd/checks.py` — add `E007` (below).
+
+Module-layout conventions: verbs in function names, helpers below public fns, absolute
+imports, `import typing as t`.
+
+## Settings schema
+
+```python
+TASKS = {
+    "default": {
+        "BACKEND": "django_absurd.backends.AbsurdBackend",
+        "OPTIONS": {
+            "SCHEDULER": "beat",          # default; "pg_cron" arrives in SP2
+            "SCHEDULE": {
+                "nightly-report": {
+                    "task": "myapp.tasks.send_report",   # dotted path to a @task
+                    "cron": "0 2 * * *",                  # 5-field, Django timezone
+                    "kwargs": {"full": True},             # optional
+                    "queue": "reports",                   # optional; backend default else
+                    "args": [],                           # optional
+                },
+            },
+        },
+    },
+}
+```
+
+`SCHEDULE`: name → spec. Required `task`, `cron`. Optional `queue`, `args`, `kwargs`.
+`SCHEDULER`: execution backend selector, default `"beat"` — works on any Postgres, so it
+stays the default for everyone. `"pg_cron"` (SP2) is an explicit opt-in requiring
+deliberate setup (extension + privileges); never auto-selected.
+
+## Behavior
+
+- **Timezone**: cron interpreted in Django `TIME_ZONE` (operator-intuitive — `0 2 * * *`
+  = 2am local). DST edge cases = standard cron behavior (document).
+- **Fire-forward-only**: on start / oversleep compute next slot ≥ now; never backfill
+  missed slots. Matches pg_cron, keeps SP2 consistent.
+- **Failure isolation**: one schedule raising (import error, enqueue error) is caught +
+  logged; loop and sibling schedules continue.
+- **Single instance**: run exactly **one** beat process. Concurrent beats double-fire
+  (operator contract, same as Celery beat). No idempotency guard (see Decisions).
+  Document prominently in the command help + user guide.
+
+## System checks (`E007`)
+
+Per `SCHEDULE` entry, no DB access (runs pre-migrate, follows existing `absurd.Exxx`
+pattern). `msg` states problem, `hint` states fix:
+
+- `task` imports and is a Django Task (not a bare callable).
+- `cron` parses under croniter.
+- only known keys (`task`, `cron`, `queue`, `args`, `kwargs`); `args`/`kwargs`
+  JSON-serializable.
+- `queue` (when given) is declared.
+
+## Dependencies
+
+- Runtime: add `croniter` to `[project] dependencies`. Scheduling is first-class — no
+  "croniter missing" degradation branch.
+- Dev: add `pytest-asyncio`, `freezegun` to the dev group.
+
+## Testing
+
+Function-based pytest, behavior-driven (assert observable enqueues, not internals).
+Drive `check`/command by running them, assert full emitted text per project conventions.
+
+Async loop tested deterministically without real waiting. freezegun controls
+`timezone.now()`; inject a fake `sleep` that ticks the frozen clock instead of waiting
+(freezegun/asyncio cannot fast-forward a real `asyncio.sleep` — the wait is injected). A
+`stop` event terminates the loop after N fires.
+
+Test sketch (RED-first; implementation follows in the plan):
+
+```python
+async def test_beat_enqueues_each_due_slot():
+    # freeze at 01:59, fake sleep advances frozen clock to the slot, stop after 2 fires
+    # assert: send_report landed on its queue at 02:00 and the next slot
+    ...
+```
+
+Cases: due slot enqueues the task on its queue; args/kwargs reach the task; multiple
+schedules fire independently; one failing schedule does not block others; fire-forward
+skips a missed slot; `absurd_beat` start/stop is clean; `check` emits `E007` text for
+each invalid entry (bad cron, unimportable task, non-Task, unknown key, undeclared
+queue, non-serializable args). Tests run on host via uv/tox; Postgres from
+`docker compose up -d db`.
+
+## Decisions (resolved in brainstorming)
+
+- **No idempotency keys.** Single-instance + fire-forward-only is already at-most-once
+  per slot without a key (post-fire restart recomputes the next _future_ slot).
+  Idempotency is insurance against concurrent beats, not correctness; operator owns
+  single-instance. pg_cron (SP2) is a single DB-side scheduler — also no concurrency.
+  Additive later if HA is ever needed (no redesign).
+- **Beat is async** (`arun_beat`), matching `arun_worker`; integrates into the worker
+  loop for `--beat`. Accepts a `pytest-asyncio` dev dep.
+- **croniter** (not cronsim) per preference; **freezegun** (not time-machine) per
+  preference.
+- **Django timezone** (not UTC) for cron evaluation.
+- Naming: module `scheduler.py`; everything else keeps "beat".
+
+## Decomposition (follow-on sub-project)
+
+Same #20; own issue + spec→plan→build cycle.
+
+- **SP2 — pg_cron backend.** `OPTIONS["SCHEDULER"]="pg_cron"`. DB-side `cron.schedule()`
+  → `absurd.spawn_task()`. Hard parts: SQL params must match Django Tasks serialization
+  byte-for-byte; ownership-prefix reconcile (upsert + **destructive prune** of owned
+  orphans, unlike non-destructive queue sync); align pg_cron timezone to Django
+  `TIME_ZONE`; privilege/availability checks (extension present, role has `USAGE` on
+  schema `cron`); cannot `CREATE EXTENSION` ourselves (superuser +
+  `shared_preload_libraries`) — assume installed, degrade + check.
+
+Explicitly **not pursued**: a Django-model / admin-managed schedule store. The beat
+approach declares schedules in settings only.

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,10 +12,10 @@ Absurd's queue tables through the Django admin (which django-absurd auto-registe
 
 ```
 examples/
-  compose.yaml   # db (Postgres, internal-only) + app (web/admin) + worker (absurd_worker)
+  compose.yaml   # db (Postgres, internal-only) + app (web/admin) + worker (absurd_worker --beat)
   Dockerfile     # image built from the repo root so it installs local django-absurd
   pyproject.toml # deps: nanodjango, django-absurd (local path), psycopg[binary]
-  app.py         # the whole app: Django(...) config, the add task, two views, admin
+  app.py         # the whole app: Django(...) config, add + ping tasks, a SCHEDULE (ping/min), views, admin
 ```
 
 ## Run it
@@ -31,8 +31,10 @@ That brings up three services:
 1. **db** — Postgres, reachable only over the compose network (no published host port).
 2. **app** — migrates, creates an `admin` / `admin` superuser (idempotent), and serves
    the web app + admin on **http://localhost:8000/**.
-3. **worker** — a long-lived `absurd_worker` consuming the `default` queue; it starts
-   once the app is healthy (i.e. migrations have run).
+3. **worker** — a long-lived `absurd_worker --beat` consuming the `default` queue; it
+   starts once the app is healthy (i.e. migrations have run). `--beat` also runs the
+   scheduler in-process: the `ping` task is enqueued every minute and run here, so the
+   worker logs print **"pong 🏓"** once a minute.
 
 Then, in a browser:
 
@@ -51,7 +53,7 @@ docker compose down -v
 ## Try more
 
 ```bash
-# Tail just the worker's per-task logs
+# Tail the worker's logs — per-task lines plus "pong 🏓" every minute (the scheduled ping)
 docker compose logs -f worker
 
 # Run a one-off management command against the stack

--- a/examples/app.py
+++ b/examples/app.py
@@ -18,6 +18,7 @@ to sqlite, so DATABASES is overridden below.
 
 import dataclasses
 import html
+import logging
 import os
 import pprint
 
@@ -48,17 +49,30 @@ app = Django(
     TASKS={
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "QUEUES": ["default"],
+            "OPTIONS": {
+                "QUEUES": {"default": {}},
+                # Recurring task: the beat scheduler (run via `absurd_worker
+                # --beat`) enqueues ping() every minute; the worker then runs it.
+                "SCHEDULE": {
+                    "ping": {"task": "app.ping", "cron": "* * * * *"},
+                },
+            },
         }
     },
-    # Surface django-absurd's per-task worker logging on the console.
+    # Surface django-absurd's per-task worker logging + the demo task's own
+    # output on the console.
     LOGGING={
         "version": 1,
         "disable_existing_loggers": False,
         "handlers": {"console": {"class": "logging.StreamHandler"}},
-        "loggers": {"django_absurd": {"handlers": ["console"], "level": "INFO"}},
+        "loggers": {
+            "django_absurd": {"handlers": ["console"], "level": "INFO"},
+            "demo": {"handlers": ["console"], "level": "INFO"},
+        },
     },
 )
+
+logger = logging.getLogger("demo")
 
 
 @task
@@ -66,6 +80,13 @@ def add(a: str, b: str) -> float:
     """Run in the worker, not the web request. Coerces here so non-numeric input
     fails the task (-> FAILED) rather than being rejected up front."""
     return float(a) + float(b)
+
+
+@task
+def ping() -> None:
+    """Scheduled every minute (see SCHEDULE above). The beat scheduler enqueues
+    it; the worker runs it and logs 'pong' to the console."""
+    logger.info("pong 🏓")
 
 
 class AddForm(forms.Form):

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -32,8 +32,10 @@ services:
       context: ..
       dockerfile: examples/Dockerfile
     # Long-lived blocking worker consuming "default". On start it reconciles the
-    # queue (creating it + indexing the admin views on first run).
-    command: nanodjango manage app.py absurd_worker
+    # queue (creating it + indexing the admin views on first run). `--beat` also
+    # runs the scheduler in-process, so the SCHEDULE entry (ping every minute)
+    # fires here — watch this service's logs for "pong" once a minute.
+    command: nanodjango manage app.py absurd_worker --beat
     depends_on:
       - app
     restart: on-failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ dev = [
   "build==1.5.0",
   "django-coverage-plugin==3.2.2",
   "django-stubs==6.0.5",
-  "hatch-vcs==0.5.0",
-  "hatchling==1.30.1",
+  "freezegun==1.5.5",
   "mypy==2.1.0",
   "psycopg[binary]==3.3.4",
   "pytest-cov==7.1.0",
@@ -18,6 +17,7 @@ dev = [
   "pytest-socket==0.8.0",
   "pytest==9.1.1",
   "ruff==0.15.18",
+  "types-croniter==6.2.2.20260518",
 ]
 
 [project]
@@ -43,6 +43,7 @@ classifiers = [
 ]
 dependencies = [
   "absurd-sdk>=0.4.0,<0.5.0",
+  "croniter>=2.0",
   "Django>=6.0",
 ]
 description = "Django integration for Absurd, the Postgres-native workflow engine."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dev = [
   "django-coverage-plugin==3.2.2",
   "django-stubs==6.0.5",
   "freezegun==1.5.5",
+  "hatch-vcs==0.5.0",
+  "hatchling==1.30.1",
   "mypy==2.1.0",
   "psycopg[binary]==3.3.4",
   "pytest-cov==7.1.0",
@@ -128,6 +130,9 @@ addopts = [
 ]
 filterwarnings = [
   "error::bs4.GuessedAtParserWarning",  # Raise error when parser not set.
+]
+markers = [
+  "packaging: builds/inspects the distribution; run only in the dev tox env (needs the build backend)",
 ]
 pythonpath = ["."]
 testpaths = ["tests"]

--- a/tests/raises_on_import.py
+++ b/tests/raises_on_import.py
@@ -1,0 +1,2 @@
+msg = "boom at import"
+raise RuntimeError(msg)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -53,6 +53,8 @@ DATABASES = {
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+TIME_ZONE = "UTC"
+
 DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
 
 TASKS = {

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -7,7 +7,14 @@ import zipfile
 from importlib.resources import files
 from pathlib import Path
 
+import pytest
+
 import django_absurd
+
+# Distribution-build tests — version-agnostic and need the build backend
+# (hatchling/hatch-vcs). Marked so the tox matrix can skip them and run them
+# only in the `dev` env (see tox.ini).
+pytestmark = pytest.mark.packaging
 
 # Top-level entries allowed in the sdist. The hatchling backend uses an explicit
 # allowlist ([tool.hatch.build.targets.sdist] include), so only the package plus the

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -22,6 +22,7 @@ from django_absurd.scheduler import (
     spawn_scheduled,
 )
 from tests.models import Payload
+from tests.tasks import make_group as make_group_task
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -300,7 +301,7 @@ def test_absurd_beat_valid_alias_and_signal_handler(settings):
         # Gating on the handler (vs a fixed sleep) removes the race where the
         # signal could arrive before the command replaces the default handler.
         deadline = time.monotonic() + 2
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline:  # pragma: no branch
             if signal.getsignal(signal.SIGINT) is not prev_sigint:
                 break
             time.sleep(0.005)
@@ -388,7 +389,7 @@ def test_worker_with_beat_runs_scheduled_task(settings):
 
     def watch():
         deadline = time.monotonic() + 15
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline:  # pragma: no branch
             if Group.objects.filter(name="beat-ran").exists():
                 break
             time.sleep(0.05)
@@ -403,3 +404,84 @@ def test_worker_with_beat_runs_scheduled_task(settings):
     watcher.join(timeout=5)
 
     assert Group.objects.filter(name="beat-ran").exists()
+
+
+def test_beat_already_stopped_on_entry_skips_loop(settings):
+    # Covers scheduler.py 92->exit: while-False branch when stop is pre-set.
+    # Beat has at least one schedule so it passes the early-return guard, reaches
+    # the while loop with stop already set → exits without enqueueing anything.
+    settings.TASKS = make_tasks_setting(
+        {
+            "p": {
+                "task": "tests.tasks.create_payload",
+                "cron": "*/1 * * * *",
+                "args": ["should-not-fire"],
+            }
+        }
+    )
+    call_command("absurd_sync_queues")
+    backend = get_absurd_backends()["default"]
+
+    stop = threading.Event()
+    stop.set()
+    run_beat(backend, stop=stop)
+
+    assert Payload.objects.count() == 0
+
+
+def test_beat_skips_not_yet_due_schedule(settings):
+    # Covers scheduler.py 99->98: if due <= current False branch.
+    # Two schedules: one every minute (due), one at 02:00 (far future, not due).
+    # After one slot cutoff only the due schedule fires.
+    settings.TASKS = make_tasks_setting(
+        {
+            "due": {
+                "task": "tests.tasks.create_payload",
+                "cron": "*/1 * * * *",
+                "args": ["due"],
+            },
+            "later": {
+                "task": "tests.tasks.create_payload",
+                "cron": "0 2 * * *",
+                "args": ["later"],
+            },
+        }
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+    # Cutoff at 00:01:30 → "due" slot 00:01 fires, "later" slot 02:00 does not.
+    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Payload.objects.count() == 1
+    assert Payload.objects.filter(data="due").exists()
+    assert not Payload.objects.filter(data="later").exists()
+
+
+def test_plain_worker_runs_blocking_worker(settings):
+    # Covers worker.py line 114: else branch of arun_worker (no burst, no beat).
+    settings.TASKS = make_tasks_setting(
+        {
+            "g": {
+                "task": "tests.tasks.make_group",
+                "cron": "*/1 * * * *",
+                "args": ["plain-worker"],
+            }
+        }
+    )
+    call_command("absurd_sync_queues")
+    make_group_task.enqueue("plain-worker")
+
+    def watch():
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:  # pragma: no branch
+            if Group.objects.filter(name="plain-worker").exists():
+                break
+            time.sleep(0.05)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    watcher = threading.Thread(target=watch, daemon=True)
+    watcher.start()
+    call_command("absurd_worker", queue="default", poll_interval=0.05)
+    watcher.join(timeout=5)
+
+    assert Group.objects.filter(name="plain-worker").exists()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,405 @@
+import datetime as dt
+import os
+import signal
+import threading
+import time
+import zoneinfo
+
+import pytest
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+from freezegun import freeze_time
+
+from django_absurd.backends import get_absurd_backends
+from django_absurd.scheduler import (
+    Schedule,
+    derive_idempotency_key,
+    get_next_datetime,
+    get_settings_schedules,
+    run_beat,
+    spawn_scheduled,
+)
+from tests.models import Payload
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def make_tasks_setting(schedule):
+    return {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {
+                "QUEUES": {"default": {}, "other": {}, "reports": {}},
+                "SCHEDULE": schedule,
+            },
+        }
+    }
+
+
+def test_settings_provider_reads_entries(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "nightly": {
+                "task": "tests.tasks.add",
+                "cron": "0 2 * * *",
+                "args": [1, 2],
+                "queue": "reports",
+            }
+        }
+    )
+    backend = get_absurd_backends()["default"]
+    schedules = get_settings_schedules(backend)
+    assert schedules == [
+        Schedule(
+            name="nightly",
+            task="tests.tasks.add",
+            cron="0 2 * * *",
+            queue="reports",
+            args=[1, 2],
+            kwargs={},
+        )
+    ]
+
+
+def test_settings_provider_defaults_and_empty(settings):
+    settings.TASKS = make_tasks_setting(
+        {"ping": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
+    )
+    backend = get_absurd_backends()["default"]
+    (s,) = get_settings_schedules(backend)
+    assert s.queue is None
+    assert s.args == []
+    assert s.kwargs == {}
+
+
+def test_settings_provider_no_schedule_key(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "QUEUES": ["default"],
+        }
+    }
+    backend = get_absurd_backends()["default"]
+    assert get_settings_schedules(backend) == []
+
+
+@freeze_time("2026-01-01 01:59:00")
+def test_get_next_datetime_same_day():
+    expected = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
+    assert get_next_datetime("0 2 * * *", timezone.now()) == expected
+
+
+@freeze_time("2026-01-01 02:00:00")
+def test_get_next_datetime_rolls_forward():
+    expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
+    assert get_next_datetime("0 2 * * *", timezone.now()) == expected
+
+
+@freeze_time("2026-01-01 12:00:00")  # 06:00 in Chicago (UTC-6)
+def test_get_next_datetime_uses_django_timezone(settings):
+    # cron interpreted in Django TIME_ZONE: 02:00 Chicago already passed -> tomorrow
+    settings.TIME_ZONE = "America/Chicago"
+    chicago = zoneinfo.ZoneInfo("America/Chicago")
+    expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=chicago)
+    result = get_next_datetime("0 2 * * *", timezone.now())
+    assert result == expected
+
+
+# run_beat_until and tests below it use run_beat's injected wait/now seam because a real
+# threading.Event.wait can't be fast-forwarded by freezegun; the command path is not
+# deterministic enough for exact multi-slot counts.
+def run_beat_until(backend, cutoff: dt.datetime) -> None:
+    with freeze_time("2026-01-01 00:00:00") as frozen:
+
+        def fake_wait(timeout: float) -> bool:
+            frozen.tick(dt.timedelta(seconds=timeout))
+            return timezone.now() >= cutoff
+
+        run_beat(backend, wait=fake_wait)
+
+
+def test_beat_fires_each_due_slot(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "p": {
+                "task": "tests.tasks.create_payload",
+                "cron": "*/1 * * * *",
+                "args": ["tick"],
+            }
+        },
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 2, 30, tzinfo=dt.UTC))
+    call_command("absurd_worker", queue="default", burst=True)
+    expected_fires = 2  # slots 00:01 and 00:02
+    assert Payload.objects.count() == expected_fires
+
+
+def test_beat_no_schedules_returns(settings):
+    settings.TASKS = make_tasks_setting({})
+    backend = get_absurd_backends()["default"]
+    run_beat(backend, stop=threading.Event())  # returns immediately, no hang
+
+
+def test_beat_isolates_failing_schedule(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "bad": {"task": "tests.tasks.does_not_exist", "cron": "*/1 * * * *"},
+            "good": {
+                "task": "tests.tasks.create_payload",
+                "cron": "*/1 * * * *",
+                "args": ["ok"],
+            },
+        },
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+    call_command("absurd_worker", queue="default", burst=True)
+    expected_good = 1  # "bad" raised in spawn (unimportable, logged); "good" still ran
+    assert Payload.objects.count() == expected_good
+
+
+def test_beat_spawns_task_with_args(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "g": {
+                "task": "tests.tasks.make_group",
+                "cron": "*/1 * * * *",
+                "args": ["beat-args"],
+            }
+        }
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="beat-args").exists()
+
+
+def test_beat_spawns_task_with_kwargs(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "g": {
+                "task": "tests.tasks.make_group",
+                "cron": "*/1 * * * *",
+                "kwargs": {"name": "beat-kw"},
+            }
+        }
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Group.objects.filter(name="beat-kw").exists()
+
+
+def test_beat_routes_task_to_queue(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "g": {
+                "task": "tests.tasks.make_group",
+                "cron": "*/1 * * * *",
+                "queue": "other",
+                "args": ["beat-routed"],
+            }
+        }
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+    call_command("absurd_worker", queue="default", burst=True)
+    assert not Group.objects.filter(name="beat-routed").exists()
+    call_command("absurd_worker", queue="other", burst=True)
+    assert Group.objects.filter(name="beat-routed").exists()
+
+
+def test_derive_idempotency_key_stable_same_inputs():
+    schedule = Schedule(name="nightly", task="tests.tasks.add", cron="0 2 * * *")
+    slot = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
+    assert derive_idempotency_key(schedule, slot) == derive_idempotency_key(
+        schedule, slot
+    )
+
+
+def test_derive_idempotency_key_differs_across_slots():
+    schedule = Schedule(name="nightly", task="tests.tasks.add", cron="0 2 * * *")
+    slot_a = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
+    slot_b = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
+    assert derive_idempotency_key(schedule, slot_a) != derive_idempotency_key(
+        schedule, slot_b
+    )
+
+
+def test_derive_idempotency_key_differs_across_names():
+    slot = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
+    s_a = Schedule(name="alpha", task="tests.tasks.add", cron="0 2 * * *")
+    s_b = Schedule(name="beta", task="tests.tasks.add", cron="0 2 * * *")
+    assert derive_idempotency_key(s_a, slot) != derive_idempotency_key(s_b, slot)
+
+
+def test_idempotency_key_dedups_same_slot(settings):
+    # The command/loop never re-fires a single slot; this tests spawn_scheduled directly
+    # to prove our key + Absurd's real dedup together collapse repeated fires to one task.
+    settings.TASKS = make_tasks_setting(
+        {
+            "p": {
+                "task": "tests.tasks.create_payload",
+                "cron": "*/1 * * * *",
+                "args": ["x"],
+            }
+        }
+    )
+    call_command("absurd_sync_queues")
+    backend = get_absurd_backends()["default"]
+    schedules = get_settings_schedules(backend)
+    (schedule,) = schedules
+    slot = dt.datetime(2026, 1, 1, 0, 1, tzinfo=dt.UTC)
+    spawn_scheduled(schedule, slot)
+    spawn_scheduled(schedule, slot)
+    call_command("absurd_worker", queue="default", burst=True)
+    assert Payload.objects.count() == 1
+
+
+def test_absurd_beat_empty_schedule_runs_handle(settings):
+    # Covers absurd_beat handle body (single-backend path via base.py:16-17).
+    # Empty SCHEDULE → run_beat returns immediately (no blocking), no threads needed.
+    settings.TASKS = make_tasks_setting({})
+    call_command("absurd_sync_queues")
+    prev_sigint = signal.getsignal(signal.SIGINT)
+    prev_sigterm = signal.getsignal(signal.SIGTERM)
+    try:
+        call_command("absurd_beat")
+    finally:
+        signal.signal(signal.SIGINT, prev_sigint)
+        signal.signal(signal.SIGTERM, prev_sigterm)
+
+
+def test_absurd_beat_valid_alias_and_signal_handler(settings):
+    # Covers base.py:15 (valid alias → backend = backends[alias]) and
+    # absurd_beat.py:27 (handle_signal body: stop.set()).
+    settings.TASKS = make_tasks_setting(
+        {
+            "nightly": {
+                "task": "tests.tasks.create_payload",
+                "cron": "0 2 * * *",
+                "args": ["x"],
+            }
+        }
+    )
+    call_command("absurd_sync_queues")
+
+    prev_sigint = signal.getsignal(signal.SIGINT)
+    prev_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def fire_sigint() -> None:
+        # Wait until absurd_beat has installed its SIGINT handler, then signal.
+        # Gating on the handler (vs a fixed sleep) removes the race where the
+        # signal could arrive before the command replaces the default handler.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if signal.getsignal(signal.SIGINT) is not prev_sigint:
+                break
+            time.sleep(0.005)
+        os.kill(os.getpid(), signal.SIGINT)
+
+    killer = threading.Thread(target=fire_sigint, daemon=True)
+    try:
+        killer.start()
+        call_command("absurd_beat", alias="default")
+    finally:
+        killer.join(timeout=2)
+        signal.signal(signal.SIGINT, prev_sigint)
+        signal.signal(signal.SIGTERM, prev_sigterm)
+
+
+def test_absurd_beat_unknown_alias_errors(settings):
+    settings.TASKS = make_tasks_setting(
+        {"m": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
+    )
+    with pytest.raises(CommandError, match="not an Absurd backend alias"):
+        call_command("absurd_beat", alias="nope")
+
+
+def test_absurd_beat_multiple_backends_requires_alias(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "QUEUES": ["default"],
+        },
+        "second": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"DATABASE": "default", "QUEUES": {"default": {}}},
+        },
+    }
+    with pytest.raises(CommandError, match="Use --alias"):
+        call_command("absurd_beat")
+
+
+def test_worker_beat_rejects_burst(settings):
+    settings.TASKS = make_tasks_setting(
+        {"g": {"task": "tests.tasks.make_group", "cron": "*/1 * * * *", "args": ["x"]}}
+    )
+    with pytest.raises(CommandError, match="--beat"):
+        call_command("absurd_worker", queue="default", burst=True, beat=True)
+
+
+def test_beat_stop_interrupts_long_sleep(settings):
+    # Real threading.Event.wait — stop.set() must wake the beat promptly.
+    settings.TASKS = make_tasks_setting(
+        {
+            "nightly": {
+                "task": "tests.tasks.create_payload",
+                "cron": "0 2 * * *",  # next slot is ~1-23h away
+                "args": ["should-not-fire"],
+            }
+        },
+    )
+    backend = get_absurd_backends()["default"]
+    call_command("absurd_sync_queues")
+
+    stop = threading.Event()
+    beat_thread = threading.Thread(
+        target=run_beat, kwargs={"backend": backend, "stop": stop}, daemon=True
+    )
+    beat_thread.start()
+    time.sleep(0.05)  # let beat enter stop.wait
+    stop.set()
+    beat_thread.join(timeout=2)
+
+    assert not beat_thread.is_alive()
+    assert Payload.objects.count() == 0
+
+
+def test_worker_with_beat_runs_scheduled_task(settings):
+    settings.TASKS = make_tasks_setting(
+        {
+            "g": {
+                "task": "tests.tasks.make_group",
+                "cron": "*/1 * * * *",
+                "args": ["beat-ran"],
+            }
+        }
+    )
+    call_command("absurd_sync_queues")
+
+    def watch():
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if Group.objects.filter(name="beat-ran").exists():
+                break
+            time.sleep(0.05)
+        os.kill(os.getpid(), signal.SIGTERM)  # stop worker + beat (main-thread handler)
+
+    watcher = threading.Thread(target=watch, daemon=True)
+    watcher.start()
+    # tick=True near a boundary: next "*/1" slot is ~1s away in real time, so beat fires
+    # almost immediately; the live worker (fast poll) drains it.
+    with freeze_time("2026-01-01 00:00:59", tick=True):
+        call_command("absurd_worker", queue="default", beat=True, poll_interval=0.05)
+    watcher.join(timeout=5)
+
+    assert Group.objects.filter(name="beat-ran").exists()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -242,6 +242,18 @@ def test_derive_idempotency_key_differs_across_names():
     assert derive_idempotency_key(s_a, slot) != derive_idempotency_key(s_b, slot)
 
 
+def test_derive_idempotency_key_distinguishes_sub_minute_slots():
+    # 6-field crons (croniter accepts them) yield sub-minute slots; the key must
+    # distinguish slots in the same minute, or two fires would collide and the
+    # second would be wrongly deduped.
+    schedule = Schedule(name="n", task="tests.tasks.add", cron="*/30 * * * * *")
+    slot_a = dt.datetime(2026, 1, 1, 2, 0, 0, tzinfo=dt.UTC)
+    slot_b = dt.datetime(2026, 1, 1, 2, 0, 30, tzinfo=dt.UTC)
+    assert derive_idempotency_key(schedule, slot_a) != derive_idempotency_key(
+        schedule, slot_b
+    )
+
+
 def test_idempotency_key_dedups_same_slot(settings):
     # The command/loop never re-fires a single slot; this tests spawn_scheduled directly
     # to prove our key + Absurd's real dedup together collapse repeated fires to one task.

--- a/tests/test_scheduler_checks.py
+++ b/tests/test_scheduler_checks.py
@@ -1,0 +1,81 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+ABSURD = "django_absurd.backends.AbsurdBackend"
+
+E007_MSG = "django-absurd: invalid SCHEDULE entry."
+
+
+@pytest.fixture
+def run_check(capsys, settings):
+    def _run(schedule):
+        settings.TASKS = {
+            "default": {
+                "BACKEND": ABSURD,
+                "OPTIONS": {
+                    "QUEUES": {"default": {}, "other": {}},
+                    "SCHEDULE": schedule,
+                },
+            }
+        }
+        try:
+            call_command("check", "django_absurd")
+        except SystemCheckError as exc:
+            cap = capsys.readouterr()
+            return cap.out + cap.err + str(exc)
+        cap = capsys.readouterr()
+        return cap.out + cap.err
+
+    return _run
+
+
+def test_valid_schedule_no_error(run_check):
+    out = run_check({"ok": {"task": "tests.tasks.add", "cron": "0 2 * * *"}})
+    assert "absurd.E007" not in out
+
+
+def test_unimportable_task(run_check):
+    out = run_check({"x": {"task": "tests.tasks.nope", "cron": "0 2 * * *"}})
+    assert (
+        f"{E007_MSG} Schedule 'x': task 'tests.tasks.nope' could not be imported."
+    ) in out
+    assert "absurd.E007" in out
+
+
+def test_not_a_task(run_check):
+    out = run_check({"x": {"task": "tests.tasks.Payload", "cron": "0 2 * * *"}})
+    assert (
+        f"{E007_MSG} Schedule 'x': 'tests.tasks.Payload' is not a Django task."
+    ) in out
+    assert "absurd.E007" in out
+
+
+def test_bad_cron(run_check):
+    out = run_check({"x": {"task": "tests.tasks.add", "cron": "not-cron"}})
+    assert (f"{E007_MSG} Schedule 'x': invalid cron expression 'not-cron'.") in out
+    assert "absurd.E007" in out
+
+
+def test_unknown_key(run_check):
+    out = run_check({"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "bogus": 1}})
+    assert (f"{E007_MSG} Schedule 'x': unknown key 'bogus'.") in out
+    assert "absurd.E007" in out
+
+
+def test_non_serializable_args(run_check):
+    out = run_check(
+        {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "args": [object()]}}
+    )
+    assert (f"{E007_MSG} Schedule 'x': args is not JSON-serializable.") in out
+    assert "absurd.E007" in out
+
+
+def test_undeclared_queue(run_check):
+    out = run_check(
+        {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": "ghost"}}
+    )
+    assert (f"{E007_MSG} Schedule 'x': queue 'ghost' is not declared.") in out
+    assert "absurd.E007" in out

--- a/tests/test_scheduler_checks.py
+++ b/tests/test_scheduler_checks.py
@@ -83,6 +83,14 @@ def test_bad_cron(run_check):
     assert "absurd.E007" in out
 
 
+def test_non_string_cron(run_check):
+    # A non-string cron (e.g. forgot the quotes) must yield a clean E007, not an
+    # AttributeError from croniter.is_valid — the check runs at worker/beat boot.
+    out = run_check({"x": {"task": "tests.tasks.add", "cron": 300}})
+    assert (f"{E007_MSG} Schedule 'x': invalid cron expression 300.") in out
+    assert "absurd.E007" in out
+
+
 def test_unknown_key(run_check):
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "bogus": 1}})
     assert (f"{E007_MSG} Schedule 'x': unknown key 'bogus'.") in out
@@ -102,4 +110,14 @@ def test_undeclared_queue(run_check):
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": "ghost"}}
     )
     assert (f"{E007_MSG} Schedule 'x': queue 'ghost' is not declared.") in out
+    assert "absurd.E007" in out
+
+
+def test_non_string_queue(run_check):
+    # A non-string queue (e.g. a list) must yield a clean E007, not a TypeError
+    # from the `queue not in declared_queues` membership test.
+    out = run_check(
+        {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": ["bad"]}}
+    )
+    assert (f"{E007_MSG} Schedule 'x': queue ['bad'] is not declared.") in out
     assert "absurd.E007" in out

--- a/tests/test_scheduler_checks.py
+++ b/tests/test_scheduler_checks.py
@@ -40,8 +40,32 @@ def test_valid_schedule_no_error(run_check):
 def test_unimportable_task(run_check):
     out = run_check({"x": {"task": "tests.tasks.nope", "cron": "0 2 * * *"}})
     assert (
-        f"{E007_MSG} Schedule 'x': task 'tests.tasks.nope' could not be imported."
+        f"{E007_MSG} Schedule 'x': task 'tests.tasks.nope' could not be imported"
     ) in out
+    assert "absurd.E007" in out
+
+
+def test_non_import_error_at_task_import(run_check):
+    out = run_check(
+        {"x": {"task": "tests.raises_on_import.anything", "cron": "0 2 * * *"}}
+    )
+    assert (
+        f"{E007_MSG} Schedule 'x': task 'tests.raises_on_import.anything' could not be imported"
+    ) in out
+    assert "RuntimeError" in out
+    assert "boom at import" in out
+    assert "absurd.E007" in out
+
+
+def test_schedule_not_a_mapping(run_check):
+    out = run_check(["nightly"])
+    assert 'OPTIONS["SCHEDULE"] must be a mapping of name -> spec' in out
+    assert "absurd.E007" in out
+
+
+def test_schedule_entry_not_a_mapping(run_check):
+    out = run_check({"nightly": "0 2 * * *"})
+    assert f"{E007_MSG} Schedule 'nightly' must be a mapping." in out
     assert "absurd.E007" in out
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ uv_resolution =
     py3{13,14}: highest
 pass_env = PG*
 commands =
-    !mypy: pytest {posargs}
+    # The matrix skips `packaging`-marked tests (they build the dist and need the
+    # build backend); the `dev` env below runs the full suite including them.
+    !mypy: pytest -m "not packaging" {posargs}
     !mypy: pytest tests/multidb {posargs}
     mypy: mypy .
 

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,8 @@ dev = [
     { name = "django-coverage-plugin" },
     { name = "django-stubs" },
     { name = "freezegun" },
+    { name = "hatch-vcs" },
+    { name = "hatchling" },
     { name = "mypy" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
@@ -268,6 +270,8 @@ dev = [
     { name = "django-coverage-plugin", specifier = "==3.2.2" },
     { name = "django-stubs", specifier = "==6.0.5" },
     { name = "freezegun", specifier = "==1.5.5" },
+    { name = "hatch-vcs", specifier = "==0.5.0" },
+    { name = "hatchling", specifier = "==1.30.1" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -329,6 +333,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
+name = "hatch-vcs"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hatchling" },
+    { name = "setuptools-scm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/4cc743d38adbee9d57d786fa496ed1daadb17e48589b6da8fa55717a0746/hatch_vcs-0.5.0.tar.gz", hash = "sha256:0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9", size = 11424, upload-time = "2025-05-27T05:16:04.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/48/1f85cee4b7b4f40b9b814b1febbc661bda6ced9649e410a0b74f6e415dd0/hatch_vcs-0.5.0-py3-none-any.whl", hash = "sha256:b49677dbdc597460cc22d01b27ab3696f5e16a21ecf2700fb01bc28e1f2a04a7", size = 8507, upload-time = "2025-05-27T05:16:03.184Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.30.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/4c/8717ccb844b4fa5a5ba6352e97d743ed24e9a22cf90b7c109c17030a46a1/hatchling-1.30.1.tar.gz", hash = "sha256:eee4fd45357f72ebb3d7a42e5d72cfb5e29ed426d79e8836288926c4258d5f2e", size = 56929, upload-time = "2026-06-02T00:09:41.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl", hash = "sha256:161eacafb3c6f91526e92116d21426369f2c36e98c36a864f11a96345ad4ee31", size = 77489, upload-time = "2026-06-02T00:09:40.139Z" },
 ]
 
 [[package]]
@@ -648,6 +680,29 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "setuptools-scm"
+version = "10.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "vcs-versioning" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/f6/4226baf8e38db72465f94f9a3ac81ed16be39bc773c4d6d13af342d3dd94/setuptools_scm-10.1.2.tar.gz", hash = "sha256:24079818acc46e99aae0d65b8d511fafe965970d9cbd060c7b9f7275ded520fb", size = 66674, upload-time = "2026-06-23T04:14:03.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6b/209c1eb9c92c49d6bbe080ee8ee54d580955f6bd0de37fd5104aa0c51d35/setuptools_scm-10.1.2-py3-none-any.whl", hash = "sha256:8bb17e208fb22ebc11e4eaf6d765955db1903eefd21a3f0ed5518fc3fb186e84", size = 27714, upload-time = "2026-06-23T04:14:02.436Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -672,6 +727,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]
@@ -708,4 +772,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "vcs-versioning"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ba/b64191fdd9b7a42a976ee465050d09b859c4cef75a56951266c6ab6ea96a/vcs_versioning-2.1.1.tar.gz", hash = "sha256:162749bbf8fa4a5db52330a7e61438cc1962033bab9f7c2d294d1078d40a4534", size = 130733, upload-time = "2026-06-23T10:57:43.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/99/0d5c1fc5c69f4d3d96dcc3776a7da700d1c8b4ee6821e0affc5099cbdc8e/vcs_versioning-2.1.1-py3-none-any.whl", hash = "sha256:67567f9053dd0753dc77ce70bf7fccbd7410f0f7489a9fcc492859da9666c731", size = 106772, upload-time = "2026-06-23T10:57:41.596Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -201,6 +201,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "django"
 version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -219,6 +231,7 @@ name = "django-absurd"
 source = { editable = "." }
 dependencies = [
     { name = "absurd-sdk" },
+    { name = "croniter" },
     { name = "django" },
 ]
 
@@ -229,8 +242,7 @@ dev = [
     { name = "build" },
     { name = "django-coverage-plugin" },
     { name = "django-stubs" },
-    { name = "hatch-vcs" },
-    { name = "hatchling" },
+    { name = "freezegun" },
     { name = "mypy" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
@@ -238,11 +250,13 @@ dev = [
     { name = "pytest-django" },
     { name = "pytest-socket" },
     { name = "ruff" },
+    { name = "types-croniter" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "absurd-sdk", specifier = ">=0.4.0,<0.5.0" },
+    { name = "croniter", specifier = ">=2.0" },
     { name = "django", specifier = ">=6.0" },
 ]
 
@@ -253,8 +267,7 @@ dev = [
     { name = "build", specifier = "==1.5.0" },
     { name = "django-coverage-plugin", specifier = "==3.2.2" },
     { name = "django-stubs", specifier = "==6.0.5" },
-    { name = "hatch-vcs", specifier = "==0.5.0" },
-    { name = "hatchling", specifier = "==1.30.1" },
+    { name = "freezegun", specifier = "==1.5.5" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -262,6 +275,7 @@ dev = [
     { name = "pytest-django", specifier = "==4.12.0" },
     { name = "pytest-socket", specifier = "==0.8.0" },
     { name = "ruff", specifier = "==0.15.18" },
+    { name = "types-croniter", specifier = "==6.2.2.20260518" },
 ]
 
 [[package]]
@@ -306,31 +320,15 @@ wheels = [
 ]
 
 [[package]]
-name = "hatch-vcs"
-version = "0.5.0"
+name = "freezegun"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "hatchling" },
-    { name = "setuptools-scm" },
+    { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/4cc743d38adbee9d57d786fa496ed1daadb17e48589b6da8fa55717a0746/hatch_vcs-0.5.0.tar.gz", hash = "sha256:0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9", size = 11424, upload-time = "2025-05-27T05:16:04.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/48/1f85cee4b7b4f40b9b814b1febbc661bda6ced9649e410a0b74f6e415dd0/hatch_vcs-0.5.0-py3-none-any.whl", hash = "sha256:b49677dbdc597460cc22d01b27ab3696f5e16a21ecf2700fb01bc28e1f2a04a7", size = 8507, upload-time = "2025-05-27T05:16:03.184Z" },
-]
-
-[[package]]
-name = "hatchling"
-version = "1.30.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "trove-classifiers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/4c/8717ccb844b4fa5a5ba6352e97d743ed24e9a22cf90b7c109c17030a46a1/hatchling-1.30.1.tar.gz", hash = "sha256:eee4fd45357f72ebb3d7a42e5d72cfb5e29ed426d79e8836288926c4258d5f2e", size = 56929, upload-time = "2026-06-02T00:09:41.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl", hash = "sha256:161eacafb3c6f91526e92116d21426369f2c36e98c36a864f11a96345ad4ee31", size = 77489, upload-time = "2026-06-02T00:09:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
 ]
 
 [[package]]
@@ -613,6 +611,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
@@ -638,26 +648,12 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "82.0.1"
+name = "six"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
-]
-
-[[package]]
-name = "setuptools-scm"
-version = "10.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "setuptools" },
-    { name = "vcs-versioning" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e263754036a0b573360bdbd6873b595725e49e11139722041/setuptools_scm-10.0.5.tar.gz", hash = "sha256:bbba8fe754516cdefd017f4456721775e6ef9662bd7887fb52ae26813d4838c3", size = 56748, upload-time = "2026-03-27T15:57:05.751Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl", hash = "sha256:f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a", size = 21695, upload-time = "2026-03-27T15:57:03.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -679,12 +675,12 @@ wheels = [
 ]
 
 [[package]]
-name = "trove-classifiers"
-version = "2026.6.1.19"
+name = "types-croniter"
+version = "6.2.2.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/02/f03a44ded34e6abb125c339647b070f2705a0583782f5638d62ab958cdc2/types_croniter-6.2.2.20260518.tar.gz", hash = "sha256:aceb426b9187bb9255b89d17713d07ac034a2b96b437bfdd5d3a56b46b4eb656", size = 12120, upload-time = "2026-05-18T06:03:11.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3d/f12c417944d00c42db71de3e334f36a69cafa6767ff3fb705c9e1d101e53/types_croniter-6.2.2.20260518-py3-none-any.whl", hash = "sha256:85018c7ce091428d3643be239ad348e27f9a8fb77ca94335cc39ebeb9403b240", size = 9743, upload-time = "2026-05-18T06:03:10.608Z" },
 ]
 
 [[package]]
@@ -712,16 +708,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
-]
-
-[[package]]
-name = "vcs-versioning"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz", hash = "sha256:fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc", size = 97575, upload-time = "2026-03-27T20:42:41.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl", hash = "sha256:b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4", size = 79851, upload-time = "2026-03-27T20:42:40.45Z" },
 ]


### PR DESCRIPTION
SP1 of #20. Declare recurring tasks in `TASKS` `OPTIONS["SCHEDULE"]`; `absurd_beat` (or `absurd_worker --beat`) enqueues each on its cron cadence via the existing enqueue path.

- Sync scheduler loop (interruptible via a stop event); daemon thread under `--beat`, worker stays async.
- Per-slot idempotency key (schedule name + UTC-minute) — overlapping beats fire each slot at most once.
- Cron in Django `TIME_ZONE`; fire-forward-only. `absurd.E007` checks validate entries. Docs in AGENTS.md/README.

pg_cron backend and an admin-managed model are follow-on sub-projects.