### PR TITLE
Events: await_event / emit_event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,11 @@ duplicate that material here.
 - **Assert the COMPLETE error message, never a fragment** (fragments are unreadable and
   brittle); assert the full stable portion up to any volatile tail.
 - **Always alphabetize** `@pytest.mark.parametrize` values and fixture `params`.
+- **Alphabetize a test function's own fixture parameters** too (e.g.
+  `def test_x(admin_user: User, client: Client)`, not `client` then `admin_user`) — no
+  ruff/flake8-pytest-style rule enforces this (checked; no `PT0xx` rule covers parameter
+  order), so it's a manual convention only. Applies going forward on touched tests, not
+  a retroactive sweep of existing ones.
 
 ## Runtime
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -816,14 +816,14 @@ idempotent (for example, use `idempotency_key` on downstream enqueues, or make d
 writes upserts).
 
 **Don't catch-all `except` in a task.** Absurd suspends and cancels runs via
-control-flow exceptions raised inside `step`/`sleep_for`/`sleep_until`. A bare `except:`
-or `except Exception:` around a durable call swallows them and silently breaks
-suspension — let them propagate.
+control-flow exceptions raised inside `step`/`sleep_for`/`sleep_until`/`await_event`. A
+bare `except:` or `except Exception:` around a durable call swallows them and silently
+breaks suspension — let them propagate.
 
 **Absurd backend only.** `get_absurd_context()` / `aget_absurd_context()` (and
-`step`/`sleep_for`/`sleep_until` on the returned context) are Absurd-specific. Calling
-them under any other Django task backend — where the Absurd runtime context is never set
-— raises `RuntimeError`.
+`step`/`sleep_for`/`sleep_until`/`await_event`/`emit_event` on the returned context) are
+Absurd-specific. Calling them under any other Django task backend — where the Absurd
+runtime context is never set — raises `RuntimeError`.
 
 Absurd's durable-execution rules also apply — deterministic step naming/order,
 JSON-serializable step return values, and finishing a step within `claim_timeout` (or

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -574,11 +574,13 @@ runtime failures Django cannot detect. Verify the versions line up before faking
 
 ## Workflows
 
-Absurd calls these primitives **Steps (Checkpoints)** and **Sleep** — see
+Absurd calls these primitives **Steps (Checkpoints)**, **Sleep**, and **Events** — see
 [Absurd — Concepts](https://earendil-works.github.io/absurd/concepts/). Call the
-matching accessor **inside** a running task to reach them. Both are orthogonal to
-Django's `TaskContext` — you do **not** need `takes_context=True` (add that only if you
-also want `context.task_result`/`.attempt`).
+matching accessor **inside** a running task to reach them. They let a task break its
+work into checkpointed steps, sleep between them, and suspend until a named signal
+arrives — persisting progress so retries and resumes pick up where they left off. Both
+are orthogonal to Django's `TaskContext` — you do **not** need `takes_context=True` (add
+that only if you also want `context.task_result`/`.attempt`).
 
 ```python
 from django_absurd import aget_absurd_context, get_absurd_context
@@ -681,16 +683,127 @@ when compared against Absurd's timezone-aware clock. A Unix timestamp (`int` or 
 is always unambiguous. Sleep resume re-claims the same run — the attempt counter does
 not increment.
 
+### Events
+
+`context.await_event(event_name, step_name=None, timeout=None)` suspends the task until
+a named event arrives, then returns its JSON payload.
+`context.emit_event(event_name, payload=None)` emits an event on the task's own queue
+(in-task, replay-safe — a re-emit after a retry is a no-op). Events are awaited by name,
+carry an optional JSON payload, and **first emit per name wins** (immutable) — a
+business-keyed name like `"warehouse.packed:order-42"` targets exactly one waiter.
+
+→ [Absurd: Concepts — Events](https://earendil-works.github.io/absurd/concepts/#events)
+
+Events are **queue-scoped**: `await_event`/`emit_event` operate on the task's own queue.
+An event emitted on queue X only wakes a waiter on queue X.
+
+#### The outside-a-task signal: top-level `emit_event`
+
+`ctx.emit_event` only reaches code running _inside_ a task. The real-world signal that
+wakes a waiter — a webhook, a view, an API handler — is ordinary Django code, not a
+task. `django_absurd.emit_event(event_name, payload=None, *, queue="default")` is that
+entry point:
+
+```python
+from django_absurd import emit_event
+
+
+def warehouse_webhook(request, order):
+    emit_event(f"warehouse.packed:{order}", {"tracking": request.POST["tracking"]},
+               queue="default")
+    return HttpResponse(status=204)
+```
+
+End-to-end: a task calls `await_event(f"warehouse.packed:{order}")` → suspends (worker
+freed) → the warehouse system POSTs the webhook → the view emits the event on the task's
+queue → the task's next claim finds it → resumes with the payload.
+
+`queue` must match the queue the waiting task actually runs on — it targets the
+client-level `emit_event`'s `queue_name`, not a database alias. An unknown queue raises
+`ImproperlyConfigured` immediately (fail fast on a typo). `emit_event` is sync; from an
+async view, wrap it in `sync_to_async`.
+
+#### Sync
+
+```python
+from django.tasks import task
+from django_absurd import get_absurd_context
+
+
+@task
+def process_order(order_id: int) -> None:
+    context = get_absurd_context()
+    context.step("charge", lambda: charge_card(order_id))
+    payload = context.await_event(f"warehouse.packed:{order_id}")
+    context.step("ship", lambda: ship(order_id, payload))
+```
+
+#### Async
+
+```python
+from django.tasks import task
+from django_absurd import aget_absurd_context
+
+
+@task
+async def process_order(order_id: int) -> None:
+    context = aget_absurd_context()
+    payload = await context.await_event(f"warehouse.packed:{order_id}")
+
+    async def ship_order():
+        return await ship(order_id, payload)
+
+    await context.step("ship", ship_order)
+```
+
+#### Timeout
+
+Pass `timeout` (seconds) to stop waiting after a bound. On timeout, `await_event` raises
+`absurd_sdk.TimeoutError` — **not** the builtin `TimeoutError`:
+
+```python
+import absurd_sdk
+from django.tasks import task
+from django_absurd import get_absurd_context
+
+
+@task
+def process_order(order_id: int) -> str:
+    context = get_absurd_context()
+    try:
+        context.await_event(f"warehouse.packed:{order_id}", timeout=3600)
+    except absurd_sdk.TimeoutError:
+        return "gave up waiting for the warehouse"
+    return "shipped"
+```
+
+!!! warning "Not the builtin `TimeoutError`"
+
+    `except TimeoutError:` (the builtin) does **not** catch this — you must
+    `import absurd_sdk` and catch `absurd_sdk.TimeoutError` explicitly.
+
+An **uncaught** `TimeoutError` fails the run, which then retries and re-waits the full
+`timeout` on each attempt until `max_attempts` — catch it if you want a one-shot
+timeout.
+
+#### `await_task_result` is not provided
+
+Absurd's SDK version of this polls + heartbeats inside a step rather than suspending
+(holding the worker slot), and is cross-queue-only. For a child task's result, use
+Django's `get_result()` / `aget_result()` instead.
+
 ### API reference
 
-| Method / property                 | Sync | Async   | What it does                                              |
-| --------------------------------- | ---- | ------- | --------------------------------------------------------- |
-| `step(name, fn)`                  | yes  | `await` | Run `fn()`, checkpoint the result; skip on replay         |
-| `sleep_for(step_name, duration)`  | yes  | `await` | Suspend the task for `duration` seconds                   |
-| `sleep_until(step_name, wake_at)` | yes  | `await` | Suspend until a `datetime`, Unix timestamp, or float      |
-| `heartbeat(seconds=None)`         | yes  | `await` | Extend the claim timeout (keep the run alive)             |
-| `headers`                         | yes  | yes     | Read-only mapping of headers passed at enqueue time       |
-| `run_step([name])` (decorator)    | yes  | —       | Convenience wrapper around `step`; derives name from `fn` |
+| Method / property                                       | Sync | Async   | What it does                                              |
+| ------------------------------------------------------- | ---- | ------- | --------------------------------------------------------- |
+| `step(name, fn)`                                        | yes  | `await` | Run `fn()`, checkpoint the result; skip on replay         |
+| `sleep_for(step_name, duration)`                        | yes  | `await` | Suspend the task for `duration` seconds                   |
+| `sleep_until(step_name, wake_at)`                       | yes  | `await` | Suspend until a `datetime`, Unix timestamp, or float      |
+| `await_event(event_name, step_name=None, timeout=None)` | yes  | `await` | Suspend until the named event arrives; return its payload |
+| `emit_event(event_name, payload=None)`                  | yes  | `await` | Emit an event on the task's own queue (replay-safe)       |
+| `heartbeat(seconds=None)`                               | yes  | `await` | Extend the claim timeout (keep the run alive)             |
+| `headers`                                               | yes  | yes     | Read-only mapping of headers passed at enqueue time       |
+| `run_step([name])` (decorator)                          | yes  | —       | Convenience wrapper around `step`; derives name from `fn` |
 
 ### Caveats
 
@@ -714,6 +827,14 @@ Absurd's durable-execution rules also apply — deterministic step naming/order,
 JSON-serializable step return values, and finishing a step within `claim_timeout` (or
 calling `context.heartbeat()`); see
 [Absurd — Concepts](https://earendil-works.github.io/absurd/concepts/).
+
+**Events are subject to cleanup_ttl.** An event emitted long before a delayed
+`await_event` can be cleaned up by the queue's `cleanup_ttl` before the waiter ever
+checks — the waiter then never wakes. Keep `cleanup_ttl` generous relative to how long a
+waiter might sleep before checking.
+
+**`TimeoutError` is `absurd_sdk.TimeoutError`, not the builtin.** `except TimeoutError:`
+silently catches nothing — `import absurd_sdk` and catch `absurd_sdk.TimeoutError`.
 
 ## Notes
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -705,6 +705,8 @@ task. `django_absurd.emit_event(event_name, payload=None, *, queue="default")` i
 entry point:
 
 ```python
+from django.http import HttpResponse
+
 from django_absurd import emit_event
 
 

--- a/django_absurd/__init__.py
+++ b/django_absurd/__init__.py
@@ -16,6 +16,7 @@ from django_absurd.context import (
     aget_absurd_context,
     get_absurd_context,
 )
+from django_absurd.events import emit_event
 
 ABSURD_SCHEMA_VERSION = "0.4.0"
 
@@ -23,5 +24,6 @@ __all__ = [
     "ABSURD_SCHEMA_VERSION",
     "AbsurdTaskContext",
     "aget_absurd_context",
+    "emit_event",
     "get_absurd_context",
 ]

--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -259,9 +259,13 @@ def build_entity_admin(
         checkpoint_model = build_admin_model(
             next(s for s in ADMIN_ENTITY_SPECS if s.name == "checkpoints")
         )
+        wait_model = build_admin_model(
+            next(s for s in ADMIN_ENTITY_SPECS if s.name == "waits")
+        )
         extra["inlines"] = [
             build_run_inline(run_model),
             build_checkpoint_inline(checkpoint_model),
+            build_wait_inline(wait_model),
         ]
         extra["fieldsets"] = TASK_FIELDSETS
         # Most recently active first: by run start, then enqueue time (both real
@@ -327,6 +331,13 @@ CHECKPOINT_INLINE_FIELDS = (
     "status",
     "state",
     "updated_at",
+)
+
+WAIT_INLINE_FIELDS = (
+    "event_name",
+    "step_name",
+    "timeout_at",
+    "created_at",
 )
 
 
@@ -408,6 +419,42 @@ def build_checkpoint_inline(
     return type(
         "CheckpointInline", (ReadOnlyCheckpointInline,), {"model": checkpoint_model}
     )
+
+
+class ReadOnlyWaitInline(_TabularInlineBase):
+    fk_name = "task"
+    extra = 0
+    can_delete = False
+    show_change_link = True
+    ordering = ("created_at",)
+    fields = WAIT_INLINE_FIELDS
+    readonly_fields = WAIT_INLINE_FIELDS
+
+    def has_add_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return False
+
+    def has_change_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return False
+
+    def has_delete_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return False
+
+    def has_view_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return True
+
+
+def build_wait_inline(
+    wait_model: "type[Model]",
+) -> "type[admin.TabularInline[t.Any, t.Any]]":
+    return type("WaitInline", (ReadOnlyWaitInline,), {"model": wait_model})
 
 
 def autoregister_admin() -> None:

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -424,12 +424,17 @@ def compose_queue_arm(spec: EntitySpec, queue: str) -> psycopg.sql.Composable:
 
 def compose_column_expr(spec: EntitySpec, col: str) -> psycopg.sql.Composable:
     # An indefinite await_event (no timeout) writes Postgres's 'infinity' sentinel
-    # into runs.available_at (absurd.await_event: `coalesce(v_timeout_at,
-    # 'infinity'::timestamptz)`) — psycopg cannot decode a literal infinity into a
-    # Python datetime. NULLIF converts it to SQL NULL at the query level, matching
-    # the Absurd SDK's own test helpers (sdks/python/tests/test_absurd.py
-    # `_fetch_run`), so the column stays a genuine timestamptz for every ordinary
-    # (non-infinite) value.
+    # into runs.available_at — absurd.await_event, upstream source:
+    # https://github.com/earendil-works/absurd/blob/9b77b356963c65ff9b183fdb4044c2dff2392f6e/sql/absurd.sql#L1662
+    # vendored at django_absurd/migrations/0001_initial_0_4_0.sql:1664
+    # (`coalesce(v_timeout_at, 'infinity'::timestamptz)`). This is a Python/psycopg
+    # limitation, not a Postgres one — psycopg cannot decode a literal infinity
+    # into a Python datetime, so an un-guarded read crashes. NULLIF converts it to
+    # SQL NULL at the query level, matching the Absurd SDK's own test helpers:
+    # https://github.com/earendil-works/absurd/blob/9b77b356963c65ff9b183fdb4044c2dff2392f6e/sdks/python/tests/test_absurd.py#L15
+    # https://github.com/earendil-works/absurd/blame/9b77b356963c65ff9b183fdb4044c2dff2392f6e/sdks/python/tests/test_task_context.py#L21
+    # so the column stays a genuine timestamptz for every ordinary (non-infinite)
+    # value.
     if spec.name == "runs" and col == "available_at":
         return psycopg.sql.SQL(
             "nullif({col}, 'infinity'::timestamptz) AS {col}"

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -160,7 +160,7 @@ ADMIN_ENTITY_SPECS: tuple[EntitySpec, ...] = (
         has_state=False,
         has_status=False,
         list_display=("natural_key", "queue", "task_id", "run_id", "step_name"),
-        search_fields=("task_id", "run_id", "step_name"),
+        search_fields=("task__task_id", "run_id", "step_name"),
     ),
 )
 
@@ -292,6 +292,20 @@ def build_model_field(
             on_delete=models.DO_NOTHING,
             null=True,
             related_name="checkpoints",
+        )
+    # Waits join to their task on task_id — same constraint-free FK treatment as runs
+    # and checkpoints so the admin can inline waits under a task. The attname stays
+    # task_id.
+    if spec.name == "waits" and col_name == "task_id":
+        tasks_spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
+        return "task", models.ForeignKey(
+            build_admin_model(tasks_spec),
+            to_field="task_id",
+            db_column="task_id",
+            db_constraint=False,
+            on_delete=models.DO_NOTHING,
+            null=True,
+            related_name="waits",
         )
     return col_name, make_field(col_type)
 

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -401,11 +401,26 @@ def compose_queue_arm(spec: EntitySpec, queue: str) -> psycopg.sql.Composable:
         + spec.natural_key_sql
     )
     col_list = psycopg.sql.SQL(", ").join(
-        psycopg.sql.Identifier(col) for col, _ in spec.columns
+        compose_column_expr(spec, col) for col, _ in spec.columns
     )
     return psycopg.sql.SQL(
         "SELECT {q}::text AS queue, {pk} AS natural_key, {cols} FROM {tbl}"
     ).format(q=queue_lit, pk=pk_expr, cols=col_list, tbl=table)
+
+
+def compose_column_expr(spec: EntitySpec, col: str) -> psycopg.sql.Composable:
+    # An indefinite await_event (no timeout) writes Postgres's 'infinity' sentinel
+    # into runs.available_at (absurd.await_event: `coalesce(v_timeout_at,
+    # 'infinity'::timestamptz)`) — psycopg cannot decode a literal infinity into a
+    # Python datetime. NULLIF converts it to SQL NULL at the query level, matching
+    # the Absurd SDK's own test helpers (sdks/python/tests/test_absurd.py
+    # `_fetch_run`), so the column stays a genuine timestamptz for every ordinary
+    # (non-infinite) value.
+    if spec.name == "runs" and col == "available_at":
+        return psycopg.sql.SQL(
+            "nullif({col}, 'infinity'::timestamptz) AS {col}"
+        ).format(col=psycopg.sql.Identifier(col))
+    return psycopg.sql.Identifier(col)
 
 
 def compose_empty_arm(spec: EntitySpec) -> psycopg.sql.Composable:

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -218,6 +218,7 @@ def fetch_task_and_run(
                 run = (
                     run_model.objects.using(database)
                     .filter(pk=task.last_attempt_run)
+                    .defer("available_at")
                     .first()
                 )
         except ProgrammingError:

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -218,6 +218,9 @@ def fetch_task_and_run(
                 run = (
                     run_model.objects.using(database)
                     .filter(pk=task.last_attempt_run)
+                    # An indefinite await_event can leave available_at as Postgres's
+                    # 'infinity' sentinel, which psycopg can't decode — defer it since
+                    # build_task_result() below never reads it.
                     .defer("available_at")
                     .first()
                 )

--- a/django_absurd/context.py
+++ b/django_absurd/context.py
@@ -19,6 +19,8 @@ if t.TYPE_CHECKING:
     import datetime as dt
     from collections.abc import Callable, Coroutine, Mapping
 
+    from absurd_sdk import JsonValue
+
 R = t.TypeVar("R")
 
 BRIDGE_TIMEOUT = 300.0
@@ -122,6 +124,16 @@ class AbsurdTaskContext:
 
     def sleep_until(self, step_name: str, wake_at: "dt.datetime | int | float") -> None:
         self.run_on_loop(self.absurd_ctx.sleep_until(step_name, wake_at))
+
+    def await_event(
+        self, event_name: str, step_name: str | None = None, timeout: int | None = None
+    ) -> "JsonValue":
+        return self.run_on_loop(
+            self.absurd_ctx.await_event(event_name, step_name, timeout)
+        )
+
+    def emit_event(self, event_name: str, payload: "JsonValue | None" = None) -> None:
+        self.run_on_loop(self.absurd_ctx.emit_event(event_name, payload))
 
     def run_on_loop(self, coro: "Coroutine[t.Any, t.Any, R]") -> R:
         future = asyncio.run_coroutine_threadsafe(coro, self.loop)

--- a/django_absurd/events.py
+++ b/django_absurd/events.py
@@ -1,0 +1,42 @@
+"""Emit an Absurd event from outside a running task (e.g. a Django view)."""
+
+import typing as t
+
+import psycopg.errors
+from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
+
+if t.TYPE_CHECKING:
+    from absurd_sdk import JsonValue
+
+
+def emit_event(
+    event_name: str, payload: "JsonValue | None" = None, *, queue: str = "default"
+) -> None:
+    from django_absurd.backends import get_declared_queues  # noqa: PLC0415
+    from django_absurd.queues import (  # noqa: PLC0415
+        get_absurd_backend,
+        get_absurd_client,
+    )
+
+    backend = get_absurd_backend()
+    if backend is None:
+        msg = "django-absurd: no Absurd backend configured."
+        raise ImproperlyConfigured(msg)
+    declared = get_declared_queues(backend)
+    if queue not in declared:
+        msg = (
+            f"Queue '{queue}' is not declared in TASKS QUEUES. "
+            "Add it to the QUEUES list in your TASKS backend settings."
+        )
+        raise ImproperlyConfigured(msg)
+    client = get_absurd_client()
+    try:
+        with transaction.atomic(using=backend.database, savepoint=True):
+            client.emit_event(event_name, payload, queue_name=queue)
+    except psycopg.errors.UndefinedTable:
+        msg = (
+            f"Queue '{queue}' is declared but its Absurd table is not provisioned. "
+            "Run: manage.py absurd_sync_queues"
+        )
+        raise ImproperlyConfigured(msg) from None

--- a/django_absurd/migrations/0001_initial_0_4_0.sql
+++ b/django_absurd/migrations/0001_initial_0_4_0.sql
@@ -1661,10 +1661,6 @@ begin
     v_timeout_at := v_now + (p_timeout::double precision * interval '1 second');
   end if;
 
-  -- Postgres 'infinity' sentinel — upstream source:
-  -- https://github.com/earendil-works/absurd/blob/9b77b356963c65ff9b183fdb4044c2dff2392f6e/sql/absurd.sql#L1662
-  -- Read via NULLIF in django_absurd/admin_views.py's compose_column_expr
-  -- (psycopg cannot decode a literal infinity into a Python datetime).
   v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
 
   execute format(

--- a/django_absurd/migrations/0001_initial_0_4_0.sql
+++ b/django_absurd/migrations/0001_initial_0_4_0.sql
@@ -1661,6 +1661,10 @@ begin
     v_timeout_at := v_now + (p_timeout::double precision * interval '1 second');
   end if;
 
+  -- Postgres 'infinity' sentinel — upstream source:
+  -- https://github.com/earendil-works/absurd/blob/9b77b356963c65ff9b183fdb4044c2dff2392f6e/sql/absurd.sql#L1662
+  -- Read via NULLIF in django_absurd/admin_views.py's compose_column_expr
+  -- (psycopg cannot decode a literal infinity into a Python datetime).
   v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
 
   execute format(

--- a/docs/plans/2026-07-19-events-await-emit.md
+++ b/docs/plans/2026-07-19-events-await-emit.md
@@ -1,0 +1,1044 @@
+# Events (await_event / emit_event) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ship Absurd's Events pillar in django-absurd — `await_event`/`emit_event`
+in-task, plus a top-level `django_absurd.emit_event` for use from outside a task (a
+view/webhook). Closes #21.
+
+**Architecture:** thin delegation to the already-shipped context-accessor pattern (#84).
+Async is free (SDK's `AsyncTaskContext` already has `await_event`/`emit_event`); sync
+gets two new bridge methods on `AbsurdTaskContext` mirroring `sleep_for`/`heartbeat`.
+The top-level `emit_event` is a new `django_absurd/events.py` module, lazy-imported from
+`__init__.py` to dodge `AppRegistryNotReady`. A Waits admin inline mirrors the shipped
+Checkpoints inline verbatim.
+
+**Tech Stack:** Django 6.0 / Python 3.12+, `absurd_sdk`, psycopg3, pytest
+(function-based).
+
+## Global Constraints
+
+- Floor: Django 6.0 / Python 3.12. psycopg (v3) backend only.
+- `import typing as t` (never `from typing import X`); absolute imports only.
+- Functions verb-named; no leading-underscore module constants/helpers.
+- No monkeypatching / `unittest.mock.patch`; behavioral tests through real entrypoints
+  (task + worker drain, admin HTTP, management commands) — never raw unit calls into
+  helpers, never raw-SQL assertions for a happy path we can reach through code.
+- HTTP mocking (if ever needed): `responses`, not `mock`. (Not needed in this plan.)
+- No ruff ignores added without asking first — hit one here (`A004`, see Task 1) and
+  resolved it by NOT re-exporting `TimeoutError`; import it directly from `absurd_sdk`,
+  `import absurd_sdk` then `absurd_sdk.TimeoutError` (never
+  `from absurd_sdk import TimeoutError` — same A004 hit in any file).
+- Full patch coverage: every added line/branch covered via a real entrypoint.
+- Assert complete error-message text (not fragments) in new tests.
+- Alphabetize `@pytest.mark.parametrize` values / fixture params (n/a here — no new
+  parametrized tests).
+- `AbsurdBackend`/project is a hard singleton (#63/E004) — `get_absurd_backend()` /
+  `get_declared_queues()` already assume this; do not build multi-backend plumbing.
+- `await_task_result` is OUT OF SCOPE (deliberately not built) — do not add it.
+- Docs mirror between `django_absurd/AGENTS.md` and `docs/web/workflows.md`; build clean
+  with `uvx zensical build` after doc edits.
+- Commit after each task (local branch `events-await-emit`, no push/PR without asking —
+  per project convention, new-feature work stays local + reviewed before any PR).
+
+---
+
+### Task 1: Top-level `django_absurd.emit_event` (outside-a-task signal)
+
+**Files:**
+
+- Create: `django_absurd/events.py`
+- Modify: `django_absurd/__init__.py`
+- Test: `tests/core/test_events.py` (new)
+- Test: `tests/core/test_admin/test_event.py` (add one case)
+
+**Interfaces:**
+
+- Produces:
+  `django_absurd.events.emit_event(event_name: str, payload: "JsonValue | None" = None, *, queue: str = "default") -> None`,
+  re-exported as `django_absurd.emit_event`. Raises
+  `django.core.exceptions.ImproperlyConfigured` on: no `AbsurdBackend` configured;
+  `queue` not in `get_declared_queues(backend)`; the queue's table not yet provisioned
+  (`psycopg.errors.UndefinedTable`).
+- Consumes: `django_absurd.queues.get_absurd_backend()`,
+  `django_absurd.queues.get_absurd_client()`,
+  `django_absurd.backends.get_declared_queues(backend)` (all existing, imported
+  **inside** the function body — a module-level import of
+  `django_absurd.queues`/`django_absurd.backends` here would transitively pull in
+  `django_absurd.models` before the app registry is ready, since `__init__.py` imports
+  this module at top level).
+
+- [ ] **Step 1: Write the failing tests in `tests/core/test_events.py`**
+
+```python
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+from pytest_django.fixtures import SettingsWrapper
+
+from django_absurd import emit_event
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_top_level_emit_event_unknown_queue_raises() -> None:
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=(
+            r"Queue 'ghost' is not declared in TASKS QUEUES\. Add it to the QUEUES "
+            r"list in your TASKS backend settings\."
+        ),
+    ):
+        emit_event("whatever", queue="ghost")
+
+
+@override_settings(TASKS={"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}})
+def test_top_level_emit_event_no_backend_configured_raises() -> None:
+    with pytest.raises(
+        ImproperlyConfigured, match=r"django-absurd: no Absurd backend configured\."
+    ):
+        emit_event("whatever")
+
+
+def test_top_level_emit_event_unsynced_queue_raises(settings: SettingsWrapper) -> None:
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {}, "unsynced": {}}},
+        }
+    }
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=(
+            r"Queue 'unsynced' is declared but its Absurd table is not provisioned\. "
+            r"Run: manage\.py absurd_sync_queues"
+        ),
+    ):
+        emit_event("whatever", queue="unsynced")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_events.py -v` Expected: FAIL —
+`ImportError: cannot import name 'emit_event' from 'django_absurd'`
+
+- [ ] **Step 3: Write `django_absurd/events.py`**
+
+```python
+"""Emit an Absurd event from outside a running task (e.g. a Django view)."""
+
+import typing as t
+
+import psycopg.errors
+from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
+
+if t.TYPE_CHECKING:
+    from absurd_sdk import JsonValue
+
+
+def emit_event(
+    event_name: str, payload: "JsonValue | None" = None, *, queue: str = "default"
+) -> None:
+    from django_absurd.backends import get_declared_queues
+    from django_absurd.queues import get_absurd_backend, get_absurd_client
+
+    backend = get_absurd_backend()
+    if backend is None:
+        msg = "django-absurd: no Absurd backend configured."
+        raise ImproperlyConfigured(msg)
+    declared = get_declared_queues(backend)
+    if queue not in declared:
+        msg = (
+            f"Queue '{queue}' is not declared in TASKS QUEUES. "
+            "Add it to the QUEUES list in your TASKS backend settings."
+        )
+        raise ImproperlyConfigured(msg)
+    client = get_absurd_client()
+    try:
+        with transaction.atomic(using=backend.database, savepoint=True):
+            client.emit_event(event_name, payload, queue_name=queue)
+    except psycopg.errors.UndefinedTable:
+        msg = (
+            f"Queue '{queue}' is declared but its Absurd table is not provisioned. "
+            "Run: manage.py absurd_sync_queues"
+        )
+        raise ImproperlyConfigured(msg) from None
+```
+
+- [ ] **Step 4: Re-export from `django_absurd/__init__.py`**
+
+Modify the existing import block and `__all__`:
+
+```python
+from django_absurd.context import (
+    AbsurdTaskContext,
+    aget_absurd_context,
+    get_absurd_context,
+)
+from django_absurd.events import emit_event
+
+ABSURD_SCHEMA_VERSION = "0.4.0"
+
+__all__ = [
+    "ABSURD_SCHEMA_VERSION",
+    "AbsurdTaskContext",
+    "aget_absurd_context",
+    "emit_event",
+    "get_absurd_context",
+]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_events.py -v` Expected: PASS (3 tests)
+
+- [ ] **Step 6: Add the happy-path admin-visible test**
+
+`tests/core/test_admin/test_event.py` already seeds the `events` queue table with raw
+SQL to test the generic changelist/detail plumbing (from #84). Add a case that seeds via
+the real `emit_event()` entrypoint instead, so the write path itself is exercised
+through the admin's read path:
+
+```python
+from django_absurd import emit_event
+
+...
+
+
+def test_emit_event_writes_a_visible_row(client: Client, admin_user: t.Any) -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.shipped:demo", {"id": 1}, queue="default")
+    client.force_login(admin_user)
+    soup = parse_html(client.get(CHANGELIST))
+    names = set()
+    for r in result_rows(soup):
+        elem = r.select_one(".field-event_name")
+        assert elem is not None
+        names.add(elem.get_text(strip=True))
+    assert "order.shipped:demo" in names
+```
+
+(Add the `from django_absurd import emit_event` import alongside the existing imports at
+the top of the file.)
+
+- [ ] **Step 7: Run the full test_event.py + test_events.py, verify pass**
+
+Run: `uv run pytest tests/core/test_events.py tests/core/test_admin/test_event.py -v`
+Expected: PASS (4 + 2 tests)
+
+- [ ] **Step 8: mypy + ruff clean**
+
+Run: `uv run mypy django_absurd/events.py django_absurd/__init__.py` Run:
+`uv run ruff check django_absurd/events.py django_absurd/__init__.py tests/core/test_events.py tests/core/test_admin/test_event.py`
+Expected: no errors (confirm `A004` does NOT fire — `events.py` never imports the name
+`TimeoutError`, so this task doesn't trip it; that hazard is Task 2's).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add django_absurd/events.py django_absurd/__init__.py tests/core/test_events.py tests/core/test_admin/test_event.py
+git commit -m "feat: top-level django_absurd.emit_event for outside-a-task signals"
+```
+
+---
+
+### Task 2: Sync bridge — `AbsurdTaskContext.await_event` / `.emit_event`
+
+**Files:**
+
+- Modify: `django_absurd/context.py`
+- Modify: `tests/tasks.py` (sync test tasks)
+- Modify: `tests/atasks.py` (async test tasks)
+- Modify: `tests/core/test_events.py` (behavioral suite)
+
+**Interfaces:**
+
+- Produces:
+  `AbsurdTaskContext.await_event(event_name: str, step_name: str | None = None, timeout: int | None = None) -> JsonValue`;
+  `AbsurdTaskContext.emit_event(event_name: str, payload: JsonValue | None = None) -> None`.
+  Both bridge `self.absurd_ctx.{await_event,emit_event}` over `run_on_loop`, exactly
+  like `sleep_for`/`heartbeat`.
+- Consumes (from Task 1):
+  `django_absurd.emit_event(event_name, payload=None, *, queue="default")` — used by the
+  tests below to wake a suspended waiter from outside the task.
+- Consumes: `absurd_sdk.TimeoutError` — imported as `import absurd_sdk` then referenced
+  as `absurd_sdk.TimeoutError` (never `from absurd_sdk import TimeoutError` — that trips
+  ruff's `A004` builtin-shadowing in ANY file, confirmed by running ruff; this is why
+  django-absurd does not re-export it either, see Global Constraints).
+
+- [ ] **Step 1: Add sync test tasks to `tests/tasks.py`**
+
+Add near the bottom, after `ssleep_until_once`:
+
+```python
+import absurd_sdk  # add to the top-of-file import block
+```
+
+```python
+@task
+def sawait_event_once(name: str) -> t.Any:
+    return get_absurd_context().await_event(name)
+
+
+@task
+def semit_event_once(name: str, payload: t.Any) -> None:
+    get_absurd_context().emit_event(name, payload)
+
+
+@task
+def sawait_event_timeout(name: str) -> str:
+    try:
+        get_absurd_context().await_event(name, timeout=0)
+    except absurd_sdk.TimeoutError:
+        return "timed-out"
+    return "no-timeout"
+```
+
+- [ ] **Step 2: Add async test tasks to `tests/atasks.py`**
+
+Add near the bottom, after `asleep_until_once`:
+
+```python
+@task
+async def aawait_event_once(name: str) -> t.Any:
+    return await aget_absurd_context().await_event(name)
+
+
+@task
+async def aemit_event_once(name: str, payload: t.Any) -> None:
+    await aget_absurd_context().emit_event(name, payload)
+```
+
+- [ ] **Step 3: Write the failing tests in `tests/core/test_events.py`**
+
+Add these functions (this file already has the Task 1 tests from above):
+
+```python
+from django.core.management import call_command
+
+from tests import atasks, tasks, utils
+
+
+def test_sync_await_event_suspends_then_top_level_emit_resumes() -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sawait_event_once.enqueue("order.packed:sync-1")
+
+    utils.run_absurd_worker()  # drain 1: no event yet -> suspend
+    suspended = utils.get_task_result(result.id)
+    assert suspended is not None
+    assert suspended.state == "sleeping"
+
+    emit_event("order.packed:sync-1", {"tracking": "abc"}, queue="default")
+
+    utils.run_absurd_worker()  # drain 2: resumes with the payload
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == {"tracking": "abc"}
+
+
+def test_async_await_event_suspends_then_top_level_emit_resumes() -> None:
+    call_command("absurd_sync_queues")
+    result = atasks.aawait_event_once.enqueue("order.packed:async-1")
+
+    utils.run_absurd_worker()
+    suspended = utils.get_task_result(result.id)
+    assert suspended is not None
+    assert suspended.state == "sleeping"
+
+    emit_event("order.packed:async-1", {"tracking": "abc"}, queue="default")
+
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == {"tracking": "abc"}
+
+
+def test_emit_before_await_returns_immediately_no_suspend() -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.packed:before-1", {"tracking": "xyz"}, queue="default")
+
+    result = tasks.sawait_event_once.enqueue("order.packed:before-1")
+    utils.run_absurd_worker()  # single drain: event already there, no suspend
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == {"tracking": "xyz"}
+
+
+def test_first_emit_per_name_wins() -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.packed:first-wins", {"tracking": "first"}, queue="default")
+    emit_event("order.packed:first-wins", {"tracking": "second"}, queue="default")
+
+    result = tasks.sawait_event_once.enqueue("order.packed:first-wins")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.result == {"tracking": "first"}
+
+
+def test_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
+    call_command("absurd_sync_queues")
+    tasks.semit_event_once.enqueue("order.packed:in-task", {"tracking": "in-task"})
+    utils.run_absurd_worker()
+
+    result = tasks.sawait_event_once.enqueue("order.packed:in-task")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.result == {"tracking": "in-task"}
+
+
+def test_uncaught_timeout_raises_absurd_sdk_timeout_error_and_is_catchable() -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sawait_event_timeout.enqueue("order.packed:never-arrives")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == "timed-out"
+```
+
+(`emit_event` is already imported at the top of this file from Task 1.)
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `uv run pytest tests/core/test_events.py -v` Expected: FAIL —
+`AttributeError: 'AbsurdTaskContext' object has no attribute 'await_event'`
+
+- [ ] **Step 5: Add the bridge methods to `django_absurd/context.py`**
+
+Extend the `TYPE_CHECKING` import block:
+
+```python
+if t.TYPE_CHECKING:
+    import datetime as dt
+    from collections.abc import Callable, Coroutine, Mapping
+
+    from absurd_sdk import JsonValue
+```
+
+Add the two methods to `AbsurdTaskContext`, after `sleep_until`:
+
+```python
+    def await_event(
+        self, event_name: str, step_name: str | None = None, timeout: int | None = None
+    ) -> "JsonValue":
+        return self.run_on_loop(
+            self.absurd_ctx.await_event(event_name, step_name, timeout)
+        )
+
+    def emit_event(self, event_name: str, payload: "JsonValue | None" = None) -> None:
+        self.run_on_loop(self.absurd_ctx.emit_event(event_name, payload))
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/core/test_events.py -v` Expected: PASS (all 9 tests — 3 from
+Task 1, 6 from this task)
+
+- [ ] **Step 7: mypy + ruff clean**
+
+Run: `uv run mypy django_absurd/context.py tests/tasks.py tests/atasks.py` Run:
+`uv run ruff check django_absurd/context.py tests/tasks.py tests/atasks.py tests/core/test_events.py`
+Expected: no errors — in particular confirm `tests/tasks.py`'s
+`except absurd_sdk.TimeoutError` does NOT trip `A004` (it references the attribute, not
+a bare imported name).
+
+- [ ] **Step 8: Full core suite green**
+
+Run: `uv run pytest tests/core -v` Expected: PASS, no regressions.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add django_absurd/context.py tests/tasks.py tests/atasks.py tests/core/test_events.py
+git commit -m "feat: AbsurdTaskContext.await_event/.emit_event sync bridge"
+```
+
+---
+
+### Task 3: Waits admin inline (mirrors the shipped Checkpoints inline)
+
+**Files:**
+
+- Modify: `django_absurd/admin_views.py`
+- Modify: `django_absurd/admin.py`
+- Modify: `tests/core/test_admin/test_task.py`
+
+**Interfaces:**
+
+- Consumes (from Task 2): `tests.tasks.sawait_event_once` — used to produce a real
+  suspended `Wait` row through the worker (no raw SQL seeding for this inline test, same
+  as the existing Checkpoints-inline test).
+- Produces:
+  `django_absurd.admin.build_wait_inline(wait_model) -> type[admin.TabularInline]`,
+  wired into the tasks admin's `inlines` alongside Runs + Checkpoints.
+
+- [ ] **Step 1: Write the failing test in `tests/core/test_admin/test_task.py`**
+
+Add `sawait_event_once` to the existing `from tests.tasks import add` line:
+
+```python
+from tests.tasks import add, sawait_event_once
+```
+
+Add this test, alongside `test_detail_inlines_checkpoints_and_run_available_at`:
+
+```python
+def test_detail_inlines_waits_for_a_suspended_await_event(
+    client: Client, admin_user: User
+) -> None:
+    call_command("absurd_sync_queues")
+    sawait_event_once.enqueue("wait-admin-demo")
+    call_command("absurd_worker", queue="default", burst=True)  # suspends
+    client.force_login(admin_user)
+
+    task = find_task("default", "tests.tasks.sawait_event_once")
+    assert task is not None
+    soup = parse_html(client.get(change_url(task.natural_key)))
+
+    assert soup.select_one('a[href*="/django_absurd/wait/"]') is not None
+    names = {cell.get_text(strip=True) for cell in soup.select(".field-event_name")}
+    assert "wait-admin-demo" in names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+`uv run pytest tests/core/test_admin/test_task.py::test_detail_inlines_waits_for_a_suspended_await_event -v`
+Expected: FAIL — no `a[href*="/django_absurd/wait/"]` in the page (no Waits inline yet).
+
+- [ ] **Step 3: Add the FK field branch in `django_absurd/admin_views.py`**
+
+In `build_model_field`, add this branch right after the existing `checkpoints`/`task_id`
+branch (before the final `return col_name, make_field(col_type)`):
+
+```python
+    # Waits join to their task on task_id — same constraint-free FK treatment as runs
+    # and checkpoints so the admin can inline waits under a task. The attname stays
+    # task_id.
+    if spec.name == "waits" and col_name == "task_id":
+        tasks_spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
+        return "task", models.ForeignKey(
+            build_admin_model(tasks_spec),
+            to_field="task_id",
+            db_column="task_id",
+            db_constraint=False,
+            on_delete=models.DO_NOTHING,
+            null=True,
+            related_name="waits",
+        )
+```
+
+Update the `waits` `EntitySpec`'s `search_fields` (first element only):
+
+```python
+        search_fields=("task__task_id", "run_id", "step_name"),
+```
+
+- [ ] **Step 4: Add the inline classes in `django_absurd/admin.py`**
+
+Add `WAIT_INLINE_FIELDS` after `CHECKPOINT_INLINE_FIELDS`:
+
+```python
+WAIT_INLINE_FIELDS = (
+    "event_name",
+    "step_name",
+    "timeout_at",
+    "created_at",
+)
+```
+
+Add `ReadOnlyWaitInline` + `build_wait_inline` after `build_checkpoint_inline`:
+
+```python
+class ReadOnlyWaitInline(_TabularInlineBase):
+    fk_name = "task"
+    extra = 0
+    can_delete = False
+    show_change_link = True
+    ordering = ("created_at",)
+    fields = WAIT_INLINE_FIELDS
+    readonly_fields = WAIT_INLINE_FIELDS
+
+    def has_add_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return False
+
+    def has_change_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return False
+
+    def has_delete_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return False
+
+    def has_view_permission(
+        self, request: "HttpRequest", obj: "models.Model | None" = None
+    ) -> bool:
+        return True
+
+
+def build_wait_inline(
+    wait_model: "type[Model]",
+) -> "type[admin.TabularInline[t.Any, t.Any]]":
+    return type("WaitInline", (ReadOnlyWaitInline,), {"model": wait_model})
+```
+
+Wire it into `build_entity_admin`'s `spec.name == "tasks"` branch:
+
+```python
+    if spec.name == "tasks":
+        run_model = build_admin_model(
+            next(s for s in ADMIN_ENTITY_SPECS if s.name == "runs")
+        )
+        checkpoint_model = build_admin_model(
+            next(s for s in ADMIN_ENTITY_SPECS if s.name == "checkpoints")
+        )
+        wait_model = build_admin_model(
+            next(s for s in ADMIN_ENTITY_SPECS if s.name == "waits")
+        )
+        extra["inlines"] = [
+            build_run_inline(run_model),
+            build_checkpoint_inline(checkpoint_model),
+            build_wait_inline(wait_model),
+        ]
+        extra["fieldsets"] = TASK_FIELDSETS
+        extra["ordering"] = ("-first_started_at", "-enqueue_at")
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+`uv run pytest tests/core/test_admin/test_task.py::test_detail_inlines_waits_for_a_suspended_await_event -v`
+Expected: PASS
+
+- [ ] **Step 6: Run the full admin suite + mypy**
+
+Run: `uv run pytest tests/core/test_admin -v` Run:
+`uv run mypy django_absurd/admin.py django_absurd/admin_views.py` Expected: all PASS, no
+regressions in `test_wait.py`'s existing composite-detail test (the `search_fields`
+change is additive — `task_id` → `task__task_id` only changes what the search box
+matches, not the changelist/detail rendering `test_wait.py` checks).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add django_absurd/admin_views.py django_absurd/admin.py tests/core/test_admin/test_task.py
+git commit -m "feat: Waits admin inline under the task detail page"
+```
+
+---
+
+### Task 4: Docs — Events section (AGENTS.md + docs/web/workflows.md)
+
+**Files:**
+
+- Modify: `django_absurd/AGENTS.md`
+- Modify: `docs/web/workflows.md`
+
+**Interfaces:**
+
+- Consumes (from Tasks 1–2): `get_absurd_context().await_event/.emit_event`,
+  `aget_absurd_context().await_event/.emit_event` (SDK passthrough), top-level
+  `django_absurd.emit_event`, `absurd_sdk.TimeoutError`.
+- No code interfaces produced — docs only. No test step (docs aren't pytest-covered);
+  verification is the `zensical build` in Step 3.
+
+- [ ] **Step 1: Extend `docs/web/workflows.md`**
+
+Update the intro paragraph (top of file) to mention Events:
+
+```markdown
+Absurd calls these primitives **Steps (Checkpoints)**, **Sleep**, and **Events** — see
+[Absurd: Concepts](https://earendil-works.github.io/absurd/concepts/). They let a task
+break its work into checkpointed steps, sleep between them, and suspend until a named
+signal arrives — persisting progress so retries and resumes pick up where they left off,
+never redoing completed steps. This page covers the django-absurd surface: the
+`get_absurd_context()` / `aget_absurd_context()` accessors.
+```
+
+Insert a new `## Events` section right after `## Sleep` (before `## API`):
+
+````markdown
+## Events
+
+`context.await_event(event_name, step_name=None, timeout=None)` suspends the task until
+a named event arrives, then returns its JSON payload.
+`context.emit_event(event_name, payload=None)` emits an event on the task's own queue
+(in-task, replay-safe — a re-emit after a retry is a no-op). Events are awaited by name,
+carry an optional JSON payload, and **first emit per name wins** (immutable) — a
+business-keyed name like `"warehouse.packed:order-42"` targets exactly one waiter.
+
+→ [Absurd: Concepts — Events](https://earendil-works.github.io/absurd/concepts/#events)
+
+Events are **queue-scoped**: `await_event`/`emit_event` operate on the task's own queue.
+An event emitted on queue X only wakes a waiter on queue X.
+
+### The outside-a-task signal: top-level `emit_event`
+
+`ctx.emit_event` only reaches code running _inside_ a task. The real-world signal that
+wakes a waiter — a webhook, a view, an API handler — is ordinary Django code, not a
+task. `django_absurd.emit_event(event_name, payload=None, *, queue="default")` is that
+entry point:
+
+```python
+from django_absurd import emit_event
+
+
+def warehouse_webhook(request, order):
+    emit_event(f"warehouse.packed:{order}", {"tracking": request.POST["tracking"]},
+               queue="default")
+    return HttpResponse(status=204)
+```
+
+End-to-end: a task calls `await_event(f"warehouse.packed:{order}")` → suspends (worker
+freed) → the warehouse system POSTs the webhook → the view emits the event on the task's
+queue → the task's next claim finds it → resumes with the payload.
+
+`queue` must match the queue the waiting task actually runs on — it targets the
+client-level `emit_event`'s `queue_name`, not a database alias. An unknown queue raises
+`ImproperlyConfigured` immediately (fail fast on a typo). `emit_event` is sync; from an
+async view, wrap it in `sync_to_async`.
+
+### Sync
+
+```python
+from django.tasks import task
+from django_absurd import get_absurd_context
+
+
+@task
+def process_order(order_id: int) -> None:
+    context = get_absurd_context()
+    context.step("charge", lambda: charge_card(order_id))
+    payload = context.await_event(f"warehouse.packed:{order_id}")
+    context.step("ship", lambda: ship(order_id, payload))
+```
+
+### Async
+
+```python
+from django.tasks import task
+from django_absurd import aget_absurd_context
+
+
+@task
+async def process_order(order_id: int) -> None:
+    context = aget_absurd_context()
+    payload = await context.await_event(f"warehouse.packed:{order_id}")
+
+    async def ship_order():
+        return await ship(order_id, payload)
+
+    await context.step("ship", ship_order)
+```
+
+### Timeout
+
+Pass `timeout` (seconds) to stop waiting after a bound. On timeout, `await_event` raises
+`absurd_sdk.TimeoutError` — **not** the builtin `TimeoutError`:
+
+```python
+import absurd_sdk
+from django.tasks import task
+from django_absurd import get_absurd_context
+
+
+@task
+def process_order(order_id: int) -> str:
+    context = get_absurd_context()
+    try:
+        context.await_event(f"warehouse.packed:{order_id}", timeout=3600)
+    except absurd_sdk.TimeoutError:
+        return "gave up waiting for the warehouse"
+    return "shipped"
+```
+
+!!! warning "Not the builtin `TimeoutError`"
+
+    `except TimeoutError:` (the builtin) does **not** catch this — you must
+    `import absurd_sdk` and catch `absurd_sdk.TimeoutError` explicitly.
+
+An **uncaught** `TimeoutError` fails the run, which then retries and re-waits the full
+`timeout` on each attempt until `max_attempts` — catch it if you want a one-shot
+timeout.
+
+### `await_task_result` is not provided
+
+Absurd's SDK version of this polls + heartbeats inside a step rather than suspending
+(holding the worker slot), and is cross-queue-only. For a child task's result, use
+Django's `get_result()` / `aget_result()` instead.
+````
+
+Extend the `## API` table with two new rows:
+
+```markdown
+| `await_event(event_name, step_name=None, timeout=None)` | yes | `await` | Suspend
+until the named event arrives; return its payload | |
+`emit_event(event_name, payload=None)` | yes | `await` | Emit an event on the task's own
+queue (replay-safe) |
+```
+
+Extend `## Caveats` with two new subsections, after `### Absurd backend only`:
+
+```markdown
+### Events are subject to cleanup_ttl
+
+An event emitted long before a delayed `await_event` can be cleaned up by the queue's
+`cleanup_ttl` before the waiter ever checks — the waiter then never wakes. Keep
+`cleanup_ttl` generous relative to how long a waiter might sleep before checking.
+
+### `TimeoutError` is `absurd_sdk.TimeoutError`, not the builtin
+
+`except TimeoutError:` silently catches nothing — `import absurd_sdk` and catch
+`absurd_sdk.TimeoutError`.
+```
+
+Extend `## Admin introspection`:
+
+```markdown
+Waits are visible in Django admin under **Waits** (one row per task suspended in
+`await_event`), and inline under the task detail page alongside Runs and Checkpoints.
+```
+
+- [ ] **Step 2: Mirror the same content into `django_absurd/AGENTS.md`**
+
+`AGENTS.md`'s Workflows section (`## Workflows` → `### Steps (checkpoints)` →
+`### Sleep` → `### API reference` → `### Caveats`) mirrors `docs/web/workflows.md`
+almost verbatim but with `###` headings instead of `##`/`###`. Apply the same content as
+Step 1 (intro line, Events section, API table rows, Caveats additions), demoting each
+heading by one level (`## Events` → `### Events`, `### Sync`/`### Async`/`### Timeout` →
+`#### Sync`/`#### Async`/`#### Timeout`, etc.) to match the existing nesting in this
+file, inserted between the existing `### Sleep` and `### API reference` sections.
+
+- [ ] **Step 3: Build docs clean**
+
+Run: `uvx zensical build` Expected: build succeeds, no broken links/anchors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add django_absurd/AGENTS.md docs/web/workflows.md
+git commit -m "docs: Events section (await_event/emit_event) on Workflows page"
+```
+
+---
+
+### Task 5: Example — order-fulfillment uses real `await_event`
+
+**Files:**
+
+- Modify: `examples/web/app.py`
+- Modify: `examples/README.md`
+
+**Interfaces:**
+
+- Consumes (from Tasks 1–2): `context.await_event(event_name)`,
+  `django_absurd.emit_event(event_name, payload, queue="default")`.
+- No test step — this is a nanodjango demo app, run manually to confirm it works (see
+  Step 4).
+
+- [ ] **Step 1: Replace the `sleep_for` stand-in with real `await_event` in
+      `examples/web/app.py`**
+
+Update the import line:
+
+```python
+from django_absurd import emit_event, get_absurd_context
+```
+
+Replace `fulfill_order`:
+
+```python
+@task
+def fulfill_order(order: str) -> str:
+    """Order-fulfillment workflow: charge, reserve inventory, wait, notify.
+
+    Mirrors the shape of Absurd's headline order-fulfillment example
+    (https://github.com/earendil-works/absurd#readme): step(charge) →
+    step(reserve inventory) → await_event(warehouse packed) → step(notify).
+
+    Each step is a checkpoint: check the admin's Checkpoints, Waits, and Runs
+    pages to see the steps and the suspended state while it waits.
+
+    Shows both step forms: ``context.step(name, fn)`` and the ``run_step``
+    decorator (sync only), which runs the function once and replaces it with the
+    step's return value.
+    """
+    context = get_absurd_context()
+    context.step("charge", lambda: f"charged: {order}")
+    context.step("reserve-inventory", lambda: f"reserved: {order}")
+    context.await_event(f"warehouse.packed:{order}")
+
+    @context.run_step("notify")
+    def notify() -> str:
+        return f"notified: {order}"
+
+    return notify
+```
+
+- [ ] **Step 2: Route the workflow result to a page showing a "mark packed" button**
+
+Update `workflow_view`'s success redirect:
+
+```python
+        if form.is_valid():
+            order = form.cleaned_data["order"]
+            result = fulfill_order.enqueue(order=order)
+            return redirect(f"/tasks/{result.id}/?order={order}")
+```
+
+Update `workflow_view`'s copy paragraph:
+
+```python
+        <p>
+          Mirrors Absurd's
+          <a href="https://github.com/earendil-works/absurd#readme">order-fulfillment
+          example</a>: <em>charge</em>, <em>reserve-inventory</em>,
+          <code>await_event</code> for the warehouse to pack the order, <em>notify</em>.
+          While waiting, check
+          <a href="/admin/django_absurd/run/">Runs</a>,
+          <a href="/admin/django_absurd/checkpoint/">Checkpoints</a>, and
+          <a href="/admin/django_absurd/wait/">Waits</a> in the admin — or click
+          "mark packed" below once the task detail page appears.
+        </p>
+```
+
+Add a new route, near `workflow_view`:
+
+```python
+@app.route("/workflow/<str:order>/pack/")
+def pack_view(request: HttpRequest, order: str) -> HttpResponse:
+    if request.method == "POST":
+        emit_event(f"warehouse.packed:{order}", {"packed_by": "warehouse demo"},
+                   queue="default")
+    next_url = request.GET.get("next", "/")
+    return redirect(next_url)
+```
+
+Update `task_detail` to show the button when an `order` is present and the task isn't
+finished yet:
+
+```python
+@app.route("/tasks/<str:result_id>/")
+def task_detail(request: HttpRequest, result_id: str) -> HttpResponse | str:
+    try:
+        result = default_task_backend.get_result(result_id)
+    except TaskResultDoesNotExist:
+        return HttpResponse(f"<h1>Unknown task {result_id}</h1>", status=404)
+
+    finished = result.status in (TaskResultStatus.SUCCESSFUL, TaskResultStatus.FAILED)
+    refresh = "" if finished else '<meta http-equiv="refresh" content="1">'
+    if result.status == TaskResultStatus.SUCCESSFUL:
+        body = f"<p>Result: <strong>{result.return_value}</strong></p>"
+    elif result.status == TaskResultStatus.FAILED:
+        body = f"<p>Failed: {result.errors}</p>"
+    else:
+        body = "<p>Working… (auto-refreshing)</p>"
+
+    order = request.GET.get("order")
+    pack_button = ""
+    if order and not finished:
+        back = f"/tasks/{result_id}/?order={order}"
+        pack_button = f"""
+        <form method="post" action="/workflow/{order}/pack/?next={back}">
+          <input type="hidden" name="csrfmiddlewaretoken" value="{get_token(request)}">
+          <button type="submit">Mark "{order}" packed by the warehouse</button>
+        </form>
+        """
+
+    fields = {f.name: getattr(result, f.name) for f in dataclasses.fields(result)}
+    dump = html.escape(pprint.pformat(fields))
+    admin_url = reverse("admin:django_absurd_task_change", args=[quote(result.id)])
+    return f"""
+        {refresh}
+        <h1>Task {result.id}</h1>
+        <p>Status: <strong>{result.status.name}</strong></p>
+        {body}
+        {pack_button}
+        <pre><code>{dump}</code></pre>
+        <p>
+          <a href="/">Add another</a> ·
+          <a href="{admin_url}">View this task in the admin</a>
+          — its Runs + Checkpoints + Waits inlines show the steps and suspended state.
+        </p>
+    """
+```
+
+Update the module docstring at the top of the file:
+
+```python
+"""Single-file nanodjango demo: django-absurd enqueue + result.
+
+Enqueue add(a, b) from a form; the worker runs it; watch the result page and
+browse the read-only queue tables in the admin (auto-registered by django-absurd).
+
+Also demonstrates Steps (checkpoints) + Sleep + Events: an order-fulfillment
+workflow that checkpoints each step and suspends on await_event until a
+"mark packed" button emits the matching event.
+
+    docker compose up
+    http://localhost:8000/         enqueue add(a, b) or the order workflow
+    http://localhost:8000/admin/   Tasks / Runs / Checkpoints / Waits / … (admin / admin)
+
+psycopg (v3) backend required — DATABASES is overridden (nanodjango defaults to sqlite).
+"""
+```
+
+- [ ] **Step 3: Update `examples/README.md`**
+
+Replace the `web/` bullet's Steps+Sleep description:
+
+```markdown
+- **[`web/`](web/)** — enqueue `add(a, b)` from a form and watch the result
+  (`get_result`); browse the read-only queue tables in the admin. Also demonstrates
+  **Steps (checkpoints), Sleep, and Events** at `/workflow/` — an order-fulfillment task
+  that checkpoints each step and suspends on `await_event` until a "mark packed" button
+  (calling the top-level `emit_event`) wakes it, with a link into the task's admin page
+  to watch its checkpoints and suspended wait.
+```
+
+- [ ] **Step 4: Run the example manually to confirm it works**
+
+```bash
+cd examples/web
+docker compose up
+```
+
+Open `http://localhost:8000/`, submit the order-fulfillment form, confirm the task
+detail page auto-refreshes, shows "Working…", and shows the "mark packed" button. Click
+it, confirm the task completes and its result shows `notified: <order>`. Check
+`/admin/django_absurd/wait/` shows the resolved wait, and the task detail's Waits inline
+shows the same `event_name`. Stop with `docker compose down`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/web/app.py examples/README.md
+git commit -m "docs(examples): order-fulfillment demo uses real await_event/emit_event"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** `await_event`/in-task `emit_event` (Task 2) · top-level
+  `emit_event` (Task 1) · `TimeoutError` handling — direct import, not re-exported, per
+  the amended spec (Task 2 + docs in Task 4) · Waits admin inline (Task 3) ·
+  docs/tests/example (Tasks 1–5) · `await_task_result` cut (Global Constraints, and
+  absent throughout).
+- **Placeholder scan:** none — every step has real code, exact test names, exact
+  commands.
+- **Type consistency:** `AbsurdTaskContext.await_event`/`.emit_event` (Task 2) match the
+  SDK signatures verbatim, matching what Tasks 1/3/5 call. `django_absurd.emit_event`'s
+  signature (Task 1) matches what Task 2's tests and Task 5's example call.

--- a/docs/plans/2026-07-19-events-await-emit.md
+++ b/docs/plans/2026-07-19-events-await-emit.md
@@ -75,7 +75,6 @@ Checkpoints inline verbatim.
 ```python
 import pytest
 from django.core.exceptions import ImproperlyConfigured
-from django.test import override_settings
 from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd import emit_event
@@ -94,15 +93,19 @@ def test_top_level_emit_event_unknown_queue_raises() -> None:
         emit_event("whatever", queue="ghost")
 
 
-@override_settings(TASKS={"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}})
-def test_top_level_emit_event_no_backend_configured_raises() -> None:
+def test_top_level_emit_event_no_backend_configured_raises(
+    settings: SettingsWrapper,
+) -> None:
+    settings.TASKS = {"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}}
     with pytest.raises(
         ImproperlyConfigured, match=r"django-absurd: no Absurd backend configured\."
     ):
         emit_event("whatever")
 
 
-def test_top_level_emit_event_unsynced_queue_raises(settings: SettingsWrapper) -> None:
+def test_top_level_emit_event_unsynced_queue_raises(
+    settings: SettingsWrapper,
+) -> None:
     settings.TASKS = {
         "default": {
             "BACKEND": "django_absurd.backends.AbsurdBackend",
@@ -227,7 +230,7 @@ the top of the file.)
 - [ ] **Step 7: Run the full test_event.py + test_events.py, verify pass**
 
 Run: `uv run pytest tests/core/test_events.py tests/core/test_admin/test_event.py -v`
-Expected: PASS (4 + 2 tests)
+Expected: PASS (3 + 2 tests)
 
 - [ ] **Step 8: mypy + ruff clean**
 
@@ -394,6 +397,18 @@ def test_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
     assert done.result == {"tracking": "in-task"}
 
 
+def test_async_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
+    call_command("absurd_sync_queues")
+    atasks.aemit_event_once.enqueue("order.packed:in-task-async", {"tracking": "async"})
+    utils.run_absurd_worker()
+
+    result = atasks.aawait_event_once.enqueue("order.packed:in-task-async")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.result == {"tracking": "async"}
+
+
 def test_uncaught_timeout_raises_absurd_sdk_timeout_error_and_is_catchable() -> None:
     call_command("absurd_sync_queues")
     result = tasks.sawait_event_timeout.enqueue("order.packed:never-arrives")
@@ -439,8 +454,8 @@ Add the two methods to `AbsurdTaskContext`, after `sleep_until`:
 
 - [ ] **Step 6: Run tests to verify they pass**
 
-Run: `uv run pytest tests/core/test_events.py -v` Expected: PASS (all 9 tests — 3 from
-Task 1, 6 from this task)
+Run: `uv run pytest tests/core/test_events.py -v` Expected: PASS (all 10 tests — 3 from
+Task 1, 7 from this task)
 
 - [ ] **Step 7: mypy + ruff clean**
 
@@ -851,9 +866,13 @@ git commit -m "docs: Events section (await_event/emit_event) on Workflows page"
 - [ ] **Step 1: Replace the `sleep_for` stand-in with real `await_event` in
       `examples/web/app.py`**
 
-Update the import line:
+Update the import lines — add the `emit_event` import and a `url_quote` alias for
+`urllib.parse.quote` (the file already imports `quote` from `django.contrib.admin.utils`
+for admin pk-quoting, so this needs a distinct name):
 
 ```python
+from urllib.parse import quote as url_quote
+
 from django_absurd import emit_event, get_absurd_context
 ```
 
@@ -949,7 +968,7 @@ def task_detail(request: HttpRequest, result_id: str) -> HttpResponse | str:
     order = request.GET.get("order")
     pack_button = ""
     if order and not finished:
-        back = f"/tasks/{result_id}/?order={order}"
+        back = url_quote(f"/tasks/{result_id}/?order={order}", safe="")
         pack_button = f"""
         <form method="post" action="/workflow/{order}/pack/?next={back}">
           <input type="hidden" name="csrfmiddlewaretoken" value="{get_token(request)}">

--- a/docs/specs/2026-07-19-events-await-emit-design.md
+++ b/docs/specs/2026-07-19-events-await-emit-design.md
@@ -1,0 +1,129 @@
+# Events: await_event + emit_event — Design
+
+**Goal:** expose Absurd's **Events** pillar to django-absurd tasks — a task suspends
+until a named event arrives (`await_event`), and events are emitted both from inside a
+task and from outside (a view). Completes the meaningful remainder of #21 (durable
+sleep/wait/await_event); **closes #21**.
+
+Builds directly on the shipped Steps + Sleep accessor pattern (#84):
+`get_absurd_context()` (sync bridge `AbsurdTaskContext`) / `aget_absurd_context()`
+(async — the SDK's `AsyncTaskContext` passthrough). Grounded in the SDK source
+(`absurd_sdk/__init__.py`) and
+[Absurd — Concepts → Events](https://earendil-works.github.io/absurd/concepts/).
+
+## Scope
+
+IN:
+
+- `await_event(event_name, step_name=None, timeout=None)` — in-task,
+  suspend-until-signal, first-emit-per-name-wins, optional timeout; returns the event
+  payload.
+- `emit_event(event_name, payload=None)` — in-task (on the task's own queue).
+- **Top-level `django_absurd.emit_event(event_name, payload=None, *, queue="default")`**
+  — emit from _outside_ a task (e.g. a view) to wake a waiter.
+- **Waits admin inline** under the task (mirrors the shipped Checkpoints inline).
+- Docs + tests + example (order-fulfillment's `sleep` stand-in → real `await_event`).
+
+OUT (deliberately not built):
+
+- **`await_task_result`** — the SDK's version polls + heartbeats inside a step (it does
+  NOT suspend — it **holds the worker slot**), is cross-queue-only (same-queue
+  deadlocks), and Django's `get_result()`/`aget_result()` already covers fetching a
+  child's result. Its only marginal add is checkpointed fan-out/join in one task body —
+  an advanced pattern with sharp edges. Use `get_result` for child results; revisit only
+  on real demand.
+
+## Events are queue-scoped (load-bearing)
+
+Verified in the SDK + schema: `ctx.emit_event` writes
+`absurd.emit_event(self._queue_name, …)` ("this task's queue"); `ctx.await_event` reads
+`absurd.await_event(self._queue_name, …)`; events live in per-queue tables
+(`e_<queue>`); first-emit-per-name-wins is **per queue**. So an event emitted on queue X
+only satisfies `await_event` for tasks waiting on queue X. The top-level `emit_event`
+helper therefore takes `queue` — you emit to the queue the awaiting task runs on.
+
+## Async is free; sync is a thin bridge
+
+`aget_absurd_context()` already returns the SDK `AsyncTaskContext`, which already has
+async `await_event`/`emit_event` — **async tasks can call them today**
+(`await context.await_event(...)`). No new production code for the async path — docs +
+tests only.
+
+Sync tasks need the bridge: add to `AbsurdTaskContext` (mirroring the shipped
+`sleep_for`/`heartbeat` bridges via `run_on_loop`), SDK signatures verbatim:
+
+```python
+def await_event(self, event_name, step_name=None, timeout=None) -> JsonValue:
+    # bridge self.absurd_ctx.await_event(...); returns payload;
+    # raises SuspendTask (→ existing control-flow arm) when it suspends,
+    # or TimeoutError when timeout elapses.
+
+def emit_event(self, event_name, payload=None) -> None:
+    # bridge self.absurd_ctx.emit_event(...)
+```
+
+`await_event` suspending → the worker's existing `except (SuspendTask, …)` control-flow
+arm already re-raises it (no worker change needed). `emit_event` is fire-and-forget.
+
+## Top-level `emit_event` (app-side)
+
+A thin public helper, mirroring Absurd's own `app.emit_event` vs `ctx.emit_event` split,
+so a view can wake a waiter without reaching into internals:
+
+```python
+from django_absurd import emit_event
+
+emit_event("warehouse.packed", {"tracking": "XYZ"}, queue="default")
+```
+
+~8 lines: resolve the Absurd DB, open a client on `queue` (the existing
+`get_absurd_client(queue)` path), call its `emit_event(event_name, payload)`, done. Runs
+on the Absurd connection; no task context required.
+
+## Waits admin
+
+`await_event` populates the `waits` view/entity (columns `task_id`, `run_id`,
+`step_name`, `event_name`, `timeout_at`, `created_at`). Surface it under the task — a
+read-only **Waits inline**, mirroring the shipped Checkpoints inline exactly:
+
+- `admin_views.build_model_field`: add a
+  `spec.name == "waits" and col_name == "task_id"` branch returning a constraint-free
+  `task` FK (`to_field="task_id"`, `db_column="task_id"`, `db_constraint=False`,
+  `DO_NOTHING`, `null=True`, `related_name="waits"`); change the `waits`
+  `EntitySpec.search_fields` `"task_id"` → `"task__task_id"`.
+- `admin.py`: `WAIT_INLINE_FIELDS` (`event_name`, `step_name`, `timeout_at`,
+  `created_at`), a `ReadOnlyWaitInline` (read-only perms, `fk_name="task"`,
+  `show_change_link`, `ordering=("created_at",)`), a `build_wait_inline`, wired into the
+  tasks admin `inlines` alongside Runs + Checkpoints.
+
+## Docs, tests, example
+
+- **Docs** — an **Events** section on the Workflows page + AGENTS: `await_event`
+  (suspend-until-signal, first-emit-wins, `timeout`, queue-scoped), in-task
+  `emit_event`, and the top-level `emit_event`; link Absurd's Concepts → Events. Note
+  `await_task_result` is intentionally not provided (use Django's `get_result` for child
+  results). Reuse the effectively-once / don't-catch-all-`except` caveats.
+- **Example** — `examples/web`: the order-fulfillment task's
+  `sleep_for("await-warehouse", …)` becomes `await_event("warehouse.packed")`; add a
+  second view/button that calls the top-level `emit_event("warehouse.packed", queue=…)`
+  to wake it — a real signal→resume demo. Update the surrounding copy +
+  `examples/README.md`.
+- **Tests** — behavioral, real worker, both task kinds parametrized where they differ:
+  - a task `await_event`s → suspends (state `sleeping`/RUNNING, a Waits row exists) → a
+    separate call to the top-level `emit_event` → next drain resumes with the payload.
+  - first-emit-per-name-wins (a second emit is ignored).
+  - `timeout` elapses → `TimeoutError` path (task fails or handles it — assert
+    observable).
+  - admin: HTTP-test the task detail shows the Waits inline (event_name) while
+    suspended.
+  - Pinned timing recipe like Sleep (no monkeypatch; `transaction=True`).
+
+## Constraints (carried from #84)
+
+Accessor pattern (no `TaskContext` subclass); async worker + sync `run_on_loop` bridge;
+thin delegation to `absurd_sdk`, mirror SDK naming/signatures; effectively-once framing;
+`import typing as t` / `import datetime as dt`; absolute imports; verb-named functions;
+the only durable-code `type: ignore` is `[call-arg]` on
+`enqueue(absurd_spawn_params=…)`; full patch coverage; behavioral tests via real
+entrypoints; assert complete message portions; docs mirror between AGENTS.md and
+`docs/web/`, build clean (`uvx zensical build`).

--- a/docs/specs/2026-07-19-events-await-emit-design.md
+++ b/docs/specs/2026-07-19-events-await-emit-design.md
@@ -98,14 +98,15 @@ with the payload.
 
 **Contract (corrected — the earlier sketch was wrong):**
 
-- **Not** `get_absurd_client(queue)` — that arg is a **DB alias**, not a queue, and the
-  client's own queue defaults to `"default"`. Treating a queue as an alias fails
-  (`ConnectionDoesNotExist` for a non-`"default"` queue) or, worse, on a non-default
-  `DATABASE` **silently emits on the wrong database** and the waiter never wakes.
-  Correct call: resolve the Absurd DB (`resolve_absurd_database()`), build a client on
-  it (`build_absurd_client(...)`), and call the **client-level**
-  `emit_event(event_name, payload, queue_name=queue)` (SDK `Absurd.emit_event` takes
-  `queue_name`).
+- **Queue is NOT the client's `using` arg.** `get_absurd_client(using=None)` already
+  encapsulates DB resolution
+  (`build_absurd_client(using or resolve_absurd_database())`), so call it with **no
+  argument** — it returns a client on the Absurd DB. The queue goes to the
+  **client-level** `emit_event`'s `queue_name` (SDK `Absurd.emit_event` takes it):
+  `get_absurd_client().emit_event(event_name, payload, queue_name=queue)`. Do NOT pass
+  the queue as `get_absurd_client(queue)` — that positional is a **DB alias**, so a
+  non-`"default"` queue would `ConnectionDoesNotExist`, or under a non-default
+  `DATABASE` silently emit on the wrong database (waiter never wakes).
 - **Validate `queue` against the declared queues** (`get_declared_queues`) and raise a
   clear error if unknown — fail fast rather than silently never-waking on a typo/wrong
   queue.
@@ -114,9 +115,9 @@ with the payload.
   (queue declared but not yet synced) → `ImproperlyConfigured` with the sync hint — so
   it fails cleanly without poisoning an enclosing transaction.
 - **Module home / export:** live in a registry-safe module (e.g.
-  `django_absurd/events.py`) and import `queues`/`build_absurd_client` **inside** the
-  function — a top-level import in `django_absurd/__init__.py` would trip
-  `AppRegistryNotReady` at app load (`queues.py` imports `models`). Re-export the
+  `django_absurd/events.py`) and import `get_absurd_client` **inside** the function — a
+  top-level `from django_absurd.queues import …` in `django_absurd/__init__.py` would
+  trip `AppRegistryNotReady` at app load (`queues.py` imports `models`). Re-export the
   function from `django_absurd`.
 - **Sync-only** (rides Django's connection); from an async view, wrap in
   `sync_to_async`.

--- a/docs/specs/2026-07-19-events-await-emit-design.md
+++ b/docs/specs/2026-07-19-events-await-emit-design.md
@@ -21,9 +21,13 @@ IN:
 - `emit_event(event_name, payload=None)` — in-task (on the task's own queue).
 - **Top-level `django_absurd.emit_event(event_name, payload=None, *, queue="default")`**
   — emit from _outside_ a task (e.g. a view) to wake a waiter.
-- Re-export **`absurd_sdk.TimeoutError`** from `django_absurd` — `await_event`'s
-  `timeout` raises it, and it is **NOT** Python's builtin `TimeoutError` (docs must
-  warn; a user `except TimeoutError` on the builtin catches nothing).
+- `await_event`'s `timeout` raises **`absurd_sdk.TimeoutError`**, imported directly from
+  `absurd_sdk` (matching the existing pattern — `CancellationPolicy`, `RetryStrategy`
+  etc. are already imported directly from `absurd_sdk` by user code, never re-exported)
+  — and it is **NOT** Python's builtin `TimeoutError` (docs must warn; a user
+  `except TimeoutError` on the builtin catches nothing). No `django_absurd` re-export:
+  re-exporting the bare name trips ruff's `A004` (builtin-shadowing, confirmed) for no
+  real benefit over importing it directly.
 - **Waits admin inline** under the task (mirrors the shipped Checkpoints inline).
 - Docs + tests + example (order-fulfillment's `sleep` stand-in → real `await_event`).
 
@@ -150,8 +154,9 @@ read-only **Waits inline**, mirroring the shipped Checkpoints inline exactly:
   suspend→emit→resume flow). Note `await_task_result` is intentionally not provided (use
   Django's `get_result` for child results). Reuse the effectively-once /
   don't-catch-all-`except` caveats, **plus these Events caveats**:
-  - `TimeoutError` is **`from absurd_sdk import TimeoutError`** (re-exported by
-    `django_absurd`), **not** the builtin — show the import, warn explicitly.
+  - `TimeoutError` is **`from absurd_sdk import TimeoutError`**, imported directly (NOT
+    re-exported by `django_absurd`), **not** the builtin — show the import, warn
+    explicitly.
   - An **uncaught** `TimeoutError` fails the run, which then **retries and re-waits the
     full `timeout` each attempt** until `max_attempts` — catch it if you want a
     one-shot.

--- a/docs/specs/2026-07-19-events-await-emit-design.md
+++ b/docs/specs/2026-07-19-events-await-emit-design.md
@@ -20,7 +20,9 @@ IN:
   payload.
 - `emit_event(event_name, payload=None)` — in-task (on the task's own queue).
 - **Top-level `django_absurd.emit_event(event_name, payload=None, *, queue="default")`**
-  — emit from _outside_ a task (e.g. a view) to wake a waiter.
+  — emit from _outside_ a task (e.g. a view) to wake a waiter. See
+  [Absurd — Concepts → Events](https://earendil-works.github.io/absurd/concepts/#events)
+  ("emit ... from anywhere — another task, an API handler, etc.").
 - `await_event`'s `timeout` raises **`absurd_sdk.TimeoutError`**, imported directly from
   `absurd_sdk` (matching the existing pattern — `CancellationPolicy`, `RetryStrategy`
   etc. are already imported directly from `absurd_sdk` by user code, never re-exported)
@@ -73,6 +75,12 @@ def emit_event(self, event_name, payload=None) -> None:
 arm already re-raises it (no worker change needed). `emit_event` is fire-and-forget.
 
 ## Top-level `emit_event` (app-side) — the outside-a-task signal
+
+**What it is, mechanically:** `django_absurd.emit_event(...)` is an ordinary Python
+function — not a task, and it does not require a running Absurd task context. Call it
+from anywhere in your Django app that already talks to the database: a view, a webhook
+handler, a management command, a signal receiver, the shell. It opens its own client via
+`get_absurd_client()` and writes the event directly.
 
 **Purpose (the "why"):** `ctx.emit_event` is only reachable _inside_ a running task, but
 the real-world signal that wakes a waiter almost always arrives from **ordinary Django

--- a/docs/specs/2026-07-19-events-await-emit-design.md
+++ b/docs/specs/2026-07-19-events-await-emit-design.md
@@ -21,6 +21,9 @@ IN:
 - `emit_event(event_name, payload=None)` — in-task (on the task's own queue).
 - **Top-level `django_absurd.emit_event(event_name, payload=None, *, queue="default")`**
   — emit from _outside_ a task (e.g. a view) to wake a waiter.
+- Re-export **`absurd_sdk.TimeoutError`** from `django_absurd` — `await_event`'s
+  `timeout` raises it, and it is **NOT** Python's builtin `TimeoutError` (docs must
+  warn; a user `except TimeoutError` on the builtin catches nothing).
 - **Waits admin inline** under the task (mirrors the shipped Checkpoints inline).
 - Docs + tests + example (order-fulfillment's `sleep` stand-in → real `await_event`).
 
@@ -93,10 +96,30 @@ End-to-end: the order task calls `await_event(f"warehouse.packed:{order}")` →
 emits the named event on the task's queue → the task's next claim finds it → **resumes**
 with the payload.
 
-The helper is ~8 lines: resolve the Absurd DB, open a client on `queue` (the existing
-`get_absurd_client(queue)` path), call its `emit_event(event_name, payload)`. Runs on
-the Absurd connection; no task context required. `queue` must be the queue the awaiting
-task runs on (events are queue-scoped — see above).
+**Contract (corrected — the earlier sketch was wrong):**
+
+- **Not** `get_absurd_client(queue)` — that arg is a **DB alias**, not a queue, and the
+  client's own queue defaults to `"default"`. Treating a queue as an alias fails
+  (`ConnectionDoesNotExist` for a non-`"default"` queue) or, worse, on a non-default
+  `DATABASE` **silently emits on the wrong database** and the waiter never wakes.
+  Correct call: resolve the Absurd DB (`resolve_absurd_database()`), build a client on
+  it (`build_absurd_client(...)`), and call the **client-level**
+  `emit_event(event_name, payload, queue_name=queue)` (SDK `Absurd.emit_event` takes
+  `queue_name`).
+- **Validate `queue` against the declared queues** (`get_declared_queues`) and raise a
+  clear error if unknown — fail fast rather than silently never-waking on a typo/wrong
+  queue.
+- **Savepoint + translate**, mirroring `AbsurdBackend.enqueue`: wrap the emit in
+  `transaction.atomic(savepoint=True)`; a missing-table `psycopg.errors.UndefinedTable`
+  (queue declared but not yet synced) → `ImproperlyConfigured` with the sync hint — so
+  it fails cleanly without poisoning an enclosing transaction.
+- **Module home / export:** live in a registry-safe module (e.g.
+  `django_absurd/events.py`) and import `queues`/`build_absurd_client` **inside** the
+  function — a top-level import in `django_absurd/__init__.py` would trip
+  `AppRegistryNotReady` at app load (`queues.py` imports `models`). Re-export the
+  function from `django_absurd`.
+- **Sync-only** (rides Django's connection); from an async view, wrap in
+  `sync_to_async`.
 
 ## Waits admin
 
@@ -125,7 +148,17 @@ read-only **Waits inline**, mirroring the shipped Checkpoints inline exactly:
   top-level `emit_event` (the outside-a-task signal — webhook/view/API handler; show the
   suspend→emit→resume flow). Note `await_task_result` is intentionally not provided (use
   Django's `get_result` for child results). Reuse the effectively-once /
-  don't-catch-all-`except` caveats.
+  don't-catch-all-`except` caveats, **plus these Events caveats**:
+  - `TimeoutError` is **`from absurd_sdk import TimeoutError`** (re-exported by
+    `django_absurd`), **not** the builtin — show the import, warn explicitly.
+  - An **uncaught** `TimeoutError` fails the run, which then **retries and re-waits the
+    full `timeout` each attempt** until `max_attempts` — catch it if you want a
+    one-shot.
+  - Events are subject to the queue's **`cleanup_ttl`**: an event emitted long before a
+    delayed `await_event` can be cleaned up first → the waiter never wakes.
+  - In-task `emit_event` is **replay-safe** (first-write-wins upsert → a re-emit after
+    retry is a no-op).
+  - `emit_event` is sync; from an **async view** wrap it in `sync_to_async`.
 - **Example** — `examples/web`: the order-fulfillment task's
   `sleep_for("await-warehouse", …)` becomes `await_event(f"warehouse.packed:{order}")`;
   add a second view/button that calls the top-level
@@ -134,12 +167,16 @@ read-only **Waits inline**, mirroring the shipped Checkpoints inline exactly:
 - **Tests** — behavioral, real worker, both task kinds parametrized where they differ:
   - a task `await_event`s → suspends (state `sleeping`/RUNNING, a Waits row exists) → a
     separate call to the top-level `emit_event` → next drain resumes with the payload.
-  - first-emit-per-name-wins (a second emit is ignored).
-  - `timeout` elapses → `TimeoutError` path (task fails or handles it — assert
-    observable).
-  - admin: HTTP-test the task detail shows the Waits inline (event_name) while
-    suspended.
-  - Pinned timing recipe like Sleep (no monkeypatch; `transaction=True`).
+  - emit-before-await: event already present → `await_event` returns immediately (no
+    suspend).
+  - first-emit-per-name-wins (a second emit is ignored — payload unchanged).
+  - **timeout (deterministic):** a task that `await_event(..., timeout=0)` and **catches
+    `absurd_sdk.TimeoutError`**, returning a sentinel → assert the sentinel result in a
+    single drain (avoids the retry-re-wait churn of an uncaught timeout).
+  - admin: HTTP-test the task detail's Waits inline shows **the specific `event_name`
+    row** (assert the value, not a row count — timeout-resume leaves stale `w_` rows).
+  - Pinned timing recipe like Sleep (no monkeypatch; `transaction=True`; emit from a
+    separate connection; drain → emit → drain).
 
 ## Constraints (carried from #84)
 

--- a/docs/specs/2026-07-19-events-await-emit-design.md
+++ b/docs/specs/2026-07-19-events-await-emit-design.md
@@ -65,20 +65,38 @@ def emit_event(self, event_name, payload=None) -> None:
 `await_event` suspending → the worker's existing `except (SuspendTask, …)` control-flow
 arm already re-raises it (no worker change needed). `emit_event` is fire-and-forget.
 
-## Top-level `emit_event` (app-side)
+## Top-level `emit_event` (app-side) — the outside-a-task signal
 
-A thin public helper, mirroring Absurd's own `app.emit_event` vs `ctx.emit_event` split,
-so a view can wake a waiter without reaching into internals:
+**Purpose (the "why"):** `ctx.emit_event` is only reachable _inside_ a running task, but
+the real-world signal that wakes a waiter almost always arrives from **ordinary Django
+code** — a webhook, a view, an API handler, an admin action. The top-level helper is
+that entry point. Absurd itself describes emitting "from anywhere — another task, an API
+handler, etc."
+([Concepts → Events](https://earendil-works.github.io/absurd/concepts/#events)).
+
+Event names typically carry a **business key** so an emit targets the one task waiting
+on that exact name — Absurd's own example is `await_event("shipment.packed:order-42")`.
+First-emit-per-name wins (immutable); payload is optional JSON.
 
 ```python
 from django_absurd import emit_event
 
-emit_event("warehouse.packed", {"tracking": "XYZ"}, queue="default")
+# a plain Django view / webhook / API handler (NOT a task):
+def warehouse_webhook(request, order):
+    emit_event(f"warehouse.packed:{order}", {"tracking": request.POST["tracking"]},
+               queue="default")
+    return HttpResponse(status=204)
 ```
 
-~8 lines: resolve the Absurd DB, open a client on `queue` (the existing
-`get_absurd_client(queue)` path), call its `emit_event(event_name, payload)`, done. Runs
-on the Absurd connection; no task context required.
+End-to-end: the order task calls `await_event(f"warehouse.packed:{order}")` →
+**suspends** (worker freed) → the warehouse system later POSTs the webhook → the view
+emits the named event on the task's queue → the task's next claim finds it → **resumes**
+with the payload.
+
+The helper is ~8 lines: resolve the Absurd DB, open a client on `queue` (the existing
+`get_absurd_client(queue)` path), call its `emit_event(event_name, payload)`. Runs on
+the Absurd connection; no task context required. `queue` must be the queue the awaiting
+task runs on (events are queue-scoped — see above).
 
 ## Waits admin
 
@@ -98,16 +116,21 @@ read-only **Waits inline**, mirroring the shipped Checkpoints inline exactly:
 
 ## Docs, tests, example
 
-- **Docs** — an **Events** section on the Workflows page + AGENTS: `await_event`
-  (suspend-until-signal, first-emit-wins, `timeout`, queue-scoped), in-task
-  `emit_event`, and the top-level `emit_event`; link Absurd's Concepts → Events. Note
-  `await_task_result` is intentionally not provided (use Django's `get_result` for child
-  results). Reuse the effectively-once / don't-catch-all-`except` caveats.
+- **Docs** — an **Events** section on the Workflows page + AGENTS, **grounded in
+  [Absurd → Concepts → Events](https://earendil-works.github.io/absurd/concepts/#events)**
+  (link it up front; mirror its terms — events awaited by name, optional JSON payload,
+  **first emit per name wins / immutable**, `timeout` → `TimeoutError`). Cover:
+  `await_event` (suspend-until-signal, queue-scoped, business-key naming like
+  `"warehouse.packed:order-42"` to target one waiter), in-task `emit_event`, and the
+  top-level `emit_event` (the outside-a-task signal — webhook/view/API handler; show the
+  suspend→emit→resume flow). Note `await_task_result` is intentionally not provided (use
+  Django's `get_result` for child results). Reuse the effectively-once /
+  don't-catch-all-`except` caveats.
 - **Example** — `examples/web`: the order-fulfillment task's
-  `sleep_for("await-warehouse", …)` becomes `await_event("warehouse.packed")`; add a
-  second view/button that calls the top-level `emit_event("warehouse.packed", queue=…)`
-  to wake it — a real signal→resume demo. Update the surrounding copy +
-  `examples/README.md`.
+  `sleep_for("await-warehouse", …)` becomes `await_event(f"warehouse.packed:{order}")`;
+  add a second view/button that calls the top-level
+  `emit_event(f"warehouse.packed:{order}", queue="default")` to wake that specific order
+  — a real signal→resume demo. Update the surrounding copy + `examples/README.md`.
 - **Tests** — behavioral, real worker, both task kinds parametrized where they differ:
   - a task `await_event`s → suspends (state `sleeping`/RUNNING, a Waits row exists) → a
     separate call to the top-level `emit_event` → next drain resumes with the payload.

--- a/docs/web/workflows.md
+++ b/docs/web/workflows.md
@@ -203,6 +203,8 @@ task. `django_absurd.emit_event(event_name, payload=None, *, queue="default")` i
 entry point:
 
 ```python
+from django.http import HttpResponse
+
 from django_absurd import emit_event
 
 
@@ -297,7 +299,7 @@ Django's `get_result()` / `aget_result()` instead.
 | `step(name, fn)`                                        | yes  | `await` | Run `fn()`, checkpoint the result; skip on replay         |
 | `sleep_for(step_name, duration)`                        | yes  | `await` | Suspend the task for `duration` seconds                   |
 | `sleep_until(step_name, wake_at)`                       | yes  | `await` | Suspend until a `datetime`, Unix timestamp, or float      |
-| `await_event(event_name, step_name=None, timeout=None)` | yes  | `await` | Suspend until the named event arrives; return its payload |     |
+| `await_event(event_name, step_name=None, timeout=None)` | yes  | `await` | Suspend until the named event arrives; return its payload |
 | `emit_event(event_name, payload=None)`                  | yes  | `await` | Emit an event on the task's own queue (replay-safe)       |
 | `heartbeat(seconds=None)`                               | yes  | `await` | Extend the claim timeout (keep the run alive)             |
 | `headers`                                               | yes  | yes     | Read-only mapping of headers passed at enqueue time       |

--- a/docs/web/workflows.md
+++ b/docs/web/workflows.md
@@ -335,15 +335,15 @@ crash causes the step to be re-run. **Keep side effects idempotent** — for exa
 ### Don't catch-all `except` in a task
 
 Absurd suspends and cancels runs via control-flow exceptions raised inside
-`step`/`sleep_for`/`sleep_until`. A bare `except:` or `except Exception:` around a
-durable call swallows them and silently breaks suspension — let them propagate.
+`step`/`sleep_for`/`sleep_until`/`await_event`. A bare `except:` or `except Exception:`
+around a durable call swallows them and silently breaks suspension — let them propagate.
 
 ### Absurd backend only
 
 `get_absurd_context()` / `aget_absurd_context()` (and `step` / `sleep_for` /
-`sleep_until` on the returned context) are Absurd-specific. Called under any other
-Django task backend — where the Absurd runtime context is never set — they raise
-`RuntimeError`.
+`sleep_until` / `await_event` / `emit_event` on the returned context) are
+Absurd-specific. Called under any other Django task backend — where the Absurd runtime
+context is never set — they raise `RuntimeError`.
 
 ### Events are subject to cleanup_ttl
 

--- a/docs/web/workflows.md
+++ b/docs/web/workflows.md
@@ -4,12 +4,12 @@ icon: lucide/git-branch
 
 # Workflows
 
-Absurd calls these primitives **Steps (Checkpoints)** and **Sleep** — see
+Absurd calls these primitives **Steps (Checkpoints)**, **Sleep**, and **Events** — see
 [Absurd: Concepts](https://earendil-works.github.io/absurd/concepts/). They let a task
-break its work into checkpointed steps and sleep between them, persisting progress so
-retries and resumes pick up where they left off, never redoing completed steps. This
-page covers the django-absurd surface: the `get_absurd_context()` /
-`aget_absurd_context()` accessors.
+break its work into checkpointed steps, sleep between them, and suspend until a named
+signal arrives — persisting progress so retries and resumes pick up where they left off,
+never redoing completed steps. This page covers the django-absurd surface: the
+`get_absurd_context()` / `aget_absurd_context()` accessors.
 
 ## Basics
 
@@ -181,16 +181,127 @@ async def send_reminder(user_id: int) -> None:
 Pass a timezone-aware `datetime` — a naive `datetime` raises when compared against
 Absurd's timezone-aware clock.
 
+## Events
+
+`context.await_event(event_name, step_name=None, timeout=None)` suspends the task until
+a named event arrives, then returns its JSON payload.
+`context.emit_event(event_name, payload=None)` emits an event on the task's own queue
+(in-task, replay-safe — a re-emit after a retry is a no-op). Events are awaited by name,
+carry an optional JSON payload, and **first emit per name wins** (immutable) — a
+business-keyed name like `"warehouse.packed:order-42"` targets exactly one waiter.
+
+→ [Absurd: Concepts — Events](https://earendil-works.github.io/absurd/concepts/#events)
+
+Events are **queue-scoped**: `await_event`/`emit_event` operate on the task's own queue.
+An event emitted on queue X only wakes a waiter on queue X.
+
+### The outside-a-task signal: top-level `emit_event`
+
+`ctx.emit_event` only reaches code running _inside_ a task. The real-world signal that
+wakes a waiter — a webhook, a view, an API handler — is ordinary Django code, not a
+task. `django_absurd.emit_event(event_name, payload=None, *, queue="default")` is that
+entry point:
+
+```python
+from django_absurd import emit_event
+
+
+def warehouse_webhook(request, order):
+    emit_event(f"warehouse.packed:{order}", {"tracking": request.POST["tracking"]},
+               queue="default")
+    return HttpResponse(status=204)
+```
+
+End-to-end: a task calls `await_event(f"warehouse.packed:{order}")` → suspends (worker
+freed) → the warehouse system POSTs the webhook → the view emits the event on the task's
+queue → the task's next claim finds it → resumes with the payload.
+
+`queue` must match the queue the waiting task actually runs on — it targets the
+client-level `emit_event`'s `queue_name`, not a database alias. An unknown queue raises
+`ImproperlyConfigured` immediately (fail fast on a typo). `emit_event` is sync; from an
+async view, wrap it in `sync_to_async`.
+
+### Sync
+
+```python
+from django.tasks import task
+from django_absurd import get_absurd_context
+
+
+@task
+def process_order(order_id: int) -> None:
+    context = get_absurd_context()
+    context.step("charge", lambda: charge_card(order_id))
+    payload = context.await_event(f"warehouse.packed:{order_id}")
+    context.step("ship", lambda: ship(order_id, payload))
+```
+
+### Async
+
+```python
+from django.tasks import task
+from django_absurd import aget_absurd_context
+
+
+@task
+async def process_order(order_id: int) -> None:
+    context = aget_absurd_context()
+    payload = await context.await_event(f"warehouse.packed:{order_id}")
+
+    async def ship_order():
+        return await ship(order_id, payload)
+
+    await context.step("ship", ship_order)
+```
+
+### Timeout
+
+Pass `timeout` (seconds) to stop waiting after a bound. On timeout, `await_event` raises
+`absurd_sdk.TimeoutError` — **not** the builtin `TimeoutError`:
+
+```python
+import absurd_sdk
+from django.tasks import task
+from django_absurd import get_absurd_context
+
+
+@task
+def process_order(order_id: int) -> str:
+    context = get_absurd_context()
+    try:
+        context.await_event(f"warehouse.packed:{order_id}", timeout=3600)
+    except absurd_sdk.TimeoutError:
+        return "gave up waiting for the warehouse"
+    return "shipped"
+```
+
+!!! warning "Not the builtin `TimeoutError`"
+
+    `except TimeoutError:` (the builtin) does **not** catch this — you must
+    `import absurd_sdk` and catch `absurd_sdk.TimeoutError` explicitly.
+
+An **uncaught** `TimeoutError` fails the run, which then retries and re-waits the full
+`timeout` on each attempt until `max_attempts` — catch it if you want a one-shot
+timeout.
+
+### `await_task_result` is not provided
+
+Absurd's SDK version of this polls + heartbeats inside a step rather than suspending
+(holding the worker slot), and is cross-queue-only. For a child task's result, use
+Django's `get_result()` / `aget_result()` instead.
+
 ## API
 
-| Method / property                         | Sync | Async   | Description                                          |
-| ----------------------------------------- | ---- | ------- | ---------------------------------------------------- |
-| `step(name, fn)`                          | yes  | `await` | Run `fn()`, checkpoint the result; skip on replay    |
-| `sleep_for(step_name, duration)`          | yes  | `await` | Suspend the task for `duration` seconds              |
-| `sleep_until(step_name, wake_at)`         | yes  | `await` | Suspend until a `datetime`, Unix timestamp, or float |
-| `heartbeat(seconds=None)`                 | yes  | `await` | Extend the claim timeout (keep the run alive)        |
-| `headers`                                 | yes  | yes     | Read-only mapping of headers passed at enqueue time  |
-| `run_step([name])` (decorator, sync only) | yes  | —       | Wraps `step`; derives the checkpoint name from `fn`  |
+| Method / property                                       | Sync | Async   | Description                                               |
+| ------------------------------------------------------- | ---- | ------- | --------------------------------------------------------- |
+| `step(name, fn)`                                        | yes  | `await` | Run `fn()`, checkpoint the result; skip on replay         |
+| `sleep_for(step_name, duration)`                        | yes  | `await` | Suspend the task for `duration` seconds                   |
+| `sleep_until(step_name, wake_at)`                       | yes  | `await` | Suspend until a `datetime`, Unix timestamp, or float      |
+| `await_event(event_name, step_name=None, timeout=None)` | yes  | `await` | Suspend until the named event arrives; return its payload |     |
+| `emit_event(event_name, payload=None)`                  | yes  | `await` | Emit an event on the task's own queue (replay-safe)       |
+| `heartbeat(seconds=None)`                               | yes  | `await` | Extend the claim timeout (keep the run alive)             |
+| `headers`                                               | yes  | yes     | Read-only mapping of headers passed at enqueue time       |
+| `run_step([name])` (decorator, sync only)               | yes  | —       | Wraps `step`; derives the checkpoint name from `fn`       |
 
 ### Reading headers
 
@@ -232,6 +343,17 @@ durable call swallows them and silently breaks suspension — let them propagate
 Django task backend — where the Absurd runtime context is never set — they raise
 `RuntimeError`.
 
+### Events are subject to cleanup_ttl
+
+An event emitted long before a delayed `await_event` can be cleaned up by the queue's
+`cleanup_ttl` before the waiter ever checks — the waiter then never wakes. Keep
+`cleanup_ttl` generous relative to how long a waiter might sleep before checking.
+
+### `TimeoutError` is `absurd_sdk.TimeoutError`, not the builtin
+
+`except TimeoutError:` silently catches nothing — `import absurd_sdk` and catch
+`absurd_sdk.TimeoutError`.
+
 ## Enqueue a durable task
 
 Durable tasks enqueue the same way as any other task:
@@ -245,5 +367,8 @@ process_order.enqueue(order_id=42)
 Checkpoints are visible in Django admin under **Checkpoints** (one row per completed
 step). The `available_at` column — a sleeping run's wake time — appears on the run
 detail page (Claim fieldset) and in the task detail's Runs inline.
+
+Waits are visible in Django admin under **Waits** (one row per task suspended in
+`await_event`), and inline under the task detail page alongside Runs and Checkpoints.
 
 → [How it works — runs, retries & checkpoints](how-it-works.md#runs-retries-checkpoints)

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,10 @@ serve on http://localhost:8000; admin login `admin` / `admin`).
 
 - **[`web/`](web/)** — enqueue `add(a, b)` from a form and watch the result
   (`get_result`); browse the read-only queue tables in the admin. Also demonstrates
-  **Steps (checkpoints) + Sleep** at `/workflow/` — an order-fulfillment task that
-  checkpoints each step and suspends on a `sleep_for`, with a link into the task's admin
-  page to watch its checkpoints and suspended run.
+  **Steps (checkpoints), Sleep, and Events** at `/workflow/` — an order-fulfillment task
+  that checkpoints each step and suspends on `await_event` until a "mark packed" button
+  (calling the top-level `emit_event`) wakes it, with a link into the task's admin page
+  to watch its checkpoints and suspended wait.
 - **[`beat/`](beat/)** — the in-process **beat** scheduler firing a task every minute.
 - **[`pg_cron/`](pg_cron/)** — the **pg_cron** scheduler firing a task directly from
   Postgres (no beat process).

--- a/examples/web/app.py
+++ b/examples/web/app.py
@@ -3,12 +3,13 @@
 Enqueue add(a, b) from a form; the worker runs it; watch the result page and
 browse the read-only queue tables in the admin (auto-registered by django-absurd).
 
-Also demonstrates Steps (checkpoints) + Sleep: enqueue an order-fulfillment
-workflow that checkpoints each step and suspends between them.
+Also demonstrates Steps (checkpoints) + Sleep + Events: an order-fulfillment
+workflow that checkpoints each step and suspends on await_event until a
+"mark packed" button emits the matching event.
 
     docker compose up
     http://localhost:8000/         enqueue add(a, b) or the order workflow
-    http://localhost:8000/admin/   Tasks / Runs / Checkpoints / … (admin / admin)
+    http://localhost:8000/admin/  Tasks / Runs / Checkpoints / Waits / … (admin / admin)
 
 psycopg (v3) backend required — DATABASES is overridden (nanodjango defaults to sqlite).
 """
@@ -18,6 +19,7 @@ import html
 import logging
 import os
 import pprint
+from urllib.parse import quote as url_quote
 
 from django import forms
 from django.contrib.admin.utils import quote
@@ -29,7 +31,7 @@ from django.tasks.exceptions import TaskResultDoesNotExist
 from django.urls import reverse
 from nanodjango import Django
 
-from django_absurd import get_absurd_context
+from django_absurd import emit_event, get_absurd_context
 
 app = Django(
     ADMIN_URL="admin/",
@@ -74,13 +76,10 @@ def fulfill_order(order: str) -> str:
 
     Mirrors the shape of Absurd's headline order-fulfillment example
     (https://github.com/earendil-works/absurd#readme): step(charge) →
-    step(reserve inventory) → wait for the warehouse to pack → step(notify).
-    Absurd's example awaits a "warehouse packed" event; Events aren't shipped
-    here yet, so `sleep_for` stands in for that wait — it becomes
-    `await_event("warehouse.packed")` once the Events pillar lands.
+    step(reserve inventory) → await_event(warehouse packed) → step(notify).
 
-    Each step is a checkpoint: check the admin's Checkpoints and Runs pages to
-    see the steps and the suspended state while it waits.
+    Each step is a checkpoint: check the admin's Checkpoints, Waits, and Runs
+    pages to see the steps and the suspended state while it waits.
 
     Shows both step forms: ``context.step(name, fn)`` and the ``run_step``
     decorator (sync only), which runs the function once and replaces it with the
@@ -89,7 +88,7 @@ def fulfill_order(order: str) -> str:
     context = get_absurd_context()
     context.step("charge", lambda: f"charged: {order}")
     context.step("reserve-inventory", lambda: f"reserved: {order}")
-    context.sleep_for("await-warehouse", 5)
+    context.await_event(f"warehouse.packed:{order}")
 
     @context.run_step("notify")
     def notify() -> str:
@@ -137,8 +136,9 @@ def workflow_view(request: HttpRequest) -> HttpResponse | str:
     if request.method == "POST":
         form = WorkflowForm(request.POST)
         if form.is_valid():
-            result = fulfill_order.enqueue(**form.cleaned_data)
-            return redirect(f"/tasks/{result.id}/")
+            order = form.cleaned_data["order"]
+            result = fulfill_order.enqueue(order=order)
+            return redirect(f"/tasks/{result.id}/?order={order}")
     else:
         form = WorkflowForm()
     return f"""
@@ -146,11 +146,13 @@ def workflow_view(request: HttpRequest) -> HttpResponse | str:
         <p>
           Mirrors Absurd's
           <a href="https://github.com/earendil-works/absurd#readme">order-fulfillment
-          example</a>: <em>charge</em>, <em>reserve-inventory</em>, wait for the
-          warehouse (a 5s sleep standing in for a "warehouse packed" event),
-          <em>notify</em>. While waiting, check
-          <a href="/admin/django_absurd/run/">Runs</a> and
-          <a href="/admin/django_absurd/checkpoint/">Checkpoints</a> in the admin.
+          example</a>: <em>charge</em>, <em>reserve-inventory</em>,
+          <code>await_event</code> for the warehouse to pack the order, <em>notify</em>.
+          While waiting, check
+          <a href="/admin/django_absurd/run/">Runs</a>,
+          <a href="/admin/django_absurd/checkpoint/">Checkpoints</a>, and
+          <a href="/admin/django_absurd/wait/">Waits</a> in the admin — or click
+          "mark packed" below once the task detail page appears.
         </p>
         <form method="post">
           <input type="hidden" name="csrfmiddlewaretoken" value="{get_token(request)}">
@@ -159,6 +161,18 @@ def workflow_view(request: HttpRequest) -> HttpResponse | str:
         </form>
         <p><a href="/">Back</a></p>
     """
+
+
+@app.route("/workflow/<str:order>/pack/")
+def pack_view(request: HttpRequest, order: str) -> HttpResponse:
+    if request.method == "POST":
+        emit_event(
+            f"warehouse.packed:{order}",
+            {"packed_by": "warehouse demo"},
+            queue="default",
+        )
+    next_url = request.GET.get("next", "/")
+    return redirect(next_url)
 
 
 @app.route("/tasks/<str:result_id>/")
@@ -177,6 +191,17 @@ def task_detail(request: HttpRequest, result_id: str) -> HttpResponse | str:
     else:
         body = "<p>Working… (auto-refreshing)</p>"
 
+    order = request.GET.get("order")
+    pack_button = ""
+    if order and not finished:
+        back = url_quote(f"/tasks/{result_id}/?order={order}", safe="")
+        pack_button = f"""
+        <form method="post" action="/workflow/{order}/pack/?next={back}">
+          <input type="hidden" name="csrfmiddlewaretoken" value="{get_token(request)}">
+          <button type="submit">Mark "{order}" packed by the warehouse</button>
+        </form>
+        """
+
     fields = {f.name: getattr(result, f.name) for f in dataclasses.fields(result)}
     dump = html.escape(pprint.pformat(fields))
     admin_url = reverse("admin:django_absurd_task_change", args=[quote(result.id)])
@@ -185,11 +210,12 @@ def task_detail(request: HttpRequest, result_id: str) -> HttpResponse | str:
         <h1>Task {result.id}</h1>
         <p>Status: <strong>{result.status.name}</strong></p>
         {body}
+        {pack_button}
         <pre><code>{dump}</code></pre>
         <p>
           <a href="/">Add another</a> ·
           <a href="{admin_url}">View this task in the admin</a>
-          — its Runs + Checkpoints inlines show the steps and suspended state.
+          — its Runs + Checkpoints + Waits inlines show the steps and suspended state.
         </p>
     """
 

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -83,3 +83,13 @@ async def asleep_for_once(key: str) -> int:
 async def asleep_until_once(key: str) -> str:
     await aget_absurd_context().sleep_until("nap", time.time() + 1.5)
     return "woke"
+
+
+@task
+async def aawait_event_once(name: str) -> t.Any:
+    return await aget_absurd_context().await_event(name)
+
+
+@task
+async def aemit_event_once(name: str, payload: t.Any) -> None:
+    await aget_absurd_context().emit_event(name, payload)

--- a/tests/core/test_admin/test_event.py
+++ b/tests/core/test_admin/test_event.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import User
@@ -6,6 +8,7 @@ from django.db import connections
 from django.test import Client
 from django.urls import reverse, reverse_lazy
 
+from django_absurd import emit_event
 from tests.core.test_admin.utils import parse_html, result_rows
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -38,3 +41,16 @@ def test_changelist_and_detail(client: Client, admin_user: User) -> None:
     name_elem = detail.select_one(".field-event_name .readonly")
     assert name_elem is not None
     assert name_elem.get_text(strip=True) == "order.shipped"
+
+
+def test_emit_event_writes_a_visible_row(client: Client, admin_user: t.Any) -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.shipped:demo", {"id": 1}, queue="default")
+    client.force_login(admin_user)
+    soup = parse_html(client.get(CHANGELIST))
+    names = set()
+    for r in result_rows(soup):
+        elem = r.select_one(".field-event_name")
+        assert elem is not None
+        names.add(elem.get_text(strip=True))
+    assert "order.shipped:demo" in names

--- a/tests/core/test_admin/test_event.py
+++ b/tests/core/test_admin/test_event.py
@@ -1,5 +1,3 @@
-import typing as t
-
 import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import User
@@ -43,7 +41,7 @@ def test_changelist_and_detail(client: Client, admin_user: User) -> None:
     assert name_elem.get_text(strip=True) == "order.shipped"
 
 
-def test_emit_event_writes_a_visible_row(client: Client, admin_user: t.Any) -> None:
+def test_emit_event_writes_a_visible_row(admin_user: User, client: Client) -> None:
     call_command("absurd_sync_queues")
     emit_event("order.shipped:demo", {"id": 1}, queue="default")
     client.force_login(admin_user)

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -94,7 +94,7 @@ def test_detail_groups_fields_into_fieldsets(
 
 def test_changelist_and_detail_survive_indefinite_available_at(
     client: Client,
-    admin_user: AbstractBaseUser,
+    admin_user: User,
 ) -> None:
     # await_event with no timeout writes Postgres's 'infinity' sentinel into
     # available_at (absurd.await_event, migrations/0001_initial_0_4_0.sql:1664:
@@ -106,7 +106,7 @@ def test_changelist_and_detail_survive_indefinite_available_at(
     sawait_event_once.enqueue("admin-infinity-check")
     call_command("absurd_worker", queue="default", burst=True)  # suspends indefinitely
 
-    client.force_login(t.cast("User", admin_user))
+    client.force_login(admin_user)
     changelist_response = client.get(CHANGELIST)
     assert changelist_response.status_code == 200
 

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -9,7 +9,7 @@ from django.urls import reverse, reverse_lazy
 
 from django_absurd.models import Run
 from tests.core.test_admin.utils import parse_html, result_rows, seed_mixed
-from tests.tasks import add
+from tests.tasks import add, sawait_event_once
 
 if t.TYPE_CHECKING:
     from bs4 import Tag
@@ -90,6 +90,33 @@ def test_detail_groups_fields_into_fieldsets(
     soup = parse_html(response)
     legends = {h.get_text(strip=True) for h in soup.select("h2.fieldset-heading")}
     assert {"Claim", "Timing", "Event", "Result"} <= legends
+
+
+def test_changelist_and_detail_survive_indefinite_available_at(
+    client: Client,
+    admin_user: AbstractBaseUser,
+) -> None:
+    # await_event with no timeout writes Postgres's 'infinity' sentinel into
+    # available_at (absurd.await_event, migrations/0001_initial_0_4_0.sql:1664:
+    # `v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz)`).
+    # psycopg cannot decode a literal infinity into a Python datetime, so an
+    # un-guarded available_at column crashes both the changelist and the detail
+    # page with a DataError before anything renders.
+    call_command("absurd_sync_queues")
+    sawait_event_once.enqueue("admin-infinity-check")
+    call_command("absurd_worker", queue="default", burst=True)  # suspends indefinitely
+
+    client.force_login(t.cast("User", admin_user))
+    changelist_response = client.get(CHANGELIST)
+    assert changelist_response.status_code == 200
+
+    run_obj = run_model.objects.get()
+    detail_response = client.get(change_url(run_obj.natural_key))
+    assert detail_response.status_code == 200
+    soup = parse_html(detail_response)
+    available = soup.select_one(".field-available_at .readonly")
+    assert available is not None
+    assert available.get_text(strip=True) == "-"
 
 
 def test_detail_shows_failure_reason(

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -2,7 +2,7 @@ import typing as t
 
 import pytest
 from django.contrib.admin.utils import quote
-from django.contrib.auth.models import AbstractBaseUser, User
+from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.test import Client
 from django.urls import reverse, reverse_lazy
@@ -32,15 +32,15 @@ def run_for(result: "TaskResult[t.Any, t.Any]") -> t.Any:
 
 
 def test_changelist_shows_dates_ordered_by_recent_activity(
+    admin_user: User,
     client: Client,
-    admin_user: AbstractBaseUser,
 ) -> None:
     call_command("absurd_sync_queues")
     older = add.enqueue(1, 1)
     call_command("absurd_worker", queue="default", burst=True)  # older run starts
     newer = add.enqueue(2, 2)
     call_command("absurd_worker", queue="default", burst=True)  # newer run starts later
-    client.force_login(t.cast("User", admin_user))
+    client.force_login(admin_user)
     response = client.get(CHANGELIST)
     soup = parse_html(response)
     # the started_at column is the (descending) primary sort, and
@@ -58,11 +58,11 @@ def test_changelist_shows_dates_ordered_by_recent_activity(
 
 
 def test_changelist_filtered_to_task(
+    admin_user: User,
     client: Client,
-    admin_user: AbstractBaseUser,
 ) -> None:
     _, failed, _ = seed_mixed()
-    client.force_login(t.cast("User", admin_user))
+    client.force_login(admin_user)
     # the natural_key is "<queue>:<task_id>";
     # search by the bare task_id
     task_id = failed.id.split(":", 1)[1]
@@ -80,11 +80,11 @@ def test_changelist_filtered_to_task(
 
 
 def test_detail_groups_fields_into_fieldsets(
+    admin_user: User,
     client: Client,
-    admin_user: AbstractBaseUser,
 ) -> None:
     seed_mixed()  # produces runs
-    client.force_login(t.cast("User", admin_user))
+    client.force_login(admin_user)
     run_obj = run_model.objects.first()
     response = client.get(change_url(run_obj.natural_key))
     soup = parse_html(response)
@@ -120,11 +120,11 @@ def test_changelist_and_detail_survive_indefinite_available_at(
 
 
 def test_detail_shows_failure_reason(
+    admin_user: User,
     client: Client,
-    admin_user: AbstractBaseUser,
 ) -> None:
     seed_mixed()
-    client.force_login(t.cast("User", admin_user))
+    client.force_login(admin_user)
     client.get(CHANGELIST)  # prime the runs view
     run_obj = run_model.objects.filter(queue="default", state="failed").first()
     response = client.get(change_url(run_obj.natural_key))

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -93,8 +93,8 @@ def test_detail_groups_fields_into_fieldsets(
 
 
 def test_changelist_and_detail_survive_indefinite_available_at(
-    client: Client,
     admin_user: User,
+    client: Client,
 ) -> None:
     # await_event with no timeout writes Postgres's 'infinity' sentinel into
     # available_at (absurd.await_event, migrations/0001_initial_0_4_0.sql:1664:

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -19,7 +19,7 @@ from tests.core.test_admin.utils import (
     seed,
     seed_mixed,
 )
-from tests.tasks import add
+from tests.tasks import add, sawait_event_once
 
 if t.TYPE_CHECKING:
     from bs4 import ResultSet, Tag
@@ -251,6 +251,23 @@ def test_detail_inlines_checkpoints_and_run_available_at(
     available = soup.select_one(".field-available_at")
     assert available is not None
     assert available.get_text(strip=True) != ""  # sleeping run has a wake time
+
+
+def test_detail_inlines_waits_for_a_suspended_await_event(
+    client: Client, admin_user: User
+) -> None:
+    call_command("absurd_sync_queues")
+    sawait_event_once.enqueue("wait-admin-demo")
+    call_command("absurd_worker", queue="default", burst=True)  # suspends
+    client.force_login(admin_user)
+
+    task = find_task("default", "tests.tasks.sawait_event_once")
+    assert task is not None
+    soup = parse_html(client.get(change_url(task.natural_key)))
+
+    assert soup.select_one('a[href*="/django_absurd/wait/"]') is not None
+    names = {cell.get_text(strip=True) for cell in soup.select(".field-event_name")}
+    assert "wait-admin-demo" in names
 
 
 def test_detail_renders_read_only(client: Client, admin_user: User) -> None:

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -254,7 +254,7 @@ def test_detail_inlines_checkpoints_and_run_available_at(
 
 
 def test_detail_inlines_waits_for_a_suspended_await_event(
-    client: Client, admin_user: User
+    admin_user: User, client: Client
 ) -> None:
     call_command("absurd_sync_queues")
     sawait_event_once.enqueue("wait-admin-demo")

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -135,9 +135,23 @@ def test_async_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
 
 def test_uncaught_timeout_raises_absurd_sdk_timeout_error_and_is_catchable() -> None:
     call_command("absurd_sync_queues")
-    result = tasks.sawait_event_timeout.enqueue("order.packed:never-arrives")
+    result = tasks.sawait_event_timeout.enqueue("order.packed:never-arrives", timeout=0)
     utils.run_absurd_worker()
     done = utils.get_task_result(result.id)
     assert done is not None
     assert done.state == "completed"
     assert done.result == "timed-out"
+
+
+def test_event_already_present_returns_no_timeout_before_deadline() -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.packed:before-timeout-1", {"tracking": "xyz"}, queue="default")
+
+    result = tasks.sawait_event_timeout.enqueue(
+        "order.packed:before-timeout-1", timeout=60
+    )
+    utils.run_absurd_worker()  # single drain: event already there, no suspend
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == "no-timeout"

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -1,8 +1,10 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command
 from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd import emit_event
+from tests import atasks, tasks, utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -45,3 +47,97 @@ def test_top_level_emit_event_unsynced_queue_raises(
         ),
     ):
         emit_event("whatever", queue="unsynced")
+
+
+def test_sync_await_event_suspends_then_top_level_emit_resumes() -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sawait_event_once.enqueue("order.packed:sync-1")
+
+    utils.run_absurd_worker()  # drain 1: no event yet -> suspend
+    suspended = utils.get_task_result(result.id)
+    assert suspended is not None
+    assert suspended.state == "sleeping"
+
+    emit_event("order.packed:sync-1", {"tracking": "abc"}, queue="default")
+
+    utils.run_absurd_worker()  # drain 2: resumes with the payload
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == {"tracking": "abc"}
+
+
+def test_async_await_event_suspends_then_top_level_emit_resumes() -> None:
+    call_command("absurd_sync_queues")
+    result = atasks.aawait_event_once.enqueue("order.packed:async-1")
+
+    utils.run_absurd_worker()
+    suspended = utils.get_task_result(result.id)
+    assert suspended is not None
+    assert suspended.state == "sleeping"
+
+    emit_event("order.packed:async-1", {"tracking": "abc"}, queue="default")
+
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == {"tracking": "abc"}
+
+
+def test_emit_before_await_returns_immediately_no_suspend() -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.packed:before-1", {"tracking": "xyz"}, queue="default")
+
+    result = tasks.sawait_event_once.enqueue("order.packed:before-1")
+    utils.run_absurd_worker()  # single drain: event already there, no suspend
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == {"tracking": "xyz"}
+
+
+def test_first_emit_per_name_wins() -> None:
+    call_command("absurd_sync_queues")
+    emit_event("order.packed:first-wins", {"tracking": "first"}, queue="default")
+    emit_event("order.packed:first-wins", {"tracking": "second"}, queue="default")
+
+    result = tasks.sawait_event_once.enqueue("order.packed:first-wins")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.result == {"tracking": "first"}
+
+
+def test_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
+    call_command("absurd_sync_queues")
+    tasks.semit_event_once.enqueue("order.packed:in-task", {"tracking": "in-task"})
+    utils.run_absurd_worker()
+
+    result = tasks.sawait_event_once.enqueue("order.packed:in-task")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.result == {"tracking": "in-task"}
+
+
+def test_async_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
+    call_command("absurd_sync_queues")
+    atasks.aemit_event_once.enqueue("order.packed:in-task-async", {"tracking": "async"})
+    utils.run_absurd_worker()
+
+    result = atasks.aawait_event_once.enqueue("order.packed:in-task-async")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.result == {"tracking": "async"}
+
+
+def test_uncaught_timeout_raises_absurd_sdk_timeout_error_and_is_catchable() -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sawait_event_timeout.enqueue("order.packed:never-arrives")
+    utils.run_absurd_worker()
+    done = utils.get_task_result(result.id)
+    assert done is not None
+    assert done.state == "completed"
+    assert done.result == "timed-out"

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -1,0 +1,47 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from pytest_django.fixtures import SettingsWrapper
+
+from django_absurd import emit_event
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_top_level_emit_event_unknown_queue_raises() -> None:
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=(
+            r"Queue 'ghost' is not declared in TASKS QUEUES\. Add it to the QUEUES "
+            r"list in your TASKS backend settings\."
+        ),
+    ):
+        emit_event("whatever", queue="ghost")
+
+
+def test_top_level_emit_event_no_backend_configured_raises(
+    settings: SettingsWrapper,
+) -> None:
+    settings.TASKS = {"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}}
+    with pytest.raises(
+        ImproperlyConfigured, match=r"django-absurd: no Absurd backend configured\."
+    ):
+        emit_event("whatever")
+
+
+def test_top_level_emit_event_unsynced_queue_raises(
+    settings: SettingsWrapper,
+) -> None:
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {}, "unsynced": {}}},
+        }
+    }
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=(
+            r"Queue 'unsynced' is declared but its Absurd table is not provisioned\. "
+            r"Run: manage\.py absurd_sync_queues"
+        ),
+    ):
+        emit_event("whatever", queue="unsynced")

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -14,7 +14,7 @@ from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.queues import get_absurd_client
 from tests.models import Payload
-from tests.tasks import add, boom, echo
+from tests.tasks import add, boom, echo, sawait_event_once
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -49,6 +49,14 @@ def test_get_result_successful() -> None:
     assert got.finished_at is not None
     assert got.last_attempted_at is not None
     assert got.worker_ids  # non-empty
+
+
+def test_get_result_suspended_on_indefinite_await_event() -> None:
+    call_command("absurd_sync_queues")
+    r = sawait_event_once.enqueue("get-result-infinity-check")
+    run_absurd_worker()
+    got = backend().get_result(r.id)
+    assert got.status == TaskResultStatus.RUNNING
 
 
 def test_refresh_round_trip() -> None:

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -156,9 +156,9 @@ def semit_event_once(name: str, payload: t.Any) -> None:
 
 
 @task
-def sawait_event_timeout(name: str) -> str:
+def sawait_event_timeout(name: str, timeout: int) -> str:
     try:
-        get_absurd_context().await_event(name, timeout=0)
+        get_absurd_context().await_event(name, timeout=timeout)
     except absurd_sdk.TimeoutError:
         return "timed-out"
     return "no-timeout"

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,6 +1,7 @@
 import time
 import typing as t
 
+import absurd_sdk
 from absurd_sdk import CancellationPolicy, JsonValue, RetryStrategy
 from django.contrib.auth.models import Group
 from django.tasks import TaskContext, task
@@ -142,3 +143,22 @@ def ssleep_for_once(key: str) -> int:
 def ssleep_until_once(key: str) -> str:
     get_absurd_context().sleep_until("nap", time.time() + 1.5)
     return "woke"
+
+
+@task
+def sawait_event_once(name: str) -> t.Any:
+    return get_absurd_context().await_event(name)
+
+
+@task
+def semit_event_once(name: str, payload: t.Any) -> None:
+    get_absurd_context().emit_event(name, payload)
+
+
+@task
+def sawait_event_timeout(name: str) -> str:
+    try:
+        get_absurd_context().await_event(name, timeout=0)
+    except absurd_sdk.TimeoutError:
+        return "timed-out"
+    return "no-timeout"


### PR DESCRIPTION
Implements Absurd's Events pillar: `await_event`/`emit_event` in-task, top-level `django_absurd.emit_event` for outside-a-task signals (views/webhooks), Waits admin inline, docs, and example update. Closes #21.

Also fixes two Postgres-infinity-sentinel crashes surfaced by indefinite `await_event` (admin views, `get_result()`).