### PR TITLE
Rename managed pg_cron job prefix absurd: → _dj:

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -440,9 +440,9 @@ schedules onto the absurd DB.) Writes that bypass `.save()` — a **data migrati
 historical model isn't the signal's sender), `bulk_create`, `QuerySet.update`, raw SQL —
 don't emit directly, but `migrate` (and `absurd_sync_crons`) reconciles admin rows, so
 their jobs materialize then. A settings schedule and an admin schedule **may** share a
-name: they are distinct, source-namespaced jobs (`absurd:s:…` vs `absurd:a:…`, the
-source abbreviated to keep the job name short). Removing admin-authored jobs at teardown
-is a guarded action (see Reconcile).
+name: they are distinct, source-namespaced jobs (`_dj:s:…` vs `_dj:a:…`, the source
+abbreviated to keep the job name short). Removing admin-authored jobs at teardown is a
+guarded action (see Reconcile).
 
 ### Validate
 
@@ -459,7 +459,7 @@ is a guarded action (see Reconcile).
 - an unknown `SCHEDULER` value
 - (`pg_cron` only) schedule name or backend alias containing characters outside
   `[A-Za-z0-9_-]`
-- (`pg_cron` only) composed job name (`absurd:s:<alias>:<name>`) exceeding 63 bytes
+- (`pg_cron` only) composed job name (`_dj:s:<alias>:<name>`) exceeding 63 bytes
 
 Fix everything `absurd.E007` reports before relying on the schedule in production.
 

--- a/django_absurd/pg_cron/checks.py
+++ b/django_absurd/pg_cron/checks.py
@@ -25,7 +25,7 @@ E007_HINT_PG_CRON_ALIAS = (
 )
 E007_HINT_PG_CRON_JOBNAME = (
     "Shorten the schedule name or backend alias so the composed job name"
-    " (absurd:s:<alias>:<name>) fits within 63 bytes."
+    " (_dj:s:<alias>:<name>) fits within 63 bytes."
 )
 
 

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -89,9 +89,9 @@ class PgCronManager(models.Manager["ScheduledTask"]):
 
     def get_managed_jobs(self, source: str | None = None) -> list[tuple[t.Any, ...]]:
         """The ``(jobname, schedule, command, active)`` rows for every job we manage
-        (all share the ``absurd:`` prefix), across aliases. Pass source to narrow to one
-        lane (``absurd:<source>:``)."""
-        prefix = f"absurd:{source}:" if source is not None else "absurd:"
+        (all share the ``_dj:`` prefix), across aliases. Pass source to narrow to one
+        lane (``_dj:<source>:``)."""
+        prefix = f"_dj:{source}:" if source is not None else "_dj:"
         with connections[resolve_absurd_database()].cursor() as cur:
             cur.execute(
                 "select jobname, schedule, command, active from cron.job "
@@ -105,7 +105,7 @@ class PgCronManager(models.Manager["ScheduledTask"]):
         self, alias: str, source: str, database: str | None = None
     ) -> None:
         """Unschedule every pg_cron job owned by one backend + source
-        (``absurd:<source>:<alias>:%``). Scoped to that exact prefix so tearing down one
+        (``_dj:<source>:<alias>:%``). Scoped to that exact prefix so tearing down one
         backend's lane never touches another backend's jobs."""
         with open_locked_cursor(database or resolve_absurd_database()) as cur:
             cur.execute(
@@ -121,7 +121,7 @@ class PgCronManager(models.Manager["ScheduledTask"]):
         keep_names: list[str],
         database: str | None = None,
     ) -> None:
-        """Unschedule owned jobs for a backend + source (``absurd:<source>:<alias>:%``)
+        """Unschedule owned jobs for a backend + source (``_dj:<source>:<alias>:%``)
         whose name isn't in keep_names — i.e. jobs with no backing row. Row deletion
         unschedules its own job via post_delete, but a row removed by a signal-less path
         (bulk delete, ``flush``, raw SQL) leaves its job orphaned — reconcile heals it
@@ -271,7 +271,7 @@ class ScheduledTask(models.Model):
         return ScheduledTask.pg_cron.get_job(self.alias, self.name, self.source)
 
     def schedule_pg_cron_job(self) -> None:
-        """(Re)schedule this row's pg_cron job (``absurd:<source>:<alias>:<name>``) and
+        """(Re)schedule this row's pg_cron job (``_dj:<source>:<alias>:<name>``) and
         arm it to its enabled state. Called by the post_save signal for every write; a
         no-op when the alias isn't a pg_cron backend."""
         if resolve_pg_cron_backend(self) is None:

--- a/django_absurd/pg_cron/reconcile.py
+++ b/django_absurd/pg_cron/reconcile.py
@@ -21,7 +21,7 @@ from django_absurd.scheduler import get_cleanup_schedule, get_settings_schedules
 # Absurd's OWN global cleanup job: reconcile schedules/unschedules exactly this
 # identity — the same jobname and command that absurd.enable_cron / `absurdctl cron
 # --enable` use — so django-absurd and absurdctl reference one shared job rather than
-# forking a parallel one. It lives outside our managed ``absurd:`` (colon) namespace,
+# forking a parallel one. It lives outside our managed ``_dj:`` (colon) namespace,
 # so get_managed_jobs() never sweeps it. When ``django_absurd.pg_cron`` is installed,
 # django-absurd is AUTHORITATIVE over this job: it schedules it from OPTIONS["CLEANUP"]
 # and removes it otherwise — including at migrate teardown / scheduler-flip even when
@@ -199,9 +199,9 @@ def teardown_crons(backend: AbsurdBackend, include_admin: bool = False) -> int:
     """Remove pg_cron jobs and ScheduledTask rows owned by this backend alias.
 
     The migrate-time path (include_admin=False, a scheduler switch away from pg_cron)
-    unschedules absurd:s:<alias>:% jobs and deletes settings rows, leaving admin
+    unschedules _dj:s:<alias>:% jobs and deletes settings rows, leaving admin
     schedules (user data) untouched. The guarded absurd_sync_crons --teardown command
-    (include_admin=True) additionally clears absurd:a:<alias>:% jobs AND deletes their
+    (include_admin=True) additionally clears _dj:a:<alias>:% jobs AND deletes their
     rows — so the teardown is terminal, not undone by the next
     migrate's admin re-emit (that is why the command confirms first).
 

--- a/django_absurd/pg_cron/validators.py
+++ b/django_absurd/pg_cron/validators.py
@@ -44,12 +44,12 @@ def validate_name_charset(value: t.Any) -> None:
 
 def build_jobname(alias: str, name: str, source: str = Source.SETTINGS) -> str:
     """Return the pg_cron job name for a scheduled task."""
-    return f"absurd:{source}:{alias}:{name}"
+    return f"_dj:{source}:{alias}:{name}"
 
 
 def build_jobname_prefix(alias: str, source: str = Source.SETTINGS) -> str:
     """Return the LIKE prefix used to prune pg_cron jobs for an alias + source."""
-    return f"absurd:{source}:{alias}:"
+    return f"_dj:{source}:{alias}:"
 
 
 def validate_jobname_length(source: str, alias: str, name: str) -> None:
@@ -104,7 +104,7 @@ def validate_pg_cron_cron(cron: str, database: str) -> None:
     """
     # Unique per call so concurrent probes never collide on the pg_cron job name
     # (each is rolled back, but a shared name would still contend on the same row).
-    probe_jobname = f"absurd:__probe__:{uuid.uuid4()}"
+    probe_jobname = f"_dj:__probe__:{uuid.uuid4()}"
     try:
         with transaction.atomic(using=database):
             with connections[database].cursor() as cur:

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -105,8 +105,8 @@ source of truth; a writable lane is a separate, deliberately deferred step.
 
 A future writable lane would author `source="admin"` rows, and the shape already
 anticipates it: `sync_crons` is scoped to `source="settings"` and never touches admin
-rows, the `absurd:settings:<alias>:<name>` / `absurd:admin:<alias>:<name>` job-name
-split gives `pg_cron`'s prune the same scoping, and the fire wrapper takes `source` as a
+rows, the `_dj:settings:<alias>:<name>` / `_dj:admin:<alias>:<name>` job-name split
+gives `pg_cron`'s prune the same scoping, and the fire wrapper takes `source` as a
 parameter — so admin-authored schedules fire through the same path with no fire-path
 change. It was deferred, not free: authoring is validation-heavy (the schedule rules
 that run at `check` time against settings must also run at row-save time), and a saved

--- a/docs/web/cron-jobs.md
+++ b/docs/web/cron-jobs.md
@@ -166,7 +166,7 @@ sync for settings schedules, at save time for admin ones — so `manage.py check
 - schedule name containing characters outside `[A-Za-z0-9_-]`
 - backend alias containing characters outside `[A-Za-z0-9_-]` (pg_cron job names share
   the same charset restriction)
-- composed job name (`absurd:s:<alias>:<name>`) exceeding 63 bytes (Postgres silently
+- composed job name (`_dj:s:<alias>:<name>`) exceeding 63 bytes (Postgres silently
   truncates longer names)
 
 **Beat and pg_cron are mutually exclusive per backend.** Setting `SCHEDULER="pg_cron"`
@@ -222,7 +222,7 @@ schedules onto the absurd DB.) Writes that bypass `.save()` — a **data migrati
 historical model isn't the signal's sender), `bulk_create`, `QuerySet.update`, raw SQL —
 don't emit directly, but `migrate` (and `absurd_sync_crons`) reconciles admin rows, so
 their jobs materialize then. A settings schedule and an admin schedule **may** share the
-same name — they are distinct, source-namespaced jobs (`absurd:s:…` vs `absurd:a:…`, the
+same name — they are distinct, source-namespaced jobs (`_dj:s:…` vs `_dj:a:…`, the
 source abbreviated to keep the job name short).
 
 ### Timezone

--- a/tests/pg_cron/conftest.py
+++ b/tests/pg_cron/conftest.py
@@ -9,7 +9,7 @@ def _clear_pg_cron_jobs(
     request: pytest.FixtureRequest,
 ) -> Iterator[None]:
     """Unschedule every pg_cron job after the test — the test DB is ours, so blow the
-    whole ``cron.job`` catalog away rather than namespacing to ``absurd:%``. Set-based
+    whole ``cron.job`` catalog away rather than namespacing to ``_dj:%``. Set-based
     via cron.unschedule (pg_cron's supported API — not a raw DELETE/TRUNCATE, which
     would desync the launcher). Skips tests without the ``django_db`` marker (they
     can't commit cron jobs, so there is nothing to unschedule).

--- a/tests/pg_cron/test_absurd_sync_crons_command.py
+++ b/tests/pg_cron/test_absurd_sync_crons_command.py
@@ -37,8 +37,8 @@ def test_sync_crons_command_creates_cron_jobs(
     call_command("absurd_sync_crons")
 
     jobs = [r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()]
-    assert "absurd:s:default:a" in jobs
-    assert "absurd:s:default:b" in jobs
+    assert "_dj:s:default:a" in jobs
+    assert "_dj:s:default:b" in jobs
     assert len(jobs) == 2
 
     out = capsys.readouterr().out

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -129,9 +129,9 @@ def test_pg_cron_jobname_too_long_rejected(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Composed jobname exceeding 63 bytes rejected under pg_cron."""
-    # alias "default" + name long enough to push absurd:s:default:<name> > 63 bytes
-    # "absurd:s:default:" = 17 chars, so name needs > 46 chars
-    long_name = "a" * 47
+    # alias "default" + name long enough to push _dj:s:default:<name> > 63 bytes
+    # "_dj:s:default:" = 14 chars, so name needs > 49 chars
+    long_name = "a" * 50
     out = run_pg_cron_check(
         settings,
         capsys,

--- a/tests/pg_cron/test_pg_cron_infra.py
+++ b/tests/pg_cron/test_pg_cron_infra.py
@@ -17,7 +17,7 @@ def test_can_schedule_and_unschedule() -> None:
     with connection.cursor() as cur:
         cur.execute(
             "select cron.schedule(%s, %s, %s)",
-            ["absurd:__probe__", "* * * * *", "select 1"],
+            ["_dj:__probe__", "* * * * *", "select 1"],
         )
         jobid = cur.fetchone()[0]
         cur.execute("select count(*) from cron.job where jobid = %s", [jobid])

--- a/tests/pg_cron/test_pg_cron_naming.py
+++ b/tests/pg_cron/test_pg_cron_naming.py
@@ -2,19 +2,19 @@ from django_absurd.pg_cron.validators import build_jobname, build_jobname_prefix
 
 
 def test_jobname_format() -> None:
-    assert build_jobname("default", "nightly") == "absurd:s:default:nightly"
+    assert build_jobname("default", "nightly") == "_dj:s:default:nightly"
 
 
 def test_jobname_custom_source() -> None:
     assert (
         build_jobname("default", "nightly", source="manual")
-        == "absurd:manual:default:nightly"
+        == "_dj:manual:default:nightly"
     )
 
 
 def test_jobname_prefix() -> None:
-    assert build_jobname_prefix("default") == "absurd:s:default:"
+    assert build_jobname_prefix("default") == "_dj:s:default:"
 
 
 def test_jobname_prefix_custom_source() -> None:
-    assert build_jobname_prefix("default", source="manual") == "absurd:manual:default:"
+    assert build_jobname_prefix("default", source="manual") == "_dj:manual:default:"

--- a/tests/pg_cron/test_pg_cron_post_migrate.py
+++ b/tests/pg_cron/test_pg_cron_post_migrate.py
@@ -58,8 +58,8 @@ def test_reconcile_creates_owned_cron_jobs_under_pg_cron(
     run_cron_sync()
 
     assert [r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()] == [
-        "absurd:s:default:a",
-        "absurd:s:default:b",
+        "_dj:s:default:a",
+        "_dj:s:default:b",
     ]
     assert ScheduledTask.objects.filter(source="s", alias="default").count() == 2
 
@@ -120,7 +120,7 @@ def test_reconcile_admin_rows_is_idempotent(
     jobs = ScheduledTask.pg_cron.get_managed_jobs(source="a")
     assert len(jobs) == 1
     jobname, schedule, _, active = jobs[0]
-    assert jobname == "absurd:a:default:seeded"
+    assert jobname == "_dj:a:default:seeded"
     assert schedule == "0 3 * * *"
     assert active is True
 
@@ -177,7 +177,7 @@ def test_reconcile_tears_down_when_scheduler_switches_to_beat(
     )
     reconcile_crons_after_migrate(sender=apps.get_app_config("django_absurd_pg_cron"))
     assert [r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()] == [
-        "absurd:s:default:a"
+        "_dj:s:default:a"
     ]
 
     settings.TASKS = build_beat_tasks(
@@ -272,7 +272,7 @@ def test_migrate_provisions_queues_and_reconciles_crons(
 
     assert set(get_absurd_client().list_queues()) == {"default", "other", "reports"}
     assert [r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()] == [
-        "absurd:s:default:a"
+        "_dj:s:default:a"
     ]
     assert ScheduledTask.objects.filter(source="s", alias="default").count() == 1
 

--- a/tests/pg_cron/test_pg_cron_sync_jobs.py
+++ b/tests/pg_cron/test_pg_cron_sync_jobs.py
@@ -42,7 +42,7 @@ def test_creates_job_with_schedule_and_constant_command(
     rows = ScheduledTask.pg_cron.get_managed_jobs()
     assert len(rows) == 1
     jobname, schedule, command, active = rows[0]
-    assert jobname == "absurd:s:default:a"
+    assert jobname == "_dj:s:default:a"
     assert schedule == "0 2 * * *"
     assert command == "select public.django_absurd_run_scheduled('s', 'default', 'a')"
     assert active is True
@@ -57,7 +57,7 @@ def test_sync_is_idempotent(settings: SettingsWrapper) -> None:
 
     rows = ScheduledTask.pg_cron.get_managed_jobs()
     assert len(rows) == 1
-    assert rows[0][0] == "absurd:s:default:a"
+    assert rows[0][0] == "_dj:s:default:a"
 
 
 def test_prune_removes_undeclared_job_but_keeps_foreign(
@@ -76,8 +76,8 @@ def test_prune_removes_undeclared_job_but_keeps_foreign(
     )
     sync_crons(get_absurd_backends()["default"])
     assert {r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()} == {
-        "absurd:s:default:a",
-        "absurd:s:default:b",
+        "_dj:s:default:a",
+        "_dj:s:default:b",
     }
 
     settings.TASKS = build_tasks(
@@ -85,7 +85,7 @@ def test_prune_removes_undeclared_job_but_keeps_foreign(
     )
     sync_crons(get_absurd_backends()["default"])
     assert {r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()} == {
-        "absurd:s:default:a"
+        "_dj:s:default:a"
     }
 
     with connection.cursor() as cur:
@@ -121,7 +121,7 @@ def test_prune_tolerates_already_unscheduled_job(
     sync_crons(get_absurd_backends()["default"])  # no exception
 
     assert {r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()} == {
-        "absurd:s:default:a"
+        "_dj:s:default:a"
     }
 
 

--- a/tests/pg_cron/validators/test_jobname_length.py
+++ b/tests/pg_cron/validators/test_jobname_length.py
@@ -3,18 +3,18 @@ import pytest_django.fixtures
 from tests.pg_cron.validators.utils import validate_from_model
 
 # The recipe is source="a" (admin), alias="default", so the jobname prefix
-# "absurd:a:default:" is 17 bytes and the name may use the remaining 63 - 17 = 46. The
+# "_dj:a:default:" is 14 bytes and the name may use the remaining 63 - 14 = 49. The
 # short source code (a, not admin) is what buys those bytes: under "admin" the prefix
-# would be 21 bytes, leaving only 42, so a 43-to-46 byte name is accepted only because
+# would be 18 bytes, leaving only 45, so a 46-to-49 byte name is accepted only because
 # the source is abbreviated.
-PREFIX = "absurd:a:default:"
-MAX_NAME = 63 - len(PREFIX)  # 46
+PREFIX = "_dj:a:default:"
+MAX_NAME = 63 - len(PREFIX)  # 49
 
 
 def test_name_filling_the_jobname_budget_is_accepted(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    # 46-byte name → composed jobname is exactly 63 bytes → allowed (would have exceeded
+    # 49-byte name → composed jobname is exactly 63 bytes → allowed (would have exceeded
     # under the old full-length "admin" source).
     assert validate_from_model(settings, name="a" * MAX_NAME) is None
 


### PR DESCRIPTION
Namespace our managed pg_cron schedule jobs as `_dj:` (colon) so they're clearly distinct from Absurd-native `absurd_*` (underscore) jobs.

Breaking, no migration (pre-1.0/alpha): a reconcile creates `_dj:` jobs; any pre-rename `absurd:` jobs must be unscheduled manually. Absurd-native jobs are unchanged.

Closes #69.