### PR TITLE
Typing fidelity sweep: replace lazy t.Any with real types

### DIFF
--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -36,7 +36,8 @@ class BoundedCountPaginator(_PaginatorBase):
     @property
     def count(self) -> int:
         # Paginator.object_list is typed as a generic Protocol with no .count(); the
-        # admin always passes a QuerySet here.
+        # admin always passes something with a real .count() (a QuerySet in
+        # production; tests may stub it, per _SupportsPagination's own shape).
         qs = t.cast("QuerySet[t.Any]", self.object_list[: ADMIN_COUNT_CAP + 1])
         n: int = qs.count()
         return min(n, ADMIN_COUNT_CAP)

--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -3,7 +3,6 @@ import typing as t
 
 from django.contrib import admin, messages
 from django.contrib.admin.sites import AdminSite
-from django.core.paginator import Paginator
 from django.db import connections, models
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.module_loading import import_string
@@ -23,24 +22,6 @@ from django_absurd.admin_views import (
 )
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_backend, resolve_absurd_database
-
-ADMIN_COUNT_CAP = 1000
-
-if t.TYPE_CHECKING:
-    _PaginatorBase = Paginator[t.Any]
-else:
-    _PaginatorBase = Paginator
-
-
-class BoundedCountPaginator(_PaginatorBase):
-    @property
-    def count(self) -> int:
-        # Paginator.object_list is typed as a generic Protocol with no .count(); the
-        # admin always passes something with a real .count() (a QuerySet in
-        # production; tests may stub it, per _SupportsPagination's own shape).
-        qs = t.cast("QuerySet[t.Any]", self.object_list[: ADMIN_COUNT_CAP + 1])
-        n: int = qs.count()
-        return min(n, ADMIN_COUNT_CAP)
 
 
 class AbsurdQueueListFilter(admin.SimpleListFilter):
@@ -126,7 +107,6 @@ class ReadOnlyAbsurdAdmin(ReadOnlyAdminBase):
 
     ordering = ("natural_key",)
     show_full_result_count = False
-    paginator = BoundedCountPaginator
 
     def get_queryset(self, request: "HttpRequest") -> "QuerySet[t.Any]":
         model: type[t.Any] = self.model

--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -35,7 +35,9 @@ else:
 class BoundedCountPaginator(_PaginatorBase):
     @property
     def count(self) -> int:
-        qs: t.Any = self.object_list[: ADMIN_COUNT_CAP + 1]
+        # Paginator.object_list is typed as a generic Protocol with no .count(); the
+        # admin always passes a QuerySet here.
+        qs = t.cast("QuerySet[t.Any]", self.object_list[: ADMIN_COUNT_CAP + 1])
         n: int = qs.count()
         return min(n, ADMIN_COUNT_CAP)
 

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -170,9 +170,6 @@ VIEW_NOT_PROVISIONED_MSG = (
 )
 
 
-AnyCallable = t.Callable[..., t.Any]
-
-
 class AbsurdViewQuerySet(models.QuerySet[models.Model]):
     def _fetch_all(self) -> None:
         try:
@@ -195,8 +192,8 @@ class AbsurdViewQuerySet(models.QuerySet[models.Model]):
         return result
 
 
-def translate_view_errors(fn: AnyCallable) -> AnyCallable:
-    def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+def translate_view_errors[**P, R](fn: t.Callable[P, R]) -> t.Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return fn(*args, **kwargs)
         except (ProgrammingError, OperationalError) as exc:
@@ -247,13 +244,21 @@ def build_admin_model(spec: EntitySpec) -> type[models.Model]:
     return type(spec.model_name, (models.Model,), fields)
 
 
-def raise_view_read_only(self: t.Any, *args: object, **kwargs: object) -> t.NoReturn:
+def raise_view_read_only(
+    self: models.Model, *args: object, **kwargs: object
+) -> t.NoReturn:
     raise QueueReadOnlyError(ADMIN_VIEW_READONLY_MSG)
 
 
-def render_natural_key(self: t.Any) -> str:
-    key: str = self.natural_key
-    return key
+class HasNaturalKey(t.Protocol):
+    """The synthesized ``natural_key`` field every ``build_admin_model`` model
+    declares — ``render_natural_key`` is installed as its ``__str__``."""
+
+    natural_key: str
+
+
+def render_natural_key(self: HasNaturalKey) -> str:
+    return self.natural_key
 
 
 def build_model_field(

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -3,7 +3,7 @@ import typing as t
 import uuid
 
 import psycopg.errors
-from absurd_sdk import CreateQueueOptions
+from absurd_sdk import CreateQueueOptions, JsonValue
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
@@ -17,12 +17,31 @@ from django.utils.module_loading import import_string
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
-from django_absurd.params import AbsurdDefaultParams
+from django_absurd.params import AbsurdDefaultParams, SpawnKwargs
 
 if t.TYPE_CHECKING:
     from django.tasks.base import Task
 
 PG_CRON_APP_NAME = "django_absurd.pg_cron"
+
+
+class TaskParams(t.TypedDict):
+    """The positional/keyword args a task was enqueued with (JSON-serializable)."""
+
+    args: list[t.Any]
+    kwargs: dict[str, t.Any]
+
+
+class FailureReason(t.TypedDict):
+    """A failed run's serialized error, shaped by absurd_sdk's _serialize_error.
+
+    ``message`` is always present; ``name``/``traceback`` are only set when the
+    original error was an Exception (vs. e.g. a plain cancellation).
+    """
+
+    message: str
+    name: t.NotRequired[str]
+    traceback: t.NotRequired[str | None]
 
 
 class TaskModel(t.Protocol):
@@ -33,11 +52,11 @@ class TaskModel(t.Protocol):
     """
 
     task_name: str
-    params: dict[str, t.Any]
+    params: TaskParams
     enqueue_at: dt.datetime | None
     first_started_at: dt.datetime | None
     state: str
-    completed_payload: t.Any
+    completed_payload: JsonValue
     cancelled_at: dt.datetime | None
     last_attempt_run: uuid.UUID | None
 
@@ -48,7 +67,7 @@ class RunModel(t.Protocol):
     started_at: dt.datetime | None
     completed_at: dt.datetime | None
     failed_at: dt.datetime | None
-    failure_reason: dict[str, t.Any] | None
+    failure_reason: FailureReason | None
 
 
 class AbsurdBackendOptions(t.TypedDict, total=False):
@@ -86,7 +105,7 @@ class AbsurdBackend(BaseTaskBackend):
         spawn_params = kwargs.pop("absurd_spawn_params", None)
         defaults = getattr(task.func, "absurd_default_params", None)
         merged = build_merged_spawn_options(defaults, spawn_params)
-        max_attempts: int = merged.pop("max_attempts", self.default_max_attempts)
+        merged["max_attempts"] = merged.pop("max_attempts", self.default_max_attempts)
         try:
             # Savepoint so a misconfig DB error (below) rolls back only the spawn,
             # leaving an enclosing transaction.atomic() block usable.
@@ -95,7 +114,6 @@ class AbsurdBackend(BaseTaskBackend):
                     task.module_path,
                     {"args": list(args), "kwargs": dict(kwargs)},
                     queue=task.queue_name,
-                    max_attempts=max_attempts,
                     **merged,
                 )
         except (
@@ -126,7 +144,6 @@ class AbsurdBackend(BaseTaskBackend):
                     task.module_path,
                     {"args": list(args), "kwargs": dict(kwargs)},
                     queue=task.queue_name,
-                    max_attempts=max_attempts,
                     **merged,
                 )
         return TaskResult(
@@ -227,7 +244,7 @@ def build_task_result(
 ) -> "TaskResult[t.Any, t.Any]":
     queue, _ = decode_result_id(result_id)
     task_name: str = task.task_name
-    params: dict[str, t.Any] = task.params
+    params: TaskParams = task.params
     enqueue_at = task.enqueue_at
     first_started_at = task.first_started_at
     state: str = task.state
@@ -292,8 +309,8 @@ def get_absurd_backends() -> dict[str, "AbsurdBackend"]:
 def build_merged_spawn_options(
     defaults: AbsurdDefaultParams | None,
     per_call: AbsurdDefaultParams | None,
-) -> dict[str, t.Any]:
-    merged: dict[str, t.Any] = {}
+) -> SpawnKwargs:
+    merged: SpawnKwargs = {}
     if defaults is not None:
         merged.update(defaults.to_kwargs())
     if per_call is not None:

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -105,7 +105,7 @@ class AbsurdBackend(BaseTaskBackend):
         spawn_params = kwargs.pop("absurd_spawn_params", None)
         defaults = getattr(task.func, "absurd_default_params", None)
         merged = build_merged_spawn_options(defaults, spawn_params)
-        merged["max_attempts"] = merged.pop("max_attempts", self.default_max_attempts)
+        merged.setdefault("max_attempts", self.default_max_attempts)
         try:
             # Savepoint so a misconfig DB error (below) rolls back only the spawn,
             # leaving an enclosing transaction.atomic() block usable.

--- a/django_absurd/context.py
+++ b/django_absurd/context.py
@@ -82,8 +82,8 @@ class AbsurdTaskContext:
     loop: asyncio.AbstractEventLoop
 
     @property
-    def headers(self) -> "Mapping[str, t.Any]":
-        headers: Mapping[str, t.Any] = self.absurd_ctx.headers
+    def headers(self) -> "Mapping[str, absurd_sdk.JsonValue]":
+        headers: Mapping[str, absurd_sdk.JsonValue] = self.absurd_ctx.headers
         return headers
 
     def step(self, name: str, fn: "Callable[[], R]") -> R:

--- a/django_absurd/params.py
+++ b/django_absurd/params.py
@@ -21,6 +21,18 @@ F = t.TypeVar("F")
 AbsurdFieldValue = int | RetryStrategy | CancellationPolicy | JsonObject | str
 
 
+class SpawnKwargs(t.TypedDict, total=False):
+    """The exact keyword-arg shape absurd_sdk's ``spawn``/``_normalize_spawn_options``
+    accept — mirrors their signatures field-for-field so ``**merged`` calls into them
+    type-check per field instead of collapsing to a union."""
+
+    max_attempts: int
+    retry_strategy: RetryStrategy
+    cancellation: CancellationPolicy
+    headers: JsonObject
+    idempotency_key: str
+
+
 @dataclasses.dataclass(frozen=True)
 class AbsurdDefaultParams:
     """Per-task default parameters passed to Absurd at enqueue time."""
@@ -29,12 +41,15 @@ class AbsurdDefaultParams:
     retry_strategy: RetryStrategy | NotSet = NOT_SET
     cancellation: CancellationPolicy | NotSet = NOT_SET
 
-    def to_kwargs(self) -> dict[str, AbsurdFieldValue]:
-        return {
-            f.name: value
-            for f in dataclasses.fields(self)
-            if (value := getattr(self, f.name)) is not NOT_SET
-        }
+    def to_kwargs(self) -> SpawnKwargs:
+        return t.cast(
+            "SpawnKwargs",
+            {
+                f.name: value
+                for f in dataclasses.fields(self)
+                if (value := getattr(self, f.name)) is not NOT_SET
+            },
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/django_absurd/pg_cron/admin.py
+++ b/django_absurd/pg_cron/admin.py
@@ -23,7 +23,6 @@ if t.TYPE_CHECKING:
     from django.contrib.admin.options import _FieldsetSpec
     from django.contrib.admin.sites import AdminSite
     from django.http import HttpRequest, HttpResponse
-    from django.utils.functional import _StrOrPromise
 
     _ScheduledTaskFormBase = forms.ModelForm[ScheduledTask]
     _ScheduledTaskAdminBase = admin.ModelAdmin[ScheduledTask]
@@ -79,11 +78,6 @@ class ScheduledTaskForm(_ScheduledTaskFormBase):
         return {} if value is None else value
 
 
-type FormErrorValueOrSequence = (
-    ValidationError | _StrOrPromise | t.Sequence[ValidationError | _StrOrPromise]
-)
-
-
 class ScheduledTaskCreateForm(ScheduledTaskForm):
     class Meta(ScheduledTaskForm.Meta):
         # The create step collects only identity + cron; every spawn column is
@@ -117,36 +111,25 @@ class ScheduledTaskCreateForm(ScheduledTaskForm):
                     setattr(self.instance, field, value)
         return cleaned
 
-    @t.overload
-    def add_error(
-        self, field: None, error: t.Mapping[str, FormErrorValueOrSequence]
-    ) -> None: ...
-    @t.overload
-    def add_error(self, field: str | None, error: FormErrorValueOrSequence) -> None: ...
-    def add_error(
-        self,
-        field: str | None,
-        error: t.Mapping[str, FormErrorValueOrSequence] | FormErrorValueOrSequence,
-    ) -> None:
+    def add_error(self, field: str | None, error: t.Any) -> None:
         # The resolved spawn columns (queue, retry_kind, ...) aren't fields on this
         # 4-field create form, so a model-validation error keyed to one of them (e.g. a
         # resolved queue that isn't declared for the backend) would raise "has no field
         # named ..." (HTTP 500). Re-home any error for a field this form doesn't expose
         # onto NON_FIELD_ERRORS so it renders as a form error instead.
+        #
+        # error stays t.Any rather than mirroring BaseForm.add_error's 2-overload
+        # signature (Mapping-of-errors vs single error): every call site in this
+        # codebase (and Django's own internal callers for this form) always passes a
+        # single ValidationError, never a raw Mapping — typing that branch would add
+        # dead, untestable code for a shape nothing here produces.
         if isinstance(error, ValidationError) and hasattr(error, "error_dict"):
             rehomed: dict[str, list[ValidationError]] = {}
             for name, messages in error.error_dict.items():
                 key = name if name in self.fields else NON_FIELD_ERRORS
                 rehomed.setdefault(key, []).extend(messages)
             error = ValidationError(rehomed)
-        if isinstance(error, t.Mapping):
-            # error carries per-field errors for multiple fields; BaseForm.add_error's
-            # own contract requires field=None here — pass the literal, not field
-            # (a caller passing both a field name and a Mapping error violates that
-            # contract; letting Django's own add_error raise on it isn't our job here).
-            super().add_error(None, error)
-        else:
-            super().add_error(field, error)
+        super().add_error(field, error)
 
 
 class ScheduledTaskAdmin(_ScheduledTaskAdminBase):

--- a/django_absurd/pg_cron/admin.py
+++ b/django_absurd/pg_cron/admin.py
@@ -23,6 +23,7 @@ if t.TYPE_CHECKING:
     from django.contrib.admin.options import _FieldsetSpec
     from django.contrib.admin.sites import AdminSite
     from django.http import HttpRequest, HttpResponse
+    from django.utils.functional import _StrOrPromise
 
     _ScheduledTaskFormBase = forms.ModelForm[ScheduledTask]
     _ScheduledTaskAdminBase = admin.ModelAdmin[ScheduledTask]
@@ -78,6 +79,11 @@ class ScheduledTaskForm(_ScheduledTaskFormBase):
         return {} if value is None else value
 
 
+type FormErrorValueOrSequence = (
+    ValidationError | _StrOrPromise | t.Sequence[ValidationError | _StrOrPromise]
+)
+
+
 class ScheduledTaskCreateForm(ScheduledTaskForm):
     class Meta(ScheduledTaskForm.Meta):
         # The create step collects only identity + cron; every spawn column is
@@ -111,7 +117,17 @@ class ScheduledTaskCreateForm(ScheduledTaskForm):
                     setattr(self.instance, field, value)
         return cleaned
 
-    def add_error(self, field: str | None, error: t.Any) -> None:
+    @t.overload
+    def add_error(
+        self, field: None, error: t.Mapping[str, FormErrorValueOrSequence]
+    ) -> None: ...
+    @t.overload
+    def add_error(self, field: str | None, error: FormErrorValueOrSequence) -> None: ...
+    def add_error(
+        self,
+        field: str | None,
+        error: t.Mapping[str, FormErrorValueOrSequence] | FormErrorValueOrSequence,
+    ) -> None:
         # The resolved spawn columns (queue, retry_kind, ...) aren't fields on this
         # 4-field create form, so a model-validation error keyed to one of them (e.g. a
         # resolved queue that isn't declared for the backend) would raise "has no field
@@ -123,7 +139,10 @@ class ScheduledTaskCreateForm(ScheduledTaskForm):
                 key = name if name in self.fields else NON_FIELD_ERRORS
                 rehomed.setdefault(key, []).extend(messages)
             error = ValidationError(rehomed)
-        super().add_error(field, error)
+        if isinstance(error, t.Mapping):
+            super().add_error(None, error)
+        else:
+            super().add_error(field, error)
 
 
 class ScheduledTaskAdmin(_ScheduledTaskAdminBase):

--- a/django_absurd/pg_cron/admin.py
+++ b/django_absurd/pg_cron/admin.py
@@ -140,6 +140,10 @@ class ScheduledTaskCreateForm(ScheduledTaskForm):
                 rehomed.setdefault(key, []).extend(messages)
             error = ValidationError(rehomed)
         if isinstance(error, t.Mapping):
+            # error carries per-field errors for multiple fields; BaseForm.add_error's
+            # own contract requires field=None here — pass the literal, not field
+            # (a caller passing both a field name and a Mapping error violates that
+            # contract; letting Django's own add_error raise on it isn't our job here).
             super().add_error(None, error)
         else:
             super().add_error(field, error)

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -30,6 +30,9 @@ from django_absurd.validators import (
 
 __all__ = ["ScheduledTask"]
 
+PgCronJobRow = tuple[str, str, str, bool]
+"""A ``(jobname, schedule, command, active)`` row from ``cron.job``."""
+
 CRON_HELP_TEXT = (
     "A 5-field cron (e.g. '0 2 * * *') or the interval form '<n> seconds' (1-59)."
     " High-frequency schedules (a few seconds) generate a lot of runs, so take care."
@@ -67,7 +70,7 @@ class PgCronManager(models.Manager["ScheduledTask"]):
     reuse an already-resolved value.
     """
 
-    def get_job(self, name: str, source: str) -> tuple[t.Any, ...] | None:
+    def get_job(self, name: str, source: str) -> PgCronJobRow | None:
         """The ``(jobname, schedule, command, active)`` row for one schedule's job."""
         with connections[resolve_absurd_database()].cursor() as cur:
             cur.execute(
@@ -75,10 +78,10 @@ class PgCronManager(models.Manager["ScheduledTask"]):
                 "where jobname = %s",
                 [build_jobname(name, source)],
             )
-            job: tuple[t.Any, ...] | None = cur.fetchone()
+            job: PgCronJobRow | None = cur.fetchone()
             return job
 
-    def get_managed_jobs(self, source: str | None = None) -> list[tuple[t.Any, ...]]:
+    def get_managed_jobs(self, source: str | None = None) -> list[PgCronJobRow]:
         """The ``(jobname, schedule, command, active)`` rows for every job we manage
         (all share the ``_dj:`` prefix). Pass source to narrow to one lane
         (``_dj:<source>:``)."""
@@ -89,7 +92,7 @@ class PgCronManager(models.Manager["ScheduledTask"]):
                 "where starts_with(jobname, %s) order by jobname",
                 [prefix],
             )
-            jobs: list[tuple[t.Any, ...]] = cur.fetchall()
+            jobs: list[PgCronJobRow] = cur.fetchall()
             return jobs
 
     def unschedule_matching(self, source: str, database: str | None = None) -> None:
@@ -243,7 +246,7 @@ class ScheduledTask(models.Model):
             errors["cron"] = exc.messages
         return errors
 
-    def get_pg_cron_job(self) -> tuple[t.Any, ...] | None:
+    def get_pg_cron_job(self) -> PgCronJobRow | None:
         """This row's own pg_cron job as ``(jobname, schedule, command, active)``, or
         None if it isn't scheduled. (The manager lives on the class — Django managers
         aren't accessible via instances.)"""

--- a/django_absurd/pg_cron/reconcile.py
+++ b/django_absurd/pg_cron/reconcile.py
@@ -53,7 +53,7 @@ def resolve_spawn_options(backend: AbsurdBackend, task_path: str) -> JsonObject:
     task = import_string(task_path)
     defaults = getattr(task.func, "absurd_default_params", None)
     merged = build_merged_spawn_options(defaults, None)
-    merged["max_attempts"] = merged.pop("max_attempts", backend.default_max_attempts)
+    merged.setdefault("max_attempts", backend.default_max_attempts)
     return _normalize_spawn_options(**merged)
 
 

--- a/django_absurd/pg_cron/reconcile.py
+++ b/django_absurd/pg_cron/reconcile.py
@@ -6,6 +6,7 @@ ScheduledTask model."""
 
 import typing as t
 
+from absurd_sdk import CancellationPolicy, JsonObject, RetryStrategy
 from django.utils.module_loading import import_string
 
 from django_absurd.backends import AbsurdBackend, build_merged_spawn_options
@@ -17,6 +18,9 @@ from django_absurd.pg_cron.models import (
 )
 from django_absurd.queues import resolve_absurd_database
 from django_absurd.scheduler import get_cleanup_schedule, get_settings_schedules
+
+if t.TYPE_CHECKING:
+    from django.db.backends.utils import CursorWrapper
 
 # Absurd's OWN global cleanup job: reconcile schedules/unschedules exactly this
 # identity — the same jobname and command that absurd.enable_cron / `absurdctl cron
@@ -32,7 +36,7 @@ ABSURD_CLEANUP_JOB = "absurd_cleanup_all"
 CLEANUP_COMMAND = "select * from absurd.cleanup_all_queues(null::text);"
 
 
-def resolve_spawn_options(backend: AbsurdBackend, task_path: str) -> dict[str, t.Any]:
+def resolve_spawn_options(backend: AbsurdBackend, task_path: str) -> JsonObject:
     """Return the normalised spawn options dict for a scheduled task.
 
     Reproduces the enqueue path's option resolution exactly: task-decorator
@@ -68,17 +72,17 @@ def build_scheduled_fields(
     task = import_string(task_path)
     queue = queue_override or task.queue_name
     opts = resolve_spawn_options(backend, task_path)
+    retry_strategy = t.cast("RetryStrategy | None", opts.get("retry_strategy")) or {}
+    cancellation = t.cast("CancellationPolicy | None", opts.get("cancellation")) or {}
     return {
         "queue": queue,
         "max_attempts": opts.get("max_attempts"),
-        "retry_kind": (opts.get("retry_strategy") or {}).get("kind") or "",
-        "retry_base_seconds": (opts.get("retry_strategy") or {}).get("base_seconds"),
-        "retry_factor": (opts.get("retry_strategy") or {}).get("factor"),
-        "retry_max_seconds": (opts.get("retry_strategy") or {}).get("max_seconds"),
-        "cancellation_max_duration": (opts.get("cancellation") or {}).get(
-            "max_duration"
-        ),
-        "cancellation_max_delay": (opts.get("cancellation") or {}).get("max_delay"),
+        "retry_kind": retry_strategy.get("kind") or "",
+        "retry_base_seconds": retry_strategy.get("base_seconds"),
+        "retry_factor": retry_strategy.get("factor"),
+        "retry_max_seconds": retry_strategy.get("max_seconds"),
+        "cancellation_max_duration": cancellation.get("max_duration"),
+        "cancellation_max_delay": cancellation.get("max_delay"),
         "headers": opts.get("headers"),
         "idempotency_key": opts.get("idempotency_key") or "",
     }
@@ -134,7 +138,7 @@ def sync_crons(backend: AbsurdBackend) -> tuple[int, int]:
     return created, pruned
 
 
-def reconcile_cleanup_job(cur: t.Any, backend: AbsurdBackend) -> None:
+def reconcile_cleanup_job(cur: "CursorWrapper", backend: AbsurdBackend) -> None:
     """Schedule or unschedule Absurd's global cleanup job from OPTIONS["CLEANUP"].
 
     Stateless (no ScheduledTask row). This targets Absurd's OWN global cleanup job —
@@ -162,7 +166,7 @@ def reconcile_cleanup_job(cur: t.Any, backend: AbsurdBackend) -> None:
         unschedule_cleanup_job(cur)
 
 
-def unschedule_cleanup_job(cur: t.Any) -> None:
+def unschedule_cleanup_job(cur: "CursorWrapper") -> None:
     """Remove Absurd's global cleanup job, tolerating an already-gone job."""
     cur.execute("select jobid from cron.job where jobname = %s", [ABSURD_CLEANUP_JOB])
     prune_pg_cron_jobs(cur, [jobid for (jobid,) in cur.fetchall()])

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -3,7 +3,7 @@ import typing as t
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
-from absurd_sdk import Absurd, CreateQueueOptions
+from absurd_sdk import Absurd, CreateQueueOptions, QueuePolicyOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.utils import ProgrammingError
@@ -74,9 +74,12 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
         client.create_queue(queue_name, **opts)
         result.created.append(queue_name)
     else:
-        mutable_opts: dict[str, t.Any] = {
-            k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS
-        }
+        # MUTABLE_OPTION_KEYS mirrors QueuePolicyOptions's fields exactly; the cast is
+        # safe by construction.
+        mutable_opts = t.cast(
+            "QueuePolicyOptions",
+            {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS},
+        )
         if mutable_opts and check_mutable_options_drifted(db, mutable_opts, existing):
             client.set_queue_policy(queue_name, **mutable_opts)
             result.reconciled.append(queue_name)
@@ -116,12 +119,13 @@ def parse_interval(using: str, interval_str: str) -> dt.timedelta:
 
 
 def check_mutable_options_drifted(
-    using: str, opts: dict[str, t.Any], existing: Queue
+    using: str, opts: QueuePolicyOptions, existing: Queue
 ) -> bool:
     for key, declared_value in opts.items():
         db_value = getattr(existing, key)
         if key in INTERVAL_OPTION_KEYS:
-            interval_str: str = declared_value
+            # Every INTERVAL_OPTION_KEYS member is a str field on QueuePolicyOptions.
+            interval_str = t.cast("str", declared_value)
             if parse_interval(using, interval_str) != db_value:
                 return True
         elif declared_value != db_value:

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -11,19 +11,28 @@ from dataclasses import dataclass
 
 import psycopg
 import psycopg.errors
-from absurd_sdk import AsyncAbsurd, CancelledTask, FailedTask, SuspendTask
+from absurd_sdk import (
+    AsyncAbsurd,
+    AsyncTaskContext,
+    CancelledTask,
+    FailedTask,
+    JsonValue,
+    SuspendTask,
+)
 from django.core.exceptions import ImproperlyConfigured
 from django.db import close_old_connections, connections
 from django.tasks import Task, TaskContext, TaskResult, TaskResultStatus
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
-from django_absurd.backends import AbsurdBackend
+from django_absurd.backends import AbsurdBackend, TaskParams
 from django_absurd.connection import register_jsonb_loader, validate_backend
 from django_absurd.context import WORKER_LOOP
 from django_absurd.scheduler import run_beat
 
 logger = logging.getLogger("django_absurd")
+
+D = t.TypeVar("D")
 
 
 @dataclass(frozen=True)
@@ -35,19 +44,29 @@ class WorkerOptions:
     worker_id: str | None = None
 
 
-class LazyTaskRegistry(dict[str, t.Any]):
+class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
     """dict subclass that resolves tasks by import_string on first claim.
 
     The SDK reads _registry.get(task_name) in both _execute_task (burst) and
     start_worker (blocking). Overriding .get intercepts all dispatch reads and
-    resolves any importable Task on demand — no tasks.py scan required.
+    resolves any importable Task on demand — no tasks.py scan required. Value type
+    matches the SDK's own ``_registry: Dict[str, Dict[str, Any]]`` declaration — each
+    entry mixes str/None/Callable fields, so the inner ``Any`` is a genuine boundary.
     """
 
     def __init__(self, queue: str) -> None:
         super().__init__()
         self.queue = queue
 
-    def get(self, name: t.Any, default: t.Any = None) -> t.Any:
+    @t.overload
+    def get(self, name: str, default: None = None, /) -> dict[str, t.Any] | None: ...
+    @t.overload
+    def get(self, name: str, default: dict[str, t.Any], /) -> dict[str, t.Any]: ...
+    @t.overload
+    def get(self, name: str, default: D, /) -> dict[str, t.Any] | D: ...
+    def get(
+        self, name: str, default: dict[str, t.Any] | D | None = None
+    ) -> dict[str, t.Any] | D | None:
         if name not in self:
             try:
                 task = import_string(name)
@@ -173,7 +192,7 @@ async def drain_queue(
 
 def build_task_context(
     task: "Task[t.Any, t.Any]",
-    ctx: t.Any,
+    ctx: AsyncTaskContext,
     args: t.Sequence[t.Any],
     kwargs: dict[str, t.Any],
 ) -> "TaskContext[t.Any, t.Any]":
@@ -200,8 +219,8 @@ def build_task_context(
 
 def build_handler(
     task: "Task[t.Any, t.Any]",
-) -> t.Callable[[t.Any, t.Any], t.Awaitable[t.Any]]:
-    async def handler(params: t.Any, ctx: t.Any) -> t.Any:
+) -> t.Callable[[TaskParams, AsyncTaskContext], t.Awaitable[JsonValue]]:
+    async def handler(params: TaskParams, ctx: AsyncTaskContext) -> JsonValue:
         WORKER_LOOP.set(asyncio.get_running_loop())
         args = params.get("args", [])
         kwargs = params.get("kwargs", {})
@@ -218,17 +237,17 @@ def build_handler(
                 ctx_ = build_task_context(task, ctx, args, kwargs)
             if inspect.iscoroutinefunction(task.func):
                 if task.takes_context:
-                    result = await task.func(ctx_, *args, **kwargs)
+                    result = t.cast("JsonValue", await task.func(ctx_, *args, **kwargs))
                 else:
-                    result = await task.func(*args, **kwargs)
+                    result = t.cast("JsonValue", await task.func(*args, **kwargs))
             else:
 
-                def call_sync() -> t.Any:
+                def call_sync() -> JsonValue:
                     close_old_connections()
                     try:
                         if task.takes_context:
-                            return task.func(ctx_, *args, **kwargs)
-                        return task.func(*args, **kwargs)
+                            return t.cast("JsonValue", task.func(ctx_, *args, **kwargs))
+                        return t.cast("JsonValue", task.func(*args, **kwargs))
                     finally:
                         close_old_connections()
 
@@ -268,7 +287,7 @@ def build_handler(
     return handler
 
 
-def read_sdk_attempt(ctx: t.Any) -> int:
+def read_sdk_attempt(ctx: AsyncTaskContext) -> int:
     attempt: int = ctx._task["attempt"]  # noqa: SLF001 -- SDK TaskContext has no public attempt property
     return attempt
 

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -2,6 +2,7 @@ import time
 import typing as t
 from asyncio import sleep as asleep
 
+from absurd_sdk import JsonValue
 from django.tasks import TaskContext, task
 
 from django_absurd import aget_absurd_context
@@ -47,16 +48,16 @@ async def areport_attempt(context: "TaskContext[t.Any, t.Any]") -> int:
 
 
 @task
-async def acreate_payload(data: t.Any) -> int:
+async def acreate_payload(data: JsonValue) -> int:
     obj = await Payload.objects.acreate(data=data)
     return obj.pk
 
 
 @task
-async def aread_payload(pk: int) -> t.Any:
+async def aread_payload(pk: int) -> JsonValue:
     # async QUERY: read a row back via Django async ORM, return its jsonb
     obj = await Payload.objects.aget(pk=pk)
-    return obj.data
+    return t.cast("JsonValue", obj.data)
 
 
 @task

--- a/tests/core/test_admin/test_event.py
+++ b/tests/core/test_admin/test_event.py
@@ -1,7 +1,6 @@
-import typing as t
-
 import pytest
 from django.contrib.admin.utils import quote
+from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.db import connections
 from django.test import Client
@@ -18,7 +17,7 @@ def change_url(pk: str) -> str:
     return reverse("admin:django_absurd_event_change", args=[quote(pk)])
 
 
-def test_changelist_and_detail(client: Client, admin_user: t.Any) -> None:
+def test_changelist_and_detail(client: Client, admin_user: User) -> None:
     call_command("absurd_sync_queues")
     with connections["default"].cursor() as cur:
         cur.execute(

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -22,7 +22,7 @@ from tests.core.test_admin.utils import (
 from tests.tasks import add
 
 if t.TYPE_CHECKING:
-    from bs4 import Tag
+    from bs4 import ResultSet, Tag
     from pytest_django.plugin import DjangoDbBlocker
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -46,7 +46,7 @@ def find_task(queue: str, task_name: str) -> t.Any:
     return model.objects.filter(queue=queue, task_name=task_name).first()
 
 
-def extract_field_texts(rows: t.Any, field: str) -> set[str]:
+def extract_field_texts(rows: "ResultSet[Tag]", field: str) -> set[str]:
     """Extract text from field elements in result rows."""
     return {t.cast("Tag", r.select_one(f".{field}")).get_text(strip=True) for r in rows}
 

--- a/tests/core/test_admin/utils.py
+++ b/tests/core/test_admin/utils.py
@@ -12,18 +12,12 @@ from django.urls import clear_url_caches
 from django_absurd.admin import register_absurd_admin
 from django_absurd.params import AbsurdSpawnParams
 from tests.tasks import add, boom
+from tests.utils import HasContent
 
 if t.TYPE_CHECKING:
     from django.tasks import TaskResult
 
 BACKEND = "django_absurd.backends.AbsurdBackend"
-
-
-class HasContent(t.Protocol):
-    """What parse_html actually needs — matches both django.http.HttpResponse and
-    the test client's private ``_MonkeyPatchedWSGIResponse``."""
-
-    content: bytes
 
 
 def parse_html(response: HasContent) -> BeautifulSoup:

--- a/tests/core/test_admin/utils.py
+++ b/tests/core/test_admin/utils.py
@@ -19,7 +19,14 @@ if t.TYPE_CHECKING:
 BACKEND = "django_absurd.backends.AbsurdBackend"
 
 
-def parse_html(response: t.Any) -> BeautifulSoup:
+class HasContent(t.Protocol):
+    """What parse_html actually needs — matches both django.http.HttpResponse and
+    the test client's private ``_MonkeyPatchedWSGIResponse``."""
+
+    content: bytes
+
+
+def parse_html(response: HasContent) -> BeautifulSoup:
     return BeautifulSoup(response.content, "html.parser")
 
 

--- a/tests/core/test_admin_models.py
+++ b/tests/core/test_admin_models.py
@@ -54,13 +54,13 @@ def test_model_str_is_the_natural_key() -> None:
 def test_run_has_task_fk_for_inlining_and_task_id_is_unique() -> None:
     tasks = build_admin_model(next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks"))
     runs = build_admin_model(next(s for s in ADMIN_ENTITY_SPECS if s.name == "runs"))
-    fk = t.cast("Field[t.Any, t.Any]", runs._meta.get_field("task"))
+    fk = t.cast("models.ForeignKey[t.Any, t.Any]", runs._meta.get_field("task"))
     assert fk.related_model is tasks
     # FK joins on task_id
-    assert t.cast("t.Any", fk).target_field.name == "task_id"
+    assert fk.target_field.name == "task_id"
     # attname stays task_id, not task_id_id
-    assert t.cast("t.Any", fk).get_attname() == "task_id"
-    # view-backed: no real FK constraint
+    assert fk.get_attname() == "task_id"
+    # view-backed: no real FK constraint (db_constraint has no stub declaration)
     assert t.cast("t.Any", fk).db_constraint is False
     # required as the FK target
     task_id_field = t.cast("Field[t.Any, t.Any]", tasks._meta.get_field("task_id"))

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -19,15 +19,33 @@ from tests.tasks import add
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def make_count_stub(n: int) -> t.Any:
-    class CountStub:
-        def __getitem__(self, item: t.Any) -> "CountStub":
-            return self
+class CountStub:
+    """A minimal object_list stand-in — only .count() after a slice matters here,
+    but Paginator.object_list's _SupportsPagination protocol also needs
+    __len__/__iter__/int-indexing to satisfy structurally."""
 
-        def count(self) -> int:
-            return n
+    def __init__(self, n: int) -> None:
+        self.n = n
 
-    return CountStub()
+    def __len__(self) -> int:
+        return self.n
+
+    def __iter__(self) -> t.Iterator[object]:
+        return iter(range(self.n))
+
+    @t.overload
+    def __getitem__(self, index: int) -> object: ...
+    @t.overload
+    def __getitem__(self, index: slice) -> "CountStub": ...
+    def __getitem__(self, index: int | slice) -> "object | CountStub":
+        return self if isinstance(index, slice) else object()
+
+    def count(self) -> int:
+        return self.n
+
+
+def make_count_stub(n: int) -> CountStub:
+    return CountStub(n)
 
 
 def test_bounded_paginator_clamps_count_to_cap() -> None:

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -5,7 +5,6 @@ import pytest
 from django.core.management import call_command
 from django.db import connections
 
-from django_absurd.admin import ADMIN_COUNT_CAP, BoundedCountPaginator
 from django_absurd.admin_views import (
     ADMIN_ENTITY_SPECS,
     EntitySpec,
@@ -17,38 +16,6 @@ from django_absurd.queues import get_absurd_client
 from tests.tasks import add
 
 pytestmark = pytest.mark.django_db(transaction=True)
-
-
-class CountStub:
-    """A minimal object_list stand-in — only .count() after a slice matters here,
-    but Paginator.object_list's _SupportsPagination protocol also needs
-    __len__/__iter__/int-indexing to satisfy structurally."""
-
-    def __init__(self, n: int) -> None:
-        self.n = n
-
-    def __len__(self) -> int:
-        return self.n
-
-    def __iter__(self) -> t.Iterator[object]:
-        return iter(range(self.n))
-
-    @t.overload
-    def __getitem__(self, index: int) -> object: ...
-    @t.overload
-    def __getitem__(self, index: slice) -> "CountStub": ...
-    def __getitem__(self, index: int | slice) -> "object | CountStub":
-        return self if isinstance(index, slice) else object()
-
-    def count(self) -> int:
-        return self.n
-
-
-def test_bounded_paginator_clamps_count_to_cap() -> None:
-    over = BoundedCountPaginator(CountStub(ADMIN_COUNT_CAP + 500), per_page=20)
-    assert over.count == ADMIN_COUNT_CAP
-    under = BoundedCountPaginator(CountStub(7), per_page=20)
-    assert under.count == 7
 
 
 TASKS_SPEC: EntitySpec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -44,14 +44,10 @@ class CountStub:
         return self.n
 
 
-def make_count_stub(n: int) -> CountStub:
-    return CountStub(n)
-
-
 def test_bounded_paginator_clamps_count_to_cap() -> None:
-    over = BoundedCountPaginator(make_count_stub(ADMIN_COUNT_CAP + 500), per_page=20)
+    over = BoundedCountPaginator(CountStub(ADMIN_COUNT_CAP + 500), per_page=20)
     assert over.count == ADMIN_COUNT_CAP
-    under = BoundedCountPaginator(make_count_stub(7), per_page=20)
+    under = BoundedCountPaginator(CountStub(7), per_page=20)
     assert under.count == 7
 
 

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -3,6 +3,7 @@ import time
 import typing as t
 
 import pytest
+from absurd_sdk import JsonValue
 from django.core.management import call_command
 from django.tasks import TaskResultStatus
 
@@ -27,7 +28,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
     "value",
     [None, 0, False, "", [], {}, {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]}],
 )
-def test_async_return_value_round_trips(value: t.Any) -> None:
+def test_async_return_value_round_trips(value: JsonValue) -> None:
     call_command("absurd_sync_queues")
     r = aecho.enqueue(value)
     run_absurd_worker()

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -1,6 +1,7 @@
 import typing as t
 
 import pytest
+from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.db import connection, connections
@@ -16,7 +17,7 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
 def build_tasks_setting(
-    queues: dict[str, dict[str, t.Any]], database: str = "default"
+    queues: dict[str, CreateQueueOptions], database: str = "default"
 ) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
@@ -83,7 +84,7 @@ def test_db_unreachable_is_silent(
 def test_self_healing_drift_no_longer_warns(
     settings: "pytest_django.fixtures.SettingsWrapper",
     capsys: pytest.CaptureFixture[str],
-    after: dict[str, dict[str, t.Any]],
+    after: dict[str, CreateQueueOptions],
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -109,9 +110,13 @@ def test_invalid_policy_modes_error(
     settings: "pytest_django.fixtures.SettingsWrapper",
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    settings.TASKS = build_tasks_setting(
-        {"q": {"storage_mode": "bogus", "detach_mode": "nope"}}
+    # Deliberately invalid values, to exercise the check's own rejection at
+    # runtime — CreateQueueOptions' Literal fields don't allow this statically.
+    invalid_queues = t.cast(
+        "dict[str, CreateQueueOptions]",
+        {"q": {"storage_mode": "bogus", "detach_mode": "nope"}},
     )
+    settings.TASKS = build_tasks_setting(invalid_queues)
     out = run_absurd_check(capsys, databases=["default"])
     assert (
         "django-absurd: invalid per-queue policy options. Queue 'q':"

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -10,6 +10,7 @@ if t.TYPE_CHECKING:
     import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -19,12 +20,7 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 def build_tasks_setting(
     queues: dict[str, CreateQueueOptions], database: str = "default"
 ) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {"DATABASE": database, "QUEUES": queues},
-        }
-    }
+    return make_tasks_settings(queues=queues, database=database)
 
 
 def run_absurd_check(

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -18,6 +18,7 @@ from django_absurd.queues import get_absurd_client
 from tests.tasks import add
 
 if t.TYPE_CHECKING:
+    from django.apps.config import AppConfig
     from pytest_django.plugin import DjangoDbBlocker
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -82,7 +83,7 @@ def test_provision_skips_when_schema_absent(
     with django_db_blocker.unblock():
         call_command("migrate", "django_absurd", "zero", verbosity=0)
     try:
-        config: t.Any = apps.get_app_config("django_absurd")
+        config: AppConfig = apps.get_app_config("django_absurd")
         provision_queues_after_migrate(config)
     finally:
         with django_db_blocker.unblock():

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -11,6 +11,7 @@ from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client, resolve_absurd_database
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -21,12 +22,7 @@ def build_tasks_setting(
     queues: dict[str, CreateQueueOptions],
     database: str = "default",
 ) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {"DATABASE": database, "QUEUES": queues},
-        }
-    }
+    return make_tasks_settings(queues=queues, database=database)
 
 
 def table_exists(name: str) -> bool:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -3,6 +3,7 @@ import typing as t
 
 import psycopg
 import pytest
+from absurd_sdk import CreateQueueOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db import connection
@@ -17,7 +18,7 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
 def build_tasks_setting(
-    queues: dict[str, dict[str, t.Any]],
+    queues: dict[str, CreateQueueOptions],
     database: str = "default",
 ) -> dict[str, dict[str, t.Any]]:
     return {

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -1,9 +1,9 @@
 import asyncio
 import datetime as dt
-import typing as t
 import uuid
 
 import pytest
+from absurd_sdk import JsonValue
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db import connections, transaction
@@ -186,7 +186,7 @@ def test_enqueue_does_not_poison_jsonfield_reads() -> None:
         {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]},
     ],
 )
-def test_echo_return_value_round_trips(value: t.Any) -> None:
+def test_echo_return_value_round_trips(value: JsonValue) -> None:
     call_command("absurd_sync_queues")
     r = echo.enqueue(value)
     run_absurd_worker()

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -14,7 +14,7 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 from freezegun import freeze_time
 
-from django_absurd.backends import get_absurd_backends
+from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.scheduler import (
     Schedule,
     derive_idempotency_key,
@@ -30,8 +30,8 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def make_tasks_setting(
-    schedule: dict[str, t.Any],
-    cleanup: dict[str, t.Any] | None = None,
+    schedule: dict[str, dict[str, object]],
+    cleanup: dict[str, str] | None = None,
 ) -> dict[str, dict[str, t.Any]]:
     options: dict[str, t.Any] = {
         "QUEUES": {"default": {}, "other": {}, "reports": {}},
@@ -152,7 +152,7 @@ def test_get_next_datetime_six_field_zero_seconds() -> None:
 # because a real threading.Event.wait can't be fast-forwarded by freezegun;
 # the command path is not deterministic enough for exact multi-slot counts.
 def run_beat_until(
-    backend: t.Any,
+    backend: AbsurdBackend,
     cutoff: dt.datetime,
 ) -> None:
     with freeze_time("2026-01-01 00:00:00") as frozen:

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -25,6 +25,7 @@ from django_absurd.scheduler import (
 )
 from tests.models import Payload
 from tests.tasks import make_group as make_group_task
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -33,18 +34,7 @@ def make_tasks_setting(
     schedule: dict[str, dict[str, object]],
     cleanup: dict[str, str] | None = None,
 ) -> dict[str, dict[str, t.Any]]:
-    options: dict[str, t.Any] = {
-        "QUEUES": {"default": {}, "other": {}, "reports": {}},
-        "SCHEDULE": schedule,
-    }
-    if cleanup is not None:
-        options["CLEANUP"] = cleanup
-    return {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": options,
-        }
-    }
+    return make_tasks_settings(schedule=schedule, cleanup=cleanup)
 
 
 def test_settings_provider_reads_entries(

--- a/tests/pg_cron/test_admin/test_admin_checks.py
+++ b/tests/pg_cron/test_admin/test_admin_checks.py
@@ -7,6 +7,9 @@ from django.core import checks
 from django_absurd.pg_cron.admin import ScheduledTaskAdmin
 from django_absurd.pg_cron.models import ScheduledTask
 
+if t.TYPE_CHECKING:
+    from django.core.checks import CheckMessage
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
@@ -21,7 +24,7 @@ def test_scheduledtask_admin_has_no_config_errors() -> None:
     fields — Django surfaces a typo only as admin.E0* under the check framework,
     and registration happens under contextlib.suppress at import, so without this
     guard a bad field name would ship silently."""
-    admin_errors: list[t.Any] = [
+    admin_errors: list[CheckMessage] = [
         e
         for e in checks.run_checks(tags=["admin"])
         if e.id is not None and e.id.startswith("admin.E")

--- a/tests/pg_cron/test_admin/test_registration.py
+++ b/tests/pg_cron/test_admin/test_registration.py
@@ -3,7 +3,7 @@ import typing as t
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib import admin as djadmin
-from django.contrib.auth.models import AbstractBaseUser, Permission
+from django.contrib.auth.models import Permission, User
 from django.test import Client
 from django.urls import reverse_lazy
 
@@ -30,16 +30,15 @@ def test_scheduledtask_registered_on_default_site() -> None:
 
 
 def test_staff_user_with_view_permission_sees_scheduledtask_in_index(
-    client: Client, staff_user: AbstractBaseUser
+    client: Client, staff_user: User
 ) -> None:
-    user: t.Any = staff_user
-    user.user_permissions.add(
+    staff_user.user_permissions.add(
         Permission.objects.get(
             codename="view_scheduledtask",
             content_type__app_label="django_absurd_pg_cron",
         )
     )
-    client.force_login(user)
+    client.force_login(staff_user)
     soup = BeautifulSoup(client.get(INDEX).content, "html.parser")
     assert (
         soup.select_one('a[href$="/django_absurd_pg_cron/scheduledtask/"]') is not None

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -15,6 +15,7 @@ if t.TYPE_CHECKING:
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
 from django_absurd.pg_cron.reconcile import sync_crons
+from tests.utils import HasContent
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -61,13 +62,6 @@ def seed(settings: "pytest_django.fixtures.SettingsWrapper") -> None:
     settings.TASKS = TASKS
     call_command("absurd_sync_queues")
     sync_crons(get_absurd_backends()["default"])
-
-
-class HasContent(t.Protocol):
-    """What rows() actually needs — matches both django.http.HttpResponse and the
-    test client's private ``_MonkeyPatchedWSGIResponse``."""
-
-    content: bytes
 
 
 def rows(response: HasContent) -> "ResultSet[Tag]":

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -2,8 +2,7 @@ import typing as t
 from html import unescape
 
 import pytest
-from bs4 import BeautifulSoup
-from bs4.element import ResultSet
+from bs4 import BeautifulSoup, Tag
 from django.contrib.auth.models import Permission, User
 from django.core.management import call_command
 from django.test import Client
@@ -11,6 +10,7 @@ from django.urls import reverse, reverse_lazy
 
 if t.TYPE_CHECKING:
     import pytest_django.fixtures
+    from bs4.element import ResultSet
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
@@ -63,12 +63,19 @@ def seed(settings: "pytest_django.fixtures.SettingsWrapper") -> None:
     sync_crons(get_absurd_backends()["default"])
 
 
-def rows(response: t.Any) -> ResultSet[t.Any]:
+class HasContent(t.Protocol):
+    """What rows() actually needs — matches both django.http.HttpResponse and the
+    test client's private ``_MonkeyPatchedWSGIResponse``."""
+
+    content: bytes
+
+
+def rows(response: HasContent) -> "ResultSet[Tag]":
     soup = BeautifulSoup(response.content, "html.parser")
     return soup.select("#result_list tbody tr")
 
 
-def get_change_url(pk: t.Any) -> str:
+def get_change_url(pk: int) -> str:
     return reverse("admin:django_absurd_pg_cron_scheduledtask_change", args=[pk])
 
 
@@ -401,7 +408,7 @@ def create_scheduled_task(
     name: str,
     task: str = "tests.tasks.add",
     cron: str = "0 3 * * *",
-) -> t.Any:
+) -> int:
     """Create source="admin" row through minimal create form; return its pk."""
     client.post(ADD, {"name": name, "task": task, "cron": cron})
     return ScheduledTask.objects.get(name=name).pk

--- a/tests/pg_cron/test_cleanup_schedule.py
+++ b/tests/pg_cron/test_cleanup_schedule.py
@@ -6,22 +6,13 @@ from django.core.management import call_command
 from django.db import connection
 
 from django_absurd.pg_cron.models import ScheduledTask
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
-ABSURD = "django_absurd.backends.AbsurdBackend"
 
-
-def build_cleanup_tasks(cleanup_schedule: str) -> dict[str, t.Any]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}, "other": {}, "reports": {}},
-                "CLEANUP": {"schedule": cleanup_schedule},
-            },
-        }
-    }
+def build_cleanup_tasks(cleanup_schedule: str) -> dict[str, dict[str, t.Any]]:
+    return make_tasks_settings(cleanup={"schedule": cleanup_schedule})
 
 
 def fetch_cleanup_row() -> tuple[str, str, str] | None:
@@ -65,14 +56,7 @@ def test_sync_unschedules_cleanup_job_when_cleanup_dropped(
     call_command("absurd_sync_crons")
     assert fetch_cleanup_row() is not None
 
-    settings.TASKS = {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}, "other": {}, "reports": {}},
-            },
-        }
-    }
+    settings.TASKS = make_tasks_settings()
     call_command("absurd_sync_crons")
 
     assert fetch_cleanup_row() is None
@@ -111,14 +95,7 @@ def test_teardown_removes_cleanup_job(
 def test_teardown_reclaims_cleanup_job_without_cleanup_option(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}, "other": {}, "reports": {}},
-            },
-        }
-    }
+    settings.TASKS = make_tasks_settings()
     with connection.cursor() as cur:
         cur.execute(
             "select cron.schedule(%s, %s, %s)",

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -8,9 +8,10 @@ from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
+from tests.utils import make_tasks_settings
+
 pytestmark = pytest.mark.django_db(transaction=True)
 
-ABSURD = "django_absurd.backends.AbsurdBackend"
 E007_MSG = "django-absurd: invalid SCHEDULE entry."
 
 # tests/tasks.py declares @task(queue_name="other") and @task(queue_name="reports")
@@ -33,15 +34,9 @@ def run_pg_cron_check(
 
     options keys: queues, schedule.
     """
-    settings.TASKS = {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": options["queues"],
-                "SCHEDULE": options["schedule"],
-            },
-        }
-    }
+    settings.TASKS = make_tasks_settings(
+        queues=options["queues"], schedule=options["schedule"]
+    )
     try:
         call_command("check", "django_absurd")
     except SystemCheckError as exc:
@@ -56,12 +51,7 @@ def run_pg_cron_cleanup_check(
     capsys: pytest.CaptureFixture[str],
     cleanup: dict[str, str],
 ) -> str:
-    settings.TASKS = {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {"QUEUES": BASE_QUEUES, "CLEANUP": cleanup},
-        }
-    }
+    settings.TASKS = make_tasks_settings(queues=BASE_QUEUES, cleanup=cleanup)
     try:
         call_command("check", "django_absurd")
     except SystemCheckError as exc:

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -4,6 +4,7 @@ import typing as t
 
 import pytest
 import pytest_django.fixtures
+from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
@@ -16,7 +17,7 @@ E007_MSG = "django-absurd: invalid SCHEDULE entry."
 # at module level; importing any task from that module validates those queue names
 # against the current backend. All tests that import from tests.tasks must
 # therefore declare at least "other" and "reports" alongside "default".
-BASE_QUEUES: dict[str, dict[str, t.Any]] = {
+BASE_QUEUES: dict[str, CreateQueueOptions] = {
     "default": {},
     "other": {},
     "reports": {},
@@ -53,7 +54,7 @@ def run_pg_cron_check(
 def run_pg_cron_cleanup_check(
     settings: pytest_django.fixtures.SettingsWrapper,
     capsys: pytest.CaptureFixture[str],
-    cleanup: dict[str, t.Any],
+    cleanup: dict[str, str],
 ) -> str:
     settings.TASKS = {
         "default": {

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -4,25 +4,15 @@ import typing as t
 
 import pytest
 import pytest_django.fixtures
-from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
+from tests.utils import DECLARED_QUEUES as BASE_QUEUES
 from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 E007_MSG = "django-absurd: invalid SCHEDULE entry."
-
-# tests/tasks.py declares @task(queue_name="other") and @task(queue_name="reports")
-# at module level; importing any task from that module validates those queue names
-# against the current backend. All tests that import from tests.tasks must
-# therefore declare at least "other" and "reports" alongside "default".
-BASE_QUEUES: dict[str, CreateQueueOptions] = {
-    "default": {},
-    "other": {},
-    "reports": {},
-}
 
 
 def run_pg_cron_check(

--- a/tests/pg_cron/test_pg_cron_options.py
+++ b/tests/pg_cron/test_pg_cron_options.py
@@ -1,29 +1,18 @@
 import pytest
 import pytest_django.fixtures
-from absurd_sdk import CreateQueueOptions
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.reconcile import resolve_spawn_options
 from django_absurd.scheduler import Schedule
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
-
-ABSURD = "django_absurd.backends.AbsurdBackend"
-
-
-BASE_QUEUES: dict[str, CreateQueueOptions] = {
-    "default": {},
-    "other": {},
-    "reports": {},
-}
 
 
 def test_max_attempts_from_decorator(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = {
-        "default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": BASE_QUEUES}}
-    }
+    settings.TASKS = make_tasks_settings()
     be = get_absurd_backends()["default"]
     s = Schedule(name="x", task="tests.tasks.capped", cron="0 2 * * *")
     assert (
@@ -34,12 +23,7 @@ def test_max_attempts_from_decorator(
 def test_max_attempts_falls_back_to_backend_default(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {"QUEUES": BASE_QUEUES, "DEFAULT_MAX_ATTEMPTS": 7},
-        }
-    }
+    settings.TASKS = make_tasks_settings(default_max_attempts=7)
     be = get_absurd_backends()["default"]
     s = Schedule(name="x", task="tests.tasks.add", cron="0 2 * * *")  # no decorator
     assert resolve_spawn_options(be, s.task)["max_attempts"] == 7  # NOT 5

--- a/tests/pg_cron/test_pg_cron_options.py
+++ b/tests/pg_cron/test_pg_cron_options.py
@@ -1,7 +1,6 @@
-import typing as t
-
 import pytest
 import pytest_django.fixtures
+from absurd_sdk import CreateQueueOptions
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.reconcile import resolve_spawn_options
@@ -12,7 +11,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
-BASE_QUEUES: dict[str, dict[str, t.Any]] = {
+BASE_QUEUES: dict[str, CreateQueueOptions] = {
     "default": {},
     "other": {},
     "reports": {},

--- a/tests/pg_cron/test_pg_cron_sync_jobs.py
+++ b/tests/pg_cron/test_pg_cron_sync_jobs.py
@@ -1,5 +1,3 @@
-import typing as t
-
 import psycopg
 import pytest
 from django.core.management import call_command
@@ -10,31 +8,16 @@ from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask, prune_pg_cron_jobs
 from django_absurd.pg_cron.reconcile import sync_crons
 from django_absurd.pg_cron.validators import build_jobname
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
-
-ABSURD = "django_absurd.backends.AbsurdBackend"
-
-
-def build_tasks(
-    schedule: dict[str, dict[str, object]],
-) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}, "other": {}, "reports": {}},
-                "SCHEDULE": schedule,
-            },
-        }
-    }
 
 
 def test_creates_job_with_schedule_and_constant_command(
     settings: SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
 
@@ -48,8 +31,8 @@ def test_creates_job_with_schedule_and_constant_command(
 
 
 def test_sync_is_idempotent(settings: SettingsWrapper) -> None:
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
     sync_crons(get_absurd_backends()["default"])
@@ -67,8 +50,8 @@ def test_prune_removes_undeclared_job_but_keeps_foreign(
             "select cron.schedule(%s, %s, %s)", ["keepme", "* * * * *", "select 1"]
         )
 
-    settings.TASKS = build_tasks(
-        {
+    settings.TASKS = make_tasks_settings(
+        schedule={
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
             "b": {"task": "tests.tasks.add", "cron": "0 3 * * *"},
         }
@@ -79,8 +62,8 @@ def test_prune_removes_undeclared_job_but_keeps_foreign(
         "_dj:s:b",
     }
 
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
     assert {r[0] for r in ScheduledTask.pg_cron.get_managed_jobs()} == {"_dj:s:a"}
@@ -94,8 +77,8 @@ def test_prune_removes_undeclared_job_but_keeps_foreign(
 def test_prune_tolerates_already_unscheduled_job(
     settings: SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {
+    settings.TASKS = make_tasks_settings(
+        schedule={
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
             "b": {"task": "tests.tasks.add", "cron": "0 3 * * *"},
         }
@@ -112,8 +95,8 @@ def test_prune_tolerates_already_unscheduled_job(
         jobid = cur.fetchone()[0]
         cur.execute("select cron.unschedule(%s)", [jobid])
 
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])  # no exception
 
@@ -126,8 +109,8 @@ def test_prune_swallows_job_vanished_after_stale_scan(
     # The stale-id scan and the unschedule are separate steps; a concurrent actor
     # can remove a job's cron.job row in between. prune_pg_cron_jobs must swallow
     # the resulting "could not find" error and finish the reconcile.
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
 
@@ -169,8 +152,8 @@ def test_prune_reraises_unexpected_error(
 
 
 def test_rearm_reenables_disabled_job(settings: SettingsWrapper) -> None:
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
 
@@ -197,8 +180,8 @@ def test_injection_args_are_quoted_and_schema_survives(
         cur.execute("select to_regnamespace('absurd')")
         assert cur.fetchone()[0] is not None
 
-    settings.TASKS = build_tasks(
-        {
+    settings.TASKS = make_tasks_settings(
+        schedule={
             "evil": {
                 "task": "tests.tasks.add",
                 "cron": "* * * * *",

--- a/tests/pg_cron/test_pg_cron_sync_jobs.py
+++ b/tests/pg_cron/test_pg_cron_sync_jobs.py
@@ -17,8 +17,8 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
 def build_tasks(
-    schedule: t.Any,
-) -> dict[str, dict[str, str | dict[str, t.Any]]]:
+    schedule: dict[str, dict[str, object]],
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD,

--- a/tests/pg_cron/test_pg_cron_sync_rows.py
+++ b/tests/pg_cron/test_pg_cron_sync_rows.py
@@ -13,7 +13,7 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
 def build_tasks(
-    schedule: dict[str, t.Any],
+    schedule: dict[str, dict[str, object]],
 ) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {

--- a/tests/pg_cron/test_pg_cron_sync_rows.py
+++ b/tests/pg_cron/test_pg_cron_sync_rows.py
@@ -1,36 +1,19 @@
-import typing as t
-
 import pytest
 import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
 from django_absurd.pg_cron.reconcile import sync_crons
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
-
-ABSURD = "django_absurd.backends.AbsurdBackend"
-
-
-def build_tasks(
-    schedule: dict[str, dict[str, object]],
-) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}, "other": {}, "reports": {}},
-                "SCHEDULE": schedule,
-            },
-        }
-    }
 
 
 def test_upsert_and_prune_settings_rows(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {
+    settings.TASKS = make_tasks_settings(
+        schedule={
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
             "b": {"task": "tests.tasks.add", "cron": "0 3 * * *"},
         }
@@ -38,8 +21,8 @@ def test_upsert_and_prune_settings_rows(
     be = get_absurd_backends()["default"]
     sync_crons(be)
     assert set(ScheduledTask.objects.values_list("name", flat=True)) == {"a", "b"}
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
     assert set(ScheduledTask.objects.values_list("name", flat=True)) == {"a"}
@@ -54,7 +37,7 @@ def test_admin_rows_untouched(
         task="tests.tasks.add",
         cron="0 2 * * *",
     )
-    settings.TASKS = build_tasks({})
+    settings.TASKS = make_tasks_settings(schedule={})
     sync_crons(get_absurd_backends()["default"])
     assert ScheduledTask.objects.filter(source="a", name="a").exists()
 
@@ -62,8 +45,8 @@ def test_admin_rows_untouched(
 def test_sync_writes_named_option_columns(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {
+    settings.TASKS = make_tasks_settings(
+        schedule={
             "nightly": {
                 "task": "tests.tasks.capped",  # decorated max_attempts=3
                 "cron": "0 2 * * *",
@@ -83,8 +66,8 @@ def test_sync_writes_named_option_columns(
 def test_reconcile_splits_cancellation_into_columns(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {"c": {"task": "tests.tasks.cancellable", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"c": {"task": "tests.tasks.cancellable", "cron": "0 2 * * *"}}
     )
     backend = get_absurd_backends()["default"]
     sync_crons(backend)
@@ -96,8 +79,8 @@ def test_reconcile_splits_cancellation_into_columns(
 def test_reconcile_splits_retry_strategy_into_columns(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {"r": {"task": "tests.tasks.retrying", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"r": {"task": "tests.tasks.retrying", "cron": "0 2 * * *"}}
     )
     backend = get_absurd_backends()["default"]
     sync_crons(backend)
@@ -109,8 +92,8 @@ def test_reconcile_splits_retry_strategy_into_columns(
 def test_sync_materializes_decorator_derived_columns(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_tasks(
-        {"full": {"task": "tests.tasks.fully_specced", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"full": {"task": "tests.tasks.fully_specced", "cron": "0 2 * * *"}}
     )
     sync_crons(get_absurd_backends()["default"])
     row = ScheduledTask.objects.get(source="s", name="full")

--- a/tests/pg_cron/test_pg_cron_teardown.py
+++ b/tests/pg_cron/test_pg_cron_teardown.py
@@ -8,31 +8,16 @@ if t.TYPE_CHECKING:
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
 from django_absurd.pg_cron.reconcile import sync_crons, teardown_crons
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
-
-ABSURD = "django_absurd.backends.AbsurdBackend"
-
-
-def build_tasks(
-    schedule: dict[str, dict[str, str]],
-) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}, "other": {}, "reports": {}},
-                "SCHEDULE": schedule,
-            },
-        }
-    }
 
 
 def test_teardown_removes_all_owned_cron_jobs_and_settings_rows(
     settings: "SettingsWrapper",
 ) -> None:
-    settings.TASKS = build_tasks(
-        {
+    settings.TASKS = make_tasks_settings(
+        schedule={
             "a": {"task": "tests.tasks.add", "cron": "0 2 * * *"},
             "b": {"task": "tests.tasks.add", "cron": "0 3 * * *"},
         }
@@ -58,8 +43,8 @@ def test_teardown_leaves_admin_rows_intact(
         task="tests.tasks.add",
         cron="0 4 * * *",
     )
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     be = get_absurd_backends()["default"]
     sync_crons(be)
@@ -70,8 +55,8 @@ def test_teardown_leaves_admin_rows_intact(
 
 
 def test_teardown_is_idempotent(settings: "SettingsWrapper") -> None:
-    settings.TASKS = build_tasks(
-        {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    settings.TASKS = make_tasks_settings(
+        schedule={"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )
     be = get_absurd_backends()["default"]
     sync_crons(be)

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -5,18 +5,12 @@ import typing as t
 
 import pytest
 import pytest_django.fixtures
-from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
-pytestmark = pytest.mark.django_db(transaction=True)
+from tests.utils import make_tasks_settings
 
-ABSURD = "django_absurd.backends.AbsurdBackend"
-BASE_QUEUES: dict[str, CreateQueueOptions] = {
-    "default": {},
-    "other": {},
-    "reports": {},
-}
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def run_check(
@@ -27,15 +21,7 @@ def run_check(
 ) -> str:
     if installed_apps is not None:
         settings.INSTALLED_APPS = installed_apps
-    options: dict[str, t.Any] = {"QUEUES": BASE_QUEUES}
-    if schedule is not None:
-        options["SCHEDULE"] = schedule
-    settings.TASKS = {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": options,
-        }
-    }
+    settings.TASKS = make_tasks_settings(schedule=schedule)
     try:
         call_command("check", "django_absurd")
     except SystemCheckError as exc:

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -5,13 +5,14 @@ import typing as t
 
 import pytest
 import pytest_django.fixtures
+from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
-BASE_QUEUES: dict[str, dict[str, t.Any]] = {
+BASE_QUEUES: dict[str, CreateQueueOptions] = {
     "default": {},
     "other": {},
     "reports": {},
@@ -22,7 +23,7 @@ def run_check(
     capsys: pytest.CaptureFixture[str],
     settings: pytest_django.fixtures.SettingsWrapper,
     installed_apps: t.Sequence[str] | None = None,
-    schedule: dict[str, t.Any] | None = None,
+    schedule: dict[str, dict[str, object]] | None = None,
 ) -> str:
     if installed_apps is not None:
         settings.INSTALLED_APPS = installed_apps

--- a/tests/pg_cron/test_scheduler_selector.py
+++ b/tests/pg_cron/test_scheduler_selector.py
@@ -1,44 +1,32 @@
 import re
-import typing as t
 
 import pytest
 import pytest_django.fixtures
+from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.management.base import BEAT_DISABLED_UNDER_PG_CRON
+from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
-ABSURD = "django_absurd.backends.AbsurdBackend"
-
-
-def build_pg_cron_tasks(
-    schedule: dict[str, dict[str, object]] | None = None,
-) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD,
-            "OPTIONS": {
-                "QUEUES": {"default": {}},
-                "SCHEDULE": schedule or {},
-            },
-        }
-    }
+# This suite never imports tests.tasks, so only "default" needs declaring.
+SINGLE_QUEUE: dict[str, CreateQueueOptions] = {"default": {}}
 
 
 def test_scheduler_is_pg_cron_when_app_installed(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_pg_cron_tasks()
+    settings.TASKS = make_tasks_settings(queues=SINGLE_QUEUE)
     assert get_absurd_backends()["default"].scheduler == "pg_cron"
 
 
 def test_beat_command_refuses_under_pg_cron(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_pg_cron_tasks()
+    settings.TASKS = make_tasks_settings(queues=SINGLE_QUEUE)
     with pytest.raises(CommandError, match=re.escape(BEAT_DISABLED_UNDER_PG_CRON)):
         call_command("absurd_beat")
 
@@ -46,6 +34,6 @@ def test_beat_command_refuses_under_pg_cron(
 def test_worker_beat_flag_refuses_under_pg_cron(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    settings.TASKS = build_pg_cron_tasks()
+    settings.TASKS = make_tasks_settings(queues=SINGLE_QUEUE)
     with pytest.raises(CommandError, match=re.escape(BEAT_DISABLED_UNDER_PG_CRON)):
         call_command("absurd_worker", queue="default", beat=True)

--- a/tests/pg_cron/test_scheduler_selector.py
+++ b/tests/pg_cron/test_scheduler_selector.py
@@ -15,8 +15,8 @@ ABSURD = "django_absurd.backends.AbsurdBackend"
 
 
 def build_pg_cron_tasks(
-    schedule: dict[str, t.Any] | None = None,
-) -> dict[str, t.Any]:
+    schedule: dict[str, dict[str, object]] | None = None,
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD,

--- a/tests/pg_cron/utils.py
+++ b/tests/pg_cron/utils.py
@@ -3,25 +3,10 @@ conftest.py; pg_cron catalog queries live on ``ScheduledTask.pg_cron``)."""
 
 import typing as t
 
-from absurd_sdk import CreateQueueOptions
-
-ABSURD_BACKEND: str = "django_absurd.backends.AbsurdBackend"
-DECLARED_QUEUES: dict[str, CreateQueueOptions] = {
-    "default": {},
-    "other": {},
-    "reports": {},
-}
+from tests.utils import make_tasks_settings
 
 
 def build_pg_cron_tasks(
     schedule: dict[str, dict[str, object]],
 ) -> dict[str, dict[str, t.Any]]:
-    return {
-        "default": {
-            "BACKEND": ABSURD_BACKEND,
-            "OPTIONS": {
-                "QUEUES": DECLARED_QUEUES,
-                "SCHEDULE": schedule,
-            },
-        }
-    }
+    return make_tasks_settings(schedule=schedule)

--- a/tests/pg_cron/utils.py
+++ b/tests/pg_cron/utils.py
@@ -3,15 +3,19 @@ conftest.py; pg_cron catalog queries live on ``ScheduledTask.pg_cron``)."""
 
 import typing as t
 
+from absurd_sdk import CreateQueueOptions
+
 ABSURD_BACKEND: str = "django_absurd.backends.AbsurdBackend"
-DECLARED_QUEUES: dict[str, dict[str, t.Any]] = {
+DECLARED_QUEUES: dict[str, CreateQueueOptions] = {
     "default": {},
     "other": {},
     "reports": {},
 }
 
 
-def build_pg_cron_tasks(schedule: dict[str, t.Any]) -> dict[str, t.Any]:
+def build_pg_cron_tasks(
+    schedule: dict[str, dict[str, object]],
+) -> dict[str, dict[str, t.Any]]:
     return {
         "default": {
             "BACKEND": ABSURD_BACKEND,

--- a/tests/pg_cron/validators/utils.py
+++ b/tests/pg_cron/validators/utils.py
@@ -5,6 +5,7 @@ import json
 import typing as t
 
 import pytest
+from absurd_sdk import CreateQueueOptions
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
@@ -29,7 +30,7 @@ def get_change_url(pk: int) -> str:
 
 
 BACKEND = "django_absurd.backends.AbsurdBackend"
-QUEUES: dict[str, dict[str, t.Any]] = {
+QUEUES: dict[str, CreateQueueOptions] = {
     "default": {},
     "other": {},
     "reports": {},
@@ -50,7 +51,7 @@ VALID: dict[str, t.Any] = {
 
 def configure_pg_cron_backend(
     settings: SettingsWrapper,
-    schedule: dict[str, t.Any] | None = None,
+    schedule: dict[str, dict[str, object]] | None = None,
 ) -> None:
     """A pg_cron 'default' backend so model clean() resolves it (declared queues),
     and the check has a SCHEDULE to validate."""
@@ -93,7 +94,7 @@ def validate_from_system_check(
     """Subject: the system check over a pg_cron SCHEDULE. Return captured text or
     None."""
     fields = {**VALID, **kwargs}
-    entry: dict[str, t.Any] = {
+    entry: dict[str, object] = {
         "cron": fields["cron"],
         "task": fields["task"],
     }
@@ -138,7 +139,7 @@ def validate_from_admin_post(
         queue="default",
         cron=t.cast("str", VALID["cron"]),
     )
-    payload: dict[str, t.Any] = {
+    payload: dict[str, str] = {
         "task": fields["task"],
         "queue": fields["queue"],
         "cron": fields["cron"],

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,7 +1,7 @@
 import time
 import typing as t
 
-from absurd_sdk import CancellationPolicy, RetryStrategy
+from absurd_sdk import CancellationPolicy, JsonValue, RetryStrategy
 from django.contrib.auth.models import Group
 from django.tasks import TaskContext, task
 
@@ -59,7 +59,7 @@ def echo(value: t.Any) -> t.Any:
 
 
 @task
-def create_payload(data: t.Any) -> int:
+def create_payload(data: JsonValue) -> int:
     return Payload.objects.create(data=data).pk
 
 
@@ -105,7 +105,7 @@ def sstep_echo(value: str) -> str:
 
 
 @task
-def scoverage() -> dict[str, t.Any]:
+def scoverage() -> dict[str, JsonValue]:
     context = get_absurd_context()
     context.heartbeat()
     tenant = context.headers.get("tenant")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,7 @@ def make_tasks_settings(
     override for tests exercising a different catalog (e.g. an undeclared queue).
     """
     options: dict[str, t.Any] = {
-        "QUEUES": DECLARED_QUEUES if queues is None else queues,
+        "QUEUES": dict(DECLARED_QUEUES if queues is None else queues),
     }
     if schedule is not None:
         options["SCHEDULE"] = schedule

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,61 @@
+import typing as t
 import uuid
 
 import psycopg
-from absurd_sdk import Absurd, TaskResultSnapshot
+from absurd_sdk import Absurd, CreateQueueOptions, TaskResultSnapshot
 from django.core.management import call_command
 from django.db import connections
 
 from django_absurd.connection import register_jsonb_loader
+
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+
+ABSURD_BACKEND = "django_absurd.backends.AbsurdBackend"
+
+# tests/tasks.py declares @task(queue_name="other") and @task(queue_name="reports")
+# at module level; importing any task from that module validates those queue names
+# against the current backend. Any test that imports from tests.tasks (directly or
+# transitively) must therefore declare at least "other" and "reports" alongside
+# "default" — this is why make_tasks_settings() defaults to all three.
+DECLARED_QUEUES: dict[str, CreateQueueOptions] = {
+    "default": {},
+    "other": {},
+    "reports": {},
+}
+
+
+class HasContent(t.Protocol):
+    """What parse_html()/rows() actually need — matches both django.http.HttpResponse
+    and the test client's private ``_MonkeyPatchedWSGIResponse``."""
+
+    content: bytes
+
+
+def make_tasks_settings(
+    queues: "Mapping[str, CreateQueueOptions] | None" = None,
+    schedule: "Mapping[str, dict[str, object]] | None" = None,
+    cleanup: dict[str, str] | None = None,
+    database: str | None = None,
+    default_max_attempts: int | None = None,
+) -> dict[str, dict[str, t.Any]]:
+    """Build a ``settings.TASKS`` dict for the AbsurdBackend.
+
+    ``queues`` defaults to ``DECLARED_QUEUES`` (default/other/reports); pass an
+    override for tests exercising a different catalog (e.g. an undeclared queue).
+    """
+    options: dict[str, t.Any] = {
+        "QUEUES": DECLARED_QUEUES if queues is None else queues,
+    }
+    if schedule is not None:
+        options["SCHEDULE"] = schedule
+    if cleanup is not None:
+        options["CLEANUP"] = cleanup
+    if database is not None:
+        options["DATABASE"] = database
+    if default_max_attempts is not None:
+        options["DEFAULT_MAX_ATTEMPTS"] = default_max_attempts
+    return {"default": {"BACKEND": ABSURD_BACKEND, "OPTIONS": options}}
 
 
 def run_absurd_worker(queue: str = "default", concurrency: int = 1) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-import typing as t
+import uuid
 
 import psycopg
 from absurd_sdk import Absurd, TaskResultSnapshot
@@ -13,8 +13,11 @@ def run_absurd_worker(queue: str = "default", concurrency: int = 1) -> None:
 
 
 def get_task_result(
-    task_id: t.Any, queue: str = "default"
+    task_id: str | uuid.UUID, queue: str = "default"
 ) -> TaskResultSnapshot | None:
+    # task_id is either a TaskResult.id ("queue:uuid" string) or a raw SpawnResult
+    # ["task_id"] — the latter is typed str by absurd_sdk's stub, but psycopg
+    # deserializes the uuid column to a real uuid.UUID at runtime.
     raw_task_id = str(task_id).rsplit(":", 1)[-1]
     params = connections["default"].get_connection_params()
     conn = psycopg.connect(**params, autocommit=True)


### PR DESCRIPTION
## Summary
- Sweep `t.Any` across `django_absurd/` and `tests/` in 3 phases (public API, admin/pg_cron/test-utils, test files), replacing lazy ones with real types (absurd_sdk TypedDicts, Django types, new Protocols/TypedDicts).
- Consolidate duplicated test helpers (`HasContent` Protocol, `make_tasks_settings`).
- Remove `BoundedCountPaginator` (misleading capped admin count).

## Test plan
- [x] `uv run mypy django_absurd tests` clean
- [x] `uv run ruff check django_absurd tests` clean
- [x] `tests/core`, `tests/pg_cron`, `tests/multidb` all green
- [x] Adversarial review (Fable) + 2 rounds of revdiff annotations addressed