### PR TITLE
fix(scheduler): treat 6-field cron seconds as leading, not trailing

### DIFF
--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -28,8 +28,13 @@ class Schedule:
 
 
 def get_next_datetime(cron: str, after: datetime.datetime) -> datetime.datetime:
+    # second_at_beginning=True: a 6-field cron carries a LEADING seconds column, so
+    # "*/30 * * * * *" means every 30 seconds. Without it croniter reads seconds as the
+    # trailing field and the expression silently degrades to every-second firing.
     local_after = timezone.localtime(after)
-    return croniter.croniter(cron, local_after).get_next(datetime.datetime)
+    return croniter.croniter(cron, local_after, second_at_beginning=True).get_next(
+        datetime.datetime
+    )
 
 
 def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 dependencies = [
   "absurd-sdk>=0.4.0,<0.5.0",
-  "croniter>=2.0",
+  "croniter>=3.0",
   "Django>=6.0",
 ]
 description = "Django integration for Absurd, the Postgres-native workflow engine."

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -108,6 +108,30 @@ def test_get_next_datetime_uses_django_timezone(settings):
     assert result == expected
 
 
+@freeze_time("2026-01-01 12:00:00")
+def test_get_next_datetime_six_field_leading_seconds():
+    # A 6-field cron uses a LEADING seconds column, so "*/30 * * * * *" means every
+    # 30 seconds -> next fire at :30, not every second (which is what a trailing-seconds
+    # reading of the same string produces).
+    expected = dt.datetime(2026, 1, 1, 12, 0, 30, tzinfo=dt.UTC)
+    assert get_next_datetime("*/30 * * * * *", timezone.now()) == expected
+
+
+@freeze_time("2026-01-01 12:00:00")
+def test_get_next_datetime_six_field_non_divisor_seconds():
+    # Leading seconds holds for any step: "*/7 * * * * *" fires at :07, not :01.
+    expected = dt.datetime(2026, 1, 1, 12, 0, 7, tzinfo=dt.UTC)
+    assert get_next_datetime("*/7 * * * * *", timezone.now()) == expected
+
+
+@freeze_time("2026-01-01 12:00:00")
+def test_get_next_datetime_six_field_zero_seconds():
+    # Leading seconds=0 with a minute step fires on the minute boundary, not every
+    # second: "0 */5 * * * *" -> next at 12:05:00.
+    expected = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.UTC)
+    assert get_next_datetime("0 */5 * * * *", timezone.now()) == expected
+
+
 # run_beat_until and tests below it use run_beat's injected wait/now seam because a real
 # threading.Event.wait can't be fast-forwarded by freezegun; the command path is not
 # deterministic enough for exact multi-slot counts.

--- a/uv.lock
+++ b/uv.lock
@@ -243,7 +243,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "absurd-sdk", specifier = ">=0.4.0,<0.5.0" },
-    { name = "croniter", specifier = ">=2.0" },
+    { name = "croniter", specifier = ">=3.0" },
     { name = "django", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
`get_next_datetime` called croniter without `second_at_beginning=True`, so a 6-field cron (`*/30 * * * * *`) was read seconds-trailing and fired every second instead of every 30s — contradicting the documented leading-seconds behavior. Adds `second_at_beginning=True` + regression tests (step, non-divisor, seconds=0).