### PR TITLE
Enforce strict typing + align pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker
+
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.16.0
     hooks:

--- a/Dockerfile.pg_cron
+++ b/Dockerfile.pg_cron
@@ -3,7 +3,8 @@
 # Alpine has no pg_cron package, so we use the Debian variant.
 FROM postgres:18
 
+# renovate: datasource=deb depName=postgresql-18-cron versioning=deb
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-18-cron; \
+    apt-get install -y --no-install-recommends postgresql-18-cron=1.6.7-3.pgdg13+1; \
     rm -rf /var/lib/apt/lists/*

--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -4,7 +4,7 @@ import typing as t
 from django.contrib import admin, messages
 from django.contrib.admin.sites import AdminSite
 from django.core.paginator import Paginator
-from django.db import connections
+from django.db import connections, models
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.module_loading import import_string
 
@@ -93,17 +93,17 @@ class ReadOnlyAdminBase(_ModelAdminBase):
         return False
 
     def has_change_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return False
 
     def has_delete_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return False
 
     def has_view_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return True
 
@@ -111,7 +111,7 @@ class ReadOnlyAdminBase(_ModelAdminBase):
         return True
 
     def get_readonly_fields(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> tuple[str, ...]:
         model_fields = tuple(f.name for f in self.model._meta.get_fields())  # noqa: SLF001
         return tuple(self.readonly_fields) + model_fields
@@ -137,13 +137,14 @@ class ReadOnlyAbsurdAdmin(ReadOnlyAdminBase):
         request: "HttpRequest",
         object_id: str,
         from_field: str | None = None,
-    ) -> "t.Any | None":
+    ) -> "models.Model | None":
         queue = object_id.split(":", 1)[0]
         queryset = self.get_queryset(request).filter(queue=queue)
         try:
-            return queryset.get(pk=object_id)
+            obj: models.Model = queryset.get(pk=object_id)
         except self.model.DoesNotExist:
             return None
+        return obj
 
     def changelist_view(
         self,
@@ -231,11 +232,12 @@ def build_queue_admin(using: str) -> type[ReadOnlyAbsurdAdmin]:
         request: "HttpRequest",
         object_id: str,
         from_field: str | None = None,
-    ) -> "t.Any | None":
+    ) -> "models.Model | None":
         try:
-            return self.get_queryset(request).get(pk=object_id)
+            obj: models.Model = self.get_queryset(request).get(pk=object_id)
         except self.model.DoesNotExist:
             return None
+        return obj
 
     return type(
         "QueueAdmin",
@@ -347,22 +349,22 @@ class ReadOnlyRunInline(_TabularInlineBase):
     readonly_fields = RUN_INLINE_FIELDS
 
     def has_add_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return False
 
     def has_change_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return False
 
     def has_delete_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return False
 
     def has_view_permission(
-        self, request: "HttpRequest", obj: "t.Any | None" = None
+        self, request: "HttpRequest", obj: "models.Model | None" = None
     ) -> bool:
         return True
 

--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -9,7 +9,11 @@ from django.db.utils import OperationalError, ProgrammingError
 from django.utils.module_loading import import_string
 
 if t.TYPE_CHECKING:
-    from django.db import models as db_models
+    from collections.abc import Iterable
+
+    from django.contrib.admin.filters import ListFilter
+    from django.db.models import Model, QuerySet
+    from django.http import HttpRequest, HttpResponse
 
 from django_absurd.admin_views import (
     ADMIN_ENTITY_SPECS,
@@ -22,14 +26,18 @@ from django_absurd.queues import get_absurd_backend, resolve_absurd_database
 
 ADMIN_COUNT_CAP = 1000
 
+if t.TYPE_CHECKING:
+    _PaginatorBase = Paginator[t.Any]
+else:
+    _PaginatorBase = Paginator
 
-class BoundedCountPaginator(Paginator):
+
+class BoundedCountPaginator(_PaginatorBase):
     @property
     def count(self) -> int:
-        qs = t.cast(
-            "db_models.QuerySet[t.Any]", self.object_list[: ADMIN_COUNT_CAP + 1]
-        )
-        return min(qs.count(), ADMIN_COUNT_CAP)
+        qs: t.Any = self.object_list[: ADMIN_COUNT_CAP + 1]
+        n: int = qs.count()
+        return min(n, ADMIN_COUNT_CAP)
 
 
 class AbsurdQueueListFilter(admin.SimpleListFilter):
@@ -38,51 +46,73 @@ class AbsurdQueueListFilter(admin.SimpleListFilter):
 
     def __init__(
         self,
-        request: t.Any,
-        params: t.Any,
-        model: t.Any,
+        request: "HttpRequest",
+        params: dict[str, list[str]],
+        model: "type[Model]",
         model_admin: "ReadOnlyAbsurdAdmin",
     ) -> None:
         self.using: str = getattr(model_admin, "using", resolve_absurd_database())
         super().__init__(request, params, model, model_admin)
 
-    def lookups(self, request: t.Any, model_admin: t.Any) -> list[tuple[str, str]]:
+    def lookups(
+        self,
+        request: "HttpRequest",
+        model_admin: "admin.ModelAdmin[t.Any]",
+    ) -> list[tuple[str, str]]:
         try:
             queues = fetch_catalog_queues(self.using)
         except (OperationalError, ProgrammingError):
             return []
         return [(q, q) for q in queues]
 
-    def queryset(self, request: t.Any, queryset: t.Any) -> t.Any:
+    def queryset(
+        self,
+        request: "HttpRequest",
+        queryset: "QuerySet[t.Any]",
+    ) -> "QuerySet[t.Any] | None":
         value = self.value()
         if value:
             return queryset.filter(queue=value)
         return queryset
 
 
-class ReadOnlyAdminBase(admin.ModelAdmin):
+if t.TYPE_CHECKING:
+    _ModelAdminBase = admin.ModelAdmin[t.Any]
+else:
+    _ModelAdminBase = admin.ModelAdmin
+
+
+class ReadOnlyAdminBase(_ModelAdminBase):
     """View-only admin: no add/change/delete, every model field read-only.
 
     Carries no queryset/ordering assumptions, so it suits both the UNION-view
     entity admins and plain-table admins (e.g. pg_cron's ScheduledTask).
     """
 
-    def has_add_permission(self, request: t.Any) -> bool:
+    def has_add_permission(self, request: "HttpRequest") -> bool:
         return False
 
-    def has_change_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_change_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return False
 
-    def has_delete_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_delete_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return False
 
-    def has_view_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_view_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return True
 
-    def has_module_permission(self, request: t.Any) -> bool:
+    def has_module_permission(self, request: "HttpRequest") -> bool:
         return True
 
-    def get_readonly_fields(self, request: t.Any, obj: t.Any = None) -> tuple[str, ...]:
+    def get_readonly_fields(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> tuple[str, ...]:
         model_fields = tuple(f.name for f in self.model._meta.get_fields())  # noqa: SLF001
         return tuple(self.readonly_fields) + model_fields
 
@@ -95,17 +125,19 @@ class ReadOnlyAbsurdAdmin(ReadOnlyAdminBase):
     show_full_result_count = False
     paginator = BoundedCountPaginator
 
-    def get_queryset(self, request: t.Any) -> t.Any:
+    def get_queryset(self, request: "HttpRequest") -> "QuerySet[t.Any]":
+        model: type[t.Any] = self.model
         if self.spec is not None and not view_exists(self.spec.view_name, self.using):
-            return self.model.objects.using(self.using).none()
-        return self.model.objects.using(self.using).all()
+            qs: QuerySet[t.Any] = model.objects.using(self.using).none()
+            return qs
+        return t.cast("QuerySet[t.Any]", model.objects.using(self.using).all())
 
     def get_object(
         self,
-        request: t.Any,
+        request: "HttpRequest",
         object_id: str,
-        from_field: t.Any = None,
-    ) -> t.Any:
+        from_field: str | None = None,
+    ) -> "t.Any | None":
         queue = object_id.split(":", 1)[0]
         queryset = self.get_queryset(request).filter(queue=queue)
         try:
@@ -113,7 +145,11 @@ class ReadOnlyAbsurdAdmin(ReadOnlyAdminBase):
         except self.model.DoesNotExist:
             return None
 
-    def changelist_view(self, request: t.Any, extra_context: t.Any = None) -> t.Any:
+    def changelist_view(
+        self,
+        request: "HttpRequest",
+        extra_context: dict[str, t.Any] | None = None,
+    ) -> "HttpResponse":
         if self.spec is not None:
             try:
                 stale = find_unindexed_queues(self.using)
@@ -173,7 +209,7 @@ def resolve_admin_sites() -> list[AdminSite]:
     return sites
 
 
-def register_absurd_admin(sites: t.Iterable[AdminSite]) -> None:
+def register_absurd_admin(sites: "Iterable[AdminSite]") -> None:
     backend = get_absurd_backend()
     using = backend.database if backend is not None else resolve_absurd_database()
 
@@ -191,11 +227,11 @@ def register_absurd_admin(sites: t.Iterable[AdminSite]) -> None:
 
 def build_queue_admin(using: str) -> type[ReadOnlyAbsurdAdmin]:
     def get_object(
-        self: t.Any,
-        request: t.Any,
+        self: ReadOnlyAbsurdAdmin,
+        request: "HttpRequest",
         object_id: str,
-        from_field: t.Any = None,
-    ) -> t.Any:
+        from_field: str | None = None,
+    ) -> "t.Any | None":
         try:
             return self.get_queryset(request).get(pk=object_id)
         except self.model.DoesNotExist:
@@ -218,9 +254,9 @@ def build_queue_admin(using: str) -> type[ReadOnlyAbsurdAdmin]:
 
 
 def build_entity_admin(
-    spec: EntitySpec, model: type, using: str
+    spec: EntitySpec, model: "type[Model]", using: str
 ) -> type[ReadOnlyAbsurdAdmin]:
-    list_filter: list[t.Any] = [AbsurdQueueListFilter]
+    list_filter: list[type[ListFilter] | str] = [AbsurdQueueListFilter]
     if spec.has_state:
         list_filter.append("state")
     if spec.has_status:
@@ -295,7 +331,13 @@ RUN_INLINE_FIELDS = (
 )
 
 
-class ReadOnlyRunInline(admin.TabularInline):
+if t.TYPE_CHECKING:
+    _TabularInlineBase = admin.TabularInline[t.Any, t.Any]
+else:
+    _TabularInlineBase = admin.TabularInline
+
+
+class ReadOnlyRunInline(_TabularInlineBase):
     fk_name = "task"
     extra = 0
     can_delete = False
@@ -304,20 +346,30 @@ class ReadOnlyRunInline(admin.TabularInline):
     fields = RUN_INLINE_FIELDS
     readonly_fields = RUN_INLINE_FIELDS
 
-    def has_add_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_add_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return False
 
-    def has_change_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_change_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return False
 
-    def has_delete_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_delete_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return False
 
-    def has_view_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_view_permission(
+        self, request: "HttpRequest", obj: "t.Any | None" = None
+    ) -> bool:
         return True
 
 
-def build_run_inline(run_model: type) -> type[admin.TabularInline]:
+def build_run_inline(
+    run_model: "type[Model]",
+) -> "type[admin.TabularInline[t.Any, t.Any]]":
     return type("RunInline", (ReadOnlyRunInline,), {"model": run_model})
 
 

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -170,7 +170,10 @@ VIEW_NOT_PROVISIONED_MSG = (
 )
 
 
-class AbsurdViewQuerySet(models.QuerySet):
+AnyCallable = t.Callable[..., t.Any]
+
+
+class AbsurdViewQuerySet(models.QuerySet[models.Model]):
     def _fetch_all(self) -> None:
         try:
             super()._fetch_all()
@@ -178,18 +181,21 @@ class AbsurdViewQuerySet(models.QuerySet):
             raise ViewNotProvisionedError(VIEW_NOT_PROVISIONED_MSG) from exc
 
     def count(self) -> int:
-        return translate_view_errors(super().count)()
+        result: int = translate_view_errors(super().count)()
+        return result
 
     def exists(self) -> bool:
-        return translate_view_errors(super().exists)()
+        result: bool = translate_view_errors(super().exists)()
+        return result
 
     def aggregate(self, *args: t.Any, **kwargs: t.Any) -> dict[str, t.Any]:
-        return translate_view_errors(super().aggregate)(*args, **kwargs)
+        result: dict[str, t.Any] = translate_view_errors(super().aggregate)(
+            *args, **kwargs
+        )
+        return result
 
 
-def translate_view_errors(
-    fn: t.Callable[..., t.Any],
-) -> t.Callable[..., t.Any]:
+def translate_view_errors(fn: AnyCallable) -> AnyCallable:
     def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
         try:
             return fn(*args, **kwargs)
@@ -209,7 +215,7 @@ def build_admin_model(spec: EntitySpec) -> type[models.Model]:
     if existing is not None:
         return existing
 
-    fields: dict[str, t.Any] = {
+    fields: dict[str, object] = {
         "natural_key": models.TextField(primary_key=True),
         "queue": models.TextField(),
     }
@@ -241,17 +247,18 @@ def build_admin_model(spec: EntitySpec) -> type[models.Model]:
     return type(spec.model_name, (models.Model,), fields)
 
 
-def raise_view_read_only(self: t.Any, *args: object, **kwargs: object) -> t.NoReturn:
+def raise_view_read_only(self: object, *args: object, **kwargs: object) -> t.NoReturn:
     raise QueueReadOnlyError(ADMIN_VIEW_READONLY_MSG)
 
 
 def render_natural_key(self: t.Any) -> str:
-    return self.natural_key
+    key: str = self.natural_key
+    return key
 
 
 def build_model_field(
     spec: EntitySpec, col_name: str, col_type: str
-) -> tuple[str, models.Field]:
+) -> tuple[str, models.Field[t.Any, t.Any]]:
     # Tasks' task_id is the FK target for the Run inline, so it must be unique.
     if spec.name == "tasks" and col_name == "task_id":
         return "task_id", models.UUIDField(null=True, unique=True)
@@ -279,7 +286,7 @@ def build_queue_table_model(spec: EntitySpec, queue: str) -> type[models.Model]:
         return existing
 
     pk_col_name = spec.columns[0][0]
-    fields: dict[str, t.Any] = {}
+    fields: dict[str, object] = {}
     for col_name, col_type in spec.columns:
         if col_name == pk_col_name:
             field_cls = FIELD_TYPE_MAP[col_type]
@@ -307,7 +314,7 @@ def build_queue_table_model(spec: EntitySpec, queue: str) -> type[models.Model]:
     return type(model_name, (models.Model,), fields)
 
 
-FIELD_TYPE_MAP: dict[str, type[models.Field]] = {
+FIELD_TYPE_MAP: dict[str, type[models.Field[t.Any, t.Any]]] = {
     "uuid": models.UUIDField,
     "text": models.TextField,
     "int": models.IntegerField,
@@ -316,7 +323,7 @@ FIELD_TYPE_MAP: dict[str, type[models.Field]] = {
 }
 
 
-def make_field(col_type: str) -> models.Field:
+def make_field(col_type: str) -> models.Field[t.Any, t.Any]:
     field_cls = FIELD_TYPE_MAP[col_type]
     return field_cls(null=True)
 
@@ -324,7 +331,7 @@ def make_field(col_type: str) -> models.Field:
 def fetch_catalog_queues(using: str) -> list[str]:
     with connections[using].cursor() as cur:
         cur.execute("SELECT queue_name FROM absurd.queues ORDER BY queue_name")
-        return [row[0] for row in cur.fetchall()]
+        return [name for (name,) in cur.fetchall()]
 
 
 def build_union_view_sql(spec: EntitySpec, queues: list[str]) -> str:

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -247,7 +247,7 @@ def build_admin_model(spec: EntitySpec) -> type[models.Model]:
     return type(spec.model_name, (models.Model,), fields)
 
 
-def raise_view_read_only(self: object, *args: object, **kwargs: object) -> t.NoReturn:
+def raise_view_read_only(self: t.Any, *args: object, **kwargs: object) -> t.NoReturn:
     raise QueueReadOnlyError(ADMIN_VIEW_READONLY_MSG)
 
 

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -258,7 +258,7 @@ def render_natural_key(self: t.Any) -> str:
 
 def build_model_field(
     spec: EntitySpec, col_name: str, col_type: str
-) -> tuple[str, models.Field[t.Any, t.Any]]:
+) -> "tuple[str, models.Field[t.Any, t.Any]]":
     # Tasks' task_id is the FK target for the Run inline, so it must be unique.
     if spec.name == "tasks" and col_name == "task_id":
         return "task_id", models.UUIDField(null=True, unique=True)
@@ -314,7 +314,7 @@ def build_queue_table_model(spec: EntitySpec, queue: str) -> type[models.Model]:
     return type(model_name, (models.Model,), fields)
 
 
-FIELD_TYPE_MAP: dict[str, type[models.Field[t.Any, t.Any]]] = {
+FIELD_TYPE_MAP: "dict[str, type[models.Field[t.Any, t.Any]]]" = {
     "uuid": models.UUIDField,
     "text": models.TextField,
     "int": models.IntegerField,
@@ -323,7 +323,7 @@ FIELD_TYPE_MAP: dict[str, type[models.Field[t.Any, t.Any]]] = {
 }
 
 
-def make_field(col_type: str) -> models.Field[t.Any, t.Any]:
+def make_field(col_type: str) -> "models.Field[t.Any, t.Any]":
     field_cls = FIELD_TYPE_MAP[col_type]
     return field_cls(null=True)
 

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -31,7 +31,7 @@ def provision_queues_after_migrate(
     sender: AppConfig,
     *,
     verbosity: int = 1,
-    stdout: t.Any = None,
+    stdout: t.IO[str] | None = None,
     **kwargs: object,
 ) -> None:
     from django_absurd.queues import provision_backend  # noqa: PLC0415

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -1,4 +1,6 @@
+import datetime as dt
 import typing as t
+import uuid
 
 import psycopg.errors
 from absurd_sdk import CreateQueueOptions
@@ -14,9 +16,36 @@ from django.utils.module_loading import import_string
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
+from django_absurd.params import AbsurdDefaultParams
 
 if t.TYPE_CHECKING:
     from django.tasks.base import Task
+
+
+class TaskModel(t.Protocol):
+    """The fields read off a per-queue Absurd task model instance.
+
+    These models are built dynamically per queue (build_queue_table_model), so
+    django-stubs cannot type their fields; this Protocol names the subset we read.
+    """
+
+    task_name: str
+    params: dict[str, t.Any]
+    enqueue_at: dt.datetime | None
+    first_started_at: dt.datetime | None
+    state: str
+    completed_payload: t.Any
+    cancelled_at: dt.datetime | None
+    last_attempt_run: uuid.UUID | None
+
+
+class RunModel(t.Protocol):
+    """The fields read off a per-queue Absurd run model instance."""
+
+    started_at: dt.datetime | None
+    completed_at: dt.datetime | None
+    failed_at: dt.datetime | None
+    failure_reason: dict[str, t.Any] | None
 
 
 class AbsurdBackendOptions(t.TypedDict, total=False):
@@ -26,8 +55,8 @@ class AbsurdBackendOptions(t.TypedDict, total=False):
     ENABLE_ADMIN: bool
     ADMIN_SITE: tuple[str, ...]
     SCHEDULER: str
-    SCHEDULE: dict[str, t.Any]
-    CLEANUP: dict[str, t.Any]
+    SCHEDULE: dict[str, dict[str, object]]
+    CLEANUP: dict[str, str]
 
 
 class AbsurdBackend(BaseTaskBackend):
@@ -46,8 +75,8 @@ class AbsurdBackend(BaseTaskBackend):
         self.scheduler: str = self.options.get("SCHEDULER", "beat")
 
     def enqueue(
-        self, task: "Task", args: list[t.Any], kwargs: dict[str, t.Any]
-    ) -> TaskResult:
+        self, task: "Task[t.Any, t.Any]", args: list[t.Any], kwargs: dict[str, t.Any]
+    ) -> "TaskResult[t.Any, t.Any]":
         self.validate_task(task)
         client = build_absurd_client(self.database)
         spawn_params = kwargs.pop("absurd_spawn_params", None)
@@ -111,14 +140,14 @@ class AbsurdBackend(BaseTaskBackend):
             worker_ids=[],
         )
 
-    def get_result(self, result_id: str) -> TaskResult:
+    def get_result(self, result_id: str) -> "TaskResult[t.Any, t.Any]":
         queue, task_id = decode_result_id(result_id)
         if queue not in self.queues:
             raise TaskResultDoesNotExist(result_id)
-        task_row, run_row, worker_ids = fetch_task_rows(
+        task, run, worker_ids = fetch_task_and_run(
             self.database, queue, task_id, result_id
         )
-        return build_task_result(self, result_id, task_row, run_row, worker_ids)
+        return build_task_result(self, result_id, task, run, worker_ids)
 
 
 def decode_result_id(result_id: str) -> tuple[str, str]:
@@ -142,30 +171,32 @@ def map_state_to_status(state: str) -> TaskResultStatus:
     return STATE_TO_STATUS.get(state, TaskResultStatus.READY)
 
 
-def fetch_task_rows(
+def fetch_task_and_run(
     database: str,
     queue: str,
     task_id: str,
     result_id: str,
-) -> tuple[t.Any, t.Any, list[str]]:
+) -> tuple[TaskModel, RunModel | None, list[str]]:
     tasks_spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     runs_spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "runs")
-    task_table = t.cast("t.Any", build_queue_table_model(tasks_spec, queue))
-    run_table = t.cast("t.Any", build_queue_table_model(runs_spec, queue))
+    task_model: type[t.Any] = build_queue_table_model(tasks_spec, queue)
+    run_model: type[t.Any] = build_queue_table_model(runs_spec, queue)
     try:
         with transaction.atomic(using=database, savepoint=True):
-            task_row = task_table.objects.using(database).filter(pk=task_id).first()
+            task: TaskModel | None = (
+                task_model.objects.using(database).filter(pk=task_id).first()
+            )
     except ProgrammingError:
         raise TaskResultDoesNotExist(result_id) from None
-    if task_row is None:
+    if task is None:
         raise TaskResultDoesNotExist(result_id)
-    run_row = None
-    if task_row.last_attempt_run is not None:
+    run: RunModel | None = None
+    if task.last_attempt_run is not None:
         try:
             with transaction.atomic(using=database, savepoint=True):
-                run_row = (
-                    run_table.objects.using(database)
-                    .filter(pk=task_row.last_attempt_run)
+                run = (
+                    run_model.objects.using(database)
+                    .filter(pk=task.last_attempt_run)
                     .first()
                 )
         except ProgrammingError:
@@ -173,35 +204,35 @@ def fetch_task_rows(
     try:
         with transaction.atomic(using=database, savepoint=True):
             worker_ids = list(
-                run_table.objects.using(database)
+                run_model.objects.using(database)
                 .filter(task_id=task_id, claimed_by__isnull=False)
                 .order_by("attempt")
                 .values_list("claimed_by", flat=True)
             )
     except ProgrammingError:
         raise TaskResultDoesNotExist(result_id) from None
-    return task_row, run_row, worker_ids
+    return task, run, worker_ids
 
 
 def build_task_result(
     backend: "AbsurdBackend",
     result_id: str,
-    task_row: t.Any,
-    run_row: t.Any,
+    task: TaskModel,
+    run: RunModel | None,
     worker_ids_list: list[str],
-) -> TaskResult:
+) -> "TaskResult[t.Any, t.Any]":
     queue, _ = decode_result_id(result_id)
-    task_name: str = task_row.task_name
-    params: dict[str, t.Any] = task_row.params
-    enqueue_at = task_row.enqueue_at
-    first_started_at = task_row.first_started_at
-    state: str = task_row.state
-    completed_payload = task_row.completed_payload
-    cancelled_at = task_row.cancelled_at
-    run_started = run_row.started_at if run_row is not None else None
-    completed_at = run_row.completed_at if run_row is not None else None
-    failed_at = run_row.failed_at if run_row is not None else None
-    failure_reason = run_row.failure_reason if run_row is not None else None
+    task_name: str = task.task_name
+    params: dict[str, t.Any] = task.params
+    enqueue_at = task.enqueue_at
+    first_started_at = task.first_started_at
+    state: str = task.state
+    completed_payload = task.completed_payload
+    cancelled_at = task.cancelled_at
+    run_started = run.started_at if run else None
+    completed_at = run.completed_at if run else None
+    failed_at = run.failed_at if run else None
+    failure_reason = run.failure_reason if run else None
     try:
         task_obj = import_string(task_name)
     except ImportError:
@@ -221,7 +252,7 @@ def build_task_result(
         ]
     finished_at = completed_at or failed_at or cancelled_at
     worker_ids: list[str] = worker_ids_list or []
-    result: TaskResult = TaskResult(
+    result: TaskResult[t.Any, t.Any] = TaskResult(
         task=task_obj,
         id=result_id,
         status=status,
@@ -240,10 +271,10 @@ def build_task_result(
     return result
 
 
-def get_declared_queues(backend: "AbsurdBackend") -> dict[str, dict]:
+def get_declared_queues(backend: "AbsurdBackend") -> dict[str, CreateQueueOptions]:
     if "QUEUES" in backend.options:
         return dict(backend.options["QUEUES"])
-    return {name: {} for name in backend.queues}
+    return {name: CreateQueueOptions() for name in backend.queues}
 
 
 def get_absurd_backends() -> dict[str, "AbsurdBackend"]:
@@ -263,7 +294,10 @@ def get_pg_cron_backends() -> dict[str, "AbsurdBackend"]:
     }
 
 
-def build_merged_spawn_options(defaults: t.Any, per_call: t.Any) -> dict[str, t.Any]:
+def build_merged_spawn_options(
+    defaults: AbsurdDefaultParams | None,
+    per_call: AbsurdDefaultParams | None,
+) -> dict[str, t.Any]:
     merged: dict[str, t.Any] = {}
     if defaults is not None:
         merged.update(defaults.to_kwargs())

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -478,7 +478,8 @@ def check_absurd_queue_state(
 
 
 def validate_queue_policy(
-    queue_name: str, policy: dict[str, t.Any]
+    queue_name: str,
+    policy: CreateQueueOptions,
 ) -> list[CheckMessage]:
     errors: list[CheckMessage] = [
         Error(
@@ -490,19 +491,21 @@ def validate_queue_policy(
         if key not in VALID_QUEUE_OPTION_KEYS
     ]
     if "storage_mode" in policy and policy["storage_mode"] not in VALID_STORAGE_MODES:
-        mode = policy["storage_mode"]
+        storage_mode_value = policy["storage_mode"]
         errors.append(
             Error(
-                f"{E003_MSG} Queue '{queue_name}': invalid storage_mode '{mode}'.",
+                f"{E003_MSG} Queue '{queue_name}':"
+                f" invalid storage_mode '{storage_mode_value}'.",
                 hint=E003_HINT,
                 id="absurd.E003",
             )
         )
     if "detach_mode" in policy and policy["detach_mode"] not in VALID_DETACH_MODES:
-        mode = policy["detach_mode"]
+        detach_mode_value = policy["detach_mode"]
         errors.append(
             Error(
-                f"{E003_MSG} Queue '{queue_name}': invalid detach_mode '{mode}'.",
+                f"{E003_MSG} Queue '{queue_name}':"
+                f" invalid detach_mode '{detach_mode_value}'.",
                 hint=E003_HINT,
                 id="absurd.E003",
             )
@@ -519,7 +522,9 @@ def router_installed() -> bool:
     return False
 
 
-def query_queue_state(alias: str, declared: dict[str, dict]) -> list[CheckMessage]:
+def query_queue_state(
+    alias: str, declared: dict[str, CreateQueueOptions]
+) -> list[CheckMessage]:
     try:
         actual = {
             q.queue_name: q

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -1,3 +1,5 @@
+import typing as t
+
 from django.core.management.base import BaseCommand, CommandError
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
@@ -11,7 +13,7 @@ BEAT_DISABLED_UNDER_PG_CRON = (
 )
 
 
-def resolve_backend(options: dict) -> tuple[str, AbsurdBackend]:
+def resolve_backend(options: dict[str, t.Any]) -> tuple[str, AbsurdBackend]:
     backends = get_absurd_backends()
     alias = options["alias"]
     if alias is not None:

--- a/django_absurd/management/commands/absurd_beat.py
+++ b/django_absurd/management/commands/absurd_beat.py
@@ -1,8 +1,9 @@
 import signal
 import threading
 import typing as t
+from types import FrameType
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from django_absurd.management.base import BEAT_DISABLED_UNDER_PG_CRON, resolve_backend
 from django_absurd.scheduler import get_settings_schedules, run_beat
@@ -11,7 +12,7 @@ from django_absurd.scheduler import get_settings_schedules, run_beat
 class Command(BaseCommand):
     help = "Start the Absurd beat scheduler."
 
-    def add_arguments(self, parser: t.Any) -> None:
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--alias",
             default=None,
@@ -26,7 +27,7 @@ class Command(BaseCommand):
 
         stop = threading.Event()
 
-        def handle_signal(signum: int, frame: t.Any) -> None:
+        def handle_signal(signum: int, frame: FrameType | None) -> None:
             stop.set()
 
         signal.signal(signal.SIGINT, handle_signal)

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -3,6 +3,9 @@ import typing as t
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import CommandError
 
+if t.TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 from django_absurd.management.base import (
     BEAT_DISABLED_UNDER_PG_CRON,
     AbsurdReportCommand,
@@ -15,7 +18,7 @@ from django_absurd.worker import WorkerOptions, run_worker
 class Command(AbsurdReportCommand):
     help = "Start the Absurd task worker."
 
-    def add_arguments(self, parser: t.Any) -> None:
+    def add_arguments(self, parser: "CommandParser") -> None:
         parser.add_argument(
             "--queue",
             default="default",

--- a/django_absurd/params.py
+++ b/django_absurd/params.py
@@ -1,27 +1,39 @@
 """Dataclasses and decorator for Absurd spawn/default parameters."""
 
 import dataclasses
+import enum
 import typing as t
 
 from absurd_sdk import CancellationPolicy, JsonObject, RetryStrategy
 from django.tasks import Task
 
-NOT_SET: t.Any = object()
+
+class NotSet(enum.Enum):
+    """Sentinel type for an unset field — distinct from None, which is a real value."""
+
+    TOKEN = enum.auto()
+
+
+NOT_SET = NotSet.TOKEN
+
+F = t.TypeVar("F")
+
+AbsurdFieldValue = int | RetryStrategy | CancellationPolicy | JsonObject | str
 
 
 @dataclasses.dataclass(frozen=True)
 class AbsurdDefaultParams:
     """Per-task default parameters passed to Absurd at enqueue time."""
 
-    max_attempts: int = NOT_SET
-    retry_strategy: RetryStrategy = NOT_SET
-    cancellation: CancellationPolicy = NOT_SET
+    max_attempts: int | NotSet = NOT_SET
+    retry_strategy: RetryStrategy | NotSet = NOT_SET
+    cancellation: CancellationPolicy | NotSet = NOT_SET
 
-    def to_kwargs(self) -> dict[str, t.Any]:
+    def to_kwargs(self) -> dict[str, AbsurdFieldValue]:
         return {
-            f.name: getattr(self, f.name)
+            f.name: value
             for f in dataclasses.fields(self)
-            if getattr(self, f.name) is not NOT_SET
+            if (value := getattr(self, f.name)) is not NOT_SET
         }
 
 
@@ -29,19 +41,21 @@ class AbsurdDefaultParams:
 class AbsurdSpawnParams(AbsurdDefaultParams):
     """Per-invocation parameters passed to Absurd at enqueue time."""
 
-    headers: JsonObject = NOT_SET
-    idempotency_key: str = NOT_SET
+    headers: JsonObject | NotSet = NOT_SET
+    idempotency_key: str | NotSet = NOT_SET
 
 
-def absurd_default_params(**kwargs: t.Any) -> t.Callable[[t.Any], t.Any]:
+def absurd_default_params(
+    **kwargs: AbsurdFieldValue,
+) -> t.Callable[[F], F]:
     """Decorator factory that attaches Absurd default params to a task function."""
-    params = AbsurdDefaultParams(**kwargs)
+    params = AbsurdDefaultParams(**kwargs)  # type: ignore[arg-type]  # kwargs match dataclass fields
 
-    def set_default(func: t.Any) -> t.Any:
+    def set_default(func: F) -> F:
         if isinstance(func, Task):
             msg = "apply @absurd_default_params below @task, not above it"
             raise TypeError(msg)
-        func.absurd_default_params = params
+        func.absurd_default_params = params  # type: ignore[attr-defined]  # dynamic attribute on decorated callable
         return func
 
     return set_default

--- a/django_absurd/pg_cron/admin.py
+++ b/django_absurd/pg_cron/admin.py
@@ -20,8 +20,19 @@ from django_absurd.pg_cron.reconcile import build_scheduled_fields
 from django_absurd.queues import get_absurd_backend
 from django_absurd.validators import validate_task_path
 
+if t.TYPE_CHECKING:
+    from django.contrib.admin.options import _FieldsetSpec
+    from django.contrib.admin.sites import AdminSite
+    from django.http import HttpRequest, HttpResponse
 
-class ScheduledTaskForm(forms.ModelForm):
+    _ScheduledTaskFormBase = forms.ModelForm[ScheduledTask]
+    _ScheduledTaskAdminBase = admin.ModelAdmin[ScheduledTask]
+else:
+    _ScheduledTaskFormBase = forms.ModelForm
+    _ScheduledTaskAdminBase = admin.ModelAdmin
+
+
+class ScheduledTaskForm(_ScheduledTaskFormBase):
     class Meta:
         model = ScheduledTask
         # source is admin-owned and read-only (set on the instance, never in the form);
@@ -60,11 +71,11 @@ class ScheduledTaskForm(forms.ModelForm):
     # A blank args/kwargs textarea cleans to None (JSONField's empty value), which would
     # hit the NOT NULL columns as an IntegrityError (HTTP 500). Fall back to the field
     # defaults instead so an empty box means "no positional args" / "no kwargs".
-    def clean_args(self) -> t.Any:
+    def clean_args(self) -> list[t.Any]:
         value = self.cleaned_data.get("args")
         return [] if value is None else value
 
-    def clean_kwargs(self) -> t.Any:
+    def clean_kwargs(self) -> dict[str, t.Any]:
         value = self.cleaned_data.get("kwargs")
         return {} if value is None else value
 
@@ -102,14 +113,14 @@ class ScheduledTaskCreateForm(ScheduledTaskForm):
                     setattr(self.instance, field, value)
         return cleaned
 
-    def add_error(self, field: t.Any, error: t.Any) -> None:
+    def add_error(self, field: str | None, error: t.Any) -> None:
         # The resolved spawn columns (queue, retry_kind, ...) aren't fields on this
         # 4-field create form, so a model-validation error keyed to one of them (e.g. a
         # resolved queue that isn't declared for the backend) would raise "has no field
         # named ..." (HTTP 500). Re-home any error for a field this form doesn't expose
         # onto NON_FIELD_ERRORS so it renders as a form error instead.
         if isinstance(error, ValidationError) and hasattr(error, "error_dict"):
-            rehomed: dict[str, t.Any] = {}
+            rehomed: dict[str, list[ValidationError]] = {}
             for name, messages in error.error_dict.items():
                 key = name if name in self.fields else NON_FIELD_ERRORS
                 rehomed.setdefault(key, []).extend(messages)
@@ -117,9 +128,11 @@ class ScheduledTaskCreateForm(ScheduledTaskForm):
         super().add_error(field, error)
 
 
-class ScheduledTaskAdmin(admin.ModelAdmin):
+class ScheduledTaskAdmin(_ScheduledTaskAdminBase):
     form = ScheduledTaskForm
-    add_fieldsets = ((None, {"fields": ("alias", "name", "task", "cron")}),)
+    add_fieldsets: "_FieldsetSpec" = (
+        (None, {"fields": ("alias", "name", "task", "cron")}),
+    )
     save_on_top = True
     ordering = ("alias", "name")
     list_display = (
@@ -164,41 +177,56 @@ class ScheduledTaskAdmin(admin.ModelAdmin):
     )
 
     def get_form(
-        self, request: t.Any, obj: t.Any = None, change: bool = False, **kwargs: t.Any
-    ) -> t.Any:
+        self,
+        request: "HttpRequest",
+        obj: ScheduledTask | None = None,
+        change: bool = False,
+        **kwargs: t.Any,
+    ) -> type[forms.ModelForm[ScheduledTask]]:
         if obj is None:
             kwargs["form"] = ScheduledTaskCreateForm
         return super().get_form(request, obj, change=change, **kwargs)
 
-    def get_fieldsets(self, request: t.Any, obj: t.Any = None) -> t.Any:
+    def get_fieldsets(
+        self, request: "HttpRequest", obj: ScheduledTask | None = None
+    ) -> "_FieldsetSpec":
         if obj is None:
             return self.add_fieldsets
         return super().get_fieldsets(request, obj)
 
     def response_add(
-        self, request: t.Any, obj: t.Any, post_url_continue: t.Any = None
-    ) -> t.Any:
+        self,
+        request: "HttpRequest",
+        obj: ScheduledTask,
+        post_url_continue: str | None = None,
+    ) -> "HttpResponse":
         # Land on the change page so the user reviews the resolved (disabled) row and
         # activates it, rather than dropping back to the changelist — except when
         # "Save and add another" was pressed or we're in a popup.
         if "_addanother" not in request.POST and IS_POPUP_VAR not in request.POST:
-            request.POST = request.POST.copy()
-            request.POST["_continue"] = 1
+            request.POST = request.POST.copy()  # type: ignore[assignment]  # QueryDict.copy() returns mutable QueryDict; HttpRequest.POST is typed as _ImmutableQueryDict
+            request.POST["_continue"] = 1  # type: ignore[misc, assignment]  # QueryDict accepts int values at runtime
         return super().response_add(request, obj, post_url_continue)
 
-    def has_change_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_change_permission(
+        self, request: "HttpRequest", obj: ScheduledTask | None = None
+    ) -> bool:
         # settings-declared rows are read-only regardless of Django permissions;
         # admin rows require the usual change permission.
         return super().has_change_permission(request, obj) and (
             obj is None or obj.source == ScheduledTask.Source.ADMIN
         )
 
-    def has_delete_permission(self, request: t.Any, obj: t.Any = None) -> bool:
+    def has_delete_permission(
+        self, request: "HttpRequest", obj: ScheduledTask | None = None
+    ) -> bool:
         return super().has_delete_permission(request, obj) and (
             obj is None or obj.source == ScheduledTask.Source.ADMIN
         )
 
-    def get_readonly_fields(self, request: t.Any, obj: t.Any = None) -> tuple[str, ...]:
+    def get_readonly_fields(
+        self, request: "HttpRequest", obj: ScheduledTask | None = None
+    ) -> tuple[str, ...]:
         if obj is not None and obj.source == ScheduledTask.Source.SETTINGS:
             return tuple(flatten_fieldsets(self.get_fieldsets(request, obj)))
         if obj is not None:
@@ -206,7 +234,7 @@ class ScheduledTaskAdmin(admin.ModelAdmin):
         return ("created_at", "source", "updated_at")
 
 
-def register_scheduled_task_admin(sites: t.Iterable[t.Any]) -> None:
+def register_scheduled_task_admin(sites: t.Iterable["AdminSite"]) -> None:
     for site in sites:
         if not site.is_registered(ScheduledTask):
             site.register(ScheduledTask, ScheduledTaskAdmin)

--- a/django_absurd/pg_cron/admin.py
+++ b/django_absurd/pg_cron/admin.py
@@ -182,7 +182,7 @@ class ScheduledTaskAdmin(_ScheduledTaskAdminBase):
         obj: ScheduledTask | None = None,
         change: bool = False,
         **kwargs: t.Any,
-    ) -> type[forms.ModelForm[ScheduledTask]]:
+    ) -> "type[forms.ModelForm[ScheduledTask]]":
         if obj is None:
             kwargs["form"] = ScheduledTaskCreateForm
         return super().get_form(request, obj, change=change, **kwargs)

--- a/django_absurd/pg_cron/apps.py
+++ b/django_absurd/pg_cron/apps.py
@@ -59,7 +59,7 @@ def reconcile_crons_after_migrate(
     sender: AppConfig,
     *,
     verbosity: int = 1,
-    stdout: t.Any = None,
+    stdout: t.TextIO | None = None,
     **kwargs: object,
 ) -> None:
     from django_absurd.pg_cron.reconcile import (  # noqa: PLC0415

--- a/django_absurd/pg_cron/management/commands/absurd_sync_crons.py
+++ b/django_absurd/pg_cron/management/commands/absurd_sync_crons.py
@@ -9,11 +9,14 @@ from django_absurd.pg_cron.reconcile import (
     teardown_crons,
 )
 
+if t.TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
 
 class Command(BaseCommand):
     help = "Reconcile pg_cron jobs for all declared SCHEDULE entries."
 
-    def add_arguments(self, parser: t.Any) -> None:
+    def add_arguments(self, parser: "CommandParser") -> None:
         parser.add_argument(
             "--alias",
             default=None,
@@ -32,19 +35,19 @@ class Command(BaseCommand):
             help="Skip the teardown confirmation prompt.",
         )
 
-    def handle(self, *args: t.Any, **options: t.Any) -> None:
+    def handle(self, *args: t.Any, **options: t.Any) -> str | None:
         alias, backend = resolve_backend(options)
 
         if options["teardown"]:
             if not options["no_input"] and not self.confirm_teardown(alias):
                 self.stdout.write("Aborted.")
-                return
+                return None
             removed = teardown_crons(backend, include_admin=True)
             self.stdout.write(
                 f"Unscheduled all pg_cron jobs and removed {removed} schedule row(s) "
                 f"— backend '{alias}'."
             )
-            return
+            return None
 
         if backend.scheduler != "pg_cron":
             msg = (
@@ -65,6 +68,7 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Synced {created} cron(s); pruned {pruned} — backend '{alias}'."
         )
+        return None
 
     def confirm_teardown(self, alias: str) -> bool:
         prompt = (

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -5,6 +5,11 @@ from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.core.validators import MinValueValidator
 from django.db import DatabaseError, InternalError, connections, models, transaction
 
+if t.TYPE_CHECKING:
+    from django.db.backends.utils import CursorWrapper
+
+    from django_absurd.backends import AbsurdBackend
+
 from django_absurd.backends import (
     get_absurd_backends,
     get_declared_queues,
@@ -64,14 +69,14 @@ def get_declared_queue_choices() -> list[tuple[str, str]]:
     return [(q, q) for q in sorted(queues)]
 
 
-class PgCronManager(models.Manager):
+class PgCronManager(models.Manager["ScheduledTask"]):
     """The pg_cron catalog (``cron.job``) operations for these schedules, kept off
     ``objects`` (which queries the ScheduledTask table). Every method defaults to the
     single absurd database (``resolve_absurd_database()``); pass ``database`` only to
     reuse an already-resolved value.
     """
 
-    def get_job(self, alias: str, name: str, source: str) -> tuple | None:
+    def get_job(self, alias: str, name: str, source: str) -> tuple[t.Any, ...] | None:
         """The ``(jobname, schedule, command, active)`` row for one schedule's job."""
         with connections[resolve_absurd_database()].cursor() as cur:
             cur.execute(
@@ -79,9 +84,10 @@ class PgCronManager(models.Manager):
                 "where jobname = %s",
                 [build_jobname(alias, name, source)],
             )
-            return cur.fetchone()
+            job: tuple[t.Any, ...] | None = cur.fetchone()
+            return job
 
-    def get_managed_jobs(self, source: str | None = None) -> list[tuple]:
+    def get_managed_jobs(self, source: str | None = None) -> list[tuple[t.Any, ...]]:
         """The ``(jobname, schedule, command, active)`` rows for every job we manage
         (all share the ``absurd:`` prefix), across aliases. Pass source to narrow to one
         lane (``absurd:<source>:``)."""
@@ -92,7 +98,8 @@ class PgCronManager(models.Manager):
                 "where starts_with(jobname, %s) order by jobname",
                 [prefix],
             )
-            return cur.fetchall()
+            jobs: list[tuple[t.Any, ...]] = cur.fetchall()
+            return jobs
 
     def unschedule_matching(
         self, alias: str, source: str, database: str | None = None
@@ -257,7 +264,7 @@ class ScheduledTask(models.Model):
             errors["cron"] = exc.messages
         return errors
 
-    def get_pg_cron_job(self) -> tuple | None:
+    def get_pg_cron_job(self) -> tuple[t.Any, ...] | None:
         """This row's own pg_cron job as ``(jobname, schedule, command, active)``, or
         None if it isn't scheduled. (The manager lives on the class — Django managers
         aren't accessible via instances.)"""
@@ -298,7 +305,7 @@ class ScheduledTask(models.Model):
             prune_pg_cron_jobs(cur, [jobid for (jobid,) in cur.fetchall()])
 
 
-def resolve_pg_cron_backend(scheduled_task: ScheduledTask) -> t.Any:
+def resolve_pg_cron_backend(scheduled_task: ScheduledTask) -> "AbsurdBackend | None":
     """The pg_cron backend for a schedule's alias, or None when the alias is not a
     configured pg_cron backend — nothing to schedule for such a row."""
     backend = get_absurd_backends().get(scheduled_task.alias)
@@ -308,7 +315,7 @@ def resolve_pg_cron_backend(scheduled_task: ScheduledTask) -> t.Any:
 
 
 @contextmanager
-def open_locked_cursor(database: str) -> t.Iterator[t.Any]:
+def open_locked_cursor(database: str) -> t.Iterator["CursorWrapper"]:
     """A cursor on ``database`` inside a transaction holding the shared advisory lock,
     so concurrent pg_cron job writers serialise."""
     advisory_lock_key = 0x616273_75726421  # "absurd!" as hex
@@ -317,7 +324,7 @@ def open_locked_cursor(database: str) -> t.Iterator[t.Any]:
         yield cur
 
 
-def prune_pg_cron_jobs(cur: t.Any, stale_jobids: list[int]) -> None:
+def prune_pg_cron_jobs(cur: "CursorWrapper", stale_jobids: list[int]) -> None:
     """Unschedule each jobid, tolerating already-removed rows.
 
     Each unschedule runs inside its own savepoint: if the cron.job row was removed

--- a/django_absurd/pg_cron/signals.py
+++ b/django_absurd/pg_cron/signals.py
@@ -20,9 +20,12 @@ stray row created out-of-band on another DB must stay deletable).
 
 import typing as t
 
+if t.TYPE_CHECKING:
+    from django_absurd.pg_cron.models import ScheduledTask
+
 
 def reject_cross_database_save(
-    sender: type, instance: t.Any, using: str | None = None, **kwargs: t.Any
+    sender: type, instance: "ScheduledTask", using: str | None = None, **kwargs: t.Any
 ) -> None:
     """pre_save: reject a write forced onto a non-absurd database before the INSERT, so
     no misplaced row is created. Cross-database schedules belong to the multi-Absurd-
@@ -36,14 +39,16 @@ def reject_cross_database_save(
         raise NotImplementedError(msg)
 
 
-def schedule_job_on_save(sender: type, instance: t.Any, **kwargs: t.Any) -> None:
+def schedule_job_on_save(
+    sender: type, instance: "ScheduledTask", **kwargs: t.Any
+) -> None:
     """post_save: (re)schedule the row's pg_cron job. Fires only for a write that
     reached the absurd DB — pre_save rejects a cross-database write before this."""
     instance.schedule_pg_cron_job()
 
 
 def unschedule_job_on_delete(
-    sender: type, instance: t.Any, using: str | None = None, **kwargs: t.Any
+    sender: type, instance: "ScheduledTask", using: str | None = None, **kwargs: t.Any
 ) -> None:
     """post_delete: remove the row's pg_cron job. Skips a row deleted from a foreign
     database — nothing of ours to unschedule there — so a stray row created out-of-band

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -66,22 +66,24 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
     result = SyncResult()
     client = build_absurd_client(db)
     try:
-        row = Queue.objects.using(db).filter(queue_name=queue_name).first()
+        existing = Queue.objects.using(db).filter(queue_name=queue_name).first()
     except ProgrammingError as exc:
         msg = "Absurd schema is not installed. Run: manage.py migrate"
         raise ImproperlyConfigured(msg) from exc
-    if row is None:
+    if existing is None:
         client.create_queue(queue_name, **opts)
         result.created.append(queue_name)
     else:
-        mutable_opts = {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS}
-        if mutable_opts and check_mutable_options_drifted(db, mutable_opts, row):
+        mutable_opts: dict[str, t.Any] = {
+            k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS
+        }
+        if mutable_opts and check_mutable_options_drifted(db, mutable_opts, existing):
             client.set_queue_policy(queue_name, **mutable_opts)
             result.reconciled.append(queue_name)
-        if "storage_mode" in opts and opts["storage_mode"] != row.storage_mode:
+        if "storage_mode" in opts and opts["storage_mode"] != existing.storage_mode:
             result.storage_warnings.append(
                 f"Queue '{queue_name}': storage_mode cannot be changed "
-                f"(existing: {row.storage_mode!r}, "
+                f"(existing: {existing.storage_mode!r}, "
                 f"declared: {opts['storage_mode']!r}); skipping."
             )
     return result
@@ -109,16 +111,18 @@ def provision_backend(backend: backends.AbsurdBackend) -> SyncResult:
 def parse_interval(using: str, interval_str: str) -> dt.timedelta:
     with connections[using].cursor() as cur:
         cur.execute("SELECT %s::interval", [interval_str])
-        return cur.fetchone()[0]
+        record: tuple[dt.timedelta, ...] = cur.fetchone()
+        return record[0]
 
 
 def check_mutable_options_drifted(
-    using: str, opts: dict[str, t.Any], row: Queue
+    using: str, opts: dict[str, t.Any], existing: Queue
 ) -> bool:
     for key, declared_value in opts.items():
-        db_value = getattr(row, key)
+        db_value = getattr(existing, key)
         if key in INTERVAL_OPTION_KEYS:
-            if parse_interval(using, declared_value) != db_value:
+            interval_str: str = declared_value
+            if parse_interval(using, interval_str) != db_value:
                 return True
         elif declared_value != db_value:
             return True

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -1,7 +1,7 @@
+import datetime as dt
 import typing as t
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import timedelta
 
 from absurd_sdk import Absurd, CreateQueueOptions
 from django.core.exceptions import ImproperlyConfigured
@@ -106,7 +106,7 @@ def provision_backend(backend: backends.AbsurdBackend) -> SyncResult:
     return result
 
 
-def parse_interval(using: str, interval_str: str) -> timedelta:
+def parse_interval(using: str, interval_str: str) -> dt.timedelta:
     with connections[using].cursor() as cur:
         cur.execute("SELECT %s::interval", [interval_str])
         return cur.fetchone()[0]

--- a/django_absurd/routers.py
+++ b/django_absurd/routers.py
@@ -2,16 +2,19 @@ import typing as t
 
 from django_absurd.queues import resolve_absurd_database
 
+if t.TYPE_CHECKING:
+    from django.db.models import Model
+
 ABSURD_APP_LABELS = frozenset({"django_absurd", "django_absurd_pg_cron"})
 
 
 class AbsurdRouter:
-    def db_for_read(self, model: t.Any, **hints: t.Any) -> str | None:
+    def db_for_read(self, model: "type[Model]", **hints: t.Any) -> str | None:
         if model._meta.app_label in ABSURD_APP_LABELS:  # noqa: SLF001
             return resolve_absurd_database()
         return None
 
-    def db_for_write(self, model: t.Any, **hints: t.Any) -> str | None:
+    def db_for_write(self, model: "type[Model]", **hints: t.Any) -> str | None:
         if model._meta.app_label in ABSURD_APP_LABELS:  # noqa: SLF001
             return resolve_absurd_database()
         return None

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -1,5 +1,5 @@
 import dataclasses
-import datetime
+import datetime as dt
 import functools
 import hashlib
 import logging
@@ -30,13 +30,13 @@ class Schedule:
     backend: str = "default"
 
 
-def get_next_datetime(cron: str, after: datetime.datetime) -> datetime.datetime:
+def get_next_datetime(cron: str, after: dt.datetime) -> dt.datetime:
     # second_at_beginning=True: a 6-field cron carries a LEADING seconds column, so
     # "*/30 * * * * *" means every 30 seconds. Without it croniter reads seconds as the
     # trailing field and the expression silently degrades to every-second firing.
     local_after = timezone.localtime(after)
     return croniter.croniter(cron, local_after, second_at_beginning=True).get_next(
-        datetime.datetime
+        dt.datetime
     )
 
 
@@ -56,15 +56,15 @@ def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:
     ]
 
 
-def derive_idempotency_key(schedule: Schedule, slot: datetime.datetime) -> str:
+def derive_idempotency_key(schedule: Schedule, slot: dt.datetime) -> str:
     # Dedup key, anchored on the schedule name (not task/cron) so args/queue-varying
     # entries don't collide. https://earendil-works.github.io/absurd/patterns/cron/
-    utc_slot = slot.astimezone(datetime.UTC).isoformat(timespec="seconds")
+    utc_slot = slot.astimezone(dt.UTC).isoformat(timespec="seconds")
     raw = f"{schedule.backend}|{schedule.name}|{schedule.cron}|{utc_slot}"
     return "cron:" + hashlib.sha256(raw.encode()).hexdigest()[:24]
 
 
-def spawn_scheduled(schedule: Schedule, slot: datetime.datetime) -> None:
+def spawn_scheduled(schedule: Schedule, slot: dt.datetime) -> None:
     close_old_connections()
     try:
         task = import_string(schedule.task)
@@ -91,7 +91,7 @@ def get_cleanup_schedule(backend: AbsurdBackend) -> str | None:
 def run_beat(
     backend: AbsurdBackend,
     *,
-    now: t.Callable[[], datetime.datetime] = timezone.now,
+    now: t.Callable[[], dt.datetime] = timezone.now,
     stop: threading.Event | None = None,
     wait: t.Callable[[float], bool] | None = None,
 ) -> None:
@@ -132,15 +132,15 @@ class BeatEntry:
     """
 
     cron: str
-    fire: t.Callable[[datetime.datetime], None]
-    next_at: datetime.datetime
+    fire: t.Callable[[dt.datetime], None]
+    next_at: dt.datetime
 
 
 def build_beat_entries(
     backend: AbsurdBackend,
     schedules: list[Schedule],
     cleanup_cron: str | None,
-    moment: datetime.datetime,
+    moment: dt.datetime,
 ) -> list[BeatEntry]:
     entries = [
         BeatEntry(
@@ -161,7 +161,7 @@ def build_beat_entries(
     return entries
 
 
-def fire_cleanup(backend: AbsurdBackend, slot: datetime.datetime) -> None:
+def fire_cleanup(backend: AbsurdBackend, slot: dt.datetime) -> None:
     close_old_connections()
     try:
         counts = cleanup_queues()
@@ -170,14 +170,14 @@ def fire_cleanup(backend: AbsurdBackend, slot: datetime.datetime) -> None:
     else:
         logger.info(
             "django-absurd cleanup ran: slot=%s counts=%s",
-            slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            slot.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             counts,
         )
     finally:
         close_old_connections()
 
 
-def fire_schedule(schedule: Schedule, slot: datetime.datetime) -> None:
+def fire_schedule(schedule: Schedule, slot: dt.datetime) -> None:
     try:
         spawn_scheduled(schedule, slot)
     except Exception:
@@ -186,5 +186,5 @@ def fire_schedule(schedule: Schedule, slot: datetime.datetime) -> None:
         logger.info(
             "django-absurd schedule enqueued: name=%s slot=%s",
             schedule.name,
-            slot.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            slot.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         )

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -25,8 +25,8 @@ class Schedule:
     task: str
     cron: str
     queue: str | None = None
-    args: list = dataclasses.field(default_factory=list)
-    kwargs: dict = dataclasses.field(default_factory=dict)
+    args: list[t.Any] = dataclasses.field(default_factory=list)
+    kwargs: dict[str, t.Any] = dataclasses.field(default_factory=dict)
     backend: str = "default"
 
 
@@ -41,7 +41,7 @@ def get_next_datetime(cron: str, after: dt.datetime) -> dt.datetime:
 
 
 def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:
-    schedule_map: dict[str, t.Any] = backend.options.get("SCHEDULE", {})
+    schedule_map: dict[str, dict[str, t.Any]] = backend.options.get("SCHEDULE", {})
     return [
         Schedule(
             name=name,
@@ -68,7 +68,7 @@ def spawn_scheduled(schedule: Schedule, slot: dt.datetime) -> None:
     close_old_connections()
     try:
         task = import_string(schedule.task)
-        overrides: dict[str, t.Any] = {"backend": schedule.backend}
+        overrides: dict[str, str] = {"backend": schedule.backend}
         if schedule.queue is not None:
             overrides["queue_name"] = schedule.queue
         task = task.using(**overrides)

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -34,7 +34,7 @@ class WorkerOptions:
     worker_id: str | None = None
 
 
-class LazyTaskRegistry(dict):
+class LazyTaskRegistry(dict[str, t.Any]):
     """dict subclass that resolves tasks by import_string on first claim.
 
     The SDK reads _registry.get(task_name) in both _execute_task (burst) and
@@ -171,27 +171,35 @@ async def drain_queue(
 
 
 def build_task_context(
-    task: Task, ctx: t.Any, args: t.Sequence[t.Any], kwargs: dict[str, t.Any]
-) -> TaskContext:
+    task: "Task[t.Any, t.Any]",
+    ctx: t.Any,
+    args: t.Sequence[t.Any],
+    kwargs: dict[str, t.Any],
+) -> "TaskContext[t.Any, t.Any]":
     attempt = read_sdk_attempt(ctx)
-    task_result: TaskResult[..., t.Any] = TaskResult(
-        task=task,
-        id=ctx.task_id,
-        status=TaskResultStatus.RUNNING,
-        enqueued_at=None,
-        started_at=timezone.now(),
-        finished_at=None,
-        last_attempted_at=None,
-        args=list(args),
-        kwargs=dict(kwargs),
-        backend=task.backend,
-        errors=[],
-        worker_ids=["absurd"] * attempt,
+    task_result = t.cast(
+        "TaskResult[t.Any, t.Any]",
+        TaskResult(
+            task=task,
+            id=ctx.task_id,
+            status=TaskResultStatus.RUNNING,
+            enqueued_at=None,
+            started_at=timezone.now(),
+            finished_at=None,
+            last_attempted_at=None,
+            args=list(args),
+            kwargs=dict(kwargs),
+            backend=task.backend,
+            errors=[],
+            worker_ids=["absurd"] * attempt,
+        ),
     )
     return TaskContext(task_result=task_result)
 
 
-def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Awaitable[t.Any]]:
+def build_handler(
+    task: "Task[t.Any, t.Any]",
+) -> t.Callable[[t.Any, t.Any], t.Awaitable[t.Any]]:
     async def handler(params: t.Any, ctx: t.Any) -> t.Any:
         args = params.get("args", [])
         kwargs = params.get("kwargs", {})
@@ -252,7 +260,8 @@ def build_handler(task: Task) -> t.Callable[[t.Any, t.Any], t.Awaitable[t.Any]]:
 
 
 def read_sdk_attempt(ctx: t.Any) -> int:
-    return ctx._task["attempt"]  # noqa: SLF001 -- SDK TaskContext has no public attempt property
+    attempt: int = ctx._task["attempt"]  # noqa: SLF001 -- SDK TaskContext has no public attempt property
+    return attempt
 
 
 async def run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,16 @@ select = ["ALL"]
   "SLF001",  # Allow private member access in tests (e.g. _meta)
 ]
 
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = [
+  "datetime",  # Use `import datetime as dt`, not `from datetime import ...`
+  "typing",  # Use `import typing as t`, not `from typing import ...`
+]
+
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+datetime = "dt"
+typing = "t"
+
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,12 +109,14 @@ source = "vcs"
 
 [tool.mypy]
 exclude = [
+  "/migrations/",
   "^build/",
   "^dist/",
   "^\\.tox/",
   "^examples/",
 ]
 plugins = ["mypy_django_plugin.main"]
+strict = true
 
 [tool.pytest.ini_options]
 addopts = [
@@ -145,8 +147,6 @@ select = ["ALL"]
   "E501",  # Allow exceeded line length in migrations.
 ]
 "tests/**/*" = [
-  "ANN",  # No type annotations required in tests
-  "E501",  # Allow long lines in tests
   "S101",  # Allow use of asserts
   "S603",  # Allow subprocess calls in tests
   "SLF001",  # Allow private member access in tests (e.g. _meta)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,12 +71,12 @@ Homepage = "https://github.com/lincolnloop/django-absurd"
 Issues = "https://github.com/lincolnloop/django-absurd/issues"
 Repository = "https://github.com/lincolnloop/django-absurd"
 
+# exclude_also ADDS to coverage's built-in defaults (pragma: no cover, `...` stub
+# bodies, `if TYPE_CHECKING:`) rather than replacing them; keep the `t.`-prefixed
+# TYPE_CHECKING form explicit since the default only matches the bare name.
 [tool.coverage.report]
-exclude_lines = [
-  "if TYPE_CHECKING:",
+exclude_also = [
   "if t.TYPE_CHECKING:",
-  "pragma: no cover",
-  "raise NotImplementedError",
   # a `msg = "..."` line immediately followed by `raise NotImplementedError(msg)`
   # (the errmsg-lint idiom) — exclude the assignment too, not just the raise.
   'msg = [rf]?".*"\n\s*raise NotImplementedError\(msg\)',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ source = "vcs"
 
 [tool.mypy]
 exclude = [
-  "/migrations/",
   "^build/",
   "^dist/",
   "^\\.tox/",

--- a/renovate.json
+++ b/renovate.json
@@ -53,5 +53,16 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "prPriority": -1
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Pin the PGDG postgresql-<major>-cron apt package in Dockerfile.pg_cron.",
+      "managerFilePatterns": ["/(^|/)Dockerfile\\.pg_cron$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)[\\s\\S]*?=(?<currentValue>[0-9][^\\s\\\\;]+)"
+      ],
+      "registryUrlTemplate": "https://apt.postgresql.org/pub/repos/apt?suite=trixie-pgdg&components=main&binaryArch=amd64"
+    }
   ]
 }

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -1,40 +1,41 @@
+import typing as t
 from asyncio import sleep as asleep
 
-from django.tasks import task
+from django.tasks import TaskContext, task
 
 from tests.models import Payload
 
 
 @task
-async def aecho(value):
+async def aecho(value: t.Any) -> t.Any:
     return value
 
 
 @task
-async def aboom():
+async def aboom() -> t.Never:
     msg = "aboom"
     raise ValueError(msg)
 
 
 @task(takes_context=True)
-async def areport_attempt(context):
+async def areport_attempt(context: TaskContext[t.Any, t.Any]) -> int:
     return context.attempt
 
 
 @task
-async def acreate_payload(data):
+async def acreate_payload(data: t.Any) -> int:
     obj = await Payload.objects.acreate(data=data)
     return obj.pk
 
 
 @task
-async def aread_payload(pk):
+async def aread_payload(pk: int) -> t.Any:
     # async QUERY: read a row back via Django async ORM, return its jsonb
     obj = await Payload.objects.aget(pk=pk)
     return obj.data
 
 
 @task
-async def asleeper(seconds):
+async def asleeper(seconds: float) -> str:
     await asleep(seconds)
     return "slept"

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -18,7 +18,7 @@ async def aboom() -> t.Never:
 
 
 @task(takes_context=True)
-async def areport_attempt(context: TaskContext[t.Any, t.Any]) -> int:
+async def areport_attempt(context: "TaskContext[t.Any, t.Any]") -> int:
     return context.attempt
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,11 @@ def _reset_absurd_queues(_enable_db: None) -> None:
 
 @pytest.fixture
 def admin_user() -> User:
-    return User.objects.create_superuser("admin", "a@x.com", "pw")
+    # No password: tests log in via force_login (never checks it), and setting one
+    # runs the deliberately-slow PBKDF2 hasher on every fixture use.
+    return User.objects.create_superuser("admin", "a@x.com")
 
 
 @pytest.fixture
 def staff_user() -> User:
-    return User.objects.create_user("staff", "s@x.com", "pw", is_staff=True)
+    return User.objects.create_user("staff", "s@x.com", is_staff=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import OperationalError, ProgrammingError
 
@@ -7,12 +7,12 @@ from django_absurd.queues import get_absurd_client
 
 
 @pytest.fixture(autouse=True)
-def _enable_db(db):
+def _enable_db(db: None) -> None:
     pass
 
 
 @pytest.fixture(autouse=True)
-def _reset_absurd_queues(_enable_db):
+def _reset_absurd_queues(_enable_db: None) -> None:
     """Drop all Absurd queues before each test.
 
     ``transaction=True`` tests create queues whose per-queue tables (DDL) and
@@ -28,10 +28,10 @@ def _reset_absurd_queues(_enable_db):
 
 
 @pytest.fixture
-def admin_user(_enable_db):
-    return get_user_model().objects.create_superuser("admin", "a@x.com", "pw")
+def admin_user() -> User:
+    return User.objects.create_superuser("admin", "a@x.com", "pw")
 
 
 @pytest.fixture
-def staff_user(_enable_db):
-    return get_user_model().objects.create_user("staff", "s@x.com", "pw", is_staff=True)
+def staff_user() -> User:
+    return User.objects.create_user("staff", "s@x.com", "pw", is_staff=True)

--- a/tests/core/test_admin/conftest.py
+++ b/tests/core/test_admin/conftest.py
@@ -4,7 +4,7 @@ from tests.core.test_admin.support import register_admin
 
 
 @pytest.fixture(autouse=True)
-def _register_admin():
+def _register_admin() -> None:
     # Register the Absurd models on the default admin site and refresh URL
     # resolution so the per-model admin URLs reverse in every test.
     register_admin()

--- a/tests/core/test_admin/support.py
+++ b/tests/core/test_admin/support.py
@@ -7,12 +7,14 @@ from bs4 import BeautifulSoup, ResultSet, Tag
 from django.conf import settings
 from django.contrib import admin as djadmin
 from django.core.management import call_command
-from django.tasks import TaskResult
 from django.urls import clear_url_caches
 
 from django_absurd.admin import register_absurd_admin
 from django_absurd.params import AbsurdSpawnParams
 from tests.tasks import add, boom
+
+if t.TYPE_CHECKING:
+    from django.tasks import TaskResult
 
 BACKEND = "django_absurd.backends.AbsurdBackend"
 
@@ -41,7 +43,7 @@ def seed() -> None:
 
 
 def seed_mixed() -> tuple[
-    TaskResult[t.Any, t.Any], TaskResult[t.Any, t.Any], TaskResult[t.Any, t.Any]
+    "TaskResult[t.Any, t.Any]", "TaskResult[t.Any, t.Any]", "TaskResult[t.Any, t.Any]"
 ]:
     """Three default-queue tasks in distinct terminal/queued states."""
     call_command("absurd_sync_queues")

--- a/tests/core/test_admin/support.py
+++ b/tests/core/test_admin/support.py
@@ -1,11 +1,13 @@
 """Shared helpers for the admin HTTP test package."""
 
 import importlib
+import typing as t
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, ResultSet, Tag
 from django.conf import settings
 from django.contrib import admin as djadmin
 from django.core.management import call_command
+from django.tasks import TaskResult
 from django.urls import clear_url_caches
 
 from django_absurd.admin import register_absurd_admin
@@ -15,21 +17,21 @@ from tests.tasks import add, boom
 BACKEND = "django_absurd.backends.AbsurdBackend"
 
 
-def parse_html(response):
+def parse_html(response: t.Any) -> BeautifulSoup:
     return BeautifulSoup(response.content, "html.parser")
 
 
-def result_rows(soup):
+def result_rows(soup: BeautifulSoup) -> ResultSet[Tag]:
     return soup.select("#result_list tbody tr")
 
 
-def register_admin():
+def register_admin() -> None:
     register_absurd_admin([djadmin.site])
     importlib.reload(importlib.import_module(settings.ROOT_URLCONF))
     clear_url_caches()
 
 
-def seed():
+def seed() -> None:
     call_command("absurd_sync_queues")
     add.enqueue(2, 3)
     add.using(queue_name="other").enqueue(7, 8)
@@ -38,11 +40,15 @@ def seed():
     call_command("absurd_worker", queue="other", burst=True)
 
 
-def seed_mixed():
+def seed_mixed() -> tuple[
+    TaskResult[t.Any, t.Any], TaskResult[t.Any, t.Any], TaskResult[t.Any, t.Any]
+]:
     """Three default-queue tasks in distinct terminal/queued states."""
     call_command("absurd_sync_queues")
     completed = add.enqueue(2, 3)
-    failed = boom.enqueue(absurd_spawn_params=AbsurdSpawnParams(max_attempts=1))
+    failed = boom.enqueue(  # type: ignore[call-arg]
+        absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)
+    )
     call_command("absurd_worker", queue="default", burst=True)
     pending = add.enqueue(5, 6)  # enqueued after the burst → never claimed
     return completed, failed, pending

--- a/tests/core/test_admin/test_checkpoint.py
+++ b/tests/core/test_admin/test_checkpoint.py
@@ -11,6 +11,9 @@ from django.urls import reverse, reverse_lazy
 
 from tests.core.test_admin.support import parse_html, result_rows
 
+if t.TYPE_CHECKING:
+    from bs4 import Tag
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 CHANGELIST = reverse_lazy("admin:django_absurd_checkpoint_changelist")
@@ -35,11 +38,10 @@ def test_changelist(client: Client, admin_user: AbstractBaseUser) -> None:
     client.force_login(t.cast("User", admin_user))
     response = client.get(CHANGELIST)
     soup = parse_html(response)
-    names: set[str] = set()
-    for r in result_rows(soup):
-        name_elem = r.select_one(".field-checkpoint_name")
-        if name_elem is not None:
-            names.add(name_elem.get_text(strip=True))
+    names = {
+        t.cast("Tag", r.select_one(".field-checkpoint_name")).get_text(strip=True)
+        for r in result_rows(soup)
+    }
     assert "cp1" in names
 
 

--- a/tests/core/test_admin/test_checkpoint.py
+++ b/tests/core/test_admin/test_checkpoint.py
@@ -1,9 +1,12 @@
+import typing as t
 import uuid
 
 import pytest
 from django.contrib.admin.utils import quote
+from django.contrib.auth.models import AbstractBaseUser, User
 from django.core.management import call_command
 from django.db import connections
+from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 from tests.core.test_admin.support import parse_html, result_rows
@@ -13,11 +16,11 @@ pytestmark = pytest.mark.django_db(transaction=True)
 CHANGELIST = reverse_lazy("admin:django_absurd_checkpoint_changelist")
 
 
-def change_url(pk):
+def change_url(pk: str) -> str:
     return reverse("admin:django_absurd_checkpoint_change", args=[quote(pk)])
 
 
-def insert_checkpoint(task_id, name, status="committed"):
+def insert_checkpoint(task_id: uuid.UUID, name: str, status: str = "committed") -> None:
     with connections["default"].cursor() as cur:
         cur.execute(
             'INSERT INTO absurd."c_default" (task_id, checkpoint_name, state, status)'
@@ -26,19 +29,21 @@ def insert_checkpoint(task_id, name, status="committed"):
         )
 
 
-def test_changelist(client, admin_user):
+def test_changelist(client: Client, admin_user: AbstractBaseUser) -> None:
     call_command("absurd_sync_queues")
     insert_checkpoint(uuid.uuid4(), "cp1")
-    client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
-    names = {
-        r.select_one(".field-checkpoint_name").get_text(strip=True)
-        for r in result_rows(soup)
-    }
+    client.force_login(t.cast("User", admin_user))
+    response = client.get(CHANGELIST)
+    soup = parse_html(response)
+    names: set[str] = set()
+    for r in result_rows(soup):
+        name_elem = r.select_one(".field-checkpoint_name")
+        if name_elem is not None:
+            names.add(name_elem.get_text(strip=True))
     assert "cp1" in names
 
 
-def test_detail_with_nasty_name(client, admin_user):
+def test_detail_with_nasty_name(client: Client, admin_user: AbstractBaseUser) -> None:
     call_command("absurd_sync_queues")
     tid = uuid.uuid4()
     with connections["default"].cursor() as cur:
@@ -47,8 +52,9 @@ def test_detail_with_nasty_name(client, admin_user):
             " VALUES (%s, %s, %s, 'committed')",
             [tid, "step/a:b c", '{"x": 1}'],
         )
-    client.force_login(admin_user)
-    soup = parse_html(client.get(change_url(f"default:{tid}:step/a:b c")))
+    client.force_login(t.cast("User", admin_user))
+    response = client.get(change_url(f"default:{tid}:step/a:b c"))
+    soup = parse_html(response)
     name_field = soup.select_one(".field-checkpoint_name .readonly")
     assert name_field is not None
     assert name_field.get_text(strip=True) == "step/a:b c"

--- a/tests/core/test_admin/test_event.py
+++ b/tests/core/test_admin/test_event.py
@@ -1,7 +1,10 @@
+import typing as t
+
 import pytest
 from django.contrib.admin.utils import quote
 from django.core.management import call_command
 from django.db import connections
+from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 from tests.core.test_admin.support import parse_html, result_rows
@@ -11,11 +14,11 @@ pytestmark = pytest.mark.django_db(transaction=True)
 CHANGELIST = reverse_lazy("admin:django_absurd_event_changelist")
 
 
-def change_url(pk):
+def change_url(pk: str) -> str:
     return reverse("admin:django_absurd_event_change", args=[quote(pk)])
 
 
-def test_changelist_and_detail(client, admin_user):
+def test_changelist_and_detail(client: Client, admin_user: t.Any) -> None:
     call_command("absurd_sync_queues")
     with connections["default"].cursor() as cur:
         cur.execute(
@@ -24,14 +27,15 @@ def test_changelist_and_detail(client, admin_user):
         )
     client.force_login(admin_user)
     soup = parse_html(client.get(CHANGELIST))
-    names = {
-        r.select_one(".field-event_name").get_text(strip=True)
-        for r in result_rows(soup)
-    }
+    names = set()
+    for r in result_rows(soup):
+        elem = r.select_one(".field-event_name")
+        assert elem is not None
+        names.add(elem.get_text(strip=True))
     assert "order.shipped" in names
 
-    detail = parse_html(client.get(change_url("default:order.shipped")))
-    assert (
-        detail.select_one(".field-event_name .readonly").get_text(strip=True)
-        == "order.shipped"
-    )
+    response = client.get(change_url("default:order.shipped"))
+    detail = parse_html(response)
+    name_elem = detail.select_one(".field-event_name .readonly")
+    assert name_elem is not None
+    assert name_elem.get_text(strip=True) == "order.shipped"

--- a/tests/core/test_admin/test_registration.py
+++ b/tests/core/test_admin/test_registration.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib import admin as djadmin
-from django.test import override_settings
+from django.contrib.auth.models import User
+from django.test import Client, override_settings
 from django.urls import reverse_lazy
 
 from django_absurd.admin import (
@@ -16,16 +17,16 @@ LOGIN = reverse_lazy("admin:login")
 INDEX = reverse_lazy("admin:index")
 
 
-def test_login_page_renders(client):
+def test_login_page_renders(client: Client) -> None:
     assert client.get(LOGIN).status_code == 200
 
 
-def test_six_entries_registered_on_default_site():
+def test_six_entries_registered_on_default_site() -> None:
     registered = {m._meta.model_name for m in djadmin.site._registry}
     assert {"task", "run", "checkpoint", "event", "wait", "queue"} <= registered
 
 
-def test_staff_user_sees_entries_in_index(client, staff_user):
+def test_staff_user_sees_entries_in_index(client: Client, staff_user: User) -> None:
     client.force_login(staff_user)
     soup = parse_html(client.get(INDEX))
     assert soup.select_one('a[href$="/django_absurd/task/"]') is not None
@@ -40,7 +41,7 @@ def test_staff_user_sees_entries_in_index(client, staff_user):
         }
     }
 )
-def test_custom_site_registration():
+def test_custom_site_registration() -> None:
     from tests.admin import custom_site  # noqa: PLC0415
 
     register_absurd_admin(resolve_admin_sites())
@@ -56,7 +57,7 @@ def test_custom_site_registration():
         }
     }
 )
-def test_bad_admin_site_fails_soft():
+def test_bad_admin_site_fails_soft() -> None:
     assert resolve_admin_sites() == []
 
 
@@ -72,7 +73,7 @@ def test_bad_admin_site_fails_soft():
         }
     }
 )
-def test_admin_disabled_skips_registration():
+def test_admin_disabled_skips_registration() -> None:
     from tests.admin import gated_site  # noqa: PLC0415
 
     autoregister_admin()
@@ -104,7 +105,7 @@ def test_admin_disabled_skips_registration():
         }
     }
 )
-def test_admin_site_tuple_registers_on_all_sites():
+def test_admin_site_tuple_registers_on_all_sites() -> None:
     from tests.admin import custom_site, other_site  # noqa: PLC0415
 
     register_absurd_admin(resolve_admin_sites())

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -4,7 +4,6 @@ import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import AbstractBaseUser, User
 from django.core.management import call_command
-from django.tasks import TaskResult
 from django.test import Client
 from django.urls import reverse, reverse_lazy
 
@@ -14,6 +13,7 @@ from tests.tasks import add
 
 if t.TYPE_CHECKING:
     from bs4 import Tag
+    from django.tasks import TaskResult
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -27,7 +27,7 @@ def change_url(pk: str) -> str:
 run_model: t.Any = Run
 
 
-def run_for(result: TaskResult[t.Any, t.Any]) -> t.Any:
+def run_for(result: "TaskResult[t.Any, t.Any]") -> t.Any:
     return run_model.objects.get(task_id=result.id.split(":", 1)[1])
 
 

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -1,78 +1,107 @@
+import typing as t
+
 import pytest
 from django.contrib.admin.utils import quote
+from django.contrib.auth.models import AbstractBaseUser, User
 from django.core.management import call_command
+from django.tasks import TaskResult
+from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 from django_absurd.models import Run
 from tests.core.test_admin.support import parse_html, result_rows, seed_mixed
 from tests.tasks import add
 
+if t.TYPE_CHECKING:
+    from bs4 import Tag
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 CHANGELIST = reverse_lazy("admin:django_absurd_run_changelist")
 
 
-def change_url(pk):
+def change_url(pk: str) -> str:
     return reverse("admin:django_absurd_run_change", args=[quote(pk)])
 
 
-def run_for(result):
-    return Run.objects.get(task_id=result.id.split(":", 1)[1])
+run_model: t.Any = Run
 
 
-def test_changelist_shows_dates_ordered_by_recent_activity(client, admin_user):
+def run_for(result: TaskResult[t.Any, t.Any]) -> t.Any:
+    return run_model.objects.get(task_id=result.id.split(":", 1)[1])
+
+
+def test_changelist_shows_dates_ordered_by_recent_activity(
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> None:
     call_command("absurd_sync_queues")
     older = add.enqueue(1, 1)
     call_command("absurd_worker", queue="default", burst=True)  # older run starts
     newer = add.enqueue(2, 2)
     call_command("absurd_worker", queue="default", burst=True)  # newer run starts later
-    client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
-    # the started_at column is the (descending) primary sort, and a date column shows
+    client.force_login(t.cast("User", admin_user))
+    response = client.get(CHANGELIST)
+    soup = parse_html(response)
+    # the started_at column is the (descending) primary sort, and
+    # a date column shows
     assert soup.select_one("th.column-started_at.sorted.descending") is not None
     assert soup.select_one(".column-completed_at") is not None
     # rows actually come back most-recently-started first
-    keys = [
-        r.select_one(".field-natural_key").get_text(strip=True)
+    keys: list[str] = [
+        t.cast("Tag", r.select_one(".field-natural_key")).get_text(strip=True)
         for r in result_rows(soup)
     ]
-    assert keys.index(run_for(newer).natural_key) < keys.index(
-        run_for(older).natural_key
-    )
+    newer_key = run_for(newer).natural_key
+    older_key = run_for(older).natural_key
+    assert keys.index(newer_key) < keys.index(older_key)
 
 
-def test_changelist_filtered_to_task(client, admin_user):
+def test_changelist_filtered_to_task(
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> None:
     _, failed, _ = seed_mixed()
-    client.force_login(admin_user)
-    # the natural_key is "<queue>:<task_id>"; search by the bare task_id
+    client.force_login(t.cast("User", admin_user))
+    # the natural_key is "<queue>:<task_id>";
+    # search by the bare task_id
     task_id = failed.id.split(":", 1)[1]
-    soup = parse_html(client.get(CHANGELIST, {"q": task_id}))
+    response = client.get(CHANGELIST, {"q": task_id})
+    soup = parse_html(response)
     rows = result_rows(soup)
     # boom runs with max_attempts=1 → exactly one (failed) run for this task
     assert len(rows) == 1
-    assert {r.select_one(".field-task_id").get_text(strip=True) for r in rows} == {
-        task_id
-    }
-    assert {r.select_one(".field-state").get_text(strip=True) for r in rows} == {
-        "failed"
-    }
+    assert {
+        t.cast("Tag", r.select_one(".field-task_id")).get_text(strip=True) for r in rows
+    } == {task_id}
+    assert {
+        t.cast("Tag", r.select_one(".field-state")).get_text(strip=True) for r in rows
+    } == {"failed"}
 
 
-def test_detail_groups_fields_into_fieldsets(client, admin_user):
+def test_detail_groups_fields_into_fieldsets(
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> None:
     seed_mixed()  # produces runs
-    client.force_login(admin_user)
-    run = Run.objects.first()
-    soup = parse_html(client.get(change_url(run.natural_key)))
+    client.force_login(t.cast("User", admin_user))
+    run_obj = run_model.objects.first()
+    response = client.get(change_url(run_obj.natural_key))
+    soup = parse_html(response)
     legends = {h.get_text(strip=True) for h in soup.select("h2.fieldset-heading")}
     assert {"Claim", "Timing", "Event", "Result"} <= legends
 
 
-def test_detail_shows_failure_reason(client, admin_user):
+def test_detail_shows_failure_reason(
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> None:
     seed_mixed()
-    client.force_login(admin_user)
+    client.force_login(t.cast("User", admin_user))
     client.get(CHANGELIST)  # prime the runs view
-    run = Run.objects.filter(queue="default", state="failed").first()
-    soup = parse_html(client.get(change_url(run.natural_key)))
+    run_obj = run_model.objects.filter(queue="default", state="failed").first()
+    response = client.get(change_url(run_obj.natural_key))
+    soup = parse_html(response)
     failure = soup.select_one(".field-failure_reason .readonly")
     assert failure is not None
     text = failure.get_text()

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -21,6 +21,7 @@ from tests.core.test_admin.support import (
 from tests.tasks import add
 
 if t.TYPE_CHECKING:
+    from bs4 import Tag
     from pytest_django.plugin import DjangoDbBlocker
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -46,12 +47,7 @@ def find_task(queue: str, task_name: str) -> t.Any:
 
 def extract_field_texts(rows: t.Any, field: str) -> set[str]:
     """Extract text from field elements in result rows."""
-    result: set[str] = set()
-    for r in rows:
-        elem = r.select_one(f".{field}")
-        if elem is not None:
-            result.add(elem.get_text(strip=True))
-    return result
+    return {t.cast("Tag", r.select_one(f".{field}")).get_text(strip=True) for r in rows}
 
 
 def test_changelist_unions_and_filters(client: Client, admin_user: User) -> None:

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -1,10 +1,12 @@
+import typing as t
 import uuid
 
 import pytest
 from django.contrib.admin.utils import quote
+from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.db import connections
-from django.test import override_settings
+from django.test import Client, override_settings
 from django.urls import reverse, reverse_lazy
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
@@ -18,6 +20,9 @@ from tests.core.test_admin.support import (
 )
 from tests.tasks import add
 
+if t.TYPE_CHECKING:
+    from pytest_django.plugin import DjangoDbBlocker
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 CHANGELIST = reverse_lazy("admin:django_absurd_task_changelist")
@@ -25,28 +30,38 @@ ADD = reverse_lazy("admin:django_absurd_task_add")
 INDEX = reverse_lazy("admin:index")
 
 
-def change_url(pk):
+def change_url(pk: str) -> str:
     return reverse("admin:django_absurd_task_change", args=[quote(pk)])
 
 
-def queue_change_url(pk):
+def queue_change_url(pk: str) -> str:
     return reverse("admin:django_absurd_queue_change", args=[quote(pk)])
 
 
-def find_task(queue, task_name):
+def find_task(queue: str, task_name: str) -> t.Any:
     spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
-    return (
-        build_admin_model(spec).objects.filter(queue=queue, task_name=task_name).first()
-    )
+    model: t.Any = build_admin_model(spec)
+    return model.objects.filter(queue=queue, task_name=task_name).first()
 
 
-def test_changelist_unions_and_filters(client, admin_user):
+def extract_field_texts(rows: t.Any, field: str) -> set[str]:
+    """Extract text from field elements in result rows."""
+    result: set[str] = set()
+    for r in rows:
+        elem = r.select_one(f".{field}")
+        if elem is not None:
+            result.add(elem.get_text(strip=True))
+    return result
+
+
+def test_changelist_unions_and_filters(client: Client, admin_user: User) -> None:
     seed()
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
     rows = result_rows(soup)
-    queues = {r.select_one(".field-queue").get_text(strip=True) for r in rows}
-    names = {r.select_one(".field-task_name").get_text(strip=True) for r in rows}
+    queues = extract_field_texts(rows, "field-queue")
+    names = extract_field_texts(rows, "field-task_name")
     assert queues == {"default", "other"}
     assert names == {"tests.tasks.add", "tests.tasks.boom"}
 
@@ -55,71 +70,84 @@ def test_changelist_unions_and_filters(client, admin_user):
     assert sidebar.select_one('a[href*="queue=default"]') is not None
     assert sidebar.select_one('a[href*="queue=other"]') is not None
 
-    fsoup = parse_html(client.get(CHANGELIST, {"queue": "other"}))
+    resp2 = client.get(CHANGELIST, {"queue": "other"})
+    fsoup = parse_html(resp2)
     frows = result_rows(fsoup)
-    assert {r.select_one(".field-queue").get_text(strip=True) for r in frows} == {
-        "other"
-    }
-    fnames = {r.select_one(".field-task_name").get_text(strip=True) for r in frows}
+    fqueues = extract_field_texts(frows, "field-queue")
+    assert fqueues == {"other"}
+    fnames = extract_field_texts(frows, "field-task_name")
     assert fnames == {"tests.tasks.add"}  # boom is on the default queue only
 
 
-def test_changelist_shows_mixed_states(client, admin_user):
+def test_changelist_shows_mixed_states(client: Client, admin_user: User) -> None:
     seed_mixed()
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
-    states = {
-        r.select_one(".field-state").get_text(strip=True) for r in result_rows(soup)
-    }
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
+    states = extract_field_texts(result_rows(soup), "field-state")
     assert states == {"pending", "completed", "failed"}
 
 
-def test_changelist_filters_by_state(client, admin_user):
+def test_changelist_filters_by_state(client: Client, admin_user: User) -> None:
     seed_mixed()
     client.force_login(admin_user)
-    failed = parse_html(client.get(CHANGELIST, {"state": "failed"}))
-    assert {
-        r.select_one(".field-state").get_text(strip=True) for r in result_rows(failed)
-    } == {"failed"}
-    pending = parse_html(client.get(CHANGELIST, {"state": "pending"}))
-    assert {
-        r.select_one(".field-state").get_text(strip=True) for r in result_rows(pending)
-    } == {"pending"}
+    resp_failed = client.get(CHANGELIST, {"state": "failed"})
+    failed = parse_html(resp_failed)
+    failed_states = extract_field_texts(result_rows(failed), "field-state")
+    assert failed_states == {"failed"}
+    resp_pending = client.get(CHANGELIST, {"state": "pending"})
+    pending = parse_html(resp_pending)
+    pending_states = extract_field_texts(result_rows(pending), "field-state")
+    assert pending_states == {"pending"}
 
 
-def test_changelist_search_narrows_by_task_name(client, admin_user):
+def test_changelist_search_narrows_by_task_name(
+    client: Client, admin_user: User
+) -> None:
     seed_mixed()  # two add tasks + one boom
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST, {"q": "tests.tasks.boom"}))
-    names = {
-        r.select_one(".field-task_name").get_text(strip=True) for r in result_rows(soup)
-    }
+    resp = client.get(CHANGELIST, {"q": "tests.tasks.boom"})
+    soup = parse_html(resp)
+    names = extract_field_texts(result_rows(soup), "field-task_name")
     assert names == {"tests.tasks.boom"}
 
 
-def test_changelist_shows_dates_ordered_by_recent_activity(client, admin_user):
+def test_changelist_shows_dates_ordered_by_recent_activity(
+    client: Client, admin_user: User
+) -> None:
     call_command("absurd_sync_queues")  # index the default queue
     older = add.enqueue(1, 1)
     newer = add.enqueue(2, 2)  # enqueued later → more recent activity
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
     rows = result_rows(soup)
     # primary sort is the first_started_at datetime column, descending
     assert soup.select_one("th.column-first_started_at.sorted.descending") is not None
-    # rows actually come back most-recent first
-    keys = [r.select_one(".field-natural_key").get_text(strip=True) for r in rows]
+    # rows actually come back most-recent first (order matters, so keep a list)
+    keys = [
+        el.get_text(strip=True)
+        for r in rows
+        if (el := r.select_one(".field-natural_key")) is not None
+    ]
     assert keys.index(newer.id) < keys.index(older.id)
     # the enqueue_at column renders an actual datetime, not an empty cell
-    assert rows[0].select_one(".field-enqueue_at").get_text(strip=True) != ""
+    enqueue_elem = rows[0].select_one(".field-enqueue_at")
+    assert enqueue_elem is not None
+    assert enqueue_elem.get_text(strip=True) != ""
 
 
-def test_changelist_warns_about_unindexed_queue(client, admin_user):
-    # build the views over the declared queues, then create a queue directly (config
-    # drift): it lands in the catalog but no view arm references it → unindexed.
+def test_changelist_warns_about_unindexed_queue(
+    client: Client, admin_user: User
+) -> None:
+    # build the views over the declared queues, then create a queue directly
+    # (config drift): it lands in the catalog but no view arm references it →
+    # unindexed.
     call_command("absurd_sync_queues")
     get_absurd_client().create_queue("drift")
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
     warning = soup.select_one("ul.messagelist li.warning")
     assert warning is not None
     text = warning.get_text()
@@ -127,16 +155,21 @@ def test_changelist_warns_about_unindexed_queue(client, admin_user):
     assert "absurd_sync_queues" in text
 
 
-def test_changelist_no_warning_when_all_queues_indexed(client, admin_user):
+def test_changelist_no_warning_when_all_queues_indexed(
+    client: Client, admin_user: User
+) -> None:
     seed_mixed()  # syncs + workers → every catalog queue is an arm
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
     assert soup.select_one("ul.messagelist li.warning") is None
 
 
 def test_changelist_survives_staleness_detection_failure(
-    client, admin_user, django_db_blocker
-):
+    client: Client,
+    admin_user: User,
+    django_db_blocker: "DjangoDbBlocker",
+) -> None:
     client.force_login(admin_user)
     with django_db_blocker.unblock():
         call_command("migrate", "django_absurd", "zero", verbosity=0)
@@ -150,25 +183,34 @@ def test_changelist_survives_staleness_detection_failure(
             call_command("migrate", "django_absurd", verbosity=0)
 
 
-def test_detail_shows_state(client, admin_user):
+def test_detail_shows_state(client: Client, admin_user: User) -> None:
     _, failed, _ = seed_mixed()
     client.force_login(admin_user)
-    soup = parse_html(client.get(change_url(failed.id)))
-    assert soup.select_one(".field-state .readonly").get_text(strip=True) == "failed"
+    resp = client.get(change_url(failed.id))
+    soup = parse_html(resp)
+    state_elem = soup.select_one(".field-state .readonly")
+    assert state_elem is not None
+    assert state_elem.get_text(strip=True) == "failed"
 
 
-def test_detail_for_missing_object_does_not_500(client, admin_user):
+def test_detail_for_missing_object_does_not_500(
+    client: Client, admin_user: User
+) -> None:
     seed_mixed()
     client.force_login(admin_user)
     resp = client.get(change_url(f"default:{uuid.uuid4()}"))
     assert resp.status_code in (302, 404)
-    assert client.get(queue_change_url("nonexistent")).status_code in (302, 404)
+    resp2 = client.get(queue_change_url("nonexistent"))
+    assert resp2.status_code in (302, 404)
 
 
-def test_detail_groups_fields_and_inlines_runs(client, admin_user):
+def test_detail_groups_fields_and_inlines_runs(
+    client: Client, admin_user: User
+) -> None:
     completed, _, _ = seed_mixed()  # a completed task → has at least one run
     client.force_login(admin_user)
-    soup = parse_html(client.get(change_url(completed.id)))
+    resp = client.get(change_url(completed.id))
+    soup = parse_html(resp)
     legends = {h.get_text(strip=True) for h in soup.select("h2.fieldset-heading")}
     assert {"State", "Schedule", "Configuration", "Result"} <= legends
     inline = soup.select_one(".inline-group")
@@ -177,38 +219,51 @@ def test_detail_groups_fields_and_inlines_runs(client, admin_user):
     assert inline.select_one(".field-state") is not None
     link = inline.select_one('a[href*="/django_absurd/run/"]')
     assert link is not None
-    assert link["href"].endswith("/change/")
+    href = link.get("href")
+    assert href is not None
+    assert isinstance(href, str)
+    assert href.endswith("/change/")
 
 
-def test_detail_renders_read_only(client, admin_user):
+def test_detail_renders_read_only(client: Client, admin_user: User) -> None:
     seed()
     client.force_login(admin_user)
     client.get(CHANGELIST)  # prime the view
     task = find_task("default", "tests.tasks.add")
-    soup = parse_html(client.get(change_url(task.natural_key)))
+    assert task is not None
+    resp2 = client.get(change_url(task.natural_key))
+    soup = parse_html(resp2)
     readonly = soup.select_one(".field-task_name .readonly")
+    assert readonly is not None
     assert readonly.get_text(strip=True) == "tests.tasks.add"
     assert soup.select_one('input[name="task_name"]') is None
     assert soup.select_one('textarea[name="params"]') is None
 
 
-def test_add_view_forbidden(client, admin_user):
+def test_add_view_forbidden(client: Client, admin_user: User) -> None:
     client.force_login(admin_user)
-    assert client.get(ADD).status_code in (403, 302)
+    resp = client.get(ADD)
+    assert resp.status_code in (403, 302)
 
 
-def test_admin_labels_app_as_absurd(client, admin_user):
+def test_admin_labels_app_as_absurd(client: Client, admin_user: User) -> None:
     _, failed, _ = seed_mixed()
     client.force_login(admin_user)
-    index = parse_html(client.get(INDEX))
+    resp_index = client.get(INDEX)
+    index = parse_html(resp_index)
     caption = index.select_one("div.app-django_absurd caption a.section")
+    assert caption is not None
     assert caption.get_text(strip=True) == "Absurd"
-    change = parse_html(client.get(change_url(failed.id)))
+    resp_change = client.get(change_url(failed.id))
+    change = parse_html(resp_change)
     app_crumb = change.select_one('.breadcrumbs a[href="/admin/django_absurd/"]')
+    assert app_crumb is not None
     assert app_crumb.get_text(strip=True) == "Absurd"
 
 
-def test_changelist_degrades_when_view_dropped(client, admin_user):
+def test_changelist_degrades_when_view_dropped(
+    client: Client, admin_user: User
+) -> None:
     call_command("absurd_sync_queues")
     with connections["default"].cursor() as cur:
         cur.execute("DROP VIEW IF EXISTS absurd.tasks_view")
@@ -224,18 +279,22 @@ def test_changelist_degrades_when_view_dropped(client, admin_user):
         "default": {
             "BACKEND": BACKEND,
             "OPTIONS": {
-                "QUEUES": {"default": {}, "part": {"storage_mode": "partitioned"}}
+                "QUEUES": {
+                    "default": {},
+                    "part": {"storage_mode": "partitioned"},
+                }
             },
         }
     }
 )
-def test_partitioned_queue_appears_in_changelist(client, admin_user):
+def test_partitioned_queue_appears_in_changelist(
+    client: Client, admin_user: User
+) -> None:
     call_command("absurd_sync_queues")
     add.using(queue_name="part").enqueue(1, 1)
     call_command("absurd_worker", queue="part", burst=True)
     client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
-    queues = {
-        r.select_one(".field-queue").get_text(strip=True) for r in result_rows(soup)
-    }
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
+    queues = extract_field_texts(result_rows(soup), "field-queue")
     assert "part" in queues

--- a/tests/core/test_admin/test_wait.py
+++ b/tests/core/test_admin/test_wait.py
@@ -11,6 +11,9 @@ from django.urls import reverse, reverse_lazy
 
 from tests.core.test_admin.support import parse_html, result_rows
 
+if t.TYPE_CHECKING:
+    from bs4 import Tag
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 CHANGELIST = reverse_lazy("admin:django_absurd_wait_changelist")
@@ -34,11 +37,10 @@ def test_changelist_and_composite_detail(
     client.force_login(t.cast("User", admin_user))
     response = client.get(CHANGELIST)
     soup = parse_html(response)
-    steps: set[str] = set()
-    for r in result_rows(soup):
-        step_elem = r.select_one(".field-step_name")
-        if step_elem is not None:
-            steps.add(step_elem.get_text(strip=True))
+    steps = {
+        t.cast("Tag", r.select_one(".field-step_name")).get_text(strip=True)
+        for r in result_rows(soup)
+    }
     assert "wait/step:1" in steps
 
     # composite-PK detail (queue:run_id:step_name) with a nasty step_name

--- a/tests/core/test_admin/test_wait.py
+++ b/tests/core/test_admin/test_wait.py
@@ -1,9 +1,12 @@
+import typing as t
 import uuid
 
 import pytest
 from django.contrib.admin.utils import quote
+from django.contrib.auth.models import AbstractBaseUser, User
 from django.core.management import call_command
 from django.db import connections
+from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 from tests.core.test_admin.support import parse_html, result_rows
@@ -13,11 +16,13 @@ pytestmark = pytest.mark.django_db(transaction=True)
 CHANGELIST = reverse_lazy("admin:django_absurd_wait_changelist")
 
 
-def change_url(pk):
+def change_url(pk: str) -> str:
     return reverse("admin:django_absurd_wait_change", args=[quote(pk)])
 
 
-def test_changelist_and_composite_detail(client, admin_user):
+def test_changelist_and_composite_detail(
+    client: Client, admin_user: AbstractBaseUser
+) -> None:
     call_command("absurd_sync_queues")
     rid, tid = uuid.uuid4(), uuid.uuid4()
     with connections["default"].cursor() as cur:
@@ -26,16 +31,19 @@ def test_changelist_and_composite_detail(client, admin_user):
             " VALUES (%s, %s, %s, %s)",
             [tid, rid, "wait/step:1", "evt"],
         )
-    client.force_login(admin_user)
-    soup = parse_html(client.get(CHANGELIST))
-    steps = {
-        r.select_one(".field-step_name").get_text(strip=True) for r in result_rows(soup)
-    }
+    client.force_login(t.cast("User", admin_user))
+    response = client.get(CHANGELIST)
+    soup = parse_html(response)
+    steps: set[str] = set()
+    for r in result_rows(soup):
+        step_elem = r.select_one(".field-step_name")
+        if step_elem is not None:
+            steps.add(step_elem.get_text(strip=True))
     assert "wait/step:1" in steps
 
     # composite-PK detail (queue:run_id:step_name) with a nasty step_name
-    detail = parse_html(client.get(change_url(f"default:{rid}:wait/step:1")))
-    assert (
-        detail.select_one(".field-step_name .readonly").get_text(strip=True)
-        == "wait/step:1"
-    )
+    detail_response = client.get(change_url(f"default:{rid}:wait/step:1"))
+    detail = parse_html(detail_response)
+    step_name_elem = detail.select_one(".field-step_name .readonly")
+    assert step_name_elem is not None
+    assert step_name_elem.get_text(strip=True) == "wait/step:1"

--- a/tests/core/test_admin_backend_resolve.py
+++ b/tests/core/test_admin_backend_resolve.py
@@ -3,10 +3,10 @@ from django.test import override_settings
 from django_absurd.backends import AbsurdBackend
 from django_absurd.queues import get_absurd_backend
 
-BACKEND = "django_absurd.backends.AbsurdBackend"
+BACKEND: str = "django_absurd.backends.AbsurdBackend"
 
 
-def test_returns_single_backend():
+def test_returns_single_backend() -> None:
     be = get_absurd_backend()
     assert isinstance(be, AbsurdBackend)
 
@@ -21,14 +21,15 @@ def test_returns_single_backend():
         "b": {"BACKEND": BACKEND, "QUEUES": ["default"]},
     }
 )
-def test_first_in_order_wins_when_sharing_db():
+def test_first_in_order_wins_when_sharing_db() -> None:
     # both on "default" → first declared ("a") wins
     be = get_absurd_backend()
+    assert isinstance(be, AbsurdBackend)
     assert be.options.get("ENABLE_ADMIN") is False
 
 
 @override_settings(TASKS={"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}})
-def test_returns_none_without_absurd_backend():
+def test_returns_none_without_absurd_backend() -> None:
     assert get_absurd_backend() is None
 
 
@@ -42,7 +43,9 @@ def test_returns_none_without_absurd_backend():
         "b": {"BACKEND": BACKEND, "QUEUES": ["default"]},
     }
 )
-def test_skips_backend_not_on_resolved_database():
+def test_skips_backend_not_on_resolved_database() -> None:
     # two backends on different DBs → resolve picks "default"; the sqlite-backed "a"
     # is skipped before the default-backed "b" is returned
-    assert get_absurd_backend().database == "default"
+    be = get_absurd_backend()
+    assert isinstance(be, AbsurdBackend)
+    assert be.database == "default"

--- a/tests/core/test_admin_checks.py
+++ b/tests/core/test_admin_checks.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import override_settings
@@ -11,7 +12,7 @@ E006_BAD_PATH_MSG = (
 )
 
 
-def run_check(capsys):
+def run_check(capsys: pytest.CaptureFixture[str]) -> str:
     try:
         call_command("check", "django_absurd")
     except SystemCheckError as exc:
@@ -30,7 +31,9 @@ def run_check(capsys):
         }
     }
 )
-def test_bad_admin_site_path_emits_e006(capsys):
+def test_bad_admin_site_path_emits_e006(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     out = run_check(capsys)
     assert "absurd.E006" in out
     assert E006_BAD_PATH_MSG in out
@@ -46,7 +49,9 @@ def test_bad_admin_site_path_emits_e006(capsys):
         }
     }
 )
-def test_non_bool_enable_admin_emits_e006(capsys):
+def test_non_bool_enable_admin_emits_e006(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     out = run_check(capsys)
     assert "absurd.E006" in out
     assert "django-absurd: OPTIONS['ENABLE_ADMIN'] must be a bool." in out
@@ -62,7 +67,9 @@ def test_non_bool_enable_admin_emits_e006(capsys):
         }
     }
 )
-def test_valid_admin_config_no_e006(capsys):
+def test_valid_admin_config_no_e006(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     out = run_check(capsys)
     assert "absurd.E006" not in out
     assert "admin.E0" not in out
@@ -70,7 +77,9 @@ def test_valid_admin_config_no_e006(capsys):
 
 
 @override_settings(TASKS={"default": {"BACKEND": IMMEDIATE}})
-def test_no_absurd_backend_emits_no_e006(capsys):
+def test_no_absurd_backend_emits_no_e006(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     out = run_check(capsys)
     assert "absurd.E006" not in out
 
@@ -84,7 +93,9 @@ def test_no_absurd_backend_emits_no_e006(capsys):
         }
     }
 )
-def test_admin_site_not_a_sequence_emits_e006(capsys):
+def test_admin_site_not_a_sequence_emits_e006(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     out = run_check(capsys)
     assert "absurd.E006" in out
     assert (
@@ -102,7 +113,9 @@ def test_admin_site_not_a_sequence_emits_e006(capsys):
         }
     }
 )
-def test_admin_site_not_an_adminsite_emits_e006(capsys):
+def test_admin_site_not_an_adminsite_emits_e006(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     out = run_check(capsys)
     assert "absurd.E006" in out
     assert "is not an AdminSite instance" in out

--- a/tests/core/test_admin_models.py
+++ b/tests/core/test_admin_models.py
@@ -1,3 +1,4 @@
+import typing as t
 import warnings
 
 import pytest
@@ -10,17 +11,21 @@ from django.db.migrations.state import ProjectState
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.models import QueueReadOnlyError
 
+if t.TYPE_CHECKING:
+    from django.db.models.fields import Field
 
-def build_all_models():
+
+def build_all_models() -> list[type[models.Model]]:
+    """Build admin models for all entity specs."""
     return [build_admin_model(s) for s in ADMIN_ENTITY_SPECS]
 
 
-def test_specs_cover_five_entities():
+def test_specs_cover_five_entities() -> None:
     names = {s.name for s in ADMIN_ENTITY_SPECS}
     assert names == {"tasks", "runs", "checkpoints", "events", "waits"}
 
 
-def test_model_maps_schema_quoted_view_unmanaged():
+def test_model_maps_schema_quoted_view_unmanaged() -> None:
     tasks_model = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
@@ -30,7 +35,7 @@ def test_model_maps_schema_quoted_view_unmanaged():
     assert isinstance(tasks_model._meta.get_field("params"), models.JSONField)
 
 
-def test_models_absent_from_global_registry():
+def test_models_absent_from_global_registry() -> None:
     build_all_models()
     names = {
         m.__name__
@@ -40,36 +45,41 @@ def test_models_absent_from_global_registry():
     assert "Task" not in names
 
 
-def test_model_str_is_the_natural_key():
+def test_model_str_is_the_natural_key() -> None:
     for spec in ADMIN_ENTITY_SPECS:
         model = build_admin_model(spec)
         assert str(model(natural_key="default:abc")) == "default:abc"
 
 
-def test_run_has_task_fk_for_inlining_and_task_id_is_unique():
+def test_run_has_task_fk_for_inlining_and_task_id_is_unique() -> None:
     tasks = build_admin_model(next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks"))
     runs = build_admin_model(next(s for s in ADMIN_ENTITY_SPECS if s.name == "runs"))
-    fk = runs._meta.get_field("task")
+    fk = t.cast("Field[t.Any, t.Any]", runs._meta.get_field("task"))
     assert fk.related_model is tasks
-    assert fk.target_field.name == "task_id"  # FK joins on task_id
-    assert fk.get_attname() == "task_id"  # attname stays task_id, not task_id_id
-    assert fk.db_constraint is False  # view-backed: no real FK constraint
-    assert tasks._meta.get_field("task_id").unique  # required as the FK target
+    # FK joins on task_id
+    assert t.cast("t.Any", fk).target_field.name == "task_id"
+    # attname stays task_id, not task_id_id
+    assert t.cast("t.Any", fk).get_attname() == "task_id"
+    # view-backed: no real FK constraint
+    assert t.cast("t.Any", fk).db_constraint is False
+    # required as the FK target
+    task_id_field = t.cast("Field[t.Any, t.Any]", tasks._meta.get_field("task_id"))
+    assert task_id_field.unique
 
 
-def test_build_admin_model_is_idempotent():
+def test_build_admin_model_is_idempotent() -> None:
     tasks_spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     assert build_admin_model(tasks_spec) is build_admin_model(tasks_spec)
 
 
-def test_build_models_twice_emits_no_runtime_warning():
+def test_build_models_twice_emits_no_runtime_warning() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", RuntimeWarning)
         build_all_models()
         build_all_models()
 
 
-def test_makemigrations_stays_clean():
+def test_makemigrations_stays_clean() -> None:
     build_all_models()
     loader = MigrationLoader(None, ignore_no_migrations=True)
     ad = MigrationAutodetector(
@@ -79,7 +89,7 @@ def test_makemigrations_stays_clean():
     assert changes.get("django_absurd", []) == []
 
 
-def test_save_is_blocked():
+def test_save_is_blocked() -> None:
     tasks_model = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -1,3 +1,4 @@
+import typing as t
 import uuid
 
 import pytest
@@ -7,6 +8,7 @@ from django.db import connections
 from django_absurd.admin import ADMIN_COUNT_CAP, BoundedCountPaginator
 from django_absurd.admin_views import (
     ADMIN_ENTITY_SPECS,
+    EntitySpec,
     build_admin_model,
     fetch_catalog_queues,
     rebuild_admin_view,
@@ -17,29 +19,29 @@ from tests.tasks import add
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def make_count_stub(n):
+def make_count_stub(n: int) -> t.Any:
     class CountStub:
-        def __getitem__(self, item):
+        def __getitem__(self, item: t.Any) -> "CountStub":
             return self
 
-        def count(self):
+        def count(self) -> int:
             return n
 
     return CountStub()
 
 
-def test_bounded_paginator_clamps_count_to_cap():
+def test_bounded_paginator_clamps_count_to_cap() -> None:
     over = BoundedCountPaginator(make_count_stub(ADMIN_COUNT_CAP + 500), per_page=20)
     assert over.count == ADMIN_COUNT_CAP
     under = BoundedCountPaginator(make_count_stub(7), per_page=20)
     assert under.count == 7
 
 
-TASKS_SPEC = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
-CHECKS_SPEC = next(s for s in ADMIN_ENTITY_SPECS if s.name == "checkpoints")
+TASKS_SPEC: EntitySpec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
+CHECKS_SPEC: EntitySpec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "checkpoints")
 
 
-def seed_two_queues():
+def seed_two_queues() -> None:
     call_command("absurd_sync_queues")
     add.enqueue(2, 3)
     add.using(queue_name="other").enqueue(7, 8)
@@ -47,51 +49,69 @@ def seed_two_queues():
     call_command("absurd_worker", queue="other", burst=True)
 
 
-def test_zero_queue_view_is_empty():
+def test_zero_queue_view_is_empty() -> None:
     call_command("absurd_sync_queues")  # tables exist but no tasks
     rebuild_admin_view(TASKS_SPEC, [], "default")
-    tasks_model = build_admin_model(TASKS_SPEC)
+    tasks_model: t.Any = build_admin_model(TASKS_SPEC)
     assert tasks_model.objects.count() == 0
 
 
-def test_union_spans_queues_and_filters():
+def test_union_spans_queues_and_filters() -> None:
     seed_two_queues()
-    rebuild_admin_view(TASKS_SPEC, fetch_catalog_queues("default"), "default")
-    tasks_model = build_admin_model(TASKS_SPEC)
+    rebuild_admin_view(
+        TASKS_SPEC,
+        fetch_catalog_queues("default"),
+        "default",
+    )
+    tasks_model: t.Any = build_admin_model(TASKS_SPEC)
     assert {row.queue for row in tasks_model.objects.all()} == {"default", "other"}
     assert tasks_model.objects.filter(queue="other").count() == 1
 
 
-def test_jsonb_decodes_and_pk_prefixed():
+def test_jsonb_decodes_and_pk_prefixed() -> None:
     seed_two_queues()
-    rebuild_admin_view(TASKS_SPEC, fetch_catalog_queues("default"), "default")
-    tasks_model = build_admin_model(TASKS_SPEC)
+    rebuild_admin_view(
+        TASKS_SPEC,
+        fetch_catalog_queues("default"),
+        "default",
+    )
+    tasks_model: t.Any = build_admin_model(TASKS_SPEC)
     row = tasks_model.objects.filter(
-        queue="default", task_name="tests.tasks.add"
+        queue="default",
+        task_name="tests.tasks.add",
     ).first()
     assert isinstance(row.params, dict)
     assert row.natural_key.startswith("default:")
 
 
-def test_composite_pk_detail_lookup():
+def test_composite_pk_detail_lookup() -> None:
     seed_two_queues()
     tid = uuid.uuid4()
     with connections["default"].cursor() as cur:
         cur.execute(
-            'INSERT INTO absurd."c_default" (task_id, checkpoint_name, state, status)'
+            'INSERT INTO absurd."c_default"'
+            " (task_id, checkpoint_name, state, status)"
             " VALUES (%s, %s, %s, 'committed')",
             [tid, "step/a:b c", '{"x": 1}'],
         )
-    rebuild_admin_view(CHECKS_SPEC, fetch_catalog_queues("default"), "default")
-    checks_model = build_admin_model(CHECKS_SPEC)
+    rebuild_admin_view(
+        CHECKS_SPEC,
+        fetch_catalog_queues("default"),
+        "default",
+    )
+    checks_model: t.Any = build_admin_model(CHECKS_SPEC)
     pk = f"default:{tid}:step/a:b c"
     assert checks_model.objects.get(pk=pk).status == "committed"
 
 
-def test_rebuild_after_drop_excludes_queue():
+def test_rebuild_after_drop_excludes_queue() -> None:
     seed_two_queues()
     rebuild_admin_view(TASKS_SPEC, ["default", "other"], "default")
     get_absurd_client().drop_queue("other")
-    rebuild_admin_view(TASKS_SPEC, fetch_catalog_queues("default"), "default")
-    tasks_model = build_admin_model(TASKS_SPEC)
+    rebuild_admin_view(
+        TASKS_SPEC,
+        fetch_catalog_queues("default"),
+        "default",
+    )
+    tasks_model: t.Any = build_admin_model(TASKS_SPEC)
     assert {row.queue for row in tasks_model.objects.all()} == {"default"}

--- a/tests/core/test_app.py
+++ b/tests/core/test_app.py
@@ -9,16 +9,21 @@ from django_absurd.exceptions import QueueReadOnlyError
 from django_absurd.models import QueueReadOnlyError as ReExportedQueueReadOnlyError
 
 
-def test_app_is_registered():
+def test_app_is_registered() -> None:
     assert apps.get_app_config("django_absurd").name == "django_absurd"
 
 
-def test_schema_version_is_concrete_semver():
+def test_schema_version_is_concrete_semver() -> None:
     assert re.fullmatch(r"\d+\.\d+\.\d+", ABSURD_SCHEMA_VERSION)
 
 
-def test_models_imports_without_cycle():
+def test_models_imports_without_cycle() -> None:
     # admin_views must NOT import models (would cycle once models imports the factory)
-    src = Path(importlib.import_module("django_absurd.admin_views").__file__)
+    module = importlib.import_module("django_absurd.admin_views")
+    module_file: str | None = module.__file__
+    if module_file is None:
+        msg = "Module file path is None"
+        raise RuntimeError(msg)
+    src = Path(module_file)
     assert "from django_absurd.models import" not in src.read_text()
     assert QueueReadOnlyError is ReExportedQueueReadOnlyError

--- a/tests/core/test_app.py
+++ b/tests/core/test_app.py
@@ -1,5 +1,6 @@
 import importlib
 import re
+import typing as t
 from pathlib import Path
 
 from django.apps import apps
@@ -20,10 +21,6 @@ def test_schema_version_is_concrete_semver() -> None:
 def test_models_imports_without_cycle() -> None:
     # admin_views must NOT import models (would cycle once models imports the factory)
     module = importlib.import_module("django_absurd.admin_views")
-    module_file: str | None = module.__file__
-    if module_file is None:
-        msg = "Module file path is None"
-        raise RuntimeError(msg)
-    src = Path(module_file)
+    src = Path(t.cast("str", module.__file__))
     assert "from django_absurd.models import" not in src.read_text()
     assert QueueReadOnlyError is ReExportedQueueReadOnlyError

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import typing as t
 
 import pytest
 from django.core.management import call_command
@@ -26,75 +27,92 @@ pytestmark = pytest.mark.django_db(transaction=True)
     "value",
     [None, 0, False, "", [], {}, {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]}],
 )
-def test_async_return_value_round_trips(value):
+def test_async_return_value_round_trips(value: t.Any) -> None:
     call_command("absurd_sync_queues")
     r = aecho.enqueue(value)
     run_absurd_worker()
     snap = get_task_result(r.id)
+    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == value
 
 
-def test_async_failure_recorded():
+def test_async_failure_recorded() -> None:
     call_command("absurd_sync_queues")
-    r = aboom.enqueue(absurd_spawn_params=AbsurdSpawnParams(max_attempts=1))
+    r = aboom.enqueue(  # type: ignore[call-arg]
+        absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)
+    )
     run_absurd_worker()
-    assert get_task_result(r.id).state == "failed"
+    snap = get_task_result(r.id)
+    assert snap is not None
+    assert snap.state == "failed"
 
 
-def test_async_takes_context_attempt_is_one():
+def test_async_takes_context_attempt_is_one() -> None:
     call_command("absurd_sync_queues")
     r = areport_attempt.enqueue()
     run_absurd_worker()
-    assert get_task_result(r.id).result == 1
+    snap = get_task_result(r.id)
+    assert snap is not None
+    assert snap.result == 1
 
 
-def test_sync_orm_jsonfield_round_trips():
+def test_sync_orm_jsonfield_round_trips() -> None:
     # ORM in a SYNC task (executor path) — matched pair with the async-ORM test below
     call_command("absurd_sync_queues")
     r = create_payload.enqueue({"sync": True, "x": [9, 8]})
     run_absurd_worker()
-    pk = get_task_result(r.id).result
+    snap = get_task_result(r.id)
+    assert snap is not None
+    pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"sync": True, "x": [9, 8]}
 
 
-def test_async_orm_jsonfield_round_trips():
+def test_async_orm_jsonfield_round_trips() -> None:
     # ORM in an ASYNC task (loop path) — matched pair with the sync-ORM test above
     call_command("absurd_sync_queues")
     r = acreate_payload.enqueue({"async": True, "y": {"z": None}})
     run_absurd_worker()
-    pk = get_task_result(r.id).result
+    snap = get_task_result(r.id)
+    assert snap is not None
+    pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
 
 
-def test_async_task_queries_payload():
+def test_async_task_queries_payload() -> None:
     # async QUERY path: a row created in the test, read back by an async task (aget)
     call_command("absurd_sync_queues")
     obj = Payload.objects.create(data={"q": [1, {"x": None}], "u": "ünï"})
     r = aread_payload.enqueue(obj.pk)
     run_absurd_worker()
     snap = get_task_result(r.id)
+    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == {"q": [1, {"x": None}], "u": "ünï"}
 
 
-def test_aenqueue_async_task_runs_end_to_end():
-    # exercise the aenqueue (produce) path for an async task, end-to-end through the worker
+def test_aenqueue_async_task_runs_end_to_end() -> None:
+    # exercise the aenqueue (produce) path for an async task, end-to-end
+    # through the worker
     call_command("absurd_sync_queues")
     r = asyncio.run(aecho.aenqueue("via-aenqueue"))
     run_absurd_worker()
-    assert get_task_result(r.id).result == "via-aenqueue"
+    snap = get_task_result(r.id)
+    assert snap is not None
+    assert snap.result == "via-aenqueue"
 
 
-def test_aenqueue_sync_task_runs_end_to_end():
+def test_aenqueue_sync_task_runs_end_to_end() -> None:
     # aenqueue a SYNC task too — runs via the worker's executor path
     call_command("absurd_sync_queues")
     r = asyncio.run(echo.aenqueue({"via": "aenqueue-sync"}))
     run_absurd_worker()
-    assert get_task_result(r.id).result == {"via": "aenqueue-sync"}
+    snap = get_task_result(r.id)
+    assert snap is not None
+    assert snap.result == {"via": "aenqueue-sync"}
 
 
-def test_full_async_workflow_aenqueue_to_aget_result():
+def test_full_async_workflow_aenqueue_to_aget_result() -> None:
     # The whole async pipeline in one flow: aenqueue (async produce) -> async task
     # on the loop doing async ORM (acreate) -> aget_result (async read of the result).
     call_command("absurd_sync_queues")
@@ -105,18 +123,23 @@ def test_full_async_workflow_aenqueue_to_aget_result():
     assert Payload.objects.filter(pk=got.return_value).exists()
 
 
-def test_sync_and_async_in_one_worker_run():
+def test_sync_and_async_in_one_worker_run() -> None:
     call_command("absurd_sync_queues")
     rs = echo.enqueue({"mixed": "sync"})
     ra = aecho.enqueue({"mixed": "async"})
     run_absurd_worker()
-    assert get_task_result(rs.id).result == {"mixed": "sync"}
-    assert get_task_result(ra.id).result == {"mixed": "async"}
+    snap_s = get_task_result(rs.id)
+    snap_a = get_task_result(ra.id)
+    assert snap_s is not None
+    assert snap_a is not None
+    assert snap_s.result == {"mixed": "sync"}
+    assert snap_a.result == {"mixed": "async"}
 
 
-def test_worker_does_not_poison_jsonfield_reads():
-    # The worker's loader is on its dedicated AsyncConnection; a Django JSONField read
-    # on the shared connection after a worker run must still decode (no SP6-style poison).
+def test_worker_does_not_poison_jsonfield_reads() -> None:
+    # The worker's loader is on its dedicated AsyncConnection; a Django
+    # JSONField read on the shared connection after a worker run must still
+    # decode (no SP6-style poison).
     call_command("absurd_sync_queues")
     aecho.enqueue("x")
     run_absurd_worker()
@@ -124,7 +147,7 @@ def test_worker_does_not_poison_jsonfield_reads():
     assert Payload.objects.get(pk=obj.pk).data == {"k": "v", "n": 7}
 
 
-def test_async_concurrency_is_not_serial():
+def test_async_concurrency_is_not_serial() -> None:
     call_command("absurd_sync_queues")
     for _ in range(4):
         asleeper.enqueue(0.5)

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -1,4 +1,7 @@
+import typing as t
+
 from django.tasks import task_backends
+from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.backends import (
     AbsurdBackend,
@@ -11,19 +14,21 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 EXTENDED = "tests.backends.ExtendedAbsurdBackend"
 
 
-def test_default_alias_is_absurd_backend():
+def test_default_alias_is_absurd_backend() -> None:
     assert isinstance(task_backends["default"], AbsurdBackend)
 
 
-def test_form_a_names_only(settings):
+def test_form_a_names_only(settings: SettingsWrapper) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "QUEUES": ["emails", "retained"]}}
-    backend = task_backends["default"]
-    assert backend.queues == {"emails", "retained"}
+    backend = t.cast("AbsurdBackend", task_backends["default"])
+    assert t.cast("set[str]", backend.queues) == {"emails", "retained"}
     assert backend.database == "default"
     assert backend.default_max_attempts == 5
 
 
-def test_form_b_pushes_keys_up_and_reads_options(settings):
+def test_form_b_pushes_keys_up_and_reads_options(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -34,19 +39,21 @@ def test_form_b_pushes_keys_up_and_reads_options(settings):
             },
         }
     }
-    backend = task_backends["default"]
-    assert backend.queues == {"emails", "retained"}
+    backend = t.cast("AbsurdBackend", task_backends["default"])
+    assert t.cast("set[str]", backend.queues) == {"emails", "retained"}
     assert backend.database == "absurd"
     assert backend.default_max_attempts == 9
 
 
-def test_get_absurd_backends_finds_default():
+def test_get_absurd_backends_finds_default() -> None:
     backends = get_absurd_backends()
     assert set(backends) == {"default"}
     assert isinstance(backends["default"], AbsurdBackend)
 
 
-def test_get_absurd_backends_matches_subclasses(settings):
+def test_get_absurd_backends_matches_subclasses(
+    settings: SettingsWrapper,
+) -> None:
     # ExtendedAbsurdBackend lives in an importable module so TASKS can name it by
     # path; the resolver must find it via isinstance, not class identity.
     settings.TASKS = {"default": {"BACKEND": EXTENDED, "QUEUES": ["x"]}}
@@ -56,13 +63,17 @@ def test_get_absurd_backends_matches_subclasses(settings):
     assert type(task_backends["default"]).__name__ == "ExtendedAbsurdBackend"
 
 
-def test_get_declared_queues_form_a_defaults_policy(settings):
+def test_get_declared_queues_form_a_defaults_policy(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "QUEUES": ["a", "b"]}}
     backend = get_absurd_backends()["default"]
     assert get_declared_queues(backend) == {"a": {}, "b": {}}
 
 
-def test_get_declared_queues_form_b_preserves_policy(settings):
+def test_get_declared_queues_form_b_preserves_policy(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -73,14 +84,16 @@ def test_get_declared_queues_form_b_preserves_policy(settings):
     assert get_declared_queues(backend) == {"a": {}, "b": {"cleanup_limit": 50}}
 
 
-def test_resolve_absurd_database_single(settings):
+def test_resolve_absurd_database_single(settings: SettingsWrapper) -> None:
     settings.TASKS = {
         "default": {"BACKEND": ABSURD, "OPTIONS": {"DATABASE": "default"}}
     }
     assert resolve_absurd_database() == "default"
 
 
-def test_resolve_absurd_database_ambiguous_degrades_to_default(settings):
+def test_resolve_absurd_database_ambiguous_degrades_to_default(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {"BACKEND": ABSURD, "OPTIONS": {"DATABASE": "default"}},
         "other": {"BACKEND": ABSURD, "OPTIONS": {"DATABASE": "absurd"}},

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -103,6 +103,24 @@ def test_storage_mode_drift_warns(
     assert "q" in out
 
 
+def test_invalid_policy_modes_error(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    settings.TASKS = build_tasks_setting(
+        {"q": {"storage_mode": "bogus", "detach_mode": "nope"}}
+    )
+    out = run_absurd_check(capsys, databases=["default"])
+    assert (
+        "django-absurd: invalid per-queue policy options. Queue 'q':"
+        " invalid storage_mode 'bogus'." in out
+    )
+    assert (
+        "django-absurd: invalid per-queue policy options. Queue 'q':"
+        " invalid detach_mode 'nope'." in out
+    )
+
+
 def test_schema_absent_check_is_silent(
     settings: "pytest_django.fixtures.SettingsWrapper",
     capsys: pytest.CaptureFixture[str],

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -1,14 +1,21 @@
+import typing as t
+
 import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.db import connection, connections
+
+if t.TYPE_CHECKING:
+    import pytest_django.fixtures
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_tasks_setting(queues, database="default"):
+def build_tasks_setting(
+    queues: dict[str, dict[str, t.Any]], database: str = "default"
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -17,7 +24,11 @@ def build_tasks_setting(queues, database="default"):
     }
 
 
-def run_absurd_check(capsys, *args, **kwargs):
+def run_absurd_check(
+    capsys: pytest.CaptureFixture[str],
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> str:
     try:
         call_command("check", "django_absurd", *args, **kwargs)
     except SystemCheckError as exc:
@@ -27,7 +38,10 @@ def run_absurd_check(capsys, *args, **kwargs):
     return cap.out + cap.err
 
 
-def test_in_sync_no_warning(settings, capsys):
+def test_in_sync_no_warning(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
     out = run_absurd_check(capsys, databases=["default"])
@@ -36,7 +50,10 @@ def test_in_sync_no_warning(settings, capsys):
     )
 
 
-def test_db_unreachable_is_silent(settings, capsys):
+def test_db_unreachable_is_silent(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
     real_name = settings.DATABASES["default"]["NAME"]
     settings.DATABASES["default"]["NAME"] = "absurd_nope_missing_db"
@@ -61,7 +78,11 @@ def test_db_unreachable_is_silent(settings, capsys):
     ],
     ids=["missing-queue", "mutable-scalar", "mutable-duration"],
 )
-def test_self_healing_drift_no_longer_warns(settings, capsys, after):
+def test_self_healing_drift_no_longer_warns(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+    after: dict[str, dict[str, t.Any]],
+) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting(after)
@@ -69,7 +90,10 @@ def test_self_healing_drift_no_longer_warns(settings, capsys, after):
     assert "absurd.W002" not in out
 
 
-def test_storage_mode_drift_warns(settings, capsys):
+def test_storage_mode_drift_warns(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
     call_command("absurd_sync_queues")  # 'q' created unpartitioned
     settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
@@ -79,7 +103,10 @@ def test_storage_mode_drift_warns(settings, capsys):
     assert "q" in out
 
 
-def test_schema_absent_check_is_silent(settings, capsys):
+def test_schema_absent_check_is_silent(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
@@ -93,7 +120,10 @@ def test_schema_absent_check_is_silent(settings, capsys):
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"])
-def test_check_errors_on_wrong_backend(settings, capsys):
+def test_check_errors_on_wrong_backend(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
     out = run_absurd_check(capsys)
     assert "absurd.E001" in out
@@ -103,18 +133,24 @@ def test_check_errors_on_wrong_backend(settings, capsys):
     )
 
 
-def test_check_errors_when_router_missing(settings, capsys):
+def test_check_errors_when_router_missing(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
     settings.DATABASE_ROUTERS = []
     out = run_absurd_check(capsys)
     assert "absurd.E005" in out
     assert (
-        "django-absurd: a non-default DATABASE is configured but AbsurdRouter is not in DATABASE_ROUTERS."
-        in out
+        "django-absurd: a non-default DATABASE is configured but "
+        "AbsurdRouter is not in DATABASE_ROUTERS." in out
     )
 
 
-def test_both_queue_forms_set_errors(settings, capsys):
+def test_both_queue_forms_set_errors(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -125,18 +161,24 @@ def test_both_queue_forms_set_errors(settings, capsys):
     out = run_absurd_check(capsys)
     assert "absurd.E002" in out
     assert (
-        "django-absurd: both top-level QUEUES and OPTIONS['QUEUES'] are set on the same backend."
-        in out
+        "django-absurd: both top-level QUEUES and OPTIONS['QUEUES'] "
+        "are set on the same backend." in out
     )
 
 
-def test_pure_options_queues_no_e002(settings, capsys):
+def test_pure_options_queues_no_e002(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": {"a": {}}}}}
     out = run_absurd_check(capsys)
     assert "absurd.E002" not in out
 
 
-def test_invalid_policy_key_errors(settings, capsys):
+def test_invalid_policy_key_errors(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -149,7 +191,10 @@ def test_invalid_policy_key_errors(settings, capsys):
     assert "a" in out
 
 
-def test_invalid_storage_mode_literal_errors(settings, capsys):
+def test_invalid_storage_mode_literal_errors(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -161,7 +206,10 @@ def test_invalid_storage_mode_literal_errors(settings, capsys):
     assert "absurd.E003" in out
 
 
-def test_multiple_backends_distinct_db_errors(settings, capsys):
+def test_multiple_backends_distinct_db_errors(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -176,7 +224,10 @@ def test_multiple_backends_distinct_db_errors(settings, capsys):
     assert "absurd.E004" in out
 
 
-def test_plain_check_skips_db_state(settings, capsys):
+def test_plain_check_skips_db_state(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
@@ -184,7 +235,10 @@ def test_plain_check_skips_db_state(settings, capsys):
     assert "absurd.W002" not in out
 
 
-def test_check_with_database_runs_db_state(settings, capsys):
+def test_check_with_database_runs_db_state(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting({"synced": {}, "missing": {}})
@@ -196,7 +250,11 @@ E009_MSG = "django-absurd: OPTIONS['DEFAULT_MAX_ATTEMPTS'] must be an integer >=
 
 
 @pytest.mark.parametrize("value", [-1, 0, 1.5, "3", True])
-def test_default_max_attempts_invalid_is_error(settings, capsys, value):
+def test_default_max_attempts_invalid_is_error(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+    value: float | str | bool,
+) -> None:
     # A DEFAULT_MAX_ATTEMPTS < 1 (or a non-int) would feed 0/garbage into every
     # reconciled schedule's max_attempts and crash migrate against the CheckConstraint;
     # catch it at check time. bool is rejected (int subclass, not an attempt count).
@@ -211,7 +269,10 @@ def test_default_max_attempts_invalid_is_error(settings, capsys, value):
     assert "absurd.E009" in out
 
 
-def test_default_max_attempts_valid_no_error(settings, capsys):
+def test_default_max_attempts_valid_no_error(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -240,7 +301,12 @@ E010_HINT = (
         ({"schedule": 5}, "beat"),
     ],
 )
-def test_invalid_cleanup_errors(settings, capsys, cleanup, scheduler):
+def test_invalid_cleanup_errors(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+    cleanup: str | dict[str, t.Any],
+    scheduler: str,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -258,7 +324,11 @@ def test_invalid_cleanup_errors(settings, capsys, cleanup, scheduler):
 
 
 @pytest.mark.parametrize("scheduler", ["beat", "pg_cron"])
-def test_valid_cleanup_no_error(settings, capsys, scheduler):
+def test_valid_cleanup_no_error(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+    scheduler: str,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -1,9 +1,11 @@
+import collections.abc
 import contextlib
 import datetime as dt
 import io
 import logging
 import re
 import sys
+import typing as t
 
 import pytest
 from django.contrib.auth.models import Group
@@ -13,10 +15,17 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from django_absurd.backends import get_absurd_backends
-from django_absurd.cleanup import cleanup_queues
+from django_absurd.cleanup import QueueCleanup, cleanup_queues
 from django_absurd.queues import get_absurd_client
 from django_absurd.scheduler import run_beat
 from tests.tasks import add, routed
+
+if t.TYPE_CHECKING:
+    import pytest_django.fixtures
+
+    import django_absurd.backends
+
+    CleanupCallable = t.Callable[..., list[QueueCleanup]]
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -24,12 +33,12 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
 def sync_queue(
-    settings,
-    cleanup_ttl="0 seconds",
-    cleanup_limit=1000,
-    names=("default",),
-    cleanup=None,
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    cleanup_ttl: str = "0 seconds",
+    cleanup_limit: int = 1000,
+    names: tuple[str, ...] = ("default",),
+    cleanup: dict[str, t.Any] | None = None,
+) -> None:
     options = {
         "QUEUES": {
             name: {"cleanup_ttl": cleanup_ttl, "cleanup_limit": cleanup_limit}
@@ -42,17 +51,20 @@ def sync_queue(
     call_command("absurd_sync_queues")
 
 
-def drain(queue="default"):
+def drain(queue: str = "default") -> None:
     call_command("absurd_worker", queue=queue, burst=True)
 
 
 @pytest.fixture(params=["command", "direct"])
-def cleanup(request, capsys):
-    """Run cleanup through both entrypoints (management command + direct call), each
-    normalized to the per-queue count dicts, so behavioral tests cover both. The command
-    path parses its stdout back into dicts."""
+def cleanup(
+    request: pytest.FixtureRequest,
+    capsys: pytest.CaptureFixture[str],
+) -> "CleanupCallable":
+    """Run cleanup through both entrypoints (management command + direct call),
+    each normalized to the per-queue count dicts, so behavioral tests cover both.
+    The command path parses its stdout back into dicts."""
 
-    def run(queues=None):
+    def run(queues: list[str] | None = None) -> list[QueueCleanup]:
         if request.param == "direct":
             return cleanup_queues(queues)
         capsys.readouterr()  # discard any prior output
@@ -64,8 +76,9 @@ def cleanup(request, capsys):
     return run
 
 
-def parse_cleanup_line(line):
+def parse_cleanup_line(line: str) -> QueueCleanup:
     match = re.fullmatch(r"(.+): (\d+) tasks, (\d+) events deleted", line)
+    assert match is not None
     return {
         "queue_name": match[1],
         "tasks_deleted": int(match[2]),
@@ -74,7 +87,7 @@ def parse_cleanup_line(line):
 
 
 @contextlib.contextmanager
-def answer(text):
+def answer(text: str) -> collections.abc.Iterator[None]:
     """Feed a line to the next input() prompt via a real stdin (no mock)."""
     original = sys.stdin
     sys.stdin = io.StringIO(text)
@@ -84,7 +97,10 @@ def answer(text):
         sys.stdin = original
 
 
-def test_cleanup_deletes_aged_terminal_tasks(settings, cleanup):
+def test_cleanup_deletes_aged_terminal_tasks(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    cleanup: "CleanupCallable",
+) -> None:
     sync_queue(settings)
     add.enqueue(2, 3)
     drain()
@@ -93,7 +109,10 @@ def test_cleanup_deletes_aged_terminal_tasks(settings, cleanup):
     ]
 
 
-def test_cleanup_skips_non_terminal_tasks(settings, cleanup):
+def test_cleanup_skips_non_terminal_tasks(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    cleanup: "CleanupCallable",
+) -> None:
     sync_queue(settings)
     add.enqueue(2, 3)  # pending — worker not run, so not terminal
     assert cleanup() == [
@@ -105,7 +124,10 @@ def test_cleanup_skips_non_terminal_tasks(settings, cleanup):
     ]
 
 
-def test_cleanup_respects_batch_limit(settings, cleanup):
+def test_cleanup_respects_batch_limit(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    cleanup: "CleanupCallable",
+) -> None:
     sync_queue(settings, cleanup_limit=2)
     for _ in range(3):
         add.enqueue(2, 3)
@@ -121,7 +143,10 @@ def test_cleanup_respects_batch_limit(settings, cleanup):
     ]
 
 
-def test_cleanup_targets_specific_queue(settings, cleanup):
+def test_cleanup_targets_specific_queue(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    cleanup: "CleanupCallable",
+) -> None:
     sync_queue(settings, names=("default", "other"))
     add.enqueue(2, 3)  # default
     routed.enqueue()  # routed is @task(queue_name="other")
@@ -136,7 +161,10 @@ def test_cleanup_targets_specific_queue(settings, cleanup):
     ]
 
 
-def test_cleanup_command_reports_per_queue_counts(settings, capsys):
+def test_cleanup_command_reports_per_queue_counts(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     sync_queue(settings)
     add.enqueue(2, 3)
     drain()
@@ -145,24 +173,33 @@ def test_cleanup_command_reports_per_queue_counts(settings, capsys):
     assert capsys.readouterr().out == "default: 1 tasks, 0 events deleted\n"
 
 
-def test_cleanup_command_reports_no_backends(settings, capsys):
+def test_cleanup_command_reports_no_backends(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {}
     call_command("absurd_cleanup")
     assert capsys.readouterr().out == "No Absurd task backends configured.\n"
 
 
-def test_flush_reports_no_backends(settings, capsys):
+def test_flush_reports_no_backends(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {}
     call_command("absurd_flush")
     assert capsys.readouterr().out == "No Absurd task backends configured.\n"
 
 
-def test_flush_reports_no_queues(capsys):
+def test_flush_reports_no_queues(capsys: pytest.CaptureFixture[str]) -> None:
     call_command("absurd_flush")
     assert capsys.readouterr().out == "No queues to flush.\n"
 
 
-def test_flush_noinput_drops_all_queues(settings, capsys):
+def test_flush_noinput_drops_all_queues(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
     call_command("absurd_flush", "--noinput")
@@ -170,7 +207,10 @@ def test_flush_noinput_drops_all_queues(settings, capsys):
     assert get_absurd_client().list_queues() == []
 
 
-def test_flush_interactive_yes_drops_all_queues(settings, capsys):
+def test_flush_interactive_yes_drops_all_queues(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
     with answer("yes\n"):
@@ -183,7 +223,10 @@ def test_flush_interactive_yes_drops_all_queues(settings, capsys):
     assert get_absurd_client().list_queues() == []
 
 
-def test_flush_interactive_no_keeps_queues(settings, capsys):
+def test_flush_interactive_no_keeps_queues(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
     with answer("no\n"):
@@ -196,7 +239,10 @@ def test_flush_interactive_no_keeps_queues(settings, capsys):
     assert sorted(get_absurd_client().list_queues()) == ["default", "other"]
 
 
-def test_flush_non_interactive_eof_keeps_queues(settings, capsys):
+def test_flush_non_interactive_eof_keeps_queues(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
     with answer(""):  # empty stdin → input() raises EOFError
@@ -209,7 +255,10 @@ def test_flush_non_interactive_eof_keeps_queues(settings, capsys):
     assert sorted(get_absurd_client().list_queues()) == ["default", "other"]
 
 
-def run_beat_until(backend, cutoff):
+def run_beat_until(
+    backend: "django_absurd.backends.AbsurdBackend",
+    cutoff: dt.datetime,
+) -> None:
     with freeze_time("2026-01-01 00:00:00") as frozen:
 
         def fake_wait(timeout: float) -> bool:
@@ -219,7 +268,10 @@ def run_beat_until(backend, cutoff):
         run_beat(backend, wait=fake_wait)
 
 
-def test_beat_fires_cleanup_on_cadence(settings, cleanup):
+def test_beat_fires_cleanup_on_cadence(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    cleanup: "CleanupCallable",
+) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
     add.enqueue(2, 3)
@@ -230,7 +282,10 @@ def test_beat_fires_cleanup_on_cadence(settings, cleanup):
     ]
 
 
-def test_beat_isolates_failing_cleanup(settings, caplog):
+def test_beat_isolates_failing_cleanup(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
     with connection.cursor() as cur:
@@ -245,7 +300,9 @@ def test_beat_isolates_failing_cleanup(settings, caplog):
         call_command("migrate", verbosity=0)  # restore absurd schema
 
 
-def test_beat_fires_cleanup_and_task_same_slot(settings):
+def test_beat_fires_cleanup_and_task_same_slot(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     # A scheduled task and CLEANUP sharing a cron slot both fire in the one tick:
     # the task enqueues (pending → survives cleanup) and cleanup deletes the aged row.
     settings.TASKS = {

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -1,12 +1,15 @@
 import asyncio
+import typing as t
 
 import pytest
+from absurd_sdk import ClaimedTask, RetryStrategy
 from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db import connection, connections, transaction
 from django.tasks import TaskResultStatus
 from django.tasks.exceptions import InvalidTask
+from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.params import AbsurdSpawnParams
@@ -16,13 +19,13 @@ from tests.tasks import add, make_group, with_default_attempts
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def claim_one():
+def claim_one() -> list[ClaimedTask]:
     client = get_absurd_client()
     register_jsonb_loader(connections["default"].connection)
     return client.claim_tasks(batch_size=1)
 
 
-def test_enqueue_lands_and_returns_taskresult():
+def test_enqueue_lands_and_returns_taskresult() -> None:
     call_command("absurd_sync_queues")
     result = add.enqueue(1, 2)
     assert isinstance(result.id, str)
@@ -37,19 +40,19 @@ def test_enqueue_lands_and_returns_taskresult():
     assert claimed[0]["params"] == {"args": [1, 2], "kwargs": {}}
 
 
-def test_enqueue_preserves_kwargs():
+def test_enqueue_preserves_kwargs() -> None:
     call_command("absurd_sync_queues")
     add.enqueue(a=1, b=2)
     assert claim_one()[0]["params"] == {"args": [], "kwargs": {"a": 1, "b": 2}}
 
 
-def test_enqueue_rides_django_transaction():
+def test_enqueue_rides_django_transaction() -> None:
     call_command("absurd_sync_queues")
 
     class BoomError(Exception):
         pass
 
-    def enqueue_then_roll_back():
+    def enqueue_then_roll_back() -> t.Never:
         with transaction.atomic():
             add.enqueue(1, 2)
             raise BoomError
@@ -59,19 +62,19 @@ def test_enqueue_rides_django_transaction():
     assert claim_one() == []
 
 
-def test_undeclared_queue_rejected():
+def test_undeclared_queue_rejected() -> None:
     call_command("absurd_sync_queues")
     with pytest.raises(InvalidTask):
         add.using(queue_name="nope").enqueue(1, 2)
 
 
-def test_aenqueue_lands():
+def test_aenqueue_lands() -> None:
     call_command("absurd_sync_queues")
     asyncio.run(add.aenqueue(1, 2))
     assert len(claim_one()) == 1
 
 
-def test_enqueue_auto_creates_declared_queue_and_runs():
+def test_enqueue_auto_creates_declared_queue_and_runs() -> None:
     # 'default' declared but unprovisioned (no absurd_sync_queues). Enqueue auto-creates
     # it; the worker then runs the task end-to-end.
     make_group.enqueue("auto")
@@ -79,13 +82,15 @@ def test_enqueue_auto_creates_declared_queue_and_runs():
     assert Group.objects.filter(name="auto").exists()
 
 
-def test_enqueue_to_undeclared_queue_raises():
+def test_enqueue_to_undeclared_queue_raises() -> None:
     # 'ghost' is not in TASKS QUEUES; validate_task raises InvalidTask naming the queue.
     with pytest.raises(InvalidTask, match="ghost"):
         add.using(queue_name="ghost").enqueue(1, 2)
 
 
-def test_enqueue_with_empty_queues_reports_undeclared(settings):
+def test_enqueue_with_empty_queues_reports_undeclared(
+    settings: SettingsWrapper,
+) -> None:
     # Empty QUEUES makes validate_task skip its queue check, reaching the backend guard.
     settings.TASKS = {
         "default": {
@@ -97,7 +102,7 @@ def test_enqueue_with_empty_queues_reports_undeclared(settings):
         add.enqueue(1, 2)
 
 
-def test_enqueue_auto_create_survives_outer_atomic():
+def test_enqueue_auto_create_survives_outer_atomic() -> None:
     with transaction.atomic():
         make_group.enqueue("inatomic")
         assert Group.objects.count() == 0  # nothing committed yet
@@ -105,7 +110,7 @@ def test_enqueue_auto_create_survives_outer_atomic():
     assert Group.objects.filter(name="inatomic").exists()
 
 
-def test_enqueue_with_absent_schema_raises_clear_error():
+def test_enqueue_with_absent_schema_raises_clear_error() -> None:
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
@@ -116,48 +121,56 @@ def test_enqueue_with_absent_schema_raises_clear_error():
         call_command("migrate", verbosity=0)  # restore absurd schema
 
 
-def test_max_attempts_uses_backend_default_when_unset():
+def test_max_attempts_uses_backend_default_when_unset() -> None:
     call_command("absurd_sync_queues")
     add.enqueue(1, 2)
     assert claim_one()[0]["max_attempts"] == 5
 
 
-def test_max_attempts_uses_decorator_default():
+def test_max_attempts_uses_decorator_default() -> None:
     call_command("absurd_sync_queues")
     with_default_attempts.enqueue(1, 2)
     assert claim_one()[0]["max_attempts"] == 7
 
 
-def test_per_call_max_attempts_overrides_decorator_and_backend():
+def test_per_call_max_attempts_overrides_decorator_and_backend() -> None:
     call_command("absurd_sync_queues")
-    with_default_attempts.enqueue(
+    with_default_attempts.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(max_attempts=9)
     )
     assert claim_one()[0]["max_attempts"] == 9
 
 
-def test_headers_reach_spawn():
+def test_headers_reach_spawn() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2, absurd_spawn_params=AbsurdSpawnParams(headers={"trace": "abc"}))
+    add.enqueue(  # type: ignore[call-arg]
+        1, 2, absurd_spawn_params=AbsurdSpawnParams(headers={"trace": "abc"})
+    )
     assert claim_one()[0]["headers"] == {"trace": "abc"}
 
 
-def test_retry_strategy_reaches_spawn():
+def test_retry_strategy_reaches_spawn() -> None:
     call_command("absurd_sync_queues")
-    strategy = {
+    strategy: RetryStrategy = {
         "kind": "fixed",
         "base_seconds": 1.0,
         "factor": 2.0,
         "max_seconds": 10.0,
     }
-    add.enqueue(1, 2, absurd_spawn_params=AbsurdSpawnParams(retry_strategy=strategy))
+    add.enqueue(  # type: ignore[call-arg]
+        1, 2, absurd_spawn_params=AbsurdSpawnParams(retry_strategy=strategy)
+    )
     assert claim_one()[0]["retry_strategy"] == strategy
 
 
-def test_idempotency_key_dedups():
+def test_idempotency_key_dedups() -> None:
     call_command("absurd_sync_queues")
-    r1 = add.enqueue(1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="dup"))
-    r2 = add.enqueue(1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="dup"))
+    r1 = add.enqueue(  # type: ignore[call-arg]
+        1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="dup")
+    )
+    r2 = add.enqueue(  # type: ignore[call-arg]
+        1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="dup")
+    )
     assert r1.id == r2.id
     register_jsonb_loader(connections["default"].connection)
     claimed = get_absurd_client().claim_tasks(
@@ -167,13 +180,15 @@ def test_idempotency_key_dedups():
     assert claimed[0]["params"] == {"args": [1, 2], "kwargs": {}}
 
 
-def test_spawn_params_not_passed_to_task_func():
+def test_spawn_params_not_passed_to_task_func() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="x"))
+    add.enqueue(  # type: ignore[call-arg]
+        1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="x")
+    )
     assert claim_one()[0]["params"] == {"args": [1, 2], "kwargs": {}}
 
 
-def test_result_id_encodes_queue():
+def test_result_id_encodes_queue() -> None:
     call_command("absurd_sync_queues")
     result = add.enqueue(1, 2)
     task_id = str(claim_one()[0]["task_id"])

--- a/tests/core/test_migrations.py
+++ b/tests/core/test_migrations.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from django.core.management import call_command
 from django.db import connection
@@ -5,21 +7,21 @@ from django.db import connection
 from django_absurd import ABSURD_SCHEMA_VERSION
 
 
-def _scalar(sql):
+def _scalar(sql: str) -> t.Any:
     with connection.cursor() as cur:
         cur.execute(sql)
         return cur.fetchone()[0]
 
 
 @pytest.mark.django_db
-def test_migrate_installs_absurd_schema_at_pinned_version():
+def test_migrate_installs_absurd_schema_at_pinned_version() -> None:
     assert _scalar("SELECT to_regnamespace('absurd') IS NOT NULL") is True
     assert _scalar("SELECT to_regclass('absurd.queues') IS NOT NULL") is True
     assert _scalar("SELECT absurd.get_schema_version()") == ABSURD_SCHEMA_VERSION
 
 
 @pytest.mark.django_db(transaction=True)
-def test_reverse_drops_absurd_schema():
+def test_reverse_drops_absurd_schema() -> None:
     call_command("migrate", "django_absurd", "zero", verbosity=0)
     assert _scalar("SELECT to_regnamespace('absurd') IS NULL") is True
     call_command("migrate", verbosity=0)  # restore absurd schema

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from django_absurd.models import Queue, QueueReadOnlyError
 
 
-def test_queue_is_read_only():
+def test_queue_is_read_only() -> None:
     # Overrides raise before any DB access, so no django_db needed.
     q = Queue(queue_name="x")
     with pytest.raises(QueueReadOnlyError):
@@ -13,17 +13,17 @@ def test_queue_is_read_only():
         q.delete()
 
 
-def test_queue_str_is_the_queue_name():
+def test_queue_str_is_the_queue_name() -> None:
     assert str(Queue(queue_name="reports")) == "reports"
 
 
-def test_queue_table_and_choices():
+def test_queue_table_and_choices() -> None:
     assert Queue._meta.db_table == 'absurd"."queues'
     assert Queue._meta.managed is False
     assert set(Queue.StorageMode.values) == {"unpartitioned", "partitioned"}
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"])
-def test_no_pending_migrations_for_app():
+def test_no_pending_migrations_for_app() -> None:
     # CreateModel op lives in 0001 — makemigrations sees no changes.
     call_command("makemigrations", "django_absurd", check=True, dry_run=True)

--- a/tests/core/test_orm_models.py
+++ b/tests/core/test_orm_models.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import typing as t
+
 import pytest
 from django.apps import apps as global_apps
 from django.core.management import call_command
@@ -16,7 +20,7 @@ from django_absurd.params import AbsurdSpawnParams
 from tests.tasks import add, boom
 
 
-def test_models_importable_and_view_backed():
+def test_models_importable_and_view_backed() -> None:
     assert Task._meta.db_table == '"absurd"."tasks_view"'
     assert Task._meta.managed is False
     assert Run._meta.db_table == '"absurd"."runs_view"'
@@ -29,7 +33,7 @@ def test_models_importable_and_view_backed():
     assert Wait._meta.managed is False
 
 
-def test_view_models_absent_from_global_registry():
+def test_view_models_absent_from_global_registry() -> None:
     _ = django_absurd.models  # ensure module imported
     names = {
         m.__name__
@@ -45,7 +49,7 @@ def test_view_models_absent_from_global_registry():
     assert pg_cron_names == set()
 
 
-def test_queue_table_model_db_table_is_quote_safe():
+def test_queue_table_model_db_table_is_quote_safe() -> None:
     spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     assert build_queue_table_model(spec, "default")._meta.db_table == (
         '"absurd"."t_default"'
@@ -55,48 +59,52 @@ def test_queue_table_model_db_table_is_quote_safe():
     assert build_queue_table_model(spec, 'a"b')._meta.db_table == ('"absurd"."t_a""b"')
 
 
-def test_admin_uses_the_models_py_classes():
+def test_admin_uses_the_models_py_classes() -> None:
     spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     assert build_admin_model(spec) is dm.Task  # idempotent factory → same class
 
 
-def seed_two_queues():
+def seed_two_queues() -> None:
     call_command("absurd_sync_queues")
     add.enqueue(2, 3)
     add.using(queue_name="other").enqueue(7, 8)
-    boom.enqueue(absurd_spawn_params=AbsurdSpawnParams(max_attempts=1))
+    boom.enqueue(  # type: ignore[call-arg]
+        absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)
+    )
     call_command("absurd_worker", queue="default", burst=True)
     call_command("absurd_worker", queue="other", burst=True)
 
 
 @pytest.mark.django_db(transaction=True)
-def test_filter_across_and_per_queue():
+def test_filter_across_and_per_queue() -> None:
     seed_two_queues()
-    assert {r.queue for r in Task.objects.all()} == {"default", "other"}
-    assert Task.objects.filter(queue="other").count() == 1
-    assert Task.objects.filter(state="completed").count() == 2
+    task_model: t.Any = Task
+    assert {r.queue for r in task_model.objects.all()} == {"default", "other"}
+    assert task_model.objects.filter(queue="other").count() == 1
+    assert task_model.objects.filter(state="completed").count() == 2
 
 
 @pytest.mark.django_db(transaction=True)
-def test_cross_queue_aggregate_and_order():
+def test_cross_queue_aggregate_and_order() -> None:
     seed_two_queues()
-    by_queue = dict(Task.objects.values_list("queue").annotate(n=Count("*")))
+    task_model: t.Any = Task
+    by_queue = dict(task_model.objects.values_list("queue").annotate(n=Count("*")))
     assert by_queue["other"] == 1
     assert by_queue["default"] >= 2
-    recent = list(Task.objects.order_by("-enqueue_at")[:2])
+    recent = list(task_model.objects.order_by("-enqueue_at")[:2])
     assert len(recent) == 2
     assert recent[0].enqueue_at >= recent[1].enqueue_at
 
 
 @pytest.mark.django_db(transaction=True)
-def test_read_only_save_blocked():
+def test_read_only_save_blocked() -> None:
     with pytest.raises(QueueReadOnlyError):
         Task().save()
     with pytest.raises(QueueReadOnlyError):
         Task().delete()
 
 
-def test_queue_table_model_is_read_only():
+def test_queue_table_model_is_read_only() -> None:
     spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     model = build_queue_table_model(spec, "default")
     with pytest.raises(QueueReadOnlyError):

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -1,4 +1,8 @@
+import typing as t
+from io import StringIO
+
 import pytest
+from django.apps import apps
 from django.core.management import call_command
 from django.db import connections, models
 
@@ -8,43 +12,50 @@ from django_absurd.admin_views import (
     build_admin_model,
     rebuild_views,
 )
+from django_absurd.apps import provision_queues_after_migrate
 from django_absurd.exceptions import ViewNotProvisionedError
 from django_absurd.queues import get_absurd_client
 from tests.tasks import add
 
+if t.TYPE_CHECKING:
+    from pytest_django.plugin import DjangoDbBlocker
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def view_oid(name):
+def view_oid(name: str) -> int | None:
     with connections["default"].cursor() as cur:
         cur.execute("SELECT to_regclass(%s)::oid", [f"absurd.{name}"])
-        return cur.fetchone()[0]
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return t.cast("int", row[0])
 
 
-def test_rebuild_views_builds_all_five():
+def test_rebuild_views_builds_all_five() -> None:
     call_command("absurd_sync_queues")
     rebuild_views("default")
     for spec in ADMIN_ENTITY_SPECS:
         assert view_oid(spec.view_name) is not None
 
 
-def test_read_path_does_no_ddl():
+def test_read_path_does_no_ddl() -> None:
     call_command("absurd_sync_queues")
     rebuild_views("default")
     spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     before = view_oid(spec.view_name)
-    task_model = build_admin_model(spec)
+    task_model: t.Any = build_admin_model(spec)
     list(task_model.objects.all())
     list(task_model.objects.filter(state="completed"))
     assert view_oid(spec.view_name) == before
 
 
 @pytest.mark.django_db(transaction=True)
-def test_migrate_provisions_declared_queues_and_views(django_db_blocker):
-    # `migrate` fires post_migrate → sync_queues: declared queues created + views built,
-    # reported on stdout in Django's migrate style.
-    from io import StringIO  # noqa: PLC0415
-
+def test_migrate_provisions_declared_queues_and_views(
+    django_db_blocker: "DjangoDbBlocker",
+) -> None:
+    # `migrate` fires post_migrate → sync_queues: declared queues created + views
+    # built, reported on stdout in Django's migrate style.
     from django_absurd.models import Queue  # noqa: PLC0415
 
     buf = StringIO()
@@ -57,32 +68,30 @@ def test_migrate_provisions_declared_queues_and_views(django_db_blocker):
     for spec in ADMIN_ENTITY_SPECS:
         assert view_oid(spec.view_name) is not None
     assert Queue.objects.filter(queue_name="default").exists()
-    task_cls = build_admin_model(
+    task_cls: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     assert list(task_cls.objects.all()) == []
 
 
 @pytest.mark.django_db(transaction=True)
-def test_provision_skips_when_schema_absent(django_db_blocker):
-    # post_migrate provisioning is best-effort: a missing schema is swallowed, not raised
-    from django_absurd.apps import (  # noqa: PLC0415
-        AbsurdConfig,
-        provision_queues_after_migrate,
-    )
-
+def test_provision_skips_when_schema_absent(
+    django_db_blocker: "DjangoDbBlocker",
+) -> None:
+    # post_migrate: best-effort; missing schema swallowed, not raised
     with django_db_blocker.unblock():
         call_command("migrate", "django_absurd", "zero", verbosity=0)
     try:
-        assert provision_queues_after_migrate(AbsurdConfig) is None
+        config: t.Any = apps.get_app_config("django_absurd")
+        provision_queues_after_migrate(config)
     finally:
         with django_db_blocker.unblock():
             call_command("migrate", verbosity=0)  # restore absurd schema
 
 
-def test_sync_command_rebuilds_views_with_new_queue():
+def test_sync_command_rebuilds_views_with_new_queue() -> None:
     call_command("absurd_sync_queues")
-    task_model = build_admin_model(
+    task_model: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     add.using(queue_name="other").enqueue(1, 1)
@@ -91,13 +100,13 @@ def test_sync_command_rebuilds_views_with_new_queue():
     assert "other" in set(qs)
 
 
-def test_self_heal_removed():
+def test_self_heal_removed() -> None:
     assert not hasattr(admin_views, "ensure_view_current")
     assert not hasattr(admin_views, "VIEW_BUILD_CACHE")
 
 
-def test_worker_start_rebuilds_when_it_created_queue():
-    task_model = build_admin_model(
+def test_worker_start_rebuilds_when_it_created_queue() -> None:
+    task_model: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     call_command("absurd_sync_queues")
@@ -109,12 +118,12 @@ def test_worker_start_rebuilds_when_it_created_queue():
     assert task_model.objects.filter(queue="other").count() >= 1
 
 
-def test_dropped_queue_read_raises_typed_error():
+def test_dropped_queue_read_raises_typed_error() -> None:
     call_command("absurd_sync_queues")
     rebuild_views("default")
     with connections["default"].cursor() as cur:
         cur.execute("DROP VIEW IF EXISTS absurd.tasks_view")
-    task_model = build_admin_model(
+    task_model: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     with pytest.raises(ViewNotProvisionedError):

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -26,10 +26,8 @@ pytestmark = pytest.mark.django_db(transaction=True)
 def view_oid(name: str) -> int | None:
     with connections["default"].cursor() as cur:
         cur.execute("SELECT to_regclass(%s)::oid", [f"absurd.{name}"])
-        row = cur.fetchone()
-        if row is None:
-            return None
-        return t.cast("int", row[0])
+        row = t.cast("tuple[int | None]", cur.fetchone())
+        return row[0]
 
 
 def test_rebuild_views_builds_all_five() -> None:
@@ -47,6 +45,8 @@ def test_read_path_does_no_ddl() -> None:
     task_model: t.Any = build_admin_model(spec)
     list(task_model.objects.all())
     list(task_model.objects.filter(state="completed"))
+    task_model.objects.exists()
+    task_model.objects.aggregate(models.Count("natural_key"))
     assert view_oid(spec.view_name) == before
 
 

--- a/tests/core/test_packaging.py
+++ b/tests/core/test_packaging.py
@@ -30,7 +30,7 @@ EXPECTED_SDIST_TOP = {
 }
 
 
-def test_dist_ships_only_django_absurd(tmp_path):
+def test_dist_ships_only_django_absurd(tmp_path: Path) -> None:
     root = Path(__file__).resolve().parent.parent.parent
     shutil.rmtree(root / "build", ignore_errors=True)
     # --no-isolation builds with the dev venv (which has build + hatchling +
@@ -71,10 +71,10 @@ def test_dist_ships_only_django_absurd(tmp_path):
     assert {"django_absurd", "pyproject.toml", "README.md", "LICENSE"} <= sdist_top
 
 
-def test_agents_guide_discoverable_via_help():
+def test_agents_guide_discoverable_via_help() -> None:
     # help(django_absurd) renders the module docstring via pydoc; it must point an
     # agent at AGENTS.md...
     assert "AGENTS.md" in pydoc.render_doc(django_absurd)
-    # ...and the guide the docstring promises must actually be readable from the package.
+    # ...and the guide the docstring promises must be readable from the package.
     guide = files("django_absurd").joinpath("AGENTS.md").read_text()
     assert guide.strip()

--- a/tests/core/test_params.py
+++ b/tests/core/test_params.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from django.tasks import task
 
@@ -12,31 +14,30 @@ from tests.tasks import add
 # Module-level: validate_task rejects a @task with a "<locals>" qualname.
 @task
 @absurd_default_params(max_attempts=7)
-def good_default(a, b):
+def good_default(a: int, b: int) -> int:
     return a + b
 
 
-def test_to_kwargs_emits_only_set_fields():
+def test_to_kwargs_emits_only_set_fields() -> None:
     assert AbsurdSpawnParams(max_attempts=3).to_kwargs() == {"max_attempts": 3}
     assert AbsurdSpawnParams().to_kwargs() == {}
 
 
-def test_spawnparams_carries_per_invocation_fields():
+def test_spawnparams_carries_per_invocation_fields() -> None:
     params = AbsurdSpawnParams(idempotency_key="k", headers={"x": "1"})
     assert params.to_kwargs() == {"idempotency_key": "k", "headers": {"x": "1"}}
 
 
-def test_decorator_rejects_per_invocation_kwarg():
+def test_decorator_rejects_per_invocation_kwarg() -> None:
     with pytest.raises(TypeError):
         absurd_default_params(idempotency_key="k")
 
 
-def test_decorator_attaches_default_to_task_func():
-    assert good_default.func.absurd_default_params == AbsurdDefaultParams(
-        max_attempts=7
-    )
+def test_decorator_attaches_default_to_task_func() -> None:
+    func_with_params: t.Any = good_default.func
+    assert func_with_params.absurd_default_params == AbsurdDefaultParams(max_attempts=7)
 
 
-def test_decorator_above_task_raises():
+def test_decorator_above_task_raises() -> None:
     with pytest.raises(TypeError):
         absurd_default_params(max_attempts=7)(add)  # add is a Task -> wrong order

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -1,10 +1,12 @@
 import datetime as dt
+import typing as t
 
 import psycopg
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db import connection
+from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client, resolve_absurd_database
@@ -14,7 +16,10 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_tasks_setting(queues, database="default"):
+def build_tasks_setting(
+    queues: dict[str, dict[str, t.Any]],
+    database: str = "default",
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -23,39 +28,44 @@ def build_tasks_setting(queues, database="default"):
     }
 
 
-def table_exists(name):
+def table_exists(name: str) -> bool:
     with connection.cursor() as cur:
         cur.execute("SELECT to_regclass(%s) IS NOT NULL", [f"absurd.{name}"])
-        return cur.fetchone()[0]
+        row = cur.fetchone()
+        return bool(row[0]) if row else False
 
 
-def test_get_absurd_client_uses_psycopg3_connection():
+def test_get_absurd_client_uses_psycopg3_connection() -> None:
     get_absurd_client()
     assert isinstance(connection.connection, psycopg.Connection)
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)
-def test_sync_command_screams_on_non_postgres_backend(settings):
+def test_sync_command_screams_on_non_postgres_backend(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
     with pytest.raises(ImproperlyConfigured):
         call_command("absurd_sync_queues")
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)
-def test_migrate_screams_on_non_postgres_backend(settings):
+def test_migrate_screams_on_non_postgres_backend(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks_setting({}, database="sqlite")
     with pytest.raises(ImproperlyConfigured):
         call_command("migrate", "django_absurd", database="sqlite", verbosity=0)
 
 
-def test_migrate_provisions_declared_queue(settings):
+def test_migrate_provisions_declared_queue(settings: SettingsWrapper) -> None:
     # post_migrate runs sync_queues, so `migrate` creates the declared queues
     settings.TASKS = build_tasks_setting({"alpha": {}})
     call_command("migrate", "django_absurd", verbosity=0)
     assert Queue.objects.filter(queue_name="alpha").exists()
 
 
-def test_sync_creates_with_options_and_model_maps(settings):
+def test_sync_creates_with_options_and_model_maps(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks_setting(
         {"x": {"storage_mode": "partitioned", "cleanup_ttl": "90 days"}}
     )
@@ -66,13 +76,13 @@ def test_sync_creates_with_options_and_model_maps(settings):
     assert table_exists("t_x")
 
 
-def test_list_shorthand(settings):
+def test_list_shorthand(settings: SettingsWrapper) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "QUEUES": ["alpha"]}}
     call_command("absurd_sync_queues")
     assert Queue.objects.filter(queue_name="alpha").exists()
 
 
-def test_sync_reconciles_changed_option_idempotent(settings):
+def test_sync_reconciles_changed_option_idempotent(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
@@ -82,7 +92,7 @@ def test_sync_reconciles_changed_option_idempotent(settings):
     assert Queue.objects.get(queue_name="q").cleanup_limit == 250
 
 
-def test_non_destructive(settings):
+def test_non_destructive(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks_setting({"keep": {}})
     call_command("absurd_sync_queues")
     settings.TASKS = build_tasks_setting({})
@@ -90,7 +100,10 @@ def test_non_destructive(settings):
     assert Queue.objects.filter(queue_name="keep").exists()
 
 
-def test_sync_reports_no_queues_when_all_in_sync(settings, capsys):
+def test_sync_reports_no_queues_when_all_in_sync(
+    settings: SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
     call_command("absurd_sync_queues")  # creates q
     capsys.readouterr()
@@ -98,20 +111,23 @@ def test_sync_reports_no_queues_when_all_in_sync(settings, capsys):
     assert "No queues to sync." in capsys.readouterr().out
 
 
-def test_get_absurd_database_resolves_from_backend(settings):
+def test_get_absurd_database_resolves_from_backend(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks_setting({}, database="default")
     assert resolve_absurd_database() == "default"
     settings.TASKS = build_tasks_setting({}, database="absurd")
     assert resolve_absurd_database() == "absurd"
 
 
-def test_sync_command_takes_no_database_flag(settings):
+def test_sync_command_takes_no_database_flag(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks_setting({})
     with pytest.raises(TypeError):
         call_command("absurd_sync_queues", database="sqlite")
 
 
-def test_sync_command_reports_nothing_when_no_absurd_backend(settings, capsys):
+def test_sync_command_reports_nothing_when_no_absurd_backend(
+    settings: SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+import datetime as dt
 
 import psycopg
 import pytest
@@ -62,7 +62,7 @@ def test_sync_creates_with_options_and_model_maps(settings):
     call_command("absurd_sync_queues")
     q = Queue.objects.get(queue_name="x")
     assert q.storage_mode == "partitioned"
-    assert q.cleanup_ttl == timedelta(days=90)
+    assert q.cleanup_ttl == dt.timedelta(days=90)
     assert table_exists("t_x")
 
 

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+import typing as t
 import uuid
 
 import pytest
@@ -9,7 +10,7 @@ from django.db import connections, transaction
 from django.tasks import TaskResultStatus
 from django.tasks.exceptions import TaskResultDoesNotExist
 
-from django_absurd.backends import get_absurd_backends
+from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.queues import get_absurd_client
 from tests.models import Payload
@@ -18,15 +19,15 @@ from tests.tasks import add, boom, echo
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def backend():
+def backend() -> AbsurdBackend:
     return get_absurd_backends()["default"]
 
 
-def run_absurd_worker(queue="default"):
+def run_absurd_worker(queue: str = "default") -> None:
     call_command("absurd_worker", queue=queue, burst=True)
 
 
-def test_get_result_pending():
+def test_get_result_pending() -> None:
     call_command("absurd_sync_queues")
     r = add.enqueue(2, 3)
     got = backend().get_result(r.id)
@@ -38,7 +39,7 @@ def test_get_result_pending():
     assert got.task.module_path == "tests.tasks.add"
 
 
-def test_get_result_successful():
+def test_get_result_successful() -> None:
     call_command("absurd_sync_queues")
     r = add.enqueue(2, 3)
     run_absurd_worker()
@@ -50,19 +51,21 @@ def test_get_result_successful():
     assert got.worker_ids  # non-empty
 
 
-def test_refresh_round_trip():
+def test_refresh_round_trip() -> None:
     call_command("absurd_sync_queues")
     r = add.enqueue(2, 3)
     assert r.status == TaskResultStatus.READY  # prior to running
     run_absurd_worker()
     r.refresh()
-    assert r.status == TaskResultStatus.SUCCESSFUL
+    assert r.status == TaskResultStatus.SUCCESSFUL  # type: ignore[comparison-overlap]
     assert r.return_value == 5
 
 
-def test_get_result_failed_has_errors():
+def test_get_result_failed_has_errors() -> None:
     call_command("absurd_sync_queues")
-    r = boom.enqueue(absurd_spawn_params=AbsurdSpawnParams(max_attempts=1))
+    r = boom.enqueue(
+        absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)  # type: ignore[call-arg]
+    )
     run_absurd_worker()
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.FAILED
@@ -71,26 +74,26 @@ def test_get_result_failed_has_errors():
     assert got.errors[0].traceback
 
 
-def test_via_task_get_result():
+def test_via_task_get_result() -> None:
     call_command("absurd_sync_queues")
     r = add.enqueue(2, 3)
     got = add.get_result(r.id)  # public path; must not raise TaskResultMismatch
     assert got.id == r.id
 
 
-def test_unknown_id_raises_does_not_exist():
+def test_unknown_id_raises_does_not_exist() -> None:
     call_command("absurd_sync_queues")
     with pytest.raises(TaskResultDoesNotExist):
         backend().get_result(f"default:{uuid.uuid4()}")
 
 
-def test_malformed_id_raises_does_not_exist():
+def test_malformed_id_raises_does_not_exist() -> None:
     call_command("absurd_sync_queues")
     with pytest.raises(TaskResultDoesNotExist):
         backend().get_result("nocolon")
 
 
-def test_get_result_inside_atomic_does_not_poison_txn():
+def test_get_result_inside_atomic_does_not_poison_txn() -> None:
     call_command("absurd_sync_queues")
     with connections["default"].cursor() as cur:
         cur.execute("DROP TABLE absurd.t_other CASCADE")
@@ -101,7 +104,7 @@ def test_get_result_inside_atomic_does_not_poison_txn():
         assert get_absurd_client().list_queues()
 
 
-def test_removed_task_raises_improperly_configured():
+def test_removed_task_raises_improperly_configured() -> None:
     call_command("absurd_sync_queues")
     # spawn a row whose task_name does not import
     spawn = get_absurd_client().spawn(
@@ -112,7 +115,7 @@ def test_removed_task_raises_improperly_configured():
         backend().get_result(rid)
 
 
-def test_injection_in_queue_segment_is_safe():
+def test_injection_in_queue_segment_is_safe() -> None:
     call_command("absurd_sync_queues")
     evil = 'default"; drop table absurd.queues; --'
     with pytest.raises(TaskResultDoesNotExist):
@@ -121,7 +124,7 @@ def test_injection_in_queue_segment_is_safe():
     assert "default" in get_absurd_client().list_queues()
 
 
-def test_aget_result_matches_get_result():
+def test_aget_result_matches_get_result() -> None:
     call_command("absurd_sync_queues")
     r = add.enqueue(2, 3)
     got = asyncio.run(backend().aget_result(r.id))
@@ -129,7 +132,7 @@ def test_aget_result_matches_get_result():
     assert got.status == TaskResultStatus.READY
 
 
-def test_get_result_does_not_poison_jsonfield_reads():
+def test_get_result_does_not_poison_jsonfield_reads() -> None:
     # get_result must not register a connection-scoped jsonb decoder: a later
     # ORM JSONField read on the same connection would then receive an
     # already-decoded dict and raise TypeError in json.loads.
@@ -159,7 +162,7 @@ def test_get_result_does_not_poison_jsonfield_reads():
     assert loaded_after.data == {"key": "value", "n": 42}
 
 
-def test_enqueue_does_not_poison_jsonfield_reads():
+def test_enqueue_does_not_poison_jsonfield_reads() -> None:
     # Regression: build_absurd_client previously registered the jsonb loader at
     # connection scope, so enqueue() (which calls build_absurd_client) poisoned the
     # shared Django connection. A JSONField read on the same connection after any
@@ -183,7 +186,7 @@ def test_enqueue_does_not_poison_jsonfield_reads():
         {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]},
     ],
 )
-def test_echo_return_value_round_trips(value):
+def test_echo_return_value_round_trips(value: t.Any) -> None:
     call_command("absurd_sync_queues")
     r = echo.enqueue(value)
     run_absurd_worker()
@@ -192,7 +195,7 @@ def test_echo_return_value_round_trips(value):
     assert got.return_value == value
 
 
-def test_echo_args_round_trip():
+def test_echo_args_round_trip() -> None:
     call_command("absurd_sync_queues")
     nested = {"items": [1, None, False, "ünïçødé"], "sub": {"x": 0}}
     r = echo.enqueue(nested)
@@ -202,7 +205,7 @@ def test_echo_args_round_trip():
     assert got.return_value == nested
 
 
-def test_echo_kwargs_round_trip():
+def test_echo_kwargs_round_trip() -> None:
     call_command("absurd_sync_queues")
     r = echo.using(queue_name="default").enqueue(value={"k": [True, None, 42]})
     run_absurd_worker()
@@ -211,7 +214,7 @@ def test_echo_kwargs_round_trip():
     assert got.return_value == {"k": [True, None, 42]}
 
 
-def test_non_json_serializable_arg_rejected_at_enqueue():
+def test_non_json_serializable_arg_rejected_at_enqueue() -> None:
     # datetime is not JSON-serializable; the backend must reject it at enqueue
     # time rather than silently producing a broken task row.
     call_command("absurd_sync_queues")

--- a/tests/core/test_router_default.py
+++ b/tests/core/test_router_default.py
@@ -2,7 +2,7 @@ from django_absurd.models import Queue
 from django_absurd.routers import AbsurdRouter
 
 
-def test_router_is_noop_at_default():
+def test_router_is_noop_at_default() -> None:
     # resolve_absurd_database() returns "default" in the main suite → router
     # routes django_absurd to "default" (a no-op).
     router = AbsurdRouter()

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -3,9 +3,11 @@ import os
 import signal
 import threading
 import time
+import typing as t
 import zoneinfo
 
 import pytest
+import pytest_django.fixtures
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -27,8 +29,11 @@ from tests.tasks import make_group as make_group_task
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def make_tasks_setting(schedule, cleanup=None):
-    options = {
+def make_tasks_setting(
+    schedule: dict[str, t.Any],
+    cleanup: dict[str, t.Any] | None = None,
+) -> dict[str, dict[str, t.Any]]:
+    options: dict[str, t.Any] = {
         "QUEUES": {"default": {}, "other": {}, "reports": {}},
         "SCHEDULE": schedule,
     }
@@ -42,7 +47,9 @@ def make_tasks_setting(schedule, cleanup=None):
     }
 
 
-def test_settings_provider_reads_entries(settings):
+def test_settings_provider_reads_entries(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "nightly": {
@@ -67,7 +74,9 @@ def test_settings_provider_reads_entries(settings):
     ]
 
 
-def test_settings_provider_defaults_and_empty(settings):
+def test_settings_provider_defaults_and_empty(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {"ping": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
     )
@@ -78,7 +87,9 @@ def test_settings_provider_defaults_and_empty(settings):
     assert s.kwargs == {}
 
 
-def test_settings_provider_no_schedule_key(settings):
+def test_settings_provider_no_schedule_key(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -90,19 +101,21 @@ def test_settings_provider_no_schedule_key(settings):
 
 
 @freeze_time("2026-01-01 01:59:00")
-def test_get_next_datetime_same_day():
+def test_get_next_datetime_same_day() -> None:
     expected = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
     assert get_next_datetime("0 2 * * *", timezone.now()) == expected
 
 
 @freeze_time("2026-01-01 02:00:00")
-def test_get_next_datetime_rolls_forward():
+def test_get_next_datetime_rolls_forward() -> None:
     expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
     assert get_next_datetime("0 2 * * *", timezone.now()) == expected
 
 
 @freeze_time("2026-01-01 12:00:00")  # 06:00 in Chicago (UTC-6)
-def test_get_next_datetime_uses_django_timezone(settings):
+def test_get_next_datetime_uses_django_timezone(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # cron interpreted in Django TIME_ZONE: 02:00 Chicago already passed -> tomorrow
     settings.TIME_ZONE = "America/Chicago"
     chicago = zoneinfo.ZoneInfo("America/Chicago")
@@ -112,7 +125,7 @@ def test_get_next_datetime_uses_django_timezone(settings):
 
 
 @freeze_time("2026-01-01 12:00:00")
-def test_get_next_datetime_six_field_leading_seconds():
+def test_get_next_datetime_six_field_leading_seconds() -> None:
     # A 6-field cron uses a LEADING seconds column, so "*/30 * * * * *" means every
     # 30 seconds -> next fire at :30, not every second (which is what a trailing-seconds
     # reading of the same string produces).
@@ -121,24 +134,27 @@ def test_get_next_datetime_six_field_leading_seconds():
 
 
 @freeze_time("2026-01-01 12:00:00")
-def test_get_next_datetime_six_field_non_divisor_seconds():
+def test_get_next_datetime_six_field_non_divisor_seconds() -> None:
     # Leading seconds holds for any step: "*/7 * * * * *" fires at :07, not :01.
     expected = dt.datetime(2026, 1, 1, 12, 0, 7, tzinfo=dt.UTC)
     assert get_next_datetime("*/7 * * * * *", timezone.now()) == expected
 
 
 @freeze_time("2026-01-01 12:00:00")
-def test_get_next_datetime_six_field_zero_seconds():
+def test_get_next_datetime_six_field_zero_seconds() -> None:
     # Leading seconds=0 with a minute step fires on the minute boundary, not every
     # second: "0 */5 * * * *" -> next at 12:05:00.
     expected = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.UTC)
     assert get_next_datetime("0 */5 * * * *", timezone.now()) == expected
 
 
-# run_beat_until and tests below it use run_beat's injected wait/now seam because a real
-# threading.Event.wait can't be fast-forwarded by freezegun; the command path is not
-# deterministic enough for exact multi-slot counts.
-def run_beat_until(backend, cutoff: dt.datetime) -> None:
+# run_beat_until and tests below it use run_beat's injected wait/now seam
+# because a real threading.Event.wait can't be fast-forwarded by freezegun;
+# the command path is not deterministic enough for exact multi-slot counts.
+def run_beat_until(
+    backend: t.Any,
+    cutoff: dt.datetime,
+) -> None:
     with freeze_time("2026-01-01 00:00:00") as frozen:
 
         def fake_wait(timeout: float) -> bool:
@@ -148,7 +164,9 @@ def run_beat_until(backend, cutoff: dt.datetime) -> None:
         run_beat(backend, wait=fake_wait)
 
 
-def test_beat_fires_each_due_slot(settings):
+def test_beat_fires_each_due_slot(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "p": {
@@ -166,7 +184,9 @@ def test_beat_fires_each_due_slot(settings):
     assert Payload.objects.count() == expected_fires
 
 
-def test_beat_fires_multiple_schedules_due_same_slot(settings):
+def test_beat_fires_multiple_schedules_due_same_slot(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Two distinct schedules sharing a cron slot both fire in the one tick pass.
     settings.TASKS = make_tasks_setting(
         {
@@ -189,13 +209,17 @@ def test_beat_fires_multiple_schedules_due_same_slot(settings):
     assert set(Group.objects.values_list("name", flat=True)) == {"a", "b"}
 
 
-def test_beat_no_schedules_returns(settings):
+def test_beat_no_schedules_returns(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting({})
     backend = get_absurd_backends()["default"]
     run_beat(backend, stop=threading.Event())  # returns immediately, no hang
 
 
-def test_beat_isolates_failing_schedule(settings):
+def test_beat_isolates_failing_schedule(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "bad": {"task": "tests.tasks.does_not_exist", "cron": "*/1 * * * *"},
@@ -214,7 +238,9 @@ def test_beat_isolates_failing_schedule(settings):
     assert Payload.objects.count() == expected_good
 
 
-def test_beat_spawns_task_with_args(settings):
+def test_beat_spawns_task_with_args(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "g": {
@@ -231,7 +257,9 @@ def test_beat_spawns_task_with_args(settings):
     assert Group.objects.filter(name="beat-args").exists()
 
 
-def test_beat_spawns_task_with_kwargs(settings):
+def test_beat_spawns_task_with_kwargs(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "g": {
@@ -248,7 +276,9 @@ def test_beat_spawns_task_with_kwargs(settings):
     assert Group.objects.filter(name="beat-kw").exists()
 
 
-def test_beat_empty_queue_string_falls_back_to_task_queue(settings):
+def test_beat_empty_queue_string_falls_back_to_task_queue(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """queue: "" normalises to the task's own queue (parity with pg_cron's
     fallback), not a literal "" queue that enqueue would reject."""
     settings.TASKS = make_tasks_setting(
@@ -268,7 +298,9 @@ def test_beat_empty_queue_string_falls_back_to_task_queue(settings):
     assert Group.objects.filter(name="beat-empty-q").exists()
 
 
-def test_beat_routes_task_to_queue(settings):
+def test_beat_routes_task_to_queue(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "g": {
@@ -288,7 +320,7 @@ def test_beat_routes_task_to_queue(settings):
     assert Group.objects.filter(name="beat-routed").exists()
 
 
-def test_derive_idempotency_key_stable_same_inputs():
+def test_derive_idempotency_key_stable_same_inputs() -> None:
     schedule = Schedule(name="nightly", task="tests.tasks.add", cron="0 2 * * *")
     slot = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
     assert derive_idempotency_key(schedule, slot) == derive_idempotency_key(
@@ -296,7 +328,7 @@ def test_derive_idempotency_key_stable_same_inputs():
     )
 
 
-def test_derive_idempotency_key_differs_across_slots():
+def test_derive_idempotency_key_differs_across_slots() -> None:
     schedule = Schedule(name="nightly", task="tests.tasks.add", cron="0 2 * * *")
     slot_a = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
     slot_b = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
@@ -305,14 +337,14 @@ def test_derive_idempotency_key_differs_across_slots():
     )
 
 
-def test_derive_idempotency_key_differs_across_names():
+def test_derive_idempotency_key_differs_across_names() -> None:
     slot = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
     s_a = Schedule(name="alpha", task="tests.tasks.add", cron="0 2 * * *")
     s_b = Schedule(name="beta", task="tests.tasks.add", cron="0 2 * * *")
     assert derive_idempotency_key(s_a, slot) != derive_idempotency_key(s_b, slot)
 
 
-def test_derive_idempotency_key_distinguishes_sub_minute_slots():
+def test_derive_idempotency_key_distinguishes_sub_minute_slots() -> None:
     # 6-field crons (croniter accepts them) yield sub-minute slots; the key must
     # distinguish slots in the same minute, or two fires would collide and the
     # second would be wrongly deduped.
@@ -324,7 +356,7 @@ def test_derive_idempotency_key_distinguishes_sub_minute_slots():
     )
 
 
-def test_derive_idempotency_key_differs_across_backends():
+def test_derive_idempotency_key_differs_across_backends() -> None:
     slot = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
     s_a = Schedule(
         name="alpha", task="tests.tasks.add", cron="0 2 * * *", backend="default"
@@ -335,7 +367,9 @@ def test_derive_idempotency_key_differs_across_backends():
     assert derive_idempotency_key(s_a, slot) != derive_idempotency_key(s_b, slot)
 
 
-def test_settings_provider_sets_backend_alias(settings):
+def test_settings_provider_sets_backend_alias(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -364,7 +398,9 @@ def test_settings_provider_sets_backend_alias(settings):
     assert schedule.backend == "second"
 
 
-def test_beat_routes_task_to_nondefault_backend(settings):
+def test_beat_routes_task_to_nondefault_backend(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -395,9 +431,12 @@ def test_beat_routes_task_to_nondefault_backend(settings):
     assert Group.objects.filter(name="cross-backend").exists()
 
 
-def test_idempotency_key_dedups_same_slot(settings):
-    # The command/loop never re-fires a single slot; this tests spawn_scheduled directly
-    # to prove our key + Absurd's real dedup together collapse repeated fires to one task.
+def test_idempotency_key_dedups_same_slot(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    # The command/loop never re-fires a single slot; this tests spawn_scheduled
+    # directly to prove our key + Absurd's real dedup together collapse repeated
+    # fires to one task.
     settings.TASKS = make_tasks_setting(
         {
             "p": {
@@ -418,7 +457,9 @@ def test_idempotency_key_dedups_same_slot(settings):
     assert Payload.objects.count() == 1
 
 
-def test_absurd_beat_empty_schedule_runs_handle(settings):
+def test_absurd_beat_empty_schedule_runs_handle(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Covers absurd_beat handle body (single-backend path via base.py:16-17).
     # Empty SCHEDULE → run_beat returns immediately (no blocking), no threads needed.
     settings.TASKS = make_tasks_setting({})
@@ -432,7 +473,9 @@ def test_absurd_beat_empty_schedule_runs_handle(settings):
         signal.signal(signal.SIGTERM, prev_sigterm)
 
 
-def test_absurd_beat_valid_alias_and_signal_handler(settings):
+def test_absurd_beat_valid_alias_and_signal_handler(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Covers base.py:15 (valid alias → backend = backends[alias]) and
     # absurd_beat.py:27 (handle_signal body: stop.set()).
     settings.TASKS = make_tasks_setting(
@@ -470,7 +513,10 @@ def test_absurd_beat_valid_alias_and_signal_handler(settings):
         signal.signal(signal.SIGTERM, prev_sigterm)
 
 
-def test_absurd_beat_startup_reports_cleanup(settings, capsys):
+def test_absurd_beat_startup_reports_cleanup(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     # Covers absurd_beat.py:38-39 (cleanup appended to the startup message). Empty
     # SCHEDULE + a CLEANUP makes run_beat loop, so a handler-gated SIGINT stops it; the
     # startup message is written before run_beat, so capsys captures it.
@@ -504,7 +550,9 @@ def test_absurd_beat_startup_reports_cleanup(settings, capsys):
     )
 
 
-def test_absurd_beat_unknown_alias_errors(settings):
+def test_absurd_beat_unknown_alias_errors(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {"m": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
     )
@@ -512,7 +560,9 @@ def test_absurd_beat_unknown_alias_errors(settings):
         call_command("absurd_beat", alias="nope")
 
 
-def test_absurd_beat_multiple_backends_requires_alias(settings):
+def test_absurd_beat_multiple_backends_requires_alias(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -527,7 +577,9 @@ def test_absurd_beat_multiple_backends_requires_alias(settings):
         call_command("absurd_beat")
 
 
-def test_worker_beat_rejects_burst(settings):
+def test_worker_beat_rejects_burst(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {"g": {"task": "tests.tasks.make_group", "cron": "*/1 * * * *", "args": ["x"]}}
     )
@@ -535,7 +587,9 @@ def test_worker_beat_rejects_burst(settings):
         call_command("absurd_worker", queue="default", burst=True, beat=True)
 
 
-def test_beat_stop_interrupts_long_sleep(settings):
+def test_beat_stop_interrupts_long_sleep(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Real threading.Event.wait — stop.set() must wake the beat promptly.
     settings.TASKS = make_tasks_setting(
         {
@@ -551,7 +605,9 @@ def test_beat_stop_interrupts_long_sleep(settings):
 
     stop = threading.Event()
     beat_thread = threading.Thread(
-        target=run_beat, kwargs={"backend": backend, "stop": stop}, daemon=True
+        target=run_beat,
+        kwargs={"backend": backend, "stop": stop},
+        daemon=True,
     )
     beat_thread.start()
     time.sleep(0.05)  # let beat enter stop.wait
@@ -562,7 +618,9 @@ def test_beat_stop_interrupts_long_sleep(settings):
     assert Payload.objects.count() == 0
 
 
-def test_worker_with_beat_runs_scheduled_task(settings):
+def test_worker_with_beat_runs_scheduled_task(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = make_tasks_setting(
         {
             "g": {
@@ -574,13 +632,14 @@ def test_worker_with_beat_runs_scheduled_task(settings):
     )
     call_command("absurd_sync_queues")
 
-    def watch():
+    def watch() -> None:
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline:  # pragma: no branch
             if Group.objects.filter(name="beat-ran").exists():
                 break
             time.sleep(0.05)
-        os.kill(os.getpid(), signal.SIGTERM)  # stop worker + beat (main-thread handler)
+        # stop worker + beat (main-thread handler)
+        os.kill(os.getpid(), signal.SIGTERM)
 
     watcher = threading.Thread(target=watch, daemon=True)
     watcher.start()
@@ -593,7 +652,9 @@ def test_worker_with_beat_runs_scheduled_task(settings):
     assert Group.objects.filter(name="beat-ran").exists()
 
 
-def test_beat_already_stopped_on_entry_skips_loop(settings):
+def test_beat_already_stopped_on_entry_skips_loop(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Covers scheduler.py 92->exit: while-False branch when stop is pre-set.
     # Beat has at least one schedule so it passes the early-return guard, reaches
     # the while loop with stop already set → exits without enqueueing anything.
@@ -616,7 +677,9 @@ def test_beat_already_stopped_on_entry_skips_loop(settings):
     assert Payload.objects.count() == 0
 
 
-def test_beat_skips_not_yet_due_schedule(settings):
+def test_beat_skips_not_yet_due_schedule(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Covers scheduler.py 99->98: if due <= current False branch.
     # Two schedules: one every minute (due), one at 02:00 (far future, not due).
     # After one slot cutoff only the due schedule fires.
@@ -637,14 +700,19 @@ def test_beat_skips_not_yet_due_schedule(settings):
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
     # Cutoff at 00:01:30 → "due" slot 00:01 fires, "later" slot 02:00 does not.
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+    run_beat_until(
+        backend,
+        dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC),
+    )
     call_command("absurd_worker", queue="default", burst=True)
     assert Payload.objects.count() == 1
     assert Payload.objects.filter(data="due").exists()
     assert not Payload.objects.filter(data="later").exists()
 
 
-def test_plain_worker_runs_blocking_worker(settings):
+def test_plain_worker_runs_blocking_worker(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Covers worker.py line 114: else branch of arun_worker (no burst, no beat).
     settings.TASKS = make_tasks_setting(
         {
@@ -658,7 +726,7 @@ def test_plain_worker_runs_blocking_worker(settings):
     call_command("absurd_sync_queues")
     make_group_task.enqueue("plain-worker")
 
-    def watch():
+    def watch() -> None:
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline:  # pragma: no branch
             if Group.objects.filter(name="plain-worker").exists():

--- a/tests/core/test_scheduler_app_checks.py
+++ b/tests/core/test_scheduler_app_checks.py
@@ -1,16 +1,23 @@
-"""E008: SCHEDULER='pg_cron' requires the pg_cron app — genuine absence in this suite."""
+"""E008: SCHEDULER='pg_cron' requires pg_cron app — genuine absence in this suite."""
+
+import typing as t
 
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
-BASE_QUEUES: dict = {"default": {}, "other": {}, "reports": {}}
+BASE_QUEUES: dict[str, t.Any] = {"default": {}, "other": {}, "reports": {}}
 
 
-def run_check(capsys, settings, scheduler):
+def run_check(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+    scheduler: str,
+) -> str:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -26,7 +33,10 @@ def run_check(capsys, settings, scheduler):
     return cap.out + cap.err
 
 
-def test_pg_cron_scheduler_without_app_errors(capsys, settings):
+def test_pg_cron_scheduler_without_app_errors(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     out = run_check(capsys, settings, "pg_cron")
     assert "absurd.E008" in out
     assert (
@@ -38,7 +48,10 @@ def test_pg_cron_scheduler_without_app_errors(capsys, settings):
     )
 
 
-def test_beat_scheduler_without_app_clean(capsys, settings):
+def test_beat_scheduler_without_app_clean(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     out = run_check(capsys, settings, "beat")
     assert "absurd.E008" not in out
     assert "absurd.W003" not in out

--- a/tests/core/test_scheduler_checks.py
+++ b/tests/core/test_scheduler_checks.py
@@ -1,6 +1,9 @@
+import typing as t
+
 import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
+from pytest_django.fixtures import SettingsWrapper
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -10,8 +13,11 @@ E007_MSG = "django-absurd: invalid SCHEDULE entry."
 
 
 @pytest.fixture
-def run_check(capsys, settings):
-    def _run(schedule):
+def run_check(
+    capsys: pytest.CaptureFixture[str],
+    settings: SettingsWrapper,
+) -> t.Callable[[t.Any], str]:
+    def _run(schedule: t.Any) -> str:
         settings.TASKS = {
             "default": {
                 "BACKEND": ABSURD,
@@ -32,12 +38,12 @@ def run_check(capsys, settings):
     return _run
 
 
-def test_valid_schedule_no_error(run_check):
+def test_valid_schedule_no_error(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"ok": {"task": "tests.tasks.add", "cron": "0 2 * * *"}})
     assert "absurd.E007" not in out
 
 
-def test_unimportable_task(run_check):
+def test_unimportable_task(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.nope", "cron": "0 2 * * *"}})
     assert (
         f"{E007_MSG} Schedule 'x': task 'tests.tasks.nope' could not be imported"
@@ -45,31 +51,32 @@ def test_unimportable_task(run_check):
     assert "absurd.E007" in out
 
 
-def test_non_import_error_at_task_import(run_check):
+def test_non_import_error_at_task_import(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.raises_on_import.anything", "cron": "0 2 * * *"}}
     )
     assert (
-        f"{E007_MSG} Schedule 'x': task 'tests.raises_on_import.anything' could not be imported"
+        f"{E007_MSG} Schedule 'x': task 'tests.raises_on_import.anything' "
+        "could not be imported"
     ) in out
     assert "RuntimeError" in out
     assert "boom at import" in out
     assert "absurd.E007" in out
 
 
-def test_schedule_not_a_mapping(run_check):
+def test_schedule_not_a_mapping(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(["nightly"])
     assert 'OPTIONS["SCHEDULE"] must be a mapping of name -> spec' in out
     assert "absurd.E007" in out
 
 
-def test_schedule_entry_not_a_mapping(run_check):
+def test_schedule_entry_not_a_mapping(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"nightly": "0 2 * * *"})
     assert f"{E007_MSG} Schedule 'nightly' must be a mapping." in out
     assert "absurd.E007" in out
 
 
-def test_not_a_task(run_check):
+def test_not_a_task(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.Payload", "cron": "0 2 * * *"}})
     assert (
         f"{E007_MSG} Schedule 'x': 'tests.tasks.Payload' is not a Django task."
@@ -77,13 +84,13 @@ def test_not_a_task(run_check):
     assert "absurd.E007" in out
 
 
-def test_bad_cron(run_check):
+def test_bad_cron(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "not-cron"}})
     assert (f"{E007_MSG} Schedule 'x': invalid cron expression 'not-cron'.") in out
     assert "absurd.E007" in out
 
 
-def test_non_string_cron(run_check):
+def test_non_string_cron(run_check: t.Callable[[t.Any], str]) -> None:
     # A non-string cron (e.g. forgot the quotes) must yield a clean E007, not an
     # AttributeError from croniter.is_valid — the check runs at worker/beat boot.
     out = run_check({"x": {"task": "tests.tasks.add", "cron": 300}})
@@ -91,20 +98,22 @@ def test_non_string_cron(run_check):
     assert "absurd.E007" in out
 
 
-def test_beat_rejects_pg_cron_interval_syntax(run_check):
+def test_beat_rejects_pg_cron_interval_syntax(
+    run_check: t.Callable[[t.Any], str],
+) -> None:
     # "[1-59] seconds" is pg_cron's grammar; under beat, croniter rejects it.
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "30 seconds"}})
     assert (f"{E007_MSG} Schedule 'x': invalid cron expression '30 seconds'.") in out
     assert "absurd.E007" in out
 
 
-def test_unknown_key(run_check):
+def test_unknown_key(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "bogus": 1}})
     assert (f"{E007_MSG} Schedule 'x': unknown key 'bogus'.") in out
     assert "absurd.E007" in out
 
 
-def test_non_serializable_args(run_check):
+def test_non_serializable_args(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "args": [object()]}}
     )
@@ -112,7 +121,7 @@ def test_non_serializable_args(run_check):
     assert "absurd.E007" in out
 
 
-def test_undeclared_queue(run_check):
+def test_undeclared_queue(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": "ghost"}}
     )
@@ -120,7 +129,7 @@ def test_undeclared_queue(run_check):
     assert "absurd.E007" in out
 
 
-def test_non_string_queue(run_check):
+def test_non_string_queue(run_check: t.Callable[[t.Any], str]) -> None:
     # A non-string queue (e.g. a list) must yield a clean E007, not a TypeError
     # from the `queue not in declared_queues` membership test.
     out = run_check(

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -1,6 +1,6 @@
 import asyncio
+import datetime as dt
 import logging
-from datetime import timedelta
 
 import psycopg
 import pytest
@@ -282,7 +282,7 @@ def test_worker_command_reconciles_changed_interval_option(settings, capsys):
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
     assert out == "Reconciled: default\nStarted worker on queue 'default'.\n"
-    assert Queue.objects.get(queue_name="default").cleanup_ttl == timedelta(days=60)
+    assert Queue.objects.get(queue_name="default").cleanup_ttl == dt.timedelta(days=60)
 
 
 def test_worker_command_no_reconcile_when_unchanged(settings, capsys):

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -1,17 +1,19 @@
 import asyncio
 import datetime as dt
 import logging
+import typing as t
 
 import psycopg
 import pytest
-from absurd_sdk import Absurd
+from absurd_sdk import Absurd, TaskResultSnapshot
 from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command, load_command_class
 from django.core.management.base import CommandError
 from django.db import connection, connections
+from pytest_django.fixtures import SettingsWrapper
 
-from django_absurd.backends import get_absurd_backends
+from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
@@ -23,16 +25,20 @@ from tests.tasks import boom, make_group, report_args, report_attempt, routed
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def backend():
-    return get_absurd_backends()["default"]
+def backend() -> AbsurdBackend:
+    backends = get_absurd_backends()
+    return backends["default"]
 
 
-def run_absurd_worker(queue="default", concurrency=1):
+def run_absurd_worker(queue: str = "default", concurrency: int = 1) -> None:
     """Run the absurd_worker management command in burst mode (drain then exit)."""
     call_command("absurd_worker", queue=queue, burst=True, concurrency=concurrency)
 
 
-def get_task_result(task_id, queue="default"):
+def get_task_result(
+    task_id: t.Any,
+    queue: str = "default",
+) -> TaskResultSnapshot | None:
     raw_task_id = str(task_id).rsplit(":", 1)[-1]
     params = connections["default"].get_connection_params()
     conn = psycopg.connect(**params, autocommit=True)
@@ -43,10 +49,10 @@ def get_task_result(task_id, queue="default"):
         conn.close()
 
 
-def test_worker_client_uses_dedicated_connection():
+def test_worker_client_uses_dedicated_connection() -> None:
     call_command("absurd_sync_queues")
 
-    async def _enter():
+    async def _enter() -> bool:
         async with aworker_client(backend(), "default") as client:
             return "default" in await client.list_queues()
 
@@ -54,7 +60,7 @@ def test_worker_client_uses_dedicated_connection():
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)
-def test_worker_client_rejects_non_psycopg3(settings):
+def test_worker_client_rejects_non_psycopg3(settings: SettingsWrapper) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -66,22 +72,22 @@ def test_worker_client_rejects_non_psycopg3(settings):
         call_command("absurd_worker", queue="default", burst=True)
 
 
-def test_worker_client_opens_without_provisioning_check():
-    # No absurd_sync_queues; 'default' unprovisioned (schema present). aworker_client must
-    # NOT raise — the provisioned-or-die check is gone.
-    async def _enter():
+def test_worker_client_opens_without_provisioning_check() -> None:
+    # No absurd_sync_queues; 'default' unprovisioned (schema present).
+    # aworker_client must NOT raise — the provisioned-or-die check is gone.
+    async def _enter() -> list[str]:
         async with aworker_client(backend(), "default") as client:
             return await client.list_queues()
 
     assert "default" not in asyncio.run(_enter())  # unprovisioned, yet no error
 
 
-def test_worker_client_absent_schema_errors():
+def test_worker_client_absent_schema_errors() -> None:
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
 
-        async def _enter():
+        async def _enter() -> None:
             async with aworker_client(backend(), "default"):
                 pass
 
@@ -92,45 +98,52 @@ def test_worker_client_absent_schema_errors():
         call_command("migrate", verbosity=0)  # restore absurd schema
 
 
-def test_end_to_end_executes_and_records_result():
+def test_end_to_end_executes_and_records_result() -> None:
     call_command("absurd_sync_queues")
     result = make_group.enqueue("alpha")
     run_absurd_worker()
     assert Group.objects.filter(name="alpha").exists()
     snap = get_task_result(result.id)
+    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == "alpha"
 
 
-def test_failing_task_records_failure():
+def test_failing_task_records_failure() -> None:
     call_command("absurd_sync_queues")
     result = boom.enqueue()
     run_absurd_worker()
-    assert get_task_result(result.id).state == "failed"
+    snap = get_task_result(result.id)
+    assert snap is not None
+    assert snap.state == "failed"
 
 
-def test_takes_context_attempt_is_one_on_first_run():
+def test_takes_context_attempt_is_one_on_first_run() -> None:
     call_command("absurd_sync_queues")
     result = report_attempt.enqueue()
     run_absurd_worker()
-    assert get_task_result(result.id).result == 1
+    snap = get_task_result(result.id)
+    assert snap is not None
+    assert snap.result == 1
 
 
-def test_takes_context_task_result_carries_real_args():
+def test_takes_context_task_result_carries_real_args() -> None:
     call_command("absurd_sync_queues")
     result = report_args.enqueue("x", "y")
     run_absurd_worker()
-    assert get_task_result(result.id).result == ["x", "y"]
+    snap = get_task_result(result.id)
+    assert snap is not None
+    assert snap.result == ["x", "y"]
 
 
-def test_using_queue_name_routes_to_worker_queue():
+def test_using_queue_name_routes_to_worker_queue() -> None:
     call_command("absurd_sync_queues")
     routed.using(queue_name="default").enqueue()
     run_absurd_worker()
     assert Group.objects.filter(name="routed").exists()
 
 
-def test_handler_logs_task_outcome(caplog):
+def test_handler_logs_task_outcome(caplog: pytest.LogCaptureFixture) -> None:
     call_command("absurd_sync_queues")
     make_group.enqueue("logged")
     with caplog.at_level(logging.INFO, logger="django_absurd"):
@@ -139,26 +152,32 @@ def test_handler_logs_task_outcome(caplog):
     assert "completed" in caplog.text
 
 
-def test_unregistered_name_defers_not_crashes():
+def test_unregistered_name_defers_not_crashes() -> None:
     call_command("absurd_sync_queues")
     spawn = get_absurd_client("default").spawn(
         "not.a.real.task", {"args": [], "kwargs": {}}, queue="default"
     )
     run_absurd_worker()
-    assert get_task_result(spawn["task_id"]).state != "failed"
+    snap = get_task_result(spawn["task_id"])
+    assert snap is not None
+    assert snap.state != "failed"
 
 
-def test_task_outside_tasks_py_runs():
+def test_task_outside_tasks_py_runs() -> None:
     # record_from_jobs is in tests/jobs.py, NOT tests/tasks.py — the old scan would
     # never find it (it would defer forever). Lazy resolution runs it by module_path.
     call_command("absurd_sync_queues")
     result = record_from_jobs.enqueue("from-jobs")
     run_absurd_worker()
     assert Group.objects.filter(name="from-jobs").exists()
-    assert get_task_result(result.id).result == "from-jobs"
+    snap = get_task_result(result.id)
+    assert snap is not None
+    assert snap.result == "from-jobs"
 
 
-def test_queue_defaults_to_default(settings, capsys):
+def test_queue_defaults_to_default(
+    settings: SettingsWrapper, capsys: pytest.CaptureFixture[str]
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -172,7 +191,7 @@ def test_queue_defaults_to_default(settings, capsys):
     assert Group.objects.filter(name="dflt").exists()
 
 
-def test_unknown_queue_errors_listing_valid(settings):
+def test_unknown_queue_errors_listing_valid(settings: SettingsWrapper) -> None:
     with pytest.raises(CommandError) as exc:
         call_command("absurd_worker", queue="nope")
     message = str(exc.value)
@@ -181,7 +200,7 @@ def test_unknown_queue_errors_listing_valid(settings):
     assert "default" in message
 
 
-def test_ambiguous_alias_requires_flag(settings):
+def test_ambiguous_alias_requires_flag(settings: SettingsWrapper) -> None:
     settings.TASKS = {
         "a": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -201,7 +220,7 @@ def test_ambiguous_alias_requires_flag(settings):
     assert "b" in message
 
 
-def test_command_parses_all_flags_with_defaults():
+def test_command_parses_all_flags_with_defaults() -> None:
     cmd = load_command_class("django_absurd", "absurd_worker")
     parser = cmd.create_parser("manage.py", "absurd_worker")
     opts = vars(parser.parse_args([]))
@@ -215,15 +234,19 @@ def test_command_parses_all_flags_with_defaults():
     assert opts["worker_id"] is None
 
 
-def test_command_burst_runs_task_end_to_end():
+def test_command_burst_runs_task_end_to_end() -> None:
     call_command("absurd_sync_queues")
     result = make_group.enqueue("via-command")
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="via-command").exists()
-    assert get_task_result(result.id).state == "completed"
+    snap = get_task_result(result.id)
+    assert snap is not None
+    assert snap.state == "completed"
 
 
-def test_worker_start_provisions_all_declared_queues(capsys):
+def test_worker_start_provisions_all_declared_queues(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     # full provision on start: every declared queue, not just the served one
     call_command("absurd_worker", queue="default", burst=True)
     created_line, started_line = capsys.readouterr().out.splitlines()
@@ -237,7 +260,9 @@ def test_worker_start_provisions_all_declared_queues(capsys):
     assert Queue.objects.filter(queue_name="other").exists()
 
 
-def test_worker_command_reconciles_changed_mutable_option(settings, capsys):
+def test_worker_command_reconciles_changed_mutable_option(
+    settings: SettingsWrapper, capsys: pytest.CaptureFixture[str]
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -258,7 +283,9 @@ def test_worker_command_reconciles_changed_mutable_option(settings, capsys):
     assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
 
 
-def test_worker_command_reconciles_changed_interval_option(settings, capsys):
+def test_worker_command_reconciles_changed_interval_option(
+    settings: SettingsWrapper, capsys: pytest.CaptureFixture[str]
+) -> None:
     # Two mutable opts: cleanup_limit unchanged (loop continues), cleanup_ttl changed
     # (interval drift via parse_interval).
     settings.TASKS = {
@@ -285,7 +312,9 @@ def test_worker_command_reconciles_changed_interval_option(settings, capsys):
     assert Queue.objects.get(queue_name="default").cleanup_ttl == dt.timedelta(days=60)
 
 
-def test_worker_command_no_reconcile_when_unchanged(settings, capsys):
+def test_worker_command_no_reconcile_when_unchanged(
+    settings: SettingsWrapper, capsys: pytest.CaptureFixture[str]
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -297,12 +326,15 @@ def test_worker_command_no_reconcile_when_unchanged(settings, capsys):
     capsys.readouterr()
     call_command("absurd_worker", queue="default", burst=True)
     out = capsys.readouterr().out
-    # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just the start line.
+    # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just
+    # the start line.
     assert out == "Started worker on queue 'default'.\n"
     assert Queue.objects.get(queue_name="default").cleanup_ttl == before
 
 
-def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
+def test_worker_command_warns_on_storage_mode_drift(
+    settings: SettingsWrapper, capsys: pytest.CaptureFixture[str]
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -326,7 +358,7 @@ def test_worker_command_warns_on_storage_mode_drift(settings, capsys):
     )
 
 
-def test_worker_command_schema_absent_errors_migrate():
+def test_worker_command_schema_absent_errors_migrate() -> None:
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
@@ -337,7 +369,7 @@ def test_worker_command_schema_absent_errors_migrate():
         call_command("migrate", verbosity=0)  # restore absurd schema
 
 
-def test_start_worker_drains_concurrently():
+def test_start_worker_drains_concurrently() -> None:
     call_command("absurd_sync_queues")
     for i in range(5):
         make_group.enqueue(f"g{i}")
@@ -346,27 +378,29 @@ def test_start_worker_drains_concurrently():
     assert Group.objects.filter(name__startswith="g").count() == 5
 
 
-def test_async_task_runs_end_to_end():
+def test_async_task_runs_end_to_end() -> None:
     call_command("absurd_sync_queues")
     r = aecho.enqueue("hi-async")
     run_absurd_worker()
     snap = get_task_result(r.id)
+    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == "hi-async"
 
 
-def test_blocking_worker_drains_then_stops():
-    # Exercises the blocking (live-worker) path deterministically — no sleeps: the stopper
-    # awaits each task to a terminal state (SDK await_task_result), THEN calls stop_worker()
-    # (the flag start_worker's loop polls). run_blocking_worker returns once stopped.
+def test_blocking_worker_drains_then_stops() -> None:
+    # Exercises the blocking (live-worker) path deterministically — no sleeps:
+    # the stopper awaits each task to a terminal state (SDK await_task_result),
+    # THEN calls stop_worker() (the flag start_worker's loop polls).
+    # run_blocking_worker returns once stopped.
     call_command("absurd_sync_queues")
     results = [make_group.enqueue(f"blk-{i}") for i in range(3)]
     task_ids = [r.id.rsplit(":", 1)[-1] for r in results]
 
-    async def drive():
+    async def drive() -> None:
         async with aworker_client(backend(), "default") as client:
 
-            async def stopper():
+            async def stopper() -> None:
                 for tid in task_ids:
                     await client.await_task_result(tid)
                 client.stop_worker()
@@ -380,12 +414,15 @@ def test_blocking_worker_drains_then_stops():
     assert Group.objects.filter(name__startswith="blk-").count() == 3
 
 
-def test_non_task_name_defers_not_crashes():
-    # A name that IMPORTS but is not a Task (asleep is the asyncio.sleep alias in atasks)
-    # -> LazyTaskRegistry resolves it, sees it's not a Task, defers (state not failed).
+def test_non_task_name_defers_not_crashes() -> None:
+    # A name that IMPORTS but is not a Task (asleep is the asyncio.sleep alias
+    # in atasks) -> LazyTaskRegistry resolves it, sees it's not a Task, defers
+    # (state not failed).
     call_command("absurd_sync_queues")
     spawn = get_absurd_client("default").spawn(
         "tests.atasks.asleep", {"args": [], "kwargs": {}}, queue="default"
     )
     run_absurd_worker()
-    assert get_task_result(spawn["task_id"]).state != "failed"
+    snap = get_task_result(spawn["task_id"])
+    assert snap is not None
+    assert snap.state != "failed"

--- a/tests/multidb/settings.py
+++ b/tests/multidb/settings.py
@@ -1,20 +1,21 @@
 import os
+import typing as t
 
 from tests.settings import *  # noqa: F403
 
-TASKS = {
-    "default": {
-        "BACKEND": "django_absurd.backends.AbsurdBackend",
-        "OPTIONS": {"DATABASE": "absurd"},  # type: ignore[dict-item]
-    },
+absurd_task: dict[str, t.Any] = {
+    "BACKEND": "django_absurd.backends.AbsurdBackend",
+    "OPTIONS": {"DATABASE": "absurd"},
 }
+TASKS = {"default": absurd_task}
 DATABASE_ROUTERS = ["django_absurd.routers.AbsurdRouter"]
 
-# DATABASES is COMPLETELY redefined here (not derived from tests.settings): two Postgres
-# aliases on the same compose server, each with its own _multidb-affixed TEST.NAME so this
-# suite's test DBs never collide with the main suite's (--reuse-db leftovers). The main
-# suite migrates django_absurd onto its default test DB; here "default" must stay clean of
-# it, which the distinct test DB guarantees. No sqlite (this suite never uses it).
+# DATABASES is COMPLETELY redefined here (not derived from tests.settings): two
+# Postgres aliases on the same compose server, each with its own _multidb-affixed
+# TEST.NAME so this suite's test DBs never collide with the main suite's (--reuse-db
+# leftovers). The main suite migrates django_absurd onto its default test DB; here
+# "default" must stay clean of it, which the distinct test DB guarantees. No sqlite
+# (this suite never uses it).
 pg = {
     "ENGINE": "django.db.backends.postgresql",
     "USER": os.environ.get("PGUSER", "postgres"),

--- a/tests/multidb/test_check.py
+++ b/tests/multidb/test_check.py
@@ -1,13 +1,20 @@
+import typing as t
+
 import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
+from pytest_django.fixtures import SettingsWrapper
 
 pytestmark = pytest.mark.django_db(databases=["default", "absurd"])
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def run_absurd_check(capsys, *args, **kwargs):
+def run_absurd_check(
+    capsys: pytest.CaptureFixture[str],
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> str:
     try:
         call_command("check", "django_absurd", *args, **kwargs)
     except SystemCheckError as exc:
@@ -17,7 +24,10 @@ def run_absurd_check(capsys, *args, **kwargs):
     return cap.out + cap.err
 
 
-def test_storage_mode_drift_detected_on_non_default_alias(settings, capsys):
+def test_storage_mode_drift_detected_on_non_default_alias(
+    settings: SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     # W002 now fires only on storage_mode drift (immutable; never self-heals). This
     # locks the alias threading through query_queue_state on a non-default database.
     settings.TASKS = {

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -1,6 +1,11 @@
+import typing as t
+
 import pytest
 from django.core.management import call_command
 from django.db import connections
+
+if t.TYPE_CHECKING:
+    import pytest_django.fixtures
 
 from django_absurd.models import Queue
 from django_absurd.routers import AbsurdRouter
@@ -10,23 +15,24 @@ pytestmark = pytest.mark.django_db(databases=["default", "absurd"])
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def absurd_schema_present(alias):
+def absurd_schema_present(alias: str) -> bool:
     with connections[alias].cursor() as cur:
         cur.execute("SELECT to_regnamespace('absurd') IS NOT NULL")
-        return cur.fetchone()[0]
+        row = cur.fetchone()
+        return bool(row[0]) if row else False
 
 
-def test_orm_routes_to_alias():
+def test_orm_routes_to_alias() -> None:
     assert Queue.objects.db == "absurd"
     assert list(Queue.objects.all()) == []
 
 
-def test_schema_provisioned_on_alias_not_default():
+def test_schema_provisioned_on_alias_not_default() -> None:
     assert absurd_schema_present("absurd") is True
     assert absurd_schema_present("default") is False
 
 
-def test_allow_migrate_contract():
+def test_allow_migrate_contract() -> None:
     router = AbsurdRouter()
     assert router.allow_migrate("absurd", "django_absurd") is True
     assert router.allow_migrate("default", "django_absurd") is False
@@ -35,13 +41,15 @@ def test_allow_migrate_contract():
     assert router.allow_migrate("absurd", "auth") is None
 
 
-def test_db_for_read_write_route_django_absurd():
+def test_db_for_read_write_route_django_absurd() -> None:
     router = AbsurdRouter()
     assert router.db_for_read(Queue) == "absurd"
     assert router.db_for_write(Queue) == "absurd"
 
 
-def test_sync_command_honors_alias(settings):
+def test_sync_command_honors_alias(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,

--- a/tests/pg_cron/conftest.py
+++ b/tests/pg_cron/conftest.py
@@ -1,9 +1,13 @@
+from collections.abc import Iterator
+
 import pytest
 from django.db import connection
 
 
 @pytest.fixture(autouse=True)
-def _clear_pg_cron_jobs(request):
+def _clear_pg_cron_jobs(
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
     """Unschedule every pg_cron job after the test — the test DB is ours, so blow the
     whole ``cron.job`` catalog away rather than namespacing to ``absurd:%``. Set-based
     via cron.unschedule (pg_cron's supported API — not a raw DELETE/TRUNCATE, which

--- a/tests/pg_cron/settings.py
+++ b/tests/pg_cron/settings.py
@@ -9,7 +9,8 @@ DATABASES["default"]["PORT"] = os.environ.get("PGPORT_PGCRON", "5434")  # noqa: 
 # TEST db name must equal db_pg_cron's cron.database_name so CREATE EXTENSION works.
 DATABASES["default"]["TEST"] = {"NAME": "absurd_test_pg_cron"}  # noqa: F405
 
-# A second alias on the SAME physical DB (identical TEST NAME → the test runner mirrors
-# it, so it isn't created/migrated twice). Its only job is to exercise the cross-database
-# guard: a ScheduledTask write via this alias has using != the absurd database.
+# A second alias on the SAME physical DB (identical TEST NAME → the test runner
+# mirrors it, so it isn't created/migrated twice). Its only job is to exercise the
+# cross-database guard: a ScheduledTask write via this alias has using != the absurd
+# database.
 DATABASES["replica"] = dict(DATABASES["default"])  # noqa: F405

--- a/tests/pg_cron/test_absurd_sync_crons_command.py
+++ b/tests/pg_cron/test_absurd_sync_crons_command.py
@@ -2,6 +2,7 @@ import io
 import sys
 
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
@@ -13,7 +14,9 @@ from tests.pg_cron.utils import build_beat_tasks, build_pg_cron_tasks
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def test_sync_crons_command_malformed_schedule_raises_commanderror(settings):
+def test_sync_crons_command_malformed_schedule_raises_commanderror(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """A SCHEDULE entry missing task/cron must surface as a clean CommandError,
     not a raw KeyError traceback."""
     settings.TASKS = build_pg_cron_tasks({"broken": {}})
@@ -21,7 +24,10 @@ def test_sync_crons_command_malformed_schedule_raises_commanderror(settings):
         call_command("absurd_sync_crons")
 
 
-def test_sync_crons_command_creates_cron_jobs(settings, capsys):
+def test_sync_crons_command_creates_cron_jobs(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
@@ -39,7 +45,10 @@ def test_sync_crons_command_creates_cron_jobs(settings, capsys):
     assert out.strip() == "Synced 2 cron(s); pruned 0 — backend 'default'."
 
 
-def test_sync_crons_command_writes_summary_to_stdout(settings, capsys):
+def test_sync_crons_command_writes_summary_to_stdout(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -49,7 +58,9 @@ def test_sync_crons_command_writes_summary_to_stdout(settings, capsys):
     assert out.strip() == "Synced 1 cron(s); pruned 0 — backend 'default'."
 
 
-def test_sync_crons_command_refuses_when_scheduler_is_beat(settings):
+def test_sync_crons_command_refuses_when_scheduler_is_beat(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_beat_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -57,7 +68,10 @@ def test_sync_crons_command_refuses_when_scheduler_is_beat(settings):
         call_command("absurd_sync_crons")
 
 
-def test_sync_crons_command_is_idempotent(settings, capsys):
+def test_sync_crons_command_is_idempotent(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -67,7 +81,10 @@ def test_sync_crons_command_is_idempotent(settings, capsys):
     assert len(ScheduledTask.pg_cron.get_managed_jobs()) == 1
 
 
-def test_teardown_removes_owned_cron_jobs(settings, capsys):
+def test_teardown_removes_owned_cron_jobs(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
@@ -90,7 +107,10 @@ def test_teardown_removes_owned_cron_jobs(settings, capsys):
     )
 
 
-def test_teardown_allowed_when_scheduler_is_beat(settings, capsys):
+def test_teardown_allowed_when_scheduler_is_beat(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     settings.TASKS = build_beat_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -103,7 +123,9 @@ def test_teardown_allowed_when_scheduler_is_beat(settings, capsys):
     )
 
 
-def test_teardown_command_deletes_admin_job_and_row_after_confirmation(settings):
+def test_teardown_command_deletes_admin_job_and_row_after_confirmation(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_pg_cron_tasks({})
     ScheduledTask.objects.create(
         source="a",
@@ -125,7 +147,9 @@ def test_teardown_command_deletes_admin_job_and_row_after_confirmation(settings)
     assert not ScheduledTask.objects.filter(source="a", name="killme").exists()
 
 
-def test_teardown_admin_schedule_does_not_resurrect_on_next_sync(settings):
+def test_teardown_admin_schedule_does_not_resurrect_on_next_sync(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """--teardown deletes the admin rows, so the next reconcile (which re-emits admin
     rows) has nothing to resurrect — the destructive teardown is terminal."""
     settings.TASKS = build_pg_cron_tasks({})
@@ -144,7 +168,11 @@ def test_teardown_admin_schedule_does_not_resurrect_on_next_sync(settings):
 
 
 @pytest.mark.parametrize("stdin_text", ["", "no\n"])
-def test_teardown_command_aborts_without_confirmation(settings, capsys, stdin_text):
+def test_teardown_command_aborts_without_confirmation(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+    stdin_text: str,
+) -> None:
     # "no\n" declines; "" is a non-interactive EOF (CI / docker exec -T) — both abort
     # without touching the job
     settings.TASKS = build_pg_cron_tasks({})

--- a/tests/pg_cron/test_admin/test_admin_checks.py
+++ b/tests/pg_cron/test_admin/test_admin_checks.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from django.contrib import admin
 from django.core import checks
@@ -8,18 +10,20 @@ from django_absurd.pg_cron.models import ScheduledTask
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def test_scheduledtask_admin_is_registered():
+def test_scheduledtask_admin_is_registered() -> None:
     """Guard the check test below: it only catches a bad field if the admin is
     actually registered when checks run."""
     assert admin.site._registry.get(ScheduledTask).__class__ is ScheduledTaskAdmin
 
 
-def test_scheduledtask_admin_has_no_config_errors():
+def test_scheduledtask_admin_has_no_config_errors() -> None:
     """The hand-listed list_display/fieldsets field names must reference real
     fields — Django surfaces a typo only as admin.E0* under the check framework,
     and registration happens under contextlib.suppress at import, so without this
     guard a bad field name would ship silently."""
-    admin_errors = [
-        e for e in checks.run_checks(tags=["admin"]) if e.id.startswith("admin.E")
+    admin_errors: list[t.Any] = [
+        e
+        for e in checks.run_checks(tags=["admin"])
+        if e.id is not None and e.id.startswith("admin.E")
     ]
     assert admin_errors == [], admin_errors

--- a/tests/pg_cron/test_admin/test_registration.py
+++ b/tests/pg_cron/test_admin/test_registration.py
@@ -1,7 +1,10 @@
+import typing as t
+
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib import admin as djadmin
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import AbstractBaseUser, Permission
+from django.test import Client
 from django.urls import reverse_lazy
 
 from django_absurd.admin import resolve_admin_sites
@@ -12,34 +15,40 @@ from django_absurd.pg_cron.admin import (
 from django_absurd.pg_cron.models import ScheduledTask
 from tests.admin import custom_site, gated_site, other_site
 
+if t.TYPE_CHECKING:
+    import pytest_django.fixtures
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 INDEX = reverse_lazy("admin:index")
 BACKEND = "django_absurd.backends.AbsurdBackend"
 
 
-def test_scheduledtask_registered_on_default_site():
+def test_scheduledtask_registered_on_default_site() -> None:
     registered = {m._meta.model_name for m in djadmin.site._registry}
     assert "scheduledtask" in registered
 
 
 def test_staff_user_with_view_permission_sees_scheduledtask_in_index(
-    client, staff_user
-):
-    staff_user.user_permissions.add(
+    client: Client, staff_user: AbstractBaseUser
+) -> None:
+    user: t.Any = staff_user
+    user.user_permissions.add(
         Permission.objects.get(
             codename="view_scheduledtask",
             content_type__app_label="django_absurd_pg_cron",
         )
     )
-    client.force_login(staff_user)
+    client.force_login(user)
     soup = BeautifulSoup(client.get(INDEX).content, "html.parser")
     assert (
         soup.select_one('a[href$="/django_absurd_pg_cron/scheduledtask/"]') is not None
     )
 
 
-def test_custom_admin_site_registration(settings):
+def test_custom_admin_site_registration(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": BACKEND,
@@ -50,7 +59,9 @@ def test_custom_admin_site_registration(settings):
     assert custom_site.is_registered(ScheduledTask)
 
 
-def test_autoregister_skips_when_enable_admin_false(settings):
+def test_autoregister_skips_when_enable_admin_false(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     gated_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {
         "default": {
@@ -65,7 +76,9 @@ def test_autoregister_skips_when_enable_admin_false(settings):
     assert not gated_site.is_registered(ScheduledTask)
 
 
-def test_register_is_idempotent(settings):
+def test_register_is_idempotent(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     other_site._registry.pop(ScheduledTask, None)
     register_scheduled_task_admin([other_site])
     register_scheduled_task_admin(
@@ -74,14 +87,18 @@ def test_register_is_idempotent(settings):
     assert other_site.is_registered(ScheduledTask)
 
 
-def test_autoregister_skips_when_no_absurd_backend(settings):
+def test_autoregister_skips_when_no_absurd_backend(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     gated_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {}
     autoregister_scheduled_task_admin()  # backend is None -> no-op, no raise
     assert not gated_site.is_registered(ScheduledTask)
 
 
-def test_autoregister_registers_when_enable_admin_true(settings):
+def test_autoregister_registers_when_enable_admin_true(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     other_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {
         "default": {

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -1,10 +1,16 @@
+import typing as t
 from html import unescape
 
 import pytest
 from bs4 import BeautifulSoup
-from django.contrib.auth.models import Permission
+from bs4.element import ResultSet
+from django.contrib.auth.models import Permission, User
 from django.core.management import call_command
+from django.test import Client
 from django.urls import reverse, reverse_lazy
+
+if t.TYPE_CHECKING:
+    import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
@@ -53,28 +59,36 @@ CHANGE_PAYLOAD = {
 }
 
 
-def seed(settings):
+def seed(settings: "pytest_django.fixtures.SettingsWrapper") -> None:
     settings.TASKS = TASKS
     call_command("absurd_sync_queues")
     sync_crons(get_absurd_backends()["default"])
 
 
-def rows(response):
+def rows(response: t.Any) -> ResultSet[t.Any]:
     soup = BeautifulSoup(response.content, "html.parser")
     return soup.select("#result_list tbody tr")
 
 
-def get_change_url(pk):
+def get_change_url(pk: t.Any) -> str:
     return reverse("admin:django_absurd_pg_cron_scheduledtask_change", args=[pk])
 
 
-def test_changelist_renders_one_row_per_schedule(settings, client, admin_user):
+def test_changelist_renders_one_row_per_schedule(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     assert len(rows(client.get(CHANGELIST))) == 2
 
 
-def test_changelist_shows_expected_columns(settings, client, admin_user):
+def test_changelist_shows_expected_columns(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     body = client.get(CHANGELIST).content.decode()
@@ -83,7 +97,11 @@ def test_changelist_shows_expected_columns(settings, client, admin_user):
     assert "tests.tasks.add" in body
 
 
-def test_queue_filter_renders_and_narrows(settings, client, admin_user):
+def test_queue_filter_renders_and_narrows(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     soup = BeautifulSoup(client.get(CHANGELIST).content, "html.parser")
@@ -93,15 +111,21 @@ def test_queue_filter_renders_and_narrows(settings, client, admin_user):
     assert "hourly" in narrowed[0].get_text()
 
 
-def test_search_by_name_narrows(settings, client, admin_user):
+def test_search_by_name_narrows(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     assert len(rows(client.get(CHANGELIST, {"q": "nightly"}))) == 1
 
 
 def test_create_resolves_all_spawn_options_and_is_disabled(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     response = client.post(
@@ -127,8 +151,10 @@ def test_create_resolves_all_spawn_options_and_is_disabled(
 
 
 def test_create_with_save_and_add_another_returns_to_the_add_view(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # "Save and add another" must NOT force the review-on-change redirect — it lands
     # back on the add view like Django's default.
     seed(settings)
@@ -147,7 +173,11 @@ def test_create_with_save_and_add_another_returns_to_the_add_view(
     assert response["Location"] == str(ADD)
 
 
-def test_add_view_renders_only_the_minimal_fields(settings, client, admin_user):
+def test_add_view_renders_only_the_minimal_fields(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     soup = BeautifulSoup(client.get(ADD).content, "html.parser")
@@ -158,10 +188,15 @@ def test_add_view_renders_only_the_minimal_fields(settings, client, admin_user):
     assert "queue" not in names
 
 
-def narrow_to_default_queue_only(settings):
-    """Re-declare the backend with only the "default" queue, leaving tests.tasks (and
-    its "other"/"reports"-queued tasks) already imported — so a create POST resolves a
-    task against a backend that no longer declares that task's queue."""
+def narrow_to_default_queue_only(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
+    """Re-declare the backend with only "default" queue.
+
+    Leaves tests.tasks (and its "other"/"reports"-queued tasks) already imported — so a
+    create POST resolves a task against a backend that no longer declares that task's
+    queue.
+    """
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -172,8 +207,10 @@ def narrow_to_default_queue_only(settings):
 
 
 def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # on_reports' own queue ("reports") resolves fine, but the backend no longer
     # declares it, so the model rejects the resolved queue. queue isn't a field on the
     # 4-field create form, so the form must re-home that queue-keyed error onto the form
@@ -197,8 +234,10 @@ def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
 
 
 def test_create_with_unimportable_task_is_form_error_not_created(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # An unimportable task path is rejected on the task field before any spawn-option
     # resolution runs (so build_scheduled_fields never sees a bad path), and nothing is
     # created.
@@ -221,8 +260,10 @@ def test_create_with_unimportable_task_is_form_error_not_created(
 
 
 def test_create_with_non_task_target_is_form_error_not_created(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # A path that imports but isn't a Django task is rejected on the task field (so
     # resolution, which reads task-only attributes, is never reached).
     seed(settings)
@@ -242,8 +283,10 @@ def test_create_with_non_task_target_is_form_error_not_created(
 
 
 def test_create_with_blank_task_skips_resolution_and_is_required_error(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # A blank task never reaches cleaned_data, so spawn-option resolution is skipped
     # entirely; the form reports the field as required and creates nothing.
     seed(settings)
@@ -257,7 +300,11 @@ def test_create_with_blank_task_skips_resolution_and_is_required_error(
     assert not ScheduledTask.objects.filter(name="notask").exists()
 
 
-def test_create_with_bad_cron_is_form_error_not_created(settings, client, admin_user):
+def test_create_with_bad_cron_is_form_error_not_created(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     response = client.post(
@@ -273,7 +320,11 @@ def test_create_with_bad_cron_is_form_error_not_created(settings, client, admin_
     assert not ScheduledTask.objects.filter(name="badcron").exists()
 
 
-def test_create_and_sync_produce_identical_spawn_columns(settings, client, admin_user):
+def test_create_and_sync_produce_identical_spawn_columns(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # parity: admin-creating a task resolves the same spawn columns as running
     # sync_crons over a settings SCHEDULE of that same task (the two write lanes).
     settings.TASKS = {
@@ -321,7 +372,11 @@ def test_create_and_sync_produce_identical_spawn_columns(settings, client, admin
         assert getattr(admin_row, col) == getattr(settings_row, col)
 
 
-def test_add_link_present_and_add_view_renders(settings, client, admin_user):
+def test_add_link_present_and_add_view_renders(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     changelist = client.get(CHANGELIST)
@@ -333,8 +388,10 @@ def test_add_link_present_and_add_view_renders(settings, client, admin_user):
 
 
 def test_add_view_backend_field_offers_only_pg_cron_backends(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)  # a single pg_cron backend "default"
     client.force_login(admin_user)
     response = client.get(ADD)
@@ -348,7 +405,11 @@ def test_add_view_backend_field_offers_only_pg_cron_backends(
     assert options == ["default"]
 
 
-def test_add_view_alias_field_labeled_alias(settings, client, admin_user):
+def test_add_view_alias_field_labeled_alias(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # The field is model-named "alias" everywhere; the add form must not relabel it to
     # "Backend" — the readonly change view shows "Alias", so both must agree.
     seed(settings)
@@ -359,11 +420,15 @@ def test_add_view_alias_field_labeled_alias(settings, client, admin_user):
     assert label.get_text(strip=True).rstrip(":") == "Alias"
 
 
-def test_add_view_cron_help_renders_pg_cron_link_as_html(settings, client, admin_user):
+def test_add_view_cron_help_renders_pg_cron_link_as_html(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # the cron field's help text embeds an <a> to the pg_cron docs; Django form
     # help_text is not auto-escaped, so it must reach the page as a real anchor (an
-    # escaped &lt;a&gt; would be inert text, not a clickable link). BeautifulSoup finding
-    # it as an <a> element inside the cron row proves it rendered as HTML.
+    # escaped &lt;a&gt; would be inert text, not a clickable link). BeautifulSoup
+    # finding it as an <a> element inside the cron row proves it rendered as HTML.
     seed(settings)
     client.force_login(admin_user)
     soup = BeautifulSoup(client.get(ADD).content, "html.parser")
@@ -374,13 +439,22 @@ def test_add_view_cron_help_renders_pg_cron_link_as_html(settings, client, admin
     assert link.get_text() == "pg_cron"
 
 
-def create_scheduled_task(client, name, task="tests.tasks.add", cron="0 3 * * *"):
-    """Create a source="admin" row through the minimal create form and return its pk."""
+def create_scheduled_task(
+    client: Client,
+    name: str,
+    task: str = "tests.tasks.add",
+    cron: str = "0 3 * * *",
+) -> t.Any:
+    """Create source="admin" row through minimal create form; return its pk."""
     client.post(ADD, {"alias": "default", "name": name, "task": task, "cron": cron})
     return ScheduledTask.objects.get(name=name).pk
 
 
-def test_change_view_shows_resolved_default_max_attempts(settings, client, admin_user):
+def test_change_view_shows_resolved_default_max_attempts(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # The create form resolves max_attempts from the task/backend (here the backend
     # default, 5); the change form then renders that resolved value editable.
     seed(settings)
@@ -393,8 +467,10 @@ def test_change_view_shows_resolved_default_max_attempts(settings, client, admin
 
 
 def test_posting_add_creates_admin_schedule_and_schedules_job(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     response = client.post(ADD, {**CHANGE_PAYLOAD, "name": "fromadmin"})
@@ -404,8 +480,10 @@ def test_posting_add_creates_admin_schedule_and_schedules_job(
 
 
 def test_posting_add_with_tampered_source_is_forced_to_admin(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # source is a hidden, pinned field: a crafted POST setting source="s" (settings)
     # must not create a settings-owned row via the writable admin.
     seed(settings)
@@ -415,7 +493,11 @@ def test_posting_add_with_tampered_source_is_forced_to_admin(
     assert ScheduledTask.objects.get(name="tamper").source == "a"
 
 
-def test_editing_over_long_name_row_is_form_error_not_500(settings, client, admin_user):
+def test_editing_over_long_name_row_is_form_error_not_500(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # A row whose name overflows the 63-byte jobname budget (created out-of-band, so it
     # skipped full_clean) must surface a form error on edit, not HTTP 500 — clean()
     # keys the jobname-length error to NON_FIELD_ERRORS, not the read-only "name" field.
@@ -437,7 +519,11 @@ def test_editing_over_long_name_row_is_form_error_not_500(settings, client, admi
     assert "Postgres silently truncates longer names)." in content
 
 
-def test_editing_blank_args_kwargs_falls_back_to_defaults(settings, client, admin_user):
+def test_editing_blank_args_kwargs_falls_back_to_defaults(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # queue="reports" (declared) so the edit exercises the "stored queue is still a
     # valid choice" path (no injection) alongside the blank args/kwargs fallback.
     seed(settings)
@@ -455,8 +541,10 @@ def test_editing_blank_args_kwargs_falls_back_to_defaults(settings, client, admi
 
 
 def test_posting_duplicate_admin_name_is_form_error_not_500(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     client.post(ADD, {**CHANGE_PAYLOAD, "name": "dup"})
@@ -470,8 +558,10 @@ def test_posting_duplicate_admin_name_is_form_error_not_500(
 
 
 def test_posting_add_with_invalid_cron_shows_pg_crons_message(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     response = client.post(ADD, {**CHANGE_PAYLOAD, "name": "badcron", "cron": "1 hour"})
@@ -481,7 +571,11 @@ def test_posting_add_with_invalid_cron_shows_pg_crons_message(
     assert not ScheduledTask.objects.filter(name="badcron").exists()
 
 
-def test_settings_schedule_detail_is_readonly(settings, client, admin_user):
+def test_settings_schedule_detail_is_readonly(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     pk = ScheduledTask.objects.get(name="hourly").pk  # a settings row
     client.force_login(admin_user)
@@ -493,8 +587,10 @@ def test_settings_schedule_detail_is_readonly(settings, client, admin_user):
 
 
 def test_admin_schedule_edit_form_cron_editable_name_immutable(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     client.post(ADD, {**CHANGE_PAYLOAD, "name": "editable"})
@@ -509,8 +605,10 @@ def test_admin_schedule_edit_form_cron_editable_name_immutable(
 
 
 def test_posting_edit_reschedules_the_job_with_the_new_cron(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     client.post(ADD, {**CHANGE_PAYLOAD, "name": "reschedule", "cron": "0 3 * * *"})
@@ -521,13 +619,17 @@ def test_posting_edit_reschedules_the_job_with_the_new_cron(
         {**CHANGE_PAYLOAD, "task": "tests.tasks.add", "cron": "30 6 * * *"},
     )
     assert response.status_code == 302
-    _, schedule, _, _ = ScheduledTask.pg_cron.get_job("default", "reschedule", "a")
+    job = ScheduledTask.pg_cron.get_job("default", "reschedule", "a")
+    assert job is not None
+    _, schedule, _, _ = job
     assert schedule == "30 6 * * *"
 
 
 def test_deleting_admin_schedule_via_admin_unschedules_the_job(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     client.post(ADD, {**CHANGE_PAYLOAD, "name": "deleteme"})
@@ -542,8 +644,10 @@ def test_deleting_admin_schedule_via_admin_unschedules_the_job(
 
 
 def test_deleting_settings_schedule_via_admin_is_forbidden(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     pk = ScheduledTask.objects.get(name="hourly").pk  # a settings row
     client.force_login(admin_user)
@@ -553,8 +657,10 @@ def test_deleting_settings_schedule_via_admin_is_forbidden(
 
 
 def test_editing_admin_schedule_after_backend_flip_is_form_error_not_500(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     # an admin row whose backend later switched off pg_cron must surface a form
     # error on edit, not crash (the alias error routes to NON_FIELD_ERRORS since
     # alias is a read-only field on the change form)
@@ -595,7 +701,11 @@ def test_editing_admin_schedule_after_backend_flip_is_form_error_not_500(
     )
 
 
-def test_change_form_rejects_a_blank_queue(settings, client, admin_user):
+def test_change_form_rejects_a_blank_queue(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     client.post(
@@ -614,8 +724,10 @@ def test_change_form_rejects_a_blank_queue(settings, client, admin_user):
 
 
 def test_change_view_queue_is_a_dropdown_of_declared_queues(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)  # QUEUES: default, other, reports
     client.force_login(admin_user)
     pk = create_scheduled_task(client, name="queuedropdown")
@@ -624,7 +736,11 @@ def test_change_view_queue_is_a_dropdown_of_declared_queues(
     assert values == ["", "default", "other", "reports"]
 
 
-def test_change_view_retry_kind_is_a_dropdown(settings, client, admin_user):
+def test_change_view_retry_kind_is_a_dropdown(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     pk = create_scheduled_task(client, name="retrykind")
@@ -634,8 +750,10 @@ def test_change_view_retry_kind_is_a_dropdown(settings, client, admin_user):
 
 
 def test_change_view_cancellation_fields_are_number_inputs(
-    settings, client, admin_user
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    admin_user: User,
+) -> None:
     seed(settings)
     client.force_login(admin_user)
     pk = create_scheduled_task(client, name="cancellation")
@@ -644,13 +762,21 @@ def test_change_view_cancellation_fields_are_number_inputs(
     assert soup.select_one('input[name="cancellation_max_delay"]') is not None
 
 
-def test_add_forbidden_for_staff_without_permission(settings, client, staff_user):
+def test_add_forbidden_for_staff_without_permission(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    staff_user: User,
+) -> None:
     seed(settings)
     client.force_login(staff_user)
     assert client.get(ADD).status_code == 403
 
 
-def test_add_allowed_for_staff_with_permission(settings, client, staff_user):
+def test_add_allowed_for_staff_with_permission(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    client: Client,
+    staff_user: User,
+) -> None:
     staff_user.user_permissions.add(
         Permission.objects.get(
             codename="add_scheduledtask",

--- a/tests/pg_cron/test_cleanup_schedule.py
+++ b/tests/pg_cron/test_cleanup_schedule.py
@@ -1,4 +1,7 @@
+import typing as t
+
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.db import connection
 
@@ -9,7 +12,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_cleanup_tasks(cleanup_schedule):
+def build_cleanup_tasks(cleanup_schedule: str) -> dict[str, t.Any]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -22,16 +25,19 @@ def build_cleanup_tasks(cleanup_schedule):
     }
 
 
-def fetch_cleanup_row():
+def fetch_cleanup_row() -> tuple[str, str, str] | None:
     with connection.cursor() as cur:
         cur.execute(
             "select jobname, schedule, command from cron.job where jobname = %s",
             ["absurd_cleanup_all"],
         )
-        return cur.fetchone()
+        row = cur.fetchone()
+        return t.cast("tuple[str, str, str] | None", row)
 
 
-def test_sync_schedules_absurd_cleanup_all_job(settings):
+def test_sync_schedules_absurd_cleanup_all_job(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
 
     call_command("absurd_sync_crons")
@@ -43,7 +49,9 @@ def test_sync_schedules_absurd_cleanup_all_job(settings):
     )
 
 
-def test_cleanup_job_is_outside_managed_namespace(settings):
+def test_cleanup_job_is_outside_managed_namespace(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
 
     call_command("absurd_sync_crons")
@@ -51,7 +59,9 @@ def test_cleanup_job_is_outside_managed_namespace(settings):
     assert ScheduledTask.pg_cron.get_managed_jobs() == []
 
 
-def test_sync_unschedules_cleanup_job_when_cleanup_dropped(settings):
+def test_sync_unschedules_cleanup_job_when_cleanup_dropped(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
     call_command("absurd_sync_crons")
     assert fetch_cleanup_row() is not None
@@ -70,7 +80,9 @@ def test_sync_unschedules_cleanup_job_when_cleanup_dropped(settings):
     assert fetch_cleanup_row() is None
 
 
-def test_cleanup_all_job_survives_flush(settings):
+def test_cleanup_all_job_survives_flush(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
 
     call_command("absurd_sync_crons")
@@ -86,7 +98,9 @@ def test_cleanup_all_job_survives_flush(settings):
     )
 
 
-def test_teardown_removes_cleanup_job(settings):
+def test_teardown_removes_cleanup_job(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
     call_command("absurd_sync_crons")
     assert fetch_cleanup_row() is not None
@@ -96,7 +110,9 @@ def test_teardown_removes_cleanup_job(settings):
     assert fetch_cleanup_row() is None
 
 
-def test_teardown_reclaims_cleanup_job_without_cleanup_option(settings):
+def test_teardown_reclaims_cleanup_job_without_cleanup_option(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,

--- a/tests/pg_cron/test_cross_source_coexistence.py
+++ b/tests/pg_cron/test_cross_source_coexistence.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_django.fixtures
 
 from django_absurd.pg_cron.models import ScheduledTask
 from tests.pg_cron.utils import build_pg_cron_tasks
@@ -6,7 +7,9 @@ from tests.pg_cron.utils import build_pg_cron_tasks
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def test_settings_and_admin_schedule_may_share_a_name(settings):
+def test_settings_and_admin_schedule_may_share_a_name(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """Namespaced by source, a settings and an admin schedule with the same
     (alias, name) coexist as two distinct pg_cron jobs — no clash, no double-fire."""
     settings.TASKS = build_pg_cron_tasks({})
@@ -28,7 +31,9 @@ def test_settings_and_admin_schedule_may_share_a_name(settings):
     assert ScheduledTask.pg_cron.get_job("default", "nightly", "a") is not None
 
 
-def test_revalidating_a_saved_admin_schedule_does_not_self_clash(settings):
+def test_revalidating_a_saved_admin_schedule_does_not_self_clash(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """full_clean's uniqueness check excludes the row's own pk, so re-validating an
     existing admin schedule (e.g. after editing a field) does not clash with itself."""
     settings.TASKS = build_pg_cron_tasks({})

--- a/tests/pg_cron/test_orm_models.py
+++ b/tests/pg_cron/test_orm_models.py
@@ -1,7 +1,7 @@
 from django.apps import apps as global_apps
 
 
-def test_pg_cron_model_in_global_registry():
+def test_pg_cron_model_in_global_registry() -> None:
     pg_cron_names = {
         m.__name__
         for m in global_apps.get_models()

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -1,6 +1,9 @@
 """Static E007 checks for SCHEDULER="pg_cron" entries."""
 
+import typing as t
+
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
@@ -13,11 +16,19 @@ E007_MSG = "django-absurd: invalid SCHEDULE entry."
 # at module level; importing any task from that module validates those queue names
 # against the current backend. All tests that import from tests.tasks must
 # therefore declare at least "other" and "reports" alongside "default".
-BASE_QUEUES: dict = {"default": {}, "other": {}, "reports": {}}
+BASE_QUEUES: dict[str, dict[str, t.Any]] = {
+    "default": {},
+    "other": {},
+    "reports": {},
+}
 
 
-def run_pg_cron_check(settings, capsys, options):
-    """Drive check with given scheduler/queues/schedule and return captured output.
+def run_pg_cron_check(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+    options: dict[str, t.Any],
+) -> str:
+    """Drive check with given scheduler/queues/schedule and return output.
 
     options keys: scheduler, alias (default "default"), queues, schedule.
     """
@@ -41,9 +52,14 @@ def run_pg_cron_check(settings, capsys, options):
     return cap.out + cap.err
 
 
-def test_pg_cron_task_import_raise_reports_e007_not_crash(settings, capsys):
-    """A scheduled task whose module raises a non-ImportError at import must
-    surface as E007, not crash `manage.py check` with a raw traceback."""
+def test_pg_cron_task_import_raise_reports_e007_not_crash(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A scheduled task whose module raises non-ImportError on import.
+
+    Must surface as E007, not crash `manage.py check` with a raw traceback.
+    """
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -63,10 +79,16 @@ def test_pg_cron_task_import_raise_reports_e007_not_crash(settings, capsys):
 
 
 @pytest.mark.parametrize("cron", ["*/30 * * * * *", "30 seconds"])
-def test_pg_cron_cron_grammar_not_checked(settings, capsys, cron):
-    """pg_cron cron grammar is DB-authoritative: neither a '[1-59] seconds' interval
-    nor a 6-field expression is rejected at check time — cron.schedule validates it
-    at sync (croniter is the beat-only validator)."""
+def test_pg_cron_cron_grammar_not_checked(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+    cron: str,
+) -> None:
+    """pg_cron cron grammar is DB-authoritative.
+
+    Neither '[1-59] seconds' interval nor 6-field expression rejected at check
+    time — cron.schedule validates at sync (croniter is beat-only validator).
+    """
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -79,8 +101,11 @@ def test_pg_cron_cron_grammar_not_checked(settings, capsys, cron):
     assert "absurd.E007" not in out
 
 
-def test_pg_cron_bad_name_charset_rejected(settings, capsys):
-    """Schedule name with spaces/special chars must be rejected under pg_cron."""
+def test_pg_cron_bad_name_charset_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Schedule name with spaces/special chars rejected under pg_cron."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -99,8 +124,11 @@ def test_pg_cron_bad_name_charset_rejected(settings, capsys):
     assert "Schedule name contains characters other than [A-Za-z0-9_-]." in out
 
 
-def test_pg_cron_jobname_too_long_rejected(settings, capsys):
-    """Composed jobname exceeding 63 bytes must be rejected under pg_cron."""
+def test_pg_cron_jobname_too_long_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Composed jobname exceeding 63 bytes rejected under pg_cron."""
     # alias "default" + name long enough to push absurd:s:default:<name> > 63 bytes
     # "absurd:s:default:" = 17 chars, so name needs > 46 chars
     long_name = "a" * 47
@@ -122,11 +150,14 @@ def test_pg_cron_jobname_too_long_rejected(settings, capsys):
     assert "job name exceeds 63 bytes" in out
 
 
-def test_pg_cron_undeclared_task_queue_rejected(settings, capsys):
-    """Task with queue_name='reports' not in declared queues must be rejected."""
-    # tests.tasks.on_reports has @task(queue_name="reports"); exclude it from declared
-    # queues so the effective-queue check finds it undeclared. Still include "other"
-    # (required by the tasks module import) but omit "reports".
+def test_pg_cron_undeclared_task_queue_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Task with queue_name='reports' not in declared queues rejected."""
+    # tests.tasks.on_reports has @task(queue_name="reports"); exclude from
+    # declared queues so effective-queue check finds it undeclared. Still
+    # include "other" (required by tasks module import) but omit "reports".
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -146,8 +177,11 @@ def test_pg_cron_undeclared_task_queue_rejected(settings, capsys):
     assert "queue 'reports' is not declared" in out
 
 
-def test_pg_cron_undeclared_explicit_queue_single_error(settings, capsys):
-    """An undeclared explicit queue override yields exactly ONE E007 (core's)."""
+def test_pg_cron_undeclared_explicit_queue_single_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Undeclared explicit queue override yields exactly ONE E007 (core's)."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -167,8 +201,11 @@ def test_pg_cron_undeclared_explicit_queue_single_error(settings, capsys):
     assert out.count("queue 'ghost' is not declared") == 1
 
 
-def test_pg_cron_non_mapping_schedule_single_error(settings, capsys):
-    """A non-mapping SCHEDULE under pg_cron yields only core's mapping E007."""
+def test_pg_cron_non_mapping_schedule_single_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-mapping SCHEDULE under pg_cron yields only core's mapping E007."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -181,8 +218,11 @@ def test_pg_cron_non_mapping_schedule_single_error(settings, capsys):
     assert out.count('OPTIONS["SCHEDULE"] must be a mapping of name -> spec') == 1
 
 
-def test_pg_cron_non_mapping_entry_single_error(settings, capsys):
-    """A non-mapping schedule entry under pg_cron yields only core's E007."""
+def test_pg_cron_non_mapping_entry_single_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-mapping schedule entry under pg_cron yields only core's E007."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -195,8 +235,11 @@ def test_pg_cron_non_mapping_entry_single_error(settings, capsys):
     assert out.count("Schedule 'nightly' must be a mapping.") == 1
 
 
-def test_pg_cron_bad_alias_charset_rejected(settings, capsys):
-    """A backend alias with characters outside [A-Za-z0-9_-] must be rejected."""
+def test_pg_cron_bad_alias_charset_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Backend alias with chars outside [A-Za-z0-9_-] rejected."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -216,9 +259,14 @@ def test_pg_cron_bad_alias_charset_rejected(settings, capsys):
     assert "Backend alias contains characters other than [A-Za-z0-9_-]." in out
 
 
-def test_pg_cron_bad_alias_charset_rejected_without_settings_schedule(settings, capsys):
-    """The alias charset is validated per-backend, so a bad alias is caught even when
-    the backend has no settings SCHEDULE (admin-only authoring)."""
+def test_pg_cron_bad_alias_charset_rejected_without_settings_schedule(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Alias charset validated per-backend.
+
+    Bad alias caught even when backend has no settings SCHEDULE (admin-only).
+    """
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -233,8 +281,11 @@ def test_pg_cron_bad_alias_charset_rejected_without_settings_schedule(settings, 
     assert "Backend alias contains characters other than [A-Za-z0-9_-]." in out
 
 
-def test_pg_cron_missing_task_no_queue_error(settings, capsys):
-    """A missing task under pg_cron yields core's import E007 only — no queue E007."""
+def test_pg_cron_missing_task_no_queue_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing task under pg_cron yields core's import E007 only."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -248,8 +299,11 @@ def test_pg_cron_missing_task_no_queue_error(settings, capsys):
     assert "is not declared" not in out
 
 
-def test_pg_cron_unimportable_task_no_queue_error(settings, capsys):
-    """An unimportable task under pg_cron yields core's import E007 — no queue E007."""
+def test_pg_cron_unimportable_task_no_queue_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Unimportable task under pg_cron yields core's import E007."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -263,8 +317,11 @@ def test_pg_cron_unimportable_task_no_queue_error(settings, capsys):
     assert "is not declared" not in out
 
 
-def test_pg_cron_non_task_no_queue_error(settings, capsys):
-    """A non-task path under pg_cron yields core's not-a-task E007 — no queue E007."""
+def test_pg_cron_non_task_no_queue_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-task path under pg_cron yields core's not-a-task E007."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -281,10 +338,16 @@ def test_pg_cron_non_task_no_queue_error(settings, capsys):
 
 
 @pytest.mark.parametrize("cron", ["", 300])
-def test_pg_cron_structurally_absent_cron_rejected(settings, capsys, cron):
-    """pg_cron cron grammar is DB-authoritative, but structural presence is not: an
-    empty or non-string cron is rejected at check time (cron.schedule can't run
-    without a schedule string)."""
+def test_pg_cron_structurally_absent_cron_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+    cron: t.Any,
+) -> None:
+    """pg_cron cron grammar DB-authoritative, structural presence is not.
+
+    Empty or non-string cron rejected at check time (cron.schedule needs
+    schedule string).
+    """
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -298,8 +361,11 @@ def test_pg_cron_structurally_absent_cron_rejected(settings, capsys, cron):
     assert "cron must be a non-empty string." in out
 
 
-def test_unknown_scheduler_value_rejected(settings, capsys):
-    """A SCHEDULER value other than 'beat'/'pg_cron' must be rejected."""
+def test_unknown_scheduler_value_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SCHEDULER value other than 'beat'/'pg_cron' rejected."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -319,8 +385,11 @@ def test_unknown_scheduler_value_rejected(settings, capsys):
     assert "'pgcron'" in out
 
 
-def test_pg_cron_trailing_newline_name_rejected(settings, capsys):
-    """Schedule name with a trailing newline must be rejected (fullmatch, not match)."""
+def test_pg_cron_trailing_newline_name_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Schedule name with trailing newline rejected (fullmatch, not match)."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -339,11 +408,14 @@ def test_pg_cron_trailing_newline_name_rejected(settings, capsys):
     assert "Schedule name contains characters other than [A-Za-z0-9_-]." in out
 
 
-def test_pg_cron_empty_string_queue_resolves_via_effective_queue(settings, capsys):
-    """queue: "" is falsy — pg_cron resolves via task queue_name, not literal "".
+def test_pg_cron_empty_string_queue_resolves_via_effective_queue(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """queue: "" is falsy — pg_cron resolves via task queue_name.
 
     Core raises one E007 (empty string is not a declared queue name); the
-    pg_cron effective-queue check must not raise a second one by treating ""
+    pg_cron effective-queue check must not raise a second by treating ""
     as a declared-queue override rather than falling back to task.queue_name.
     """
     out = run_pg_cron_check(
@@ -364,8 +436,11 @@ def test_pg_cron_empty_string_queue_resolves_via_effective_queue(settings, capsy
     assert out.count("queue '' is not declared") == 1
 
 
-def test_pg_cron_valid_five_field_cron_no_error(settings, capsys):
-    """Valid 5-field cron under pg_cron must pass without absurd.E007."""
+def test_pg_cron_valid_five_field_cron_no_error(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Valid 5-field cron under pg_cron passes without absurd.E007."""
     out = run_pg_cron_check(
         settings,
         capsys,
@@ -383,8 +458,11 @@ def test_pg_cron_valid_five_field_cron_no_error(settings, capsys):
     assert "absurd.E007" not in out
 
 
-def test_pg_cron_non_string_name_yields_e007_not_typeerror(settings, capsys):
-    """SCHEDULE key that is an integer must yield E007, not a TypeError."""
+def test_pg_cron_non_string_name_yields_e007_not_typeerror(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SCHEDULE key that is integer yields E007, not TypeError."""
     out = run_pg_cron_check(
         settings,
         capsys,

--- a/tests/pg_cron/test_pg_cron_e2e.py
+++ b/tests/pg_cron/test_pg_cron_e2e.py
@@ -3,6 +3,7 @@ drain the queue, and assert the task result is persisted.
 """
 
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.db import connection
 
@@ -32,7 +33,9 @@ TASKS_PG_CRON = {
 }
 
 
-def test_e2e_sync_fire_worker_assert_payload(settings):
+def test_e2e_sync_fire_worker_assert_payload(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """Sync schedule into pg_cron, fire wrapper directly, drain queue, assert row."""
     settings.TASKS = TASKS_PG_CRON
 

--- a/tests/pg_cron/test_pg_cron_infra.py
+++ b/tests/pg_cron/test_pg_cron_infra.py
@@ -4,7 +4,7 @@ from django.db import connection
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def test_pg_cron_extension_available():
+def test_pg_cron_extension_available() -> None:
     with connection.cursor() as cur:
         cur.execute("select extversion from pg_extension where extname = 'pg_cron'")
         row = cur.fetchone()
@@ -13,7 +13,7 @@ def test_pg_cron_extension_available():
     assert (major, minor) >= (1, 4), f"pg_cron {row[0]} < 1.4"
 
 
-def test_can_schedule_and_unschedule():
+def test_can_schedule_and_unschedule() -> None:
     with connection.cursor() as cur:
         cur.execute(
             "select cron.schedule(%s, %s, %s)",

--- a/tests/pg_cron/test_pg_cron_naming.py
+++ b/tests/pg_cron/test_pg_cron_naming.py
@@ -1,20 +1,20 @@
 from django_absurd.pg_cron.validators import build_jobname, build_jobname_prefix
 
 
-def test_jobname_format():
+def test_jobname_format() -> None:
     assert build_jobname("default", "nightly") == "absurd:s:default:nightly"
 
 
-def test_jobname_custom_source():
+def test_jobname_custom_source() -> None:
     assert (
         build_jobname("default", "nightly", source="manual")
         == "absurd:manual:default:nightly"
     )
 
 
-def test_jobname_prefix():
+def test_jobname_prefix() -> None:
     assert build_jobname_prefix("default") == "absurd:s:default:"
 
 
-def test_jobname_prefix_custom_source():
+def test_jobname_prefix_custom_source() -> None:
     assert build_jobname_prefix("default", source="manual") == "absurd:manual:default:"

--- a/tests/pg_cron/test_pg_cron_options.py
+++ b/tests/pg_cron/test_pg_cron_options.py
@@ -1,4 +1,7 @@
+import typing as t
+
 import pytest
+import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.reconcile import resolve_spawn_options
@@ -9,10 +12,16 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-BASE_QUEUES: dict[str, dict] = {"default": {}, "other": {}, "reports": {}}
+BASE_QUEUES: dict[str, dict[str, t.Any]] = {
+    "default": {},
+    "other": {},
+    "reports": {},
+}
 
 
-def test_max_attempts_from_decorator(settings):
+def test_max_attempts_from_decorator(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": BASE_QUEUES}}
     }
@@ -23,7 +32,9 @@ def test_max_attempts_from_decorator(settings):
     )  # capped => @absurd_default_params(max_attempts=3)
 
 
-def test_max_attempts_falls_back_to_backend_default(settings):
+def test_max_attempts_falls_back_to_backend_default(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,

--- a/tests/pg_cron/test_pg_cron_post_migrate.py
+++ b/tests/pg_cron/test_pg_cron_post_migrate.py
@@ -1,4 +1,6 @@
+import collections.abc
 import logging
+import typing as t
 from io import StringIO
 
 import pytest
@@ -10,6 +12,9 @@ from django_absurd.pg_cron.apps import reconcile_crons_after_migrate
 from django_absurd.pg_cron.models import ScheduledTask
 from django_absurd.queues import get_absurd_client
 from tests.pg_cron.utils import build_beat_tasks, build_pg_cron_tasks
+
+if t.TYPE_CHECKING:
+    import pytest_django.fixtures
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -23,12 +28,15 @@ def run_scheduled(source: str, alias: str, name: str) -> None:
 
 
 @pytest.fixture(params=["absurd_sync_crons", "migrate"])
-def run_cron_sync(request):
-    """Run a reconcile through each real entrypoint — the absurd_sync_crons command and a
-    full migrate (which fires post_migrate). Behavioral tests assert the same outcome for
-    both, so the pg_cron jobs stay correct however the reconcile is triggered."""
+def run_cron_sync(
+    request: pytest.FixtureRequest,
+) -> collections.abc.Callable[[], None]:
+    """Run reconcile through each real entrypoint — absurd_sync_crons command
+    and full migrate (which fires post_migrate). Behavioral tests assert the
+    same outcome for both, so pg_cron jobs stay correct however reconcile is
+    triggered."""
 
-    def run():
+    def run() -> None:
         if request.param == "migrate":
             call_command("migrate", verbosity=0)
         else:
@@ -37,7 +45,10 @@ def run_cron_sync(request):
     return run
 
 
-def test_reconcile_creates_owned_cron_jobs_under_pg_cron(settings, run_cron_sync):
+def test_reconcile_creates_owned_cron_jobs_under_pg_cron(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    run_cron_sync: collections.abc.Callable[[], None],
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
@@ -54,8 +65,9 @@ def test_reconcile_creates_owned_cron_jobs_under_pg_cron(settings, run_cron_sync
 
 
 def test_reconcile_emits_jobs_for_admin_rows_created_without_signal(
-    settings, run_cron_sync
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    run_cron_sync: collections.abc.Callable[[], None],
+) -> None:
     """A source="a" row created without firing post_save (a data migration's
     historical model, or bulk_create) has no pg_cron job; the reconcile re-emits it so
     pg_cron matches the rows."""
@@ -76,12 +88,17 @@ def test_reconcile_emits_jobs_for_admin_rows_created_without_signal(
 
     run_cron_sync()
 
-    _, schedule, _, active = ScheduledTask.pg_cron.get_job("default", "seeded", "a")
+    job = ScheduledTask.pg_cron.get_job("default", "seeded", "a")
+    assert job is not None
+    _, schedule, _, active = job
     assert schedule == "0 3 * * *"
     assert active is True
 
 
-def test_reconcile_admin_rows_is_idempotent(settings, run_cron_sync):
+def test_reconcile_admin_rows_is_idempotent(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    run_cron_sync: collections.abc.Callable[[], None],
+) -> None:
     """Re-running the reconcile re-emits admin jobs harmlessly (cron.schedule is an
     upsert) — one row still maps to exactly one job, unchanged."""
     settings.TASKS = build_pg_cron_tasks({})
@@ -109,12 +126,13 @@ def test_reconcile_admin_rows_is_idempotent(settings, run_cron_sync):
 
 
 def test_reconcile_prunes_owned_settings_job_whose_row_vanished(
-    settings, run_cron_sync
-):
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    run_cron_sync: collections.abc.Callable[[], None],
+) -> None:
     """A settings job with no backing row — its row was removed out-of-band (a
-    signal-less delete), so no post_delete unscheduled it — is orphaned; the reconcile
-    prunes it so cron.job reconverges to the declared state. Set up by scheduling from an
-    unsaved instance: a job with no row behind it."""
+    signal-less delete), so no post_delete unscheduled it — is orphaned; reconcile
+    prunes it so cron.job reconverges to declared state. Set up by scheduling from
+    an unsaved instance: a job with no row behind it."""
     settings.TASKS = build_pg_cron_tasks({})  # nothing declared
     ScheduledTask(
         source="s",
@@ -130,7 +148,10 @@ def test_reconcile_prunes_owned_settings_job_whose_row_vanished(
     assert ScheduledTask.pg_cron.get_job("default", "orphan", "s") is None
 
 
-def test_reconcile_prunes_admin_job_whose_row_vanished(settings, run_cron_sync):
+def test_reconcile_prunes_admin_job_whose_row_vanished(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    run_cron_sync: collections.abc.Callable[[], None],
+) -> None:
     """An admin job with no backing row is orphaned; the reconcile prunes it (symmetric
     with the settings lane). Set up by scheduling from an unsaved instance."""
     settings.TASKS = build_pg_cron_tasks({})
@@ -148,11 +169,13 @@ def test_reconcile_prunes_admin_job_whose_row_vanished(settings, run_cron_sync):
     assert ScheduledTask.pg_cron.get_job("default", "orphan", "a") is None
 
 
-def test_reconcile_tears_down_when_scheduler_switches_to_beat(settings):
+def test_reconcile_tears_down_when_scheduler_switches_to_beat(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
-    reconcile_crons_after_migrate(sender=None)
+    reconcile_crons_after_migrate(sender=apps.get_app_config("django_absurd_pg_cron"))
     assert [r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()] == [
         "absurd:s:default:a"
     ]
@@ -160,17 +183,19 @@ def test_reconcile_tears_down_when_scheduler_switches_to_beat(settings):
     settings.TASKS = build_beat_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
-    reconcile_crons_after_migrate(sender=None)
+    reconcile_crons_after_migrate(sender=apps.get_app_config("django_absurd_pg_cron"))
 
     assert ScheduledTask.pg_cron.get_managed_jobs() == []
     assert not ScheduledTask.objects.filter(source="s", alias="default").exists()
 
 
-def test_reconcile_missing_row_fires_clean_noop(settings):
+def test_reconcile_missing_row_fires_clean_noop(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
-    reconcile_crons_after_migrate(sender=None)
+    reconcile_crons_after_migrate(sender=apps.get_app_config("django_absurd_pg_cron"))
 
     # Drop the backing row out-of-band; the committed cron.job wrapper must fire
     # as a clean no-op (the reconcile does not leave a firing job that errors).
@@ -179,7 +204,10 @@ def test_reconcile_missing_row_fires_clean_noop(settings):
     run_scheduled("s", "default", "a")  # no exception
 
 
-def test_reconcile_survives_missing_scheduledtask_table(settings, caplog):
+def test_reconcile_survives_missing_scheduledtask_table(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -190,7 +218,9 @@ def test_reconcile_survives_missing_scheduledtask_table(settings, caplog):
         editor.delete_model(ScheduledTask)
     try:
         with caplog.at_level(logging.WARNING, logger="django_absurd"):
-            reconcile_crons_after_migrate(sender=None)
+            reconcile_crons_after_migrate(
+                sender=apps.get_app_config("django_absurd_pg_cron")
+            )
     finally:
         with connection.schema_editor() as editor:
             editor.create_model(ScheduledTask)
@@ -198,32 +228,42 @@ def test_reconcile_survives_missing_scheduledtask_table(settings, caplog):
     assert "skipped cron reconcile for backend 'default'" in caplog.text
 
 
-def test_reconcile_skips_on_malformed_schedule_spec(settings):
+def test_reconcile_skips_on_malformed_schedule_spec(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks({"broken": {}})  # no task/cron keys
 
-    reconcile_crons_after_migrate(sender=None)  # must NOT raise
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron")
+    )  # must NOT raise
 
     assert ScheduledTask.pg_cron.get_managed_jobs() == []
 
 
-def test_reconcile_skips_on_bad_dotted_path(settings):
+def test_reconcile_skips_on_bad_dotted_path(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.does_not_exist", "cron": "0 2 * * *"}}
     )
 
-    reconcile_crons_after_migrate(sender=None)  # must NOT raise
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron")
+    )  # must NOT raise
 
     assert ScheduledTask.pg_cron.get_managed_jobs() == []
 
 
-def test_pg_cron_app_registered_after_core():
+def test_pg_cron_app_registered_after_core() -> None:
     # post_migrate receivers fire in INSTALLED_APPS order; reconcile must run
     # after core queue provisioning, so the app must be listed after the core app.
     labels = [config.label for config in apps.get_app_configs()]
     assert labels.index("django_absurd") < labels.index("django_absurd_pg_cron")
 
 
-def test_migrate_provisions_queues_and_reconciles_crons(settings):
+def test_migrate_provisions_queues_and_reconciles_crons(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -237,72 +277,100 @@ def test_migrate_provisions_queues_and_reconciles_crons(settings):
     assert ScheduledTask.objects.filter(source="s", alias="default").count() == 1
 
 
-def test_reconcile_emits_migrate_stdout_on_sync(settings):
+def test_reconcile_emits_migrate_stdout_on_sync(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     buf = StringIO()
-    reconcile_crons_after_migrate(sender=None, verbosity=1, stdout=buf)
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron"), verbosity=1, stdout=buf
+    )
     out = buf.getvalue()
     assert "Reconciling pg_cron schedules (default):" in out
     assert "Scheduled 1" in out
 
 
-def test_reconcile_is_quiet_on_noop_migrate(settings):
+def test_reconcile_is_quiet_on_noop_migrate(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     """A second migrate with an unchanged SCHEDULE creates and prunes nothing,
     so it must emit no reconcile output (parity with queue provisioning)."""
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
-    reconcile_crons_after_migrate(sender=None)  # first run creates the row + job
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron")
+    )  # first run creates the row + job
     buf = StringIO()
-    reconcile_crons_after_migrate(sender=None, verbosity=1, stdout=buf)
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron"), verbosity=1, stdout=buf
+    )
     assert buf.getvalue() == ""
 
 
-def test_reconcile_emits_prune_line_on_sync(settings):
+def test_reconcile_emits_prune_line_on_sync(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
-    reconcile_crons_after_migrate(sender=None)
+    reconcile_crons_after_migrate(sender=apps.get_app_config("django_absurd_pg_cron"))
     settings.TASKS = build_pg_cron_tasks({})
     buf = StringIO()
-    reconcile_crons_after_migrate(sender=None, verbosity=1, stdout=buf)
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron"), verbosity=1, stdout=buf
+    )
     out = buf.getvalue()
     assert "Reconciling pg_cron schedules (default):" in out
     assert "Pruned 1" in out
 
 
-def test_reconcile_emits_teardown_notice_when_backend_switches(settings):
+def test_reconcile_emits_teardown_notice_when_backend_switches(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
-    reconcile_crons_after_migrate(sender=None)
+    reconcile_crons_after_migrate(sender=apps.get_app_config("django_absurd_pg_cron"))
     settings.TASKS = build_beat_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     buf = StringIO()
-    reconcile_crons_after_migrate(sender=None, verbosity=1, stdout=buf)
+    reconcile_crons_after_migrate(
+        sender=apps.get_app_config("django_absurd_pg_cron"), verbosity=1, stdout=buf
+    )
     out = buf.getvalue()
     assert "Removed 1 pg_cron schedule(s)" in out
     assert 'no longer uses SCHEDULER="pg_cron"' in out
 
 
-def test_reconcile_warns_on_none_task_path(settings, caplog):
+def test_reconcile_warns_on_none_task_path(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     settings.TASKS = build_pg_cron_tasks({"x": {"task": None, "cron": "0 2 * * *"}})
     with caplog.at_level(logging.WARNING, logger="django_absurd"):
-        reconcile_crons_after_migrate(sender=None)
+        reconcile_crons_after_migrate(
+            sender=apps.get_app_config("django_absurd_pg_cron")
+        )
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
     assert len(warnings) == 1
     assert "skipped cron reconcile" in warnings[0].message
 
 
-def test_reconcile_warns_on_string_kwargs(settings, caplog):
+def test_reconcile_warns_on_string_kwargs(
+    settings: "pytest_django.fixtures.SettingsWrapper",
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     settings.TASKS = build_pg_cron_tasks(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "kwargs": "abc"}}
     )
     with caplog.at_level(logging.WARNING, logger="django_absurd"):
-        reconcile_crons_after_migrate(sender=None)
+        reconcile_crons_after_migrate(
+            sender=apps.get_app_config("django_absurd_pg_cron")
+        )
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
     assert len(warnings) == 1
     assert "skipped cron reconcile" in warnings[0].message

--- a/tests/pg_cron/test_pg_cron_sync_jobs.py
+++ b/tests/pg_cron/test_pg_cron_sync_jobs.py
@@ -1,7 +1,10 @@
+import typing as t
+
 import psycopg
 import pytest
 from django.core.management import call_command
 from django.db import DatabaseError, connection, connections, transaction
+from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask, prune_pg_cron_jobs
@@ -13,7 +16,9 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_tasks(schedule):
+def build_tasks(
+    schedule: t.Any,
+) -> dict[str, dict[str, str | dict[str, t.Any]]]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -26,7 +31,9 @@ def build_tasks(schedule):
     }
 
 
-def test_creates_job_with_schedule_and_constant_command(settings):
+def test_creates_job_with_schedule_and_constant_command(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -41,7 +48,7 @@ def test_creates_job_with_schedule_and_constant_command(settings):
     assert active is True
 
 
-def test_sync_is_idempotent(settings):
+def test_sync_is_idempotent(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -53,7 +60,9 @@ def test_sync_is_idempotent(settings):
     assert rows[0][0] == "absurd:s:default:a"
 
 
-def test_prune_removes_undeclared_job_but_keeps_foreign(settings):
+def test_prune_removes_undeclared_job_but_keeps_foreign(
+    settings: SettingsWrapper,
+) -> None:
     with connection.cursor() as cur:
         cur.execute(
             "select cron.schedule(%s, %s, %s)", ["keepme", "* * * * *", "select 1"]
@@ -85,7 +94,9 @@ def test_prune_removes_undeclared_job_but_keeps_foreign(settings):
         cur.execute("select cron.unschedule('keepme')")  # don't leak the foreign job
 
 
-def test_prune_tolerates_already_unscheduled_job(settings):
+def test_prune_tolerates_already_unscheduled_job(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
@@ -114,7 +125,9 @@ def test_prune_tolerates_already_unscheduled_job(settings):
     }
 
 
-def test_prune_swallows_job_vanished_after_stale_scan(settings):
+def test_prune_swallows_job_vanished_after_stale_scan(
+    settings: SettingsWrapper,
+) -> None:
     # The stale-id scan and the unschedule are separate steps; a concurrent actor
     # can remove a job's cron.job row in between. prune_pg_cron_jobs must swallow
     # the resulting "could not find" error and finish the reconcile.
@@ -145,17 +158,22 @@ def test_prune_swallows_job_vanished_after_stale_scan(settings):
     assert ScheduledTask.pg_cron.get_managed_jobs() == []
 
 
-def test_prune_reraises_unexpected_error(settings):
+def test_prune_reraises_unexpected_error(
+    settings: SettingsWrapper,
+) -> None:
     # A non-"could not find" DatabaseError (bad cast) is not swallowed.
     with (
         transaction.atomic(),
         connection.cursor() as cur,
         pytest.raises(DatabaseError),
     ):
-        prune_pg_cron_jobs(cur, [{"bad": "type"}])
+        prune_pg_cron_jobs(
+            cur,
+            [{"bad": "type"}],  # type: ignore[list-item]
+        )
 
 
-def test_rearm_reenables_disabled_job(settings):
+def test_rearm_reenables_disabled_job(settings: SettingsWrapper) -> None:
     settings.TASKS = build_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
@@ -176,7 +194,9 @@ def test_rearm_reenables_disabled_job(settings):
     assert rows[0][3] is True
 
 
-def test_injection_args_are_quoted_and_schema_survives(settings):
+def test_injection_args_are_quoted_and_schema_survives(
+    settings: SettingsWrapper,
+) -> None:
     call_command("absurd_sync_queues")
     with connection.cursor() as cur:
         cur.execute("select to_regnamespace('absurd')")

--- a/tests/pg_cron/test_pg_cron_sync_rows.py
+++ b/tests/pg_cron/test_pg_cron_sync_rows.py
@@ -1,4 +1,7 @@
+import typing as t
+
 import pytest
+import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
@@ -9,7 +12,9 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_tasks(schedule):
+def build_tasks(
+    schedule: dict[str, t.Any],
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -22,7 +27,9 @@ def build_tasks(schedule):
     }
 
 
-def test_upsert_and_prune_settings_rows(settings):
+def test_upsert_and_prune_settings_rows(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
@@ -39,7 +46,9 @@ def test_upsert_and_prune_settings_rows(settings):
     assert set(ScheduledTask.objects.values_list("name", flat=True)) == {"a"}
 
 
-def test_admin_rows_untouched(settings):
+def test_admin_rows_untouched(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     ScheduledTask.objects.create(
         name="a",
         source="a",
@@ -52,7 +61,9 @@ def test_admin_rows_untouched(settings):
     assert ScheduledTask.objects.filter(source="a", name="a").exists()
 
 
-def test_sync_writes_named_option_columns(settings):
+def test_sync_writes_named_option_columns(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {
             "nightly": {
@@ -71,7 +82,9 @@ def test_sync_writes_named_option_columns(settings):
     assert row.max_attempts == 3
 
 
-def test_reconcile_splits_cancellation_into_columns(settings):
+def test_reconcile_splits_cancellation_into_columns(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {"c": {"task": "tests.tasks.cancellable", "cron": "0 2 * * *"}}
     )
@@ -82,7 +95,9 @@ def test_reconcile_splits_cancellation_into_columns(settings):
     assert row.cancellation_max_delay is None
 
 
-def test_reconcile_splits_retry_strategy_into_columns(settings):
+def test_reconcile_splits_retry_strategy_into_columns(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {"r": {"task": "tests.tasks.retrying", "cron": "0 2 * * *"}}
     )
@@ -93,7 +108,9 @@ def test_reconcile_splits_retry_strategy_into_columns(settings):
     assert row.retry_base_seconds == 2.0
 
 
-def test_sync_materializes_decorator_derived_columns(settings):
+def test_sync_materializes_decorator_derived_columns(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_tasks(
         {"full": {"task": "tests.tasks.fully_specced", "cron": "0 2 * * *"}}
     )

--- a/tests/pg_cron/test_pg_cron_teardown.py
+++ b/tests/pg_cron/test_pg_cron_teardown.py
@@ -1,4 +1,9 @@
+import typing as t
+
 import pytest
+
+if t.TYPE_CHECKING:
+    from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
@@ -9,7 +14,9 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_tasks(schedule):
+def build_tasks(
+    schedule: dict[str, dict[str, str]],
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -22,7 +29,9 @@ def build_tasks(schedule):
     }
 
 
-def test_teardown_removes_all_owned_cron_jobs_and_settings_rows(settings):
+def test_teardown_removes_all_owned_cron_jobs_and_settings_rows(
+    settings: "SettingsWrapper",
+) -> None:
     settings.TASKS = build_tasks(
         {
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
@@ -41,7 +50,9 @@ def test_teardown_removes_all_owned_cron_jobs_and_settings_rows(settings):
     assert not ScheduledTask.objects.filter(source="s", alias="default").exists()
 
 
-def test_teardown_leaves_admin_rows_intact(settings):
+def test_teardown_leaves_admin_rows_intact(
+    settings: "SettingsWrapper",
+) -> None:
     ScheduledTask.objects.create(
         name="admin-job",
         source="a",
@@ -60,7 +71,7 @@ def test_teardown_leaves_admin_rows_intact(settings):
     assert ScheduledTask.objects.filter(source="a", name="admin-job").exists()
 
 
-def test_teardown_is_idempotent(settings):
+def test_teardown_is_idempotent(settings: "SettingsWrapper") -> None:
     settings.TASKS = build_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )

--- a/tests/pg_cron/test_run_scheduled_fn.py
+++ b/tests/pg_cron/test_run_scheduled_fn.py
@@ -11,11 +11,11 @@ from tests.tasks import capped, on_reports
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def test_capped_task_returns_sum():
+def test_capped_task_returns_sum() -> None:
     assert capped.func(3, 4) == 7
 
 
-def test_on_reports_task_returns_string():
+def test_on_reports_task_returns_string() -> None:
     assert on_reports.func() == "on_reports"
 
 

--- a/tests/pg_cron/test_schedule_emission.py
+++ b/tests/pg_cron/test_schedule_emission.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 
 from django_absurd.pg_cron.models import ScheduledTask
@@ -13,7 +14,9 @@ LOADED_SCHEDULE_FIXTURE = str(
 )
 
 
-def test_saving_admin_schedule_schedules_the_job(settings):
+def test_saving_admin_schedule_schedules_the_job(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_pg_cron_tasks({})
     scheduled_task = ScheduledTask.objects.create(
         source="a",
@@ -23,12 +26,16 @@ def test_saving_admin_schedule_schedules_the_job(settings):
         cron="0 2 * * *",
         enabled=True,
     )
-    _, schedule, _, active = scheduled_task.get_pg_cron_job()
+    job = scheduled_task.get_pg_cron_job()
+    assert job is not None
+    _, schedule, _, active = job
     assert schedule == "0 2 * * *"
     assert active is True
 
 
-def test_saving_disabled_admin_schedule_is_inactive(settings):
+def test_saving_disabled_admin_schedule_is_inactive(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_pg_cron_tasks({})
     ScheduledTask.objects.create(
         source="a",
@@ -38,10 +45,14 @@ def test_saving_disabled_admin_schedule_is_inactive(settings):
         cron="0 2 * * *",
         enabled=False,
     )
-    assert ScheduledTask.pg_cron.get_job("default", "paused", "a")[3] is False
+    job = ScheduledTask.pg_cron.get_job("default", "paused", "a")
+    assert job is not None
+    assert job[3] is False
 
 
-def test_saving_settings_schedule_also_schedules_the_job(settings):
+def test_saving_settings_schedule_also_schedules_the_job(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """Unified path: a settings row emits through the same signal (reconcile upserts
     rows; the signal schedules the jobs)."""
     settings.TASKS = build_pg_cron_tasks({})
@@ -55,7 +66,9 @@ def test_saving_settings_schedule_also_schedules_the_job(settings):
     assert ScheduledTask.pg_cron.get_job("default", "via_reconcile", "s") is not None
 
 
-def test_deleting_admin_schedule_unschedules_the_job(settings):
+def test_deleting_admin_schedule_unschedules_the_job(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_pg_cron_tasks({})
     scheduled_task = ScheduledTask.objects.create(
         source="a",
@@ -69,7 +82,9 @@ def test_deleting_admin_schedule_unschedules_the_job(settings):
     assert ScheduledTask.pg_cron.get_job("default", "gone", "a") is None
 
 
-def test_saving_non_pg_cron_backend_schedule_is_a_noop(settings):
+def test_saving_non_pg_cron_backend_schedule_is_a_noop(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """A row whose backend isn't pg_cron has no job to (un)schedule — save and delete
     are clean no-ops (the signal skips it)."""
     settings.TASKS = build_beat_tasks({})
@@ -84,7 +99,9 @@ def test_saving_non_pg_cron_backend_schedule_is_a_noop(settings):
     scheduled_task.delete()  # unschedule no-op, no error
 
 
-def test_saving_unconfigured_alias_is_a_noop(settings):
+def test_saving_unconfigured_alias_is_a_noop(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """An alias mapping to no configured backend has nothing to (un)schedule — neither
     save nor delete errors."""
     settings.TASKS = build_pg_cron_tasks({})
@@ -101,7 +118,9 @@ def test_saving_unconfigured_alias_is_a_noop(settings):
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "replica"])
-def test_cross_database_write_is_rejected(settings):
+def test_cross_database_write_is_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """A ScheduledTask forced onto a non-absurd database (here via .using on a second
     alias) is rejected before the row is inserted — schedules live only on the absurd
     DB, so no misplaced row and no phantom job is created."""
@@ -124,10 +143,12 @@ def test_cross_database_write_is_rejected(settings):
 
 
 @pytest.mark.django_db(transaction=True, databases=["default", "replica"])
-def test_cross_database_row_stays_deletable(settings):
-    """A stray row created out-of-band on a foreign DB (bulk_create bypasses the pre_save
-    guard) must stay deletable — the delete receiver skips it instead of raising, so it
-    isn't trapped in the database."""
+def test_cross_database_row_stays_deletable(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    """A stray row created out-of-band on a foreign DB (bulk_create bypasses
+    the pre_save guard) must stay deletable — the delete receiver skips it
+    instead of raising, so it isn't trapped in the database."""
     settings.TASKS = build_pg_cron_tasks({})
     ScheduledTask.objects.using("replica").bulk_create(
         [
@@ -144,12 +165,16 @@ def test_cross_database_row_stays_deletable(settings):
     assert not ScheduledTask.objects.using("replica").filter(name="stray").exists()
 
 
-def test_loaddata_schedules_the_job(settings):
+def test_loaddata_schedules_the_job(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """loaddata is a real write, so the row's job materializes — the row is the source
     of truth, so a loaded/restored schedule is a live schedule."""
     settings.TASKS = build_pg_cron_tasks({})
     call_command("loaddata", LOADED_SCHEDULE_FIXTURE)
     assert ScheduledTask.objects.filter(source="a", name="loaded").exists()
-    _, schedule, _, active = ScheduledTask.pg_cron.get_job("default", "loaded", "a")
+    job = ScheduledTask.pg_cron.get_job("default", "loaded", "a")
+    assert job is not None
+    _, schedule, _, active = job
     assert schedule == "0 5 * * *"
     assert active is True

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -1,10 +1,11 @@
 import pytest
 from django.db import IntegrityError, transaction
+from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.pg_cron.models import ScheduledTask
 
 
-def test_scheduledtask_has_explicit_option_columns():
+def test_scheduledtask_has_explicit_option_columns() -> None:
     task = ScheduledTask.objects.create(
         name="nightly",
         alias="default",
@@ -32,7 +33,7 @@ def test_scheduledtask_has_explicit_option_columns():
     assert str(task) == "s:default:nightly"
 
 
-def test_scheduledtask_option_columns_default_empty():
+def test_scheduledtask_option_columns_default_empty() -> None:
     task = ScheduledTask.objects.create(
         name="x", alias="default", task="demo.tasks.ping", cron="* * * * *"
     )
@@ -47,7 +48,9 @@ def test_scheduledtask_option_columns_default_empty():
     assert task.idempotency_key == ""
 
 
-def test_scheduledtask_max_attempts_default_bubbles_from_backend(settings):
+def test_scheduledtask_max_attempts_default_bubbles_from_backend(
+    settings: SettingsWrapper,
+) -> None:
     # the field default is the backend's DEFAULT_MAX_ATTEMPTS, not a hardcoded 5
     settings.TASKS = {
         "default": {
@@ -69,7 +72,7 @@ def test_scheduledtask_max_attempts_default_bubbles_from_backend(settings):
     assert task.max_attempts == 3
 
 
-def test_scheduledtask_max_attempts_none_means_infinite():
+def test_scheduledtask_max_attempts_none_means_infinite() -> None:
     # explicit None is allowed and kept — Absurd treats NULL max_attempts as unbounded
     # retries (a deliberate opt-in, distinct from "unset", which defaults to 5).
     task = ScheduledTask.objects.create(
@@ -84,7 +87,7 @@ def test_scheduledtask_max_attempts_none_means_infinite():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_scheduledtask_max_attempts_below_one_violates_db_constraint():
+def test_scheduledtask_max_attempts_below_one_violates_db_constraint() -> None:
     # The DB CheckConstraint guards writes that skip full_clean (bulk_create, raw SQL):
     # Absurd's spawn_task rejects max_attempts < 1, so 0 must never reach the table.
     with transaction.atomic(), pytest.raises(IntegrityError):
@@ -102,7 +105,7 @@ def test_scheduledtask_max_attempts_below_one_violates_db_constraint():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_scheduledtask_unique_per_source_alias_name():
+def test_scheduledtask_unique_per_source_alias_name() -> None:
     ScheduledTask.objects.create(
         name="dup",
         source="s",

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -1,21 +1,36 @@
-"""W003: pg_cron app ordered before django_absurd — app genuinely present in this suite."""
+"""W003: pg_cron app ordered before django_absurd — app genuinely present in this
+suite."""
+
+import typing as t
 
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
-BASE_QUEUES: dict = {"default": {}, "other": {}, "reports": {}}
+BASE_QUEUES: dict[str, dict[str, t.Any]] = {
+    "default": {},
+    "other": {},
+    "reports": {},
+}
 
 
 def run_check(
-    capsys, settings, installed_apps=None, schedule=None, scheduler="pg_cron"
-):
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+    installed_apps: t.Sequence[str] | None = None,
+    schedule: dict[str, t.Any] | None = None,
+    scheduler: str = "pg_cron",
+) -> str:
     if installed_apps is not None:
         settings.INSTALLED_APPS = installed_apps
-    options: dict = {"SCHEDULER": scheduler, "QUEUES": BASE_QUEUES}
+    options: dict[str, t.Any] = {
+        "SCHEDULER": scheduler,
+        "QUEUES": BASE_QUEUES,
+    }
     if schedule is not None:
         options["SCHEDULE"] = schedule
     settings.TASKS = {
@@ -33,14 +48,19 @@ def run_check(
     return cap.out + cap.err
 
 
-def build_apps_with_pg_cron_first(settings):
+def build_apps_with_pg_cron_first(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> list[str]:
     apps_without = [
         app for app in settings.INSTALLED_APPS if app != "django_absurd.pg_cron"
     ]
     return ["django_absurd.pg_cron", *apps_without]
 
 
-def test_pg_cron_app_before_core_warns(capsys, settings):
+def test_pg_cron_app_before_core_warns(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     out = run_check(capsys, settings, build_apps_with_pg_cron_first(settings))
     assert "absurd.W003" in out
     assert (
@@ -53,7 +73,10 @@ def test_pg_cron_app_before_core_warns(capsys, settings):
     )
 
 
-def test_pg_cron_app_before_core_warns_under_beat(capsys, settings):
+def test_pg_cron_app_before_core_warns_under_beat(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """W003 tracks INSTALLED_APPS ordering, not the active scheduler: a beat
     backend with the pg_cron app mis-ordered must still warn (the misordering
     bites the moment the backend switches to pg_cron)."""
@@ -66,13 +89,19 @@ def test_pg_cron_app_before_core_warns_under_beat(capsys, settings):
     assert "absurd.W003" in out
 
 
-def test_pg_cron_app_after_core_clean(capsys, settings):
+def test_pg_cron_app_after_core_clean(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     out = run_check(capsys, settings)
     assert "absurd.E008" not in out
     assert "absurd.W003" not in out
 
 
-def test_pg_cron_schedule_error_reported(capsys, settings):
+def test_pg_cron_schedule_error_reported(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     out = run_check(
         capsys,
         settings,
@@ -88,7 +117,10 @@ def test_pg_cron_schedule_error_reported(capsys, settings):
     assert "queue 'ghost' is not declared." in out
 
 
-def test_pg_cron_app_config_path_before_core_warns(capsys, settings):
+def test_pg_cron_app_config_path_before_core_warns(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     """Dotted AppConfig path for pg_cron listed before core must still trigger W003."""
     apps_with_config_path_first = [
         "django_absurd.pg_cron.apps.PgCronConfig",

--- a/tests/pg_cron/test_scheduler_selector.py
+++ b/tests/pg_cron/test_scheduler_selector.py
@@ -1,6 +1,8 @@
 import re
+import typing as t
 
 import pytest
+import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
@@ -12,7 +14,9 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def build_pg_cron_tasks(schedule=None):
+def build_pg_cron_tasks(
+    schedule: dict[str, t.Any] | None = None,
+) -> dict[str, t.Any]:
     return {
         "default": {
             "BACKEND": ABSURD,
@@ -25,18 +29,24 @@ def build_pg_cron_tasks(schedule=None):
     }
 
 
-def test_scheduler_defaults_to_beat(settings):
+def test_scheduler_defaults_to_beat(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "QUEUES": ["default"]}}
     assert get_absurd_backends()["default"].scheduler == "beat"
 
 
-def test_beat_command_refuses_under_pg_cron(settings):
+def test_beat_command_refuses_under_pg_cron(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_pg_cron_tasks()
     with pytest.raises(CommandError, match=re.escape(BEAT_DISABLED_UNDER_PG_CRON)):
         call_command("absurd_beat")
 
 
-def test_worker_beat_flag_refuses_under_pg_cron(settings):
+def test_worker_beat_flag_refuses_under_pg_cron(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     settings.TASKS = build_pg_cron_tasks()
     with pytest.raises(CommandError, match=re.escape(BEAT_DISABLED_UNDER_PG_CRON)):
         call_command("absurd_worker", queue="default", beat=True)

--- a/tests/pg_cron/utils.py
+++ b/tests/pg_cron/utils.py
@@ -3,8 +3,12 @@ conftest.py; pg_cron catalog queries live on ``ScheduledTask.pg_cron``)."""
 
 import typing as t
 
-ABSURD_BACKEND = "django_absurd.backends.AbsurdBackend"
-DECLARED_QUEUES: dict = {"default": {}, "other": {}, "reports": {}}
+ABSURD_BACKEND: str = "django_absurd.backends.AbsurdBackend"
+DECLARED_QUEUES: dict[str, dict[str, t.Any]] = {
+    "default": {},
+    "other": {},
+    "reports": {},
+}
 
 
 def build_pg_cron_tasks(schedule: dict[str, t.Any]) -> dict[str, t.Any]:

--- a/tests/pg_cron/validators/conftest.py
+++ b/tests/pg_cron/validators/conftest.py
@@ -1,4 +1,9 @@
+import collections.abc
+
 import pytest
+import pytest_django.fixtures
+from django.contrib.auth.models import AbstractBaseUser
+from django.test import Client
 
 from tests.pg_cron.validators.utils import (
     validate_from_admin_post,
@@ -8,7 +13,13 @@ from tests.pg_cron.validators.utils import (
 
 
 @pytest.fixture(params=["check", "form", "model"])
-def validate(request, settings, capsys, client, admin_user):
+def validate(
+    request: pytest.FixtureRequest,
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> collections.abc.Callable[..., str | None]:
     """Parametrized subject: run a case through each real enforcing entrypoint —
     the system check, the admin change-form POST, and ScheduledTask.full_clean()."""
     if request.param == "check":
@@ -21,7 +32,11 @@ def validate(request, settings, capsys, client, admin_user):
 
 
 @pytest.fixture(params=["check", "model"])
-def validate_check_and_model(request, settings, capsys):
+def validate_check_and_model(
+    request: pytest.FixtureRequest,
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> collections.abc.Callable[..., str | None]:
     """Subjects for rules the admin form cannot express (e.g. a non-JSON Python
     object for args/kwargs is not a form text input): the system check + full_clean."""
     if request.param == "check":
@@ -30,7 +45,12 @@ def validate_check_and_model(request, settings, capsys):
 
 
 @pytest.fixture(params=["form", "model"])
-def validate_model_and_form(request, settings, client, admin_user):
+def validate_model_and_form(
+    request: pytest.FixtureRequest,
+    settings: pytest_django.fixtures.SettingsWrapper,
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> collections.abc.Callable[..., str | None]:
     """Subjects for rules the system check does not enforce (e.g. cron grammar is
     DB-authoritative, deferred from check time): the admin form POST + full_clean."""
     if request.param == "form":

--- a/tests/pg_cron/validators/conftest.py
+++ b/tests/pg_cron/validators/conftest.py
@@ -1,11 +1,10 @@
-import collections.abc
-
 import pytest
 import pytest_django.fixtures
-from django.contrib.auth.models import AbstractBaseUser
+from django.contrib.auth.models import User
 from django.test import Client
 
 from tests.pg_cron.validators.utils import (
+    ValidateSubject,
     validate_from_admin_post,
     validate_from_model,
     validate_from_system_check,
@@ -18,8 +17,8 @@ def validate(
     settings: pytest_django.fixtures.SettingsWrapper,
     capsys: pytest.CaptureFixture[str],
     client: Client,
-    admin_user: AbstractBaseUser,
-) -> collections.abc.Callable[..., str | None]:
+    admin_user: User,
+) -> ValidateSubject:
     """Parametrized subject: run a case through each real enforcing entrypoint —
     the system check, the admin change-form POST, and ScheduledTask.full_clean()."""
     if request.param == "check":
@@ -36,7 +35,7 @@ def validate_check_and_model(
     request: pytest.FixtureRequest,
     settings: pytest_django.fixtures.SettingsWrapper,
     capsys: pytest.CaptureFixture[str],
-) -> collections.abc.Callable[..., str | None]:
+) -> ValidateSubject:
     """Subjects for rules the admin form cannot express (e.g. a non-JSON Python
     object for args/kwargs is not a form text input): the system check + full_clean."""
     if request.param == "check":
@@ -49,8 +48,8 @@ def validate_model_and_form(
     request: pytest.FixtureRequest,
     settings: pytest_django.fixtures.SettingsWrapper,
     client: Client,
-    admin_user: AbstractBaseUser,
-) -> collections.abc.Callable[..., str | None]:
+    admin_user: User,
+) -> ValidateSubject:
     """Subjects for rules the system check does not enforce (e.g. cron grammar is
     DB-authoritative, deferred from check time): the admin form POST + full_clean."""
     if request.param == "form":

--- a/tests/pg_cron/validators/test_alias_is_pg_cron_backend.py
+++ b/tests/pg_cron/validators/test_alias_is_pg_cron_backend.py
@@ -1,3 +1,5 @@
+from pytest_django.fixtures import SettingsWrapper
+
 from tests.pg_cron.validators.utils import (
     BACKEND,
     QUEUES,
@@ -6,14 +8,14 @@ from tests.pg_cron.validators.utils import (
 )
 
 
-def test_unknown_alias_rejected(settings):
+def test_unknown_alias_rejected(settings: SettingsWrapper) -> None:
     # model-only: the check's alias is a real backend key, always valid
     result = validate_from_model(settings, alias="ghost")
     assert result
     assert "backend 'ghost' is not a configured pg_cron backend." in result
 
 
-def test_beat_backend_alias_rejected(settings):
+def test_beat_backend_alias_rejected(settings: SettingsWrapper) -> None:
     # alias resolves to a real backend, but one whose scheduler is beat, not pg_cron
     settings.TASKS = {
         "default": {

--- a/tests/pg_cron/validators/test_args_kwargs_serializable.py
+++ b/tests/pg_cron/validators/test_args_kwargs_serializable.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 
 
@@ -10,7 +12,12 @@ import pytest
         ("kwargs", "kwargs is not JSON-serializable.", {"a": {1, 2}}),
     ],
 )
-def test_non_json_rejected(validate_check_and_model, field, message, value):
+def test_non_json_rejected(
+    validate_check_and_model: t.Callable[..., str | None],
+    field: str,
+    message: str,
+    value: t.Any,
+) -> None:
     result = validate_check_and_model(**{field: value})
     assert result
     assert message in result

--- a/tests/pg_cron/validators/test_args_kwargs_serializable.py
+++ b/tests/pg_cron/validators/test_args_kwargs_serializable.py
@@ -2,6 +2,8 @@ import typing as t
 
 import pytest
 
+from tests.pg_cron.validators.utils import ValidateSubject
+
 
 # One rule, both subjects: the check validates the raw settings dict; the model's
 # JSONField.validate raises the same text (aligned via the field's error_messages).
@@ -13,7 +15,7 @@ import pytest
     ],
 )
 def test_non_json_rejected(
-    validate_check_and_model: t.Callable[..., str | None],
+    validate_check_and_model: ValidateSubject,
     field: str,
     message: str,
     value: t.Any,

--- a/tests/pg_cron/validators/test_args_kwargs_shape.py
+++ b/tests/pg_cron/validators/test_args_kwargs_shape.py
@@ -1,10 +1,9 @@
-import collections.abc
 import typing as t
 
 import pytest
 import pytest_django.fixtures
 
-from tests.pg_cron.validators.utils import validate_from_model
+from tests.pg_cron.validators.utils import ValidateSubject, validate_from_model
 
 
 # One rule per field, all real entrypoints: args must be a JSON array, kwargs a JSON
@@ -18,7 +17,7 @@ from tests.pg_cron.validators.utils import validate_from_model
     ],
 )
 def test_wrong_shape_rejected(
-    validate: collections.abc.Callable[..., str | None],
+    validate: ValidateSubject,
     field: str,
     message: str,
     value: t.Any,

--- a/tests/pg_cron/validators/test_args_kwargs_shape.py
+++ b/tests/pg_cron/validators/test_args_kwargs_shape.py
@@ -1,4 +1,8 @@
+import collections.abc
+import typing as t
+
 import pytest
+import pytest_django.fixtures
 
 from tests.pg_cron.validators.utils import validate_from_model
 
@@ -13,7 +17,12 @@ from tests.pg_cron.validators.utils import validate_from_model
         ("kwargs", "kwargs must be a JSON object (dict).", [1, 2]),
     ],
 )
-def test_wrong_shape_rejected(validate, field, message, value):
+def test_wrong_shape_rejected(
+    validate: collections.abc.Callable[..., str | None],
+    field: str,
+    message: str,
+    value: t.Any,
+) -> None:
     result = validate(**{field: value})
     assert result
     assert message in result
@@ -21,11 +30,15 @@ def test_wrong_shape_rejected(validate, field, message, value):
 
 # headers is model/admin-only (not a SCHEDULE key), so the check subject can't express
 # it — validate it through full_clean. null is allowed; any other non-object is not.
-def test_headers_wrong_shape_rejected_by_model(settings):
+def test_headers_wrong_shape_rejected_by_model(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     result = validate_from_model(settings, headers=[1, 2])
     assert result
     assert "headers must be a JSON object (dict)." in result
 
 
-def test_headers_object_accepted_by_model(settings):
+def test_headers_object_accepted_by_model(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     assert validate_from_model(settings, headers={"x": "y"}) is None

--- a/tests/pg_cron/validators/test_cancellation.py
+++ b/tests/pg_cron/validators/test_cancellation.py
@@ -1,13 +1,19 @@
+from pytest_django.fixtures import SettingsWrapper
+
 from tests.pg_cron.validators.utils import validate_from_model
 
 
-def test_cancellation_max_duration_rejects_non_integer(settings):
+def test_cancellation_max_duration_rejects_non_integer(
+    settings: SettingsWrapper,
+) -> None:
     result = validate_from_model(settings, cancellation_max_duration="soon")
     assert result
     assert "“soon” value must be an integer." in result
 
 
-def test_cancellation_max_delay_rejects_non_integer(settings):
+def test_cancellation_max_delay_rejects_non_integer(
+    settings: SettingsWrapper,
+) -> None:
     result = validate_from_model(settings, cancellation_max_delay="soon")
     assert result
     assert "“soon” value must be an integer." in result

--- a/tests/pg_cron/validators/test_cron.py
+++ b/tests/pg_cron/validators/test_cron.py
@@ -1,6 +1,6 @@
-import collections.abc
-
 import pytest
+
+from tests.pg_cron.validators.utils import ValidateSubject
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -16,7 +16,7 @@ GOOD: list[str] = ["*/5 * * * *", "0 2 * * *", "30 seconds"]
 
 @pytest.mark.parametrize("cron", GOOD)
 def test_valid_pg_cron_expression_accepted(
-    validate_model_and_form: collections.abc.Callable[..., str | None],
+    validate_model_and_form: ValidateSubject,
     cron: str,
 ) -> None:
     assert validate_model_and_form(cron=cron) is None
@@ -24,7 +24,7 @@ def test_valid_pg_cron_expression_accepted(
 
 @pytest.mark.parametrize("cron", BAD)
 def test_invalid_pg_cron_expression_rejected(
-    validate_model_and_form: collections.abc.Callable[..., str | None],
+    validate_model_and_form: ValidateSubject,
     cron: str,
 ) -> None:
     result = validate_model_and_form(cron=cron)

--- a/tests/pg_cron/validators/test_cron.py
+++ b/tests/pg_cron/validators/test_cron.py
@@ -1,3 +1,5 @@
+import collections.abc
+
 import pytest
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -8,17 +10,23 @@ PG_CRON_INVALID_HINT = (
     "HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'"
 )
 
-BAD = ["* * *", "1 hour", "not a cron"]
-GOOD = ["*/5 * * * *", "0 2 * * *", "30 seconds"]
+BAD: list[str] = ["* * *", "1 hour", "not a cron"]
+GOOD: list[str] = ["*/5 * * * *", "0 2 * * *", "30 seconds"]
 
 
 @pytest.mark.parametrize("cron", GOOD)
-def test_valid_pg_cron_expression_accepted(validate_model_and_form, cron):
+def test_valid_pg_cron_expression_accepted(
+    validate_model_and_form: collections.abc.Callable[..., str | None],
+    cron: str,
+) -> None:
     assert validate_model_and_form(cron=cron) is None
 
 
 @pytest.mark.parametrize("cron", BAD)
-def test_invalid_pg_cron_expression_rejected(validate_model_and_form, cron):
+def test_invalid_pg_cron_expression_rejected(
+    validate_model_and_form: collections.abc.Callable[..., str | None],
+    cron: str,
+) -> None:
     result = validate_model_and_form(cron=cron)
     assert result
     expected = f"invalid schedule: {cron}\n{PG_CRON_INVALID_HINT}"

--- a/tests/pg_cron/validators/test_declared_queue.py
+++ b/tests/pg_cron/validators/test_declared_queue.py
@@ -1,4 +1,7 @@
+import collections.abc
+
 import pytest
+import pytest_django.fixtures
 from django.core.exceptions import ValidationError
 
 from django_absurd.pg_cron.models import ScheduledTask
@@ -10,15 +13,21 @@ from tests.pg_cron.validators.utils import (
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-def test_undeclared_queue_override_rejected_by_check(settings, capsys):
-    # The core check validates explicit queue overrides via validate_schedule, which calls
-    # validate_declared_queue with the override value and emits the custom message.
+def test_undeclared_queue_override_rejected_by_check(
+    settings: pytest_django.fixtures.SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The core check validates explicit queue overrides via validate_schedule, which
+    # calls validate_declared_queue with the override value and emits the custom
+    # message.
     result = validate_from_system_check(settings, capsys, queue="ghost")
     assert result
     assert "queue 'ghost' is not declared." in result
 
 
-def test_undeclared_queue_override_rejected_by_model(settings):
+def test_undeclared_queue_override_rejected_by_model(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # Model full_clean: the queue field's callable choices enforce membership at the
     # field level (Django emits its own message) before clean() runs.
     result = validate_from_model(settings, queue="ghost")
@@ -26,11 +35,13 @@ def test_undeclared_queue_override_rejected_by_model(settings):
     assert "Value 'ghost' is not a valid choice." in result
 
 
-def test_explicit_queue_declared_only_by_another_backend_rejected(settings):
+def test_explicit_queue_declared_only_by_another_backend_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # The queue field's choices union queues across ALL pg_cron backends, so a queue
-    # declared only by a different backend passes field-choice validation; clean() must
-    # still reject it for the row's own backend (the queue doesn't exist there → every
-    # fire would fail).
+    # declared only by a different backend passes field-choice validation; clean()
+    # must still reject it for the row's own backend (the queue doesn't exist there →
+    # every fire would fail).
     settings.TASKS = {
         "default": {
             "BACKEND": ABSURD,
@@ -59,11 +70,13 @@ def test_explicit_queue_declared_only_by_another_backend_rejected(settings):
 # value like "ghost" cannot reach the server via the normal admin form POST.
 
 
-def test_bad_task_no_queue_reports_task_not_queue(validate_check_and_model):
-    # blank queue + unimportable/not-a-task path: validate_declared_queue must SWALLOW
-    # the task error (reported by validate_task_path) and not mislabel it as a queue
-    # error. Check + model only: queue is now a required no-blank-choice field, so the
-    # admin form can't submit a blank queue to reach this branch.
+def test_bad_task_no_queue_reports_task_not_queue(
+    validate_check_and_model: collections.abc.Callable[..., str | None],
+) -> None:
+    # blank queue + unimportable/not-a-task path: validate_declared_queue must
+    # SWALLOW the task error (reported by validate_task_path) and not mislabel it as
+    # a queue error. Check + model only: queue is now a required no-blank-choice
+    # field, so the admin form can't submit a blank queue to reach this branch.
     result = validate_check_and_model(queue="", task="os.getpid")
     assert result
     assert "is not a Django task." in result

--- a/tests/pg_cron/validators/test_declared_queue.py
+++ b/tests/pg_cron/validators/test_declared_queue.py
@@ -1,11 +1,10 @@
-import collections.abc
-
 import pytest
 import pytest_django.fixtures
 from django.core.exceptions import ValidationError
 
 from django_absurd.pg_cron.models import ScheduledTask
 from tests.pg_cron.validators.utils import (
+    ValidateSubject,
     validate_from_model,
     validate_from_system_check,
 )
@@ -71,7 +70,7 @@ def test_explicit_queue_declared_only_by_another_backend_rejected(
 
 
 def test_bad_task_no_queue_reports_task_not_queue(
-    validate_check_and_model: collections.abc.Callable[..., str | None],
+    validate_check_and_model: ValidateSubject,
 ) -> None:
     # blank queue + unimportable/not-a-task path: validate_declared_queue must
     # SWALLOW the task error (reported by validate_task_path) and not mislabel it as

--- a/tests/pg_cron/validators/test_jobname_length.py
+++ b/tests/pg_cron/validators/test_jobname_length.py
@@ -1,3 +1,5 @@
+import pytest_django.fixtures
+
 from tests.pg_cron.validators.utils import validate_from_model
 
 # The recipe is source="a" (admin), alias="default", so the jobname prefix
@@ -9,13 +11,17 @@ PREFIX = "absurd:a:default:"
 MAX_NAME = 63 - len(PREFIX)  # 46
 
 
-def test_name_filling_the_jobname_budget_is_accepted(settings):
+def test_name_filling_the_jobname_budget_is_accepted(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     # 46-byte name → composed jobname is exactly 63 bytes → allowed (would have exceeded
     # under the old full-length "admin" source).
     assert validate_from_model(settings, name="a" * MAX_NAME) is None
 
 
-def test_name_over_the_jobname_budget_is_rejected(settings):
+def test_name_over_the_jobname_budget_is_rejected(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
     name = "a" * (MAX_NAME + 1)
     jobname = f"{PREFIX}{name}"
     size = len(jobname.encode())

--- a/tests/pg_cron/validators/test_max_attempts.py
+++ b/tests/pg_cron/validators/test_max_attempts.py
@@ -1,7 +1,11 @@
+from pytest_django.fixtures import SettingsWrapper
+
 from tests.pg_cron.validators.utils import validate_from_model
 
 
-def test_max_attempts_below_one_rejected(settings):
+def test_max_attempts_below_one_rejected(
+    settings: SettingsWrapper,
+) -> None:
     # Absurd's spawn_task rejects max_attempts < 1; the model's MinValueValidator(1)
     # catches it at authoring instead of at fire time.
     result = validate_from_model(settings, max_attempts=0)

--- a/tests/pg_cron/validators/test_name_charset.py
+++ b/tests/pg_cron/validators/test_name_charset.py
@@ -1,3 +1,5 @@
+import collections.abc
+
 import pytest
 
 NAME_MSG = "Schedule name contains characters other than [A-Za-z0-9_-]."
@@ -5,17 +7,24 @@ BAD = ["dot.dot", "has space", "unicodé", "with/slash"]
 GOOD = ["MixedCase123", "ok", "with-dash", "with_underscore"]
 
 
-# name IS on the create form, but it's read-only on the change form (set once at create,
-# immutable after). Rather than split subjects by form, enforce this rule model-first via
-# the check + model subjects — both still assert the complete message.
+# name IS on the create form, but it's read-only on the change form
+# (set once at create, immutable after). Rather than split subjects by
+# form, enforce this rule model-first via the check + model subjects —
+# both still assert the complete message.
 @pytest.mark.parametrize("name", BAD)
-def test_bad_name_rejected(validate_check_and_model, name):
+def test_bad_name_rejected(
+    validate_check_and_model: collections.abc.Callable[..., str | None],
+    name: str,
+) -> None:
     result = validate_check_and_model(name=name)
     assert result
     assert NAME_MSG in result
 
 
 @pytest.mark.parametrize("name", GOOD)
-def test_good_name_accepted(validate_check_and_model, name):
+def test_good_name_accepted(
+    validate_check_and_model: collections.abc.Callable[..., str | None],
+    name: str,
+) -> None:
     result = validate_check_and_model(name=name)
     assert not result or NAME_MSG not in result

--- a/tests/pg_cron/validators/test_name_charset.py
+++ b/tests/pg_cron/validators/test_name_charset.py
@@ -1,6 +1,6 @@
-import collections.abc
-
 import pytest
+
+from tests.pg_cron.validators.utils import ValidateSubject
 
 NAME_MSG = "Schedule name contains characters other than [A-Za-z0-9_-]."
 BAD = ["dot.dot", "has space", "unicodé", "with/slash"]
@@ -13,7 +13,7 @@ GOOD = ["MixedCase123", "ok", "with-dash", "with_underscore"]
 # both still assert the complete message.
 @pytest.mark.parametrize("name", BAD)
 def test_bad_name_rejected(
-    validate_check_and_model: collections.abc.Callable[..., str | None],
+    validate_check_and_model: ValidateSubject,
     name: str,
 ) -> None:
     result = validate_check_and_model(name=name)
@@ -23,7 +23,7 @@ def test_bad_name_rejected(
 
 @pytest.mark.parametrize("name", GOOD)
 def test_good_name_accepted(
-    validate_check_and_model: collections.abc.Callable[..., str | None],
+    validate_check_and_model: ValidateSubject,
     name: str,
 ) -> None:
     result = validate_check_and_model(name=name)

--- a/tests/pg_cron/validators/test_retry_strategy.py
+++ b/tests/pg_cron/validators/test_retry_strategy.py
@@ -1,13 +1,19 @@
+from pytest_django.fixtures import SettingsWrapper
+
 from tests.pg_cron.validators.utils import validate_from_model
 
 
-def test_retry_kind_invalid_choice_rejected(settings):
+def test_retry_kind_invalid_choice_rejected(
+    settings: SettingsWrapper,
+) -> None:
     result = validate_from_model(settings, retry_kind="bogus")
     assert result
     assert "Value 'bogus' is not a valid choice." in result
 
 
-def test_retry_timing_without_kind_rejected(settings):
+def test_retry_timing_without_kind_rejected(
+    settings: SettingsWrapper,
+) -> None:
     result = validate_from_model(settings, retry_base_seconds=1.5)
     assert result
     assert "Set a retry kind to configure retry timing." in result

--- a/tests/pg_cron/validators/test_task.py
+++ b/tests/pg_cron/validators/test_task.py
@@ -1,6 +1,6 @@
-import typing as t
-
 import pytest
+
+from tests.pg_cron.validators.utils import ValidateSubject
 
 
 @pytest.mark.parametrize(
@@ -18,7 +18,7 @@ import pytest
     ],
 )
 def test_bad_task_rejected(
-    validate: t.Callable[..., str | None],
+    validate: ValidateSubject,
     path: str,
     message: str,
 ) -> None:

--- a/tests/pg_cron/validators/test_task.py
+++ b/tests/pg_cron/validators/test_task.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 
 
@@ -15,7 +17,11 @@ import pytest
         ),
     ],
 )
-def test_bad_task_rejected(validate, path, message):
+def test_bad_task_rejected(
+    validate: t.Callable[..., str | None],
+    path: str,
+    message: str,
+) -> None:
     # both subjects (model full_clean + core system check) via the fixture
     result = validate(task=path)
     assert result

--- a/tests/pg_cron/validators/utils.py
+++ b/tests/pg_cron/validators/utils.py
@@ -2,24 +2,32 @@
 entrypoint and return the emitted error text (or None)."""
 
 import json
+import typing as t
 
+import pytest
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
+from django.test import Client
 from django.urls import reverse
+from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.pg_cron.models import ScheduledTask
 
 
-def get_change_url(pk):
+def get_change_url(pk: int) -> str:
     return reverse("admin:django_absurd_pg_cron_scheduledtask_change", args=[pk])
 
 
 BACKEND = "django_absurd.backends.AbsurdBackend"
-QUEUES: dict = {"default": {}, "other": {}, "reports": {}}
+QUEUES: dict[str, dict[str, t.Any]] = {
+    "default": {},
+    "other": {},
+    "reports": {},
+}
 
 # Valid baseline: every field passes, so a single override isolates one rule.
-VALID = {
+VALID: dict[str, t.Any] = {
     "source": "a",
     "alias": "default",
     "name": "ok",
@@ -32,7 +40,10 @@ VALID = {
 }
 
 
-def configure_pg_cron_backend(settings, schedule=None):
+def configure_pg_cron_backend(
+    settings: SettingsWrapper,
+    schedule: dict[str, t.Any] | None = None,
+) -> None:
     """A pg_cron 'default' backend so model clean() resolves it (declared queues,
     alias-is-pg_cron-backend), and the check has a SCHEDULE to validate."""
     settings.TASKS = {
@@ -47,7 +58,7 @@ def configure_pg_cron_backend(settings, schedule=None):
     }
 
 
-def clean_scheduled_task(**kwargs):
+def clean_scheduled_task(**kwargs: t.Any) -> str | None:
     """Run ScheduledTask.full_clean() over the baseline + overrides. Return joined
     error text or None. Does NOT configure settings — callers needing a specific
     TASKS layout (e.g. a non-pg_cron backend) set it first."""
@@ -58,16 +69,27 @@ def clean_scheduled_task(**kwargs):
     return None
 
 
-def validate_from_model(settings, **kwargs):
+def validate_from_model(
+    settings: SettingsWrapper,
+    **kwargs: t.Any,
+) -> str | None:
     """Subject: ScheduledTask.full_clean(). Return joined error text or None."""
     configure_pg_cron_backend(settings)
     return clean_scheduled_task(**kwargs)
 
 
-def validate_from_system_check(settings, capsys, **kwargs):
-    """Subject: the system check over a pg_cron SCHEDULE. Return captured text or None."""
+def validate_from_system_check(
+    settings: SettingsWrapper,
+    capsys: pytest.CaptureFixture[str],
+    **kwargs: t.Any,
+) -> str | None:
+    """Subject: the system check over a pg_cron SCHEDULE. Return captured text or
+    None."""
     fields = {**VALID, **kwargs}
-    entry = {"cron": fields["cron"], "task": fields["task"]}
+    entry: dict[str, t.Any] = {
+        "cron": fields["cron"],
+        "task": fields["task"],
+    }
     # omit empty optionals so the baseline is clean (a literal queue="" would read
     # as an undeclared queue; empty args/kwargs are the defaults)
     for key in ("args", "kwargs", "queue"):
@@ -84,7 +106,12 @@ def validate_from_system_check(settings, capsys, **kwargs):
     return out if "absurd.E007" in out else None
 
 
-def validate_from_admin_post(client, admin_user, settings, **kwargs):
+def validate_from_admin_post(
+    client: Client,
+    admin_user: t.Any,
+    settings: SettingsWrapper,
+    **kwargs: t.Any,
+) -> str | None:
     """Subject: the admin change-form POST over a pre-seeded admin row. Return the
     joined form-error text, or None when the form validates (the POST redirects).
 
@@ -99,13 +126,13 @@ def validate_from_admin_post(client, admin_user, settings, **kwargs):
     fields = {**VALID, **kwargs}
     scheduled_task = ScheduledTask.objects.create(
         source="a",
-        alias=VALID["alias"],
-        name=VALID["name"],
-        task=VALID["task"],
+        alias=t.cast("str", VALID["alias"]),
+        name=t.cast("str", VALID["name"]),
+        task=t.cast("str", VALID["task"]),
         queue="default",
-        cron=VALID["cron"],
+        cron=t.cast("str", VALID["cron"]),
     )
-    payload = {
+    payload: dict[str, t.Any] = {
         "task": fields["task"],
         "queue": fields["queue"],
         "cron": fields["cron"],

--- a/tests/pg_cron/validators/utils.py
+++ b/tests/pg_cron/validators/utils.py
@@ -5,6 +5,7 @@ import json
 import typing as t
 
 import pytest
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
@@ -13,6 +14,14 @@ from django.urls import reverse
 from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.pg_cron.models import ScheduledTask
+
+
+class ValidateSubject(t.Protocol):
+    """A validator-test subject: run field overrides through a real enforcing
+    entrypoint (system check / model full_clean / admin POST) and return the emitted
+    error text, or None when it validates."""
+
+    def __call__(self, **kwargs: t.Any) -> str | None: ...
 
 
 def get_change_url(pk: int) -> str:
@@ -108,7 +117,7 @@ def validate_from_system_check(
 
 def validate_from_admin_post(
     client: Client,
-    admin_user: t.Any,
+    admin_user: User,
     settings: SettingsWrapper,
     **kwargs: t.Any,
 ) -> str | None:

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -26,13 +26,13 @@ def boom() -> t.Never:
 
 
 @task(takes_context=True)
-def report_attempt(context: TaskContext[t.Any, t.Any]) -> int:
+def report_attempt(context: "TaskContext[t.Any, t.Any]") -> int:
     return context.attempt
 
 
 @task(takes_context=True)
 def report_args(
-    context: TaskContext[t.Any, t.Any], *args: t.Any, **kwargs: t.Any
+    context: "TaskContext[t.Any, t.Any]", *args: t.Any, **kwargs: t.Any
 ) -> list[t.Any]:
     return context.task_result.args
 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,81 +1,85 @@
+import typing as t
+
 from absurd_sdk import CancellationPolicy, RetryStrategy
 from django.contrib.auth.models import Group
-from django.tasks import task
+from django.tasks import TaskContext, task
 
 from django_absurd.params import absurd_default_params
 from tests.models import Payload
 
 
 @task
-def add(a, b):
+def add(a: int, b: int) -> int:
     return a + b
 
 
 @task
-def make_group(name):
+def make_group(name: str) -> str:
     Group.objects.create(name=name)
     return name
 
 
 @task
-def boom():
+def boom() -> t.Never:
     msg = "boom"
     raise ValueError(msg)
 
 
 @task(takes_context=True)
-def report_attempt(context):
+def report_attempt(context: TaskContext[t.Any, t.Any]) -> int:
     return context.attempt
 
 
 @task(takes_context=True)
-def report_args(context, *args, **kwargs):
+def report_args(
+    context: TaskContext[t.Any, t.Any], *args: t.Any, **kwargs: t.Any
+) -> list[t.Any]:
     return context.task_result.args
 
 
 @task(queue_name="other")
-def routed():
+def routed() -> str:
     Group.objects.create(name="routed")
     return "routed"
 
 
 @task
 @absurd_default_params(max_attempts=7)
-def with_default_attempts(a, b):
+def with_default_attempts(a: int, b: int) -> int:
     return a + b
 
 
 @task
-def echo(value):
+def echo(value: t.Any) -> t.Any:
     return value
 
 
 @task
-def create_payload(data):
+def create_payload(data: t.Any) -> int:
     return Payload.objects.create(data=data).pk
 
 
 @task
 @absurd_default_params(max_attempts=3)
-def capped(a, b):
+def capped(a: int, b: int) -> int:
     return a + b
 
 
 @task(queue_name="reports")
-def on_reports():
+def on_reports() -> str:
     return "on_reports"
 
 
 @task
 @absurd_default_params(retry_strategy=RetryStrategy(kind="exponential", base_seconds=2))
-def retrying():
+def retrying() -> t.Never:
     msg = "path-resolved for its decorator; never run"
     raise NotImplementedError(msg)
 
 
 @task
 @absurd_default_params(cancellation=CancellationPolicy(max_duration=30))
-def cancellable():
+def cancellable() -> t.Never:
     msg = "path-resolved for its decorator; never run"
     raise NotImplementedError(msg)
 
@@ -86,6 +90,6 @@ def cancellable():
     retry_strategy=RetryStrategy(kind="fixed", base_seconds=5),
     cancellation=CancellationPolicy(max_duration=45, max_delay=3),
 )
-def fully_specced():
+def fully_specced() -> t.Never:
     msg = "path-resolved for its decorator; never run"
     raise NotImplementedError(msg)


### PR DESCRIPTION
Turn on mypy `strict` and enforce ruff ANN/E501 in tests; align pre-commit with the lincolnloop standard.

- strict typing across package + all three suites (110→18 forced ignores; 10 tracked for a typed-enqueue follow-up)
- TaskModel/RunModel Protocols, NotSet sentinel, TYPE_CHECKING admin bases, concrete model types
- pre-commit: hadolint hook, ruff import-conventions, pg_cron apt pin + Renovate deb manager