### PR TITLE
feat(pg_cron): read-only ScheduledTask admin (#44)

### DIFF
--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -60,13 +60,12 @@ class AbsurdQueueListFilter(admin.SimpleListFilter):
         return queryset
 
 
-class ReadOnlyAbsurdAdmin(admin.ModelAdmin):
-    spec: EntitySpec | None  # None on the Queue admin (the catalog, not an entity view)
-    using: str
+class ReadOnlyAdminBase(admin.ModelAdmin):
+    """View-only admin: no add/change/delete, every model field read-only.
 
-    ordering = ("natural_key",)
-    show_full_result_count = False
-    paginator = BoundedCountPaginator
+    Carries no queryset/ordering assumptions, so it suits both the UNION-view
+    entity admins and plain-table admins (e.g. pg_cron's ScheduledTask).
+    """
 
     def has_add_permission(self, request: t.Any) -> bool:
         return False
@@ -86,6 +85,15 @@ class ReadOnlyAbsurdAdmin(admin.ModelAdmin):
     def get_readonly_fields(self, request: t.Any, obj: t.Any = None) -> tuple[str, ...]:
         model_fields = tuple(f.name for f in self.model._meta.get_fields())  # noqa: SLF001
         return tuple(self.readonly_fields) + model_fields
+
+
+class ReadOnlyAbsurdAdmin(ReadOnlyAdminBase):
+    spec: EntitySpec | None  # None on the Queue admin (the catalog, not an entity view)
+    using: str
+
+    ordering = ("natural_key",)
+    show_full_result_count = False
+    paginator = BoundedCountPaginator
 
     def get_queryset(self, request: t.Any) -> t.Any:
         if self.spec is not None and not view_exists(self.spec.view_name, self.using):

--- a/django_absurd/pg_cron/admin.py
+++ b/django_absurd/pg_cron/admin.py
@@ -1,0 +1,62 @@
+"""Read-only Django admin for pg_cron ScheduledTask rows (registered at import)."""
+
+import contextlib
+import typing as t
+
+from django_absurd.admin import ReadOnlyAdminBase, resolve_admin_sites
+from django_absurd.pg_cron.models import ScheduledTask
+from django_absurd.queues import get_absurd_backend
+
+
+class ScheduledTaskAdmin(ReadOnlyAdminBase):
+    ordering = ("alias", "name")
+    list_display = (
+        "name",
+        "alias",
+        "task",
+        "queue",
+        "cron",
+        "enabled",
+        "source",
+        "updated_at",
+    )
+    list_filter = ("alias", "enabled", "source", "queue")
+    search_fields = ("name", "task")
+    fieldsets = (
+        ("Identity", {"fields": ("source", "alias", "name")}),
+        ("Schedule", {"fields": ("task", "queue", "cron", "enabled")}),
+        (
+            "Spawn options",
+            {
+                "fields": (
+                    "args",
+                    "kwargs",
+                    "max_attempts",
+                    "retry_strategy",
+                    "headers",
+                    "cancellation",
+                    "idempotency_key",
+                )
+            },
+        ),
+        ("Audit", {"fields": ("created_at", "updated_at")}),
+    )
+
+
+def register_scheduled_task_admin(sites: t.Iterable[t.Any]) -> None:
+    for site in sites:
+        if not site.is_registered(ScheduledTask):
+            site.register(ScheduledTask, ScheduledTaskAdmin)
+
+
+def autoregister_scheduled_task_admin() -> None:
+    backend = get_absurd_backend()
+    if backend is None:
+        return
+    if not backend.options.get("ENABLE_ADMIN", True):
+        return
+    register_scheduled_task_admin(resolve_admin_sites())
+
+
+with contextlib.suppress(Exception):
+    autoregister_scheduled_task_admin()

--- a/django_absurd/pg_cron/apps.py
+++ b/django_absurd/pg_cron/apps.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("django_absurd")
 class PgCronConfig(AppConfig):
     name = "django_absurd.pg_cron"
     label = "django_absurd_pg_cron"
-    verbose_name = "Absurd pg_cron"
+    verbose_name = "Absurd Cron"
 
     def ready(self) -> None:
         import django_absurd.pg_cron.checks  # noqa: F401, PLC0415

--- a/docs/plans/2026-07-07-pgcron-schedule-admin.md
+++ b/docs/plans/2026-07-07-pgcron-schedule-admin.md
@@ -1,0 +1,345 @@
+# Read-only pg_cron schedule admin — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans (inline) or
+> subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** Read-only Django admin for pg_cron `ScheduledTask` rows.
+
+**Architecture:** New `django_absurd/pg_cron/admin.py` registers `ScheduledTask` on the
+resolved admin site(s) at import, gated by `ENABLE_ADMIN`. Read-only behavior comes from
+a small `ReadOnlyAdminMixin` extracted from the existing `ReadOnlyAbsurdAdmin` in
+`django_absurd/admin.py` (the permission methods + `get_readonly_fields` — NOT the
+UNION-view-specific `ordering`/`get_object`/`get_queryset`). Non-default-DB routing is
+handled by the existing `AbsurdRouter` (covers `django_absurd_pg_cron`), so the default
+admin queryset already reads the Absurd DB.
+
+**Tech Stack:** Django 6 admin, pytest (function-based), BeautifulSoup4 DOM assertions.
+
+## Global Constraints
+
+- Python 3.12+, Django 6.0+; psycopg v3 only.
+- `import typing as t`; absolute imports only; functions contain a verb; no
+  leading-underscore module helpers.
+- Tests: pytest function-based; no monkeypatch/`unittest.mock`; drive via the HTTP
+  client
+  - real rows; assert on rendered DOM (bs4), not internals.
+- Admin HTTP tests in a package under `tests/pg_cron/test_admin/`; URLs via
+  `reverse_lazy` constants (no-arg) + `reverse` helpers (args) — never hand-written
+  paths.
+- Read-only ONLY (no add/change/delete); pg_cron-only; `source="admin"` authoring
+  deferred.
+- Reuse `ReadOnlyAbsurdAdmin`/mixin, `resolve_admin_sites()`, `ENABLE_ADMIN`; mirror
+  core `autoregister_admin` (register at import under `contextlib.suppress(Exception)`).
+- Full patch coverage on changed lines.
+
+---
+
+### Task 1: `ReadOnlyAdminMixin` extraction + `ScheduledTaskAdmin` registration
+
+**Files:**
+
+- Modify: `django_absurd/admin.py` (extract mixin from `ReadOnlyAbsurdAdmin`)
+- Create: `django_absurd/pg_cron/admin.py`
+- Create: `tests/pg_cron/test_admin/__init__.py` (empty),
+  `tests/pg_cron/test_admin/support.py`
+- Test: `tests/pg_cron/test_admin/test_registration.py`
+
+**Interfaces:**
+
+- Consumes: `django_absurd.admin.resolve_admin_sites() -> list[AdminSite]`; the model
+  `django_absurd.pg_cron.models.ScheduledTask`; `sync_crons(backend)` +
+  `get_absurd_backends()` for seeding; the existing suite helper
+  `build_pg_cron_tasks(schedule)` pattern.
+- Produces: `django_absurd.pg_cron.admin.register_scheduled_task_admin(sites)`,
+  `autoregister_scheduled_task_admin()`, `ScheduledTaskAdmin`; admin URL names
+  `admin:django_absurd_pg_cron_scheduledtask_{changelist,change,add}`.
+
+- [ ] **Step 1: support.py helpers**
+
+`tests/pg_cron/test_admin/support.py` — bs4 + seed helpers (no assertions here):
+
+```python
+from bs4 import BeautifulSoup
+from django.core.management import call_command
+
+from django_absurd.backends import get_absurd_backends
+from django_absurd.pg_cron.reconcile import sync_crons
+
+BACKEND = "django_absurd.backends.AbsurdBackend"
+
+
+def pg_cron_tasks(schedule):
+    return {
+        "default": {
+            "BACKEND": BACKEND,
+            "OPTIONS": {
+                "QUEUES": {"default": {}, "other": {}, "reports": {}},
+                "SCHEDULER": "pg_cron",
+                "SCHEDULE": schedule,
+            },
+        }
+    }
+
+
+def parse_html(response):
+    return BeautifulSoup(response.content, "html.parser")
+
+
+def result_rows(soup):
+    return soup.select("#result_list tbody tr")
+
+
+def seed(settings, schedule):
+    settings.TASKS = pg_cron_tasks(schedule)
+    call_command("absurd_sync_queues")
+    sync_crons(get_absurd_backends()["default"])
+```
+
+- [ ] **Step 2: Write the failing registration test**
+
+`tests/pg_cron/test_admin/test_registration.py`:
+
+```python
+import pytest
+from django.contrib import admin as djadmin
+from django.urls import reverse_lazy
+
+from django_absurd.pg_cron.admin import (
+    autoregister_scheduled_task_admin,
+    register_scheduled_task_admin,
+)
+from django_absurd.admin import resolve_admin_sites
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+LOGIN = reverse_lazy("admin:login")
+INDEX = reverse_lazy("admin:index")
+
+
+def test_scheduledtask_registered_on_default_site():
+    registered = {m._meta.model_name for m in djadmin.site._registry}
+    assert "scheduledtask" in registered
+
+
+def test_staff_user_sees_scheduledtask_in_index(client, staff_user):
+    from tests.pg_cron.test_admin.support import parse_html
+
+    client.force_login(staff_user)
+    soup = parse_html(client.get(INDEX))
+    assert (
+        soup.select_one('a[href$="/django_absurd_pg_cron/scheduledtask/"]') is not None
+    )
+
+
+def test_enable_admin_false_skips_registration(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"ENABLE_ADMIN": False},
+        }
+    }
+    from django.contrib.admin import AdminSite
+
+    site = AdminSite()
+    register_scheduled_task_admin([site])  # gate is in autoregister; see impl note
+    autoregister_scheduled_task_admin()  # honors ENABLE_ADMIN=False
+    assert not any(
+        m._meta.model_name == "scheduledtask" for m in site._registry
+    )
+
+
+def test_custom_admin_site_registration(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"ADMIN_SITE": ("tests.admin.custom_site",)},
+        }
+    }
+    from tests.admin import custom_site
+
+    register_scheduled_task_admin(resolve_admin_sites())
+    assert any(m._meta.model_name == "scheduledtask" for m in custom_site._registry)
+```
+
+Note for impl: `register_scheduled_task_admin(sites)` registers unconditionally on the
+given sites (idempotent — skip if already registered); the `ENABLE_ADMIN` gate lives in
+`autoregister_scheduled_task_admin()`. The `test_enable_admin_false` test asserts the
+autoregister path (gate) leaves a fresh site unregistered — adjust the test to call only
+`autoregister_scheduled_task_admin()` against a site it controls, OR assert via a fresh
+`AdminSite` that autoregister targets `resolve_admin_sites()` (default site). Keep the
+test asserting the observable gate behavior; refine during RED.
+
+- [ ] **Step 3: Run tests — verify they fail**
+
+Run: `uv run pytest tests/pg_cron/test_admin/test_registration.py -q` Expected: FAIL —
+`ModuleNotFoundError: django_absurd.pg_cron.admin` (module absent).
+
+- [ ] **Step 4: Extract `ReadOnlyAdminMixin` (prose)**
+
+In `django_absurd/admin.py`: pull the five `has_*_permission` methods and
+`get_readonly_fields` out of `ReadOnlyAbsurdAdmin` into a new `ReadOnlyAdminMixin`
+(mixin, not subclassing `ModelAdmin`). Redefine
+`class ReadOnlyAbsurdAdmin(ReadOnlyAdminMixin, admin.ModelAdmin)` keeping its
+view-specific attrs/methods (`spec`, `using`, `ordering = ("natural_key",)`,
+`get_queryset`, `get_object`, `changelist_view`, paginator). Behavior-preserving — the
+core admin suite must stay green.
+
+- [ ] **Step 5: Create `django_absurd/pg_cron/admin.py` (prose)**
+
+Define `ScheduledTaskAdmin(ReadOnlyAdminMixin, admin.ModelAdmin)` for `ScheduledTask`
+with `ordering = ("alias", "name")` (ScheduledTask has no `natural_key`). Do NOT
+override `get_queryset` — the default reads through `AbsurdRouter`. Set list attrs in
+Task 2. Write `register_scheduled_task_admin(sites)`: for each site,
+`site.register(ScheduledTask, ScheduledTaskAdmin)` guarded by
+`if not site.is_registered(ScheduledTask)`. Write `autoregister_scheduled_task_admin()`:
+resolve backend; if `backend.options.get("ENABLE_ADMIN", True)` is false → return; else
+`register_scheduled_task_admin(resolve_admin_sites())`. At module bottom, call it under
+`with contextlib.suppress(Exception):` (mirrors core `admin.py`). Imports:
+`import typing as t`, `import contextlib`, absolute imports.
+
+- [ ] **Step 6: Run tests — verify pass + core admin regression**
+
+Run: `uv run pytest tests/pg_cron/test_admin/test_registration.py -q` Then:
+`uv run pytest tests/core/test_admin -q` (mixin refactor regression). Expected: PASS
+both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add django_absurd/admin.py django_absurd/pg_cron/admin.py tests/pg_cron/test_admin/
+git commit -m "feat(pg_cron): register read-only ScheduledTask admin"
+```
+
+---
+
+### Task 2: Changelist display, filters, search, read-only enforcement
+
+**Files:**
+
+- Modify: `django_absurd/pg_cron/admin.py` (list attrs)
+- Test: `tests/pg_cron/test_admin/test_scheduledtask.py`
+
+**Interfaces:**
+
+- Consumes: `ScheduledTaskAdmin` (Task 1); `support.seed`, `parse_html`, `result_rows`.
+- Produces: final `list_display`/`list_filter`/`search_fields` on `ScheduledTaskAdmin`.
+
+- [ ] **Step 1: Write the failing changelist tests**
+
+`tests/pg_cron/test_admin/test_scheduledtask.py`:
+
+```python
+import pytest
+from django.urls import reverse_lazy
+
+from tests.pg_cron.test_admin.support import parse_html, result_rows, seed
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+CHANGELIST = reverse_lazy("admin:django_absurd_pg_cron_scheduledtask_changelist")
+ADD = reverse_lazy("admin:django_absurd_pg_cron_scheduledtask_add")
+
+SCHEDULE = {
+    "nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
+    "hourly": {"task": "tests.tasks.on_reports", "cron": "0 * * * *", "queue": "reports"},
+}
+
+
+def test_changelist_renders_one_row_per_schedule(settings, client, admin_user):
+    seed(settings, SCHEDULE)
+    client.force_login(admin_user)
+    soup = parse_html(client.get(CHANGELIST))
+    assert len(result_rows(soup)) == 2
+
+
+def test_changelist_shows_expected_columns(settings, client, admin_user):
+    seed(settings, SCHEDULE)
+    client.force_login(admin_user)
+    body = client.get(CHANGELIST).content.decode()
+    assert "nightly" in body and "0 2 * * *" in body and "tests.tasks.add" in body
+
+
+def test_filter_by_queue_narrows(settings, client, admin_user):
+    seed(settings, SCHEDULE)
+    client.force_login(admin_user)
+    soup = parse_html(client.get(CHANGELIST, {"queue": "reports"}))
+    rows = result_rows(soup)
+    assert len(rows) == 1 and "hourly" in rows[0].get_text()
+
+
+def test_search_by_name_narrows(settings, client, admin_user):
+    seed(settings, SCHEDULE)
+    client.force_login(admin_user)
+    soup = parse_html(client.get(CHANGELIST, {"q": "nightly"}))
+    assert len(result_rows(soup)) == 1
+
+
+def test_no_add_permission(settings, client, admin_user):
+    seed(settings, SCHEDULE)
+    client.force_login(admin_user)
+    soup = parse_html(client.get(CHANGELIST))
+    assert soup.select_one('a.addlink') is None
+    assert client.get(ADD).status_code in (403, 302)
+
+
+def test_detail_view_is_readonly_and_shows_options(settings, client, admin_user):
+    from django_absurd.pg_cron.models import ScheduledTask
+
+    seed(settings, SCHEDULE)
+    pk = ScheduledTask.objects.get(name="hourly").pk
+    change = reverse_lazy(
+        "admin:django_absurd_pg_cron_scheduledtask_change", args=[pk]
+    )
+    client.force_login(admin_user)
+    resp = client.get(change)
+    body = resp.content.decode()
+    assert resp.status_code == 200
+    assert "reports" in body  # queue option column rendered
+    assert '<input' not in body.split('id="scheduledtask_form"')[-1] or True  # readonly
+```
+
+(Refine the read-only detail assertion during RED to a concrete DOM check — e.g. the
+change form has no editable `<input name="cron">`; assert the field renders as readonly
+text.)
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `uv run pytest tests/pg_cron/test_admin/test_scheduledtask.py -q` Expected: FAIL —
+columns/filters absent (rows render but assertions on columns/filter/ search fail).
+
+- [ ] **Step 3: Set list attrs (prose)**
+
+On `ScheduledTaskAdmin`:
+`list_display = ("name", "alias", "task", "queue", "cron", "enabled", "source", "updated_at")`;
+`list_filter = ("alias", "enabled", "source", "queue")`;
+`search_fields = ("name", "task")`. Read-only + detail-shows-options already come from
+`ReadOnlyAdminMixin.get_readonly_fields` (all fields) + no-add permission.
+
+- [ ] **Step 4: Run tests — verify pass**
+
+Run: `uv run pytest tests/pg_cron/test_admin -q` Expected: PASS.
+
+- [ ] **Step 5: Full-suite regression + coverage**
+
+Run: `uv run pytest tests/pg_cron -q` (all green, no coverage regression on changed
+lines).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add django_absurd/pg_cron/admin.py tests/pg_cron/test_admin/test_scheduledtask.py
+git commit -m "feat(pg_cron): ScheduledTask admin changelist columns, filters, search"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** read-only mixin + registration (Task 1); columns/filters/search +
+  read-only enforcement + detail options (Task 2); ENABLE_ADMIN gate + custom ADMIN_SITE
+  (Task 1 tests); pg_cron-only (lives in opt-in app); routing (default queryset via
+  router). Non-goals (authoring, beat) untouched. ✓
+- **Placeholders:** the two "refine during RED" notes are genuine test-shape refinements
+  (read-only DOM assertion), not skipped work — resolve them when the test is first run.
+- **Naming:** verb-named fns (`register_scheduled_task_admin`,
+  `autoregister_scheduled_task_admin`); `ReadOnlyAdminMixin`, `ScheduledTaskAdmin`.

--- a/docs/specs/2026-07-07-pgcron-schedule-admin-design.md
+++ b/docs/specs/2026-07-07-pgcron-schedule-admin-design.md
@@ -1,0 +1,76 @@
+# pg_cron schedule admin (read-only) — design
+
+**Goal:** Read-only Django admin for pg_cron `ScheduledTask` rows — view declared
+schedules + their spawn options in admin. No editing.
+
+**Issue:** #44. Follows #43 (beat + pg_cron schedulers delivered).
+
+## Scope
+
+- Read-only ONLY. Settings `SCHEDULE` stays source of truth. No add/change/delete.
+- pg_cron-only: `ScheduledTask` lives in opt-in `django_absurd.pg_cron` app; admin
+  exists only when app installed. Beat = settings-only (no table), not shown.
+- **NEXT unit of work (deferred, own sub-project):** fully DB/admin-driven schedule
+  authoring — `source="admin"` create/edit in admin + reconcile emitting pg_cron jobs
+  for admin rows. Foundation present (`source` split, reconcile never touches
+  `source="admin"`, `build_jobname(…, source=…)` parameterized). Out of scope here.
+
+## Architecture
+
+New `django_absurd/pg_cron/admin.py`, mirroring core `django_absurd/admin.py`:
+
+- Reuse `ReadOnlyAbsurdAdmin` base (no add/change/delete, view-only,
+  `get_readonly_fields` = all model fields).
+- Reuse `resolve_admin_sites()` (reads backend `OPTIONS["ADMIN_SITE"]`, default
+  `django.contrib.admin.site`) and the `ENABLE_ADMIN` gate.
+- Register `ScheduledTask` on each resolved site at module import under
+  `contextlib.suppress(Exception)`. Django admin autodiscover imports the app's
+  `admin.py` when the app is installed.
+- Routing: `AbsurdRouter` already covers `django_absurd_pg_cron`, so the default
+  queryset reads the Absurd DB (non-default-DB safe). Confirm
+  `ReadOnlyAbsurdAdmin.get_queryset` doesn't force a wrong `using`; if it needs a
+  `using` attr, set via `resolve_absurd_database(backend)` or override to plain
+  `super().get_queryset()` (router routes). Resolve in the plan.
+
+## Component: `ScheduledTaskAdmin(ReadOnlyAbsurdAdmin)`
+
+- `list_display` = name, alias, task, queue, cron, enabled, source, updated_at
+- `list_filter` = alias, enabled, source, queue
+- `search_fields` = name, task
+- `verbose_name` / plural = "Scheduled task" / "Scheduled tasks"
+- `ordering` = (alias, name)
+- detail (read-only) shows option columns too: args, kwargs, max_attempts,
+  retry_strategy, headers, cancellation, idempotency_key, created_at, updated_at
+
+## Registration
+
+`autoregister_scheduled_task_admin()` (verb-named): resolve pg_cron backend; if
+`ENABLE_ADMIN` false → skip; else register `ScheduledTask` on `resolve_admin_sites()`.
+Called at import via `contextlib.suppress(Exception)`. Mirror core `autoregister_admin`.
+
+## Tests (TDD, bs4) — `tests/pg_cron/test_admin/`
+
+Package per [[admin-test-url-pattern]]: module per concern; URLs via `reverse_lazy`
+constants (no-arg) + `reverse` helpers (args), never hand-written paths. bs4 DOM
+assertions (`parse_html`, `result_rows`). Behavioral via HTTP client + real rows seeded
+by `sync_crons` (not raw ORM where a public path exists).
+
+- `support.py` — bs4 helpers; register helper (register on `djadmin.site`, reload
+  `ROOT_URLCONF`, `clear_url_caches`); seed rows via `sync_crons`.
+- `test_scheduledtask.py`:
+  - changelist 200, one row per `ScheduledTask`, expected columns rendered
+  - each `list_filter` narrows the rendered rows (alias, enabled, source, queue)
+  - search by name / task narrows
+  - read-only: no "Add" link; change-view fields disabled; POST to change mutates
+    nothing
+  - detail view renders the option columns
+- `test_registration.py`:
+  - `ENABLE_ADMIN` default → `ScheduledTask` registered on site
+  - `ENABLE_ADMIN=False` → not registered
+  - custom `ADMIN_SITE` → registered there
+
+## Non-goals
+
+- Editable / admin-authored schedules (→ next sub-project).
+- Beat schedule visibility (no backing table).
+- Custom actions, inlines, next-run computation.

--- a/tests/pg_cron/test_admin/test_admin_checks.py
+++ b/tests/pg_cron/test_admin/test_admin_checks.py
@@ -1,0 +1,25 @@
+import pytest
+from django.contrib import admin
+from django.core import checks
+
+from django_absurd.pg_cron.admin import ScheduledTaskAdmin
+from django_absurd.pg_cron.models import ScheduledTask
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_scheduledtask_admin_is_registered():
+    """Guard the check test below: it only catches a bad field if the admin is
+    actually registered when checks run."""
+    assert admin.site._registry.get(ScheduledTask).__class__ is ScheduledTaskAdmin
+
+
+def test_scheduledtask_admin_has_no_config_errors():
+    """The hand-listed list_display/fieldsets field names must reference real
+    fields — Django surfaces a typo only as admin.E0* under the check framework,
+    and registration happens under contextlib.suppress at import, so without this
+    guard a bad field name would ship silently."""
+    admin_errors = [
+        e for e in checks.run_checks(tags=["admin"]) if e.id.startswith("admin.E")
+    ]
+    assert admin_errors == [], admin_errors

--- a/tests/pg_cron/test_admin/test_registration.py
+++ b/tests/pg_cron/test_admin/test_registration.py
@@ -1,0 +1,87 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.contrib import admin as djadmin
+from django.urls import reverse_lazy
+
+from django_absurd.admin import resolve_admin_sites
+from django_absurd.pg_cron.admin import (
+    autoregister_scheduled_task_admin,
+    register_scheduled_task_admin,
+)
+from django_absurd.pg_cron.models import ScheduledTask
+from tests.admin import custom_site, gated_site, other_site
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+INDEX = reverse_lazy("admin:index")
+BACKEND = "django_absurd.backends.AbsurdBackend"
+
+
+def test_scheduledtask_registered_on_default_site():
+    registered = {m._meta.model_name for m in djadmin.site._registry}
+    assert "scheduledtask" in registered
+
+
+def test_staff_user_sees_scheduledtask_in_index(client, staff_user):
+    client.force_login(staff_user)
+    soup = BeautifulSoup(client.get(INDEX).content, "html.parser")
+    assert (
+        soup.select_one('a[href$="/django_absurd_pg_cron/scheduledtask/"]') is not None
+    )
+
+
+def test_custom_admin_site_registration(settings):
+    settings.TASKS = {
+        "default": {
+            "BACKEND": BACKEND,
+            "OPTIONS": {"ADMIN_SITE": ("tests.admin.custom_site",)},
+        }
+    }
+    register_scheduled_task_admin(resolve_admin_sites())
+    assert custom_site.is_registered(ScheduledTask)
+
+
+def test_autoregister_skips_when_enable_admin_false(settings):
+    gated_site._registry.pop(ScheduledTask, None)
+    settings.TASKS = {
+        "default": {
+            "BACKEND": BACKEND,
+            "OPTIONS": {
+                "ENABLE_ADMIN": False,
+                "ADMIN_SITE": ("tests.admin.gated_site",),
+            },
+        }
+    }
+    autoregister_scheduled_task_admin()
+    assert not gated_site.is_registered(ScheduledTask)
+
+
+def test_register_is_idempotent(settings):
+    other_site._registry.pop(ScheduledTask, None)
+    register_scheduled_task_admin([other_site])
+    register_scheduled_task_admin(
+        [other_site]
+    )  # second call skips (already registered)
+    assert other_site.is_registered(ScheduledTask)
+
+
+def test_autoregister_skips_when_no_absurd_backend(settings):
+    gated_site._registry.pop(ScheduledTask, None)
+    settings.TASKS = {}
+    autoregister_scheduled_task_admin()  # backend is None -> no-op, no raise
+    assert not gated_site.is_registered(ScheduledTask)
+
+
+def test_autoregister_registers_when_enable_admin_true(settings):
+    other_site._registry.pop(ScheduledTask, None)
+    settings.TASKS = {
+        "default": {
+            "BACKEND": BACKEND,
+            "OPTIONS": {
+                "ENABLE_ADMIN": True,
+                "ADMIN_SITE": ("tests.admin.other_site",),
+            },
+        }
+    }
+    autoregister_scheduled_task_admin()
+    assert other_site.is_registered(ScheduledTask)

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -1,0 +1,98 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.core.management import call_command
+from django.urls import reverse, reverse_lazy
+
+from django_absurd.backends import get_absurd_backends
+from django_absurd.pg_cron.models import ScheduledTask
+from django_absurd.pg_cron.reconcile import sync_crons
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+CHANGELIST = reverse_lazy("admin:django_absurd_pg_cron_scheduledtask_changelist")
+ADD = reverse_lazy("admin:django_absurd_pg_cron_scheduledtask_add")
+
+TASKS = {
+    "default": {
+        "BACKEND": "django_absurd.backends.AbsurdBackend",
+        "OPTIONS": {
+            "QUEUES": {"default": {}, "other": {}, "reports": {}},
+            "SCHEDULER": "pg_cron",
+            "SCHEDULE": {
+                "nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
+                "hourly": {
+                    "task": "tests.tasks.on_reports",
+                    "cron": "0 * * * *",
+                    "queue": "reports",
+                },
+            },
+        },
+    }
+}
+
+
+def seed(settings):
+    settings.TASKS = TASKS
+    call_command("absurd_sync_queues")
+    sync_crons(get_absurd_backends()["default"])
+
+
+def rows(response):
+    soup = BeautifulSoup(response.content, "html.parser")
+    return soup.select("#result_list tbody tr")
+
+
+def change_url(pk):
+    return reverse("admin:django_absurd_pg_cron_scheduledtask_change", args=[pk])
+
+
+def test_changelist_renders_one_row_per_schedule(settings, client, admin_user):
+    seed(settings)
+    client.force_login(admin_user)
+    assert len(rows(client.get(CHANGELIST))) == 2
+
+
+def test_changelist_shows_expected_columns(settings, client, admin_user):
+    seed(settings)
+    client.force_login(admin_user)
+    body = client.get(CHANGELIST).content.decode()
+    assert "nightly" in body
+    assert "0 2 * * *" in body
+    assert "tests.tasks.add" in body
+
+
+def test_queue_filter_renders_and_narrows(settings, client, admin_user):
+    seed(settings)
+    client.force_login(admin_user)
+    # list_filter must render a queue filter in the sidebar (a raw URL param would
+    # narrow regardless, so assert the filter UI exists — not just the narrowing).
+    soup = BeautifulSoup(client.get(CHANGELIST).content, "html.parser")
+    assert soup.select_one('#changelist-filter a[href*="queue=reports"]') is not None
+    narrowed = rows(client.get(CHANGELIST, {"queue": "reports"}))
+    assert len(narrowed) == 1
+    assert "hourly" in narrowed[0].get_text()
+
+
+def test_search_by_name_narrows(settings, client, admin_user):
+    seed(settings)
+    client.force_login(admin_user)
+    assert len(rows(client.get(CHANGELIST, {"q": "nightly"}))) == 1
+
+
+def test_no_add_link_and_add_forbidden(settings, client, admin_user):
+    seed(settings)
+    client.force_login(admin_user)
+    soup = BeautifulSoup(client.get(CHANGELIST).content, "html.parser")
+    assert soup.select_one(".object-tools a.addlink") is None
+    assert client.get(ADD).status_code == 403
+
+
+def test_detail_is_readonly_and_shows_option_columns(settings, client, admin_user):
+    seed(settings)
+    pk = ScheduledTask.objects.get(name="hourly").pk
+    client.force_login(admin_user)
+    resp = client.get(change_url(pk))
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content, "html.parser")
+    assert soup.select_one('input[name="cron"]') is None  # read-only, not editable
+    assert "reports" in resp.content.decode()  # queue option column rendered


### PR DESCRIPTION
Read-only Django admin for pg_cron `ScheduledTask` — changelist (filters + search) and fieldset-grouped detail, under an "Absurd Cron" section. Registration gated by `ENABLE_ADMIN`, honors `ADMIN_SITE`; routes via `AbsurdRouter`. Reuses an extracted `ReadOnlyAdminBase`. bs4 admin tests. Closes #44.