### PR TITLE
docs: favour uv install with prerelease flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ separate broker — reusing Django's own database connection.
 
 ## Install
 
+django-absurd is in **alpha** — only pre-releases are published, so your installer must
+be allowed to pick them up.
+
 ```console
-pip install django-absurd
+uv add django-absurd --prerelease allow
+```
+
+Using pip:
+
+```console
+pip install --pre django-absurd
 ```
 
 ## Quickstart

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -26,8 +26,17 @@ existing database connection.
 
 ## Install
 
+django-absurd is in **alpha** — only pre-releases are published, so your installer must
+be allowed to pick them up.
+
 ```bash
-pip install django-absurd
+uv add django-absurd --prerelease allow
+```
+
+Using pip:
+
+```bash
+pip install --pre django-absurd
 ```
 
 ## Quickstart


### PR DESCRIPTION
Lead install docs with `uv add django-absurd --prerelease allow`; pip `--pre` as alternative. Alpha-only package, so the prerelease flag is required. README + docs site.