### PR TITLE
Test the example apps + include them in Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,40 +61,56 @@ jobs:
           fail_ci_if_error: true
           files: junit-core.xml,junit-pg_cron.xml,junit-multidb.xml
 
-  examples-web:
-    name: examples/web pytest suite
+  examples:
+    name: examples/${{ matrix.example }} pytest suite
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - example: web
+            service: db
+            pgport: "5432"
+            pgdatabase: postgres
+          - example: beat
+            service: db
+            pgport: "5432"
+            pgdatabase: postgres
+          - example: pg_cron
+            service: db_pg_cron
+            pgport: "5434"
+            pgdatabase: demo
     env:
       PGHOST: localhost
       PGUSER: postgres
       PGPASSWORD: postgres
-      PGDATABASE: postgres
-      PGPORT: "5432"
+      PGDATABASE: ${{ matrix.pgdatabase }}
+      PGPORT: ${{ matrix.pgport }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Start Postgres service
-        run: docker compose up -d --build --wait db
+        run: docker compose up -d --build --wait ${{ matrix.service }}
       - name: Run pytest
-        run: cd examples/web && uv sync && uv run pytest
+        run: cd examples/${{ matrix.example }} && uv sync && uv run pytest
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: examples-web
+          flags: examples-${{ matrix.example }}
           fail_ci_if_error: true
-          files: examples/web/coverage.xml
+          files: examples/${{ matrix.example }}/coverage.xml
       - name: Upload test results to Codecov
         if: ${{ success() || failure() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          flags: examples-web
+          flags: examples-${{ matrix.example }}
           fail_ci_if_error: true
-          files: examples/web/junit-examples-web.xml
+          files: examples/${{ matrix.example }}/junit-examples-${{ matrix.example }}.xml
 
   build:
     name: build distribution

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,3 +23,21 @@ docker compose up
 Each demo installs django-absurd from this checkout (editable path dependency), so it
 exercises the local source, and `nanodjango run` applies migrations and creates the
 `admin`/`admin` superuser on startup.
+
+## Running the tests
+
+Each demo has a pytest suite (high-level HTTP for `web`; enqueue-and-drain for the
+scheduled `beat`/`pg_cron` tasks — the schedulers themselves are covered in
+django-absurd's own tests). Start the Postgres service from the repo root, then run the
+suite against it:
+
+```bash
+docker compose up -d db db_pg_cron    # from the repo root
+
+cd examples/web    && uv run pytest    # web + beat use `db` on PGPORT (5432)
+cd examples/beat   && uv run pytest
+cd examples/pg_cron && PGPORT=5434 uv run pytest    # pg_cron needs the db_pg_cron server
+```
+
+`pg_cron` must run against the `db_pg_cron` server (`PGPORT=5434`): its migration
+creates the `pg_cron` extension, which the plain `db` server doesn't provide.

--- a/examples/beat/app.py
+++ b/examples/beat/app.py
@@ -63,5 +63,5 @@ def index(request: HttpRequest) -> HttpResponse:
     return redirect("/admin/")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     app.run()

--- a/examples/beat/pyproject.toml
+++ b/examples/beat/pyproject.toml
@@ -1,3 +1,10 @@
+[dependency-groups]
+dev = [
+  "pytest",
+  "pytest-cov",
+  "pytest-django",
+]
+
 [project]
 dependencies = [
   "django-absurd",
@@ -8,6 +15,12 @@ dependencies = [
 name = "django-absurd-example-beat"
 requires-python = ">=3.12"
 version = "0"
+
+[tool.coverage]
+
+[tool.coverage.run]
+branch = true
+source = ["app", "tests"]
 
 # django-absurd from the local checkout (repo root), so the demo exercises THIS
 # branch's code — not a released version.

--- a/examples/beat/pytest.toml
+++ b/examples/beat/pytest.toml
@@ -1,0 +1,11 @@
+[pytest]
+addopts = [
+  "--cov",
+  "--cov-report=term",
+  "--cov-report=xml",
+  "--junitxml=junit-examples-beat.xml",
+  "--reuse-db",
+  "--strict-markers",
+]
+pythonpath = ["."]
+testpaths = ["."]

--- a/examples/beat/tests/conftest.py
+++ b/examples/beat/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from app import app
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prepare_nanodjango() -> None:
+    """Finish nanodjango's setup (admin/API routes) once per session — mirrors
+    nanodjango's own (unmerged) example-app tests:
+    https://github.com/radiac/nanodjango/pull/28."""
+    app._prepare()

--- a/examples/beat/tests/test_beat.py
+++ b/examples/beat/tests/test_beat.py
@@ -17,10 +17,12 @@ def test_index_redirects_to_admin(client: Client) -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_tick_task_runs_via_drain(
-    absurd_drain_queue: t.Callable[..., None],
+    absurd_drain_queue: t.Callable[..., None], caplog: pytest.LogCaptureFixture
 ) -> None:
     result = tick.enqueue()
-    absurd_drain_queue()
+    with caplog.at_level("INFO", logger="demo"):
+        absurd_drain_queue()
     result.refresh()
     assert result.status == "SUCCESSFUL"
     assert result.return_value is None
+    assert any("tock" in record.message for record in caplog.records)

--- a/examples/beat/tests/test_beat.py
+++ b/examples/beat/tests/test_beat.py
@@ -1,0 +1,26 @@
+"""Tests for the beat demo: the index redirect, and the scheduled `tick` task run
+end-to-end through `absurd_drain_queue` (the beat process itself isn't exercised —
+its cadence is time-driven; here we drive the task the beat would enqueue)."""
+
+import typing as t
+
+import pytest
+from app import tick
+from django.test import Client
+
+
+def test_index_redirects_to_admin(client: Client) -> None:
+    resp = client.get("/")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/admin/"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tick_task_runs_via_drain(
+    absurd_drain_queue: t.Callable[..., None],
+) -> None:
+    result = tick.enqueue()
+    absurd_drain_queue()
+    result.refresh()
+    assert result.status == "SUCCESSFUL"
+    assert result.return_value is None

--- a/examples/pg_cron/app.py
+++ b/examples/pg_cron/app.py
@@ -66,5 +66,5 @@ def index(request: HttpRequest) -> HttpResponse:
     return redirect("/admin/")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     app.run()

--- a/examples/pg_cron/pyproject.toml
+++ b/examples/pg_cron/pyproject.toml
@@ -1,3 +1,10 @@
+[dependency-groups]
+dev = [
+  "pytest",
+  "pytest-cov",
+  "pytest-django",
+]
+
 [project]
 dependencies = [
   "django-absurd",
@@ -8,6 +15,12 @@ dependencies = [
 name = "django-absurd-example-pg-cron"
 requires-python = ">=3.12"
 version = "0"
+
+[tool.coverage]
+
+[tool.coverage.run]
+branch = true
+source = ["app", "tests"]
 
 # django-absurd from the local checkout (repo root), so the demo exercises THIS
 # branch's code — not a released version.

--- a/examples/pg_cron/pytest.toml
+++ b/examples/pg_cron/pytest.toml
@@ -1,0 +1,11 @@
+[pytest]
+addopts = [
+  "--cov",
+  "--cov-report=term",
+  "--cov-report=xml",
+  "--junitxml=junit-examples-pg_cron.xml",
+  "--reuse-db",
+  "--strict-markers",
+]
+pythonpath = ["."]
+testpaths = ["."]

--- a/examples/pg_cron/tests/conftest.py
+++ b/examples/pg_cron/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+from app import app
+from django.conf import settings
+
+# pg_cron only permits CREATE EXTENSION in the database named by the server's
+# cron.database_name (the db_pg_cron compose service sets it to absurd_test_pg_cron).
+# So the test database must use that exact name, not pytest-django's test_<db> default,
+# or the pg_cron app's migration fails with "can only create extension in database …".
+settings.DATABASES["default"].setdefault("TEST", {})
+settings.DATABASES["default"]["TEST"]["NAME"] = "absurd_test_pg_cron"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prepare_nanodjango() -> None:
+    """Finish nanodjango's setup (admin/API routes) once per session — mirrors
+    nanodjango's own (unmerged) example-app tests:
+    https://github.com/radiac/nanodjango/pull/28."""
+    app._prepare()

--- a/examples/pg_cron/tests/conftest.py
+++ b/examples/pg_cron/tests/conftest.py
@@ -2,12 +2,21 @@ import pytest
 from app import app
 from django.conf import settings
 
-# pg_cron only permits CREATE EXTENSION in the database named by the server's
-# cron.database_name (the db_pg_cron compose service sets it to absurd_test_pg_cron).
-# So the test database must use that exact name, not pytest-django's test_<db> default,
-# or the pg_cron app's migration fails with "can only create extension in database …".
-settings.DATABASES["default"].setdefault("TEST", {})
-settings.DATABASES["default"]["TEST"]["NAME"] = "absurd_test_pg_cron"
+
+@pytest.fixture(scope="session")
+def django_db_modify_db_settings(django_db_modify_db_settings: None) -> None:
+    """Pin the test database name to the server's ``cron.database_name``.
+
+    pg_cron only permits ``CREATE EXTENSION`` in the database named by
+    ``cron.database_name`` (a single server-level value; the db_pg_cron compose
+    service sets it to ``absurd_test_pg_cron``), so the test database must use that
+    exact name — not pytest-django's ``test_<db>`` default — or this app's migration
+    fails with "can only create extension in database …". The name is necessarily
+    shared with the internal ``tests/pg_cron`` suite: whichever suite last ran
+    ``--create-db`` owns the schema on a given server.
+    """
+    settings.DATABASES["default"].setdefault("TEST", {})
+    settings.DATABASES["default"]["TEST"]["NAME"] = "absurd_test_pg_cron"
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/examples/pg_cron/tests/test_pg_cron.py
+++ b/examples/pg_cron/tests/test_pg_cron.py
@@ -1,0 +1,26 @@
+"""Tests for the pg_cron demo: the index redirect, and the scheduled `ping` task run
+end-to-end through `absurd_drain_queue`. pg_cron's own firing (Postgres-side, cadence-
+driven) isn't exercised here — we drive the task pg_cron would enqueue."""
+
+import typing as t
+
+import pytest
+from app import ping
+from django.test import Client
+
+
+def test_index_redirects_to_admin(client: Client) -> None:
+    resp = client.get("/")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/admin/"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_ping_task_runs_via_drain(
+    absurd_drain_queue: t.Callable[..., None],
+) -> None:
+    result = ping.enqueue()
+    absurd_drain_queue()
+    result.refresh()
+    assert result.status == "SUCCESSFUL"
+    assert result.return_value == "pong"

--- a/examples/web/app.py
+++ b/examples/web/app.py
@@ -220,5 +220,5 @@ def task_detail(request: HttpRequest, result_id: str) -> HttpResponse | str:
     """
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     app.run()

--- a/examples/web/pyproject.toml
+++ b/examples/web/pyproject.toml
@@ -19,7 +19,8 @@ version = "0"
 [tool.coverage]
 
 [tool.coverage.run]
-source = ["tests"]
+branch = true
+source = ["app", "tests"]
 
 # django-absurd from the local checkout (repo root), so the demo exercises THIS
 # branch's code — not a released version.

--- a/examples/web/tests/conftest.py
+++ b/examples/web/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from app import app
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prepare_nanodjango() -> None:
+    """Finish nanodjango's setup (admin/API routes) once per session — mirrors
+    nanodjango's own (unmerged) example-app tests:
+    https://github.com/radiac/nanodjango/pull/28."""
+    app._prepare()

--- a/examples/web/tests/test_absurd_cleanup.py
+++ b/examples/web/tests/test_absurd_cleanup.py
@@ -19,16 +19,9 @@ no-DB proof lives in tests/core.
 import typing as t
 
 import pytest
-from app import add, app  # app.py's own Django(...) instance + its `add` task
+from app import add  # app.py's own `add` task
 
 from django_absurd.models import Queue, Task
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _init() -> None:
-    """Finish nanodjango's setup (admin/API routes) — mirrors nanodjango's own
-    (unmerged) example-app tests: https://github.com/radiac/nanodjango/pull/28."""
-    app._prepare()
 
 
 @pytest.mark.django_db(transaction=True)

--- a/examples/web/tests/test_add.py
+++ b/examples/web/tests/test_add.py
@@ -1,14 +1,7 @@
 import typing as t
 
 import pytest
-from app import add, app  # app.py's own Django(...) instance + its `add` task
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _init() -> None:
-    """Finish nanodjango's setup (admin/API routes) — mirrors nanodjango's own
-    (unmerged) example-app tests: https://github.com/radiac/nanodjango/pull/28."""
-    app._prepare()
+from app import add  # app.py's own `add` task
 
 
 # transaction=True (not plain `db`): absurd_drain_queue's burst worker opens its

--- a/examples/web/tests/test_views.py
+++ b/examples/web/tests/test_views.py
@@ -19,7 +19,7 @@ def test_index_get_renders_the_add_form(client: Client) -> None:
 def test_index_post_invalid_rerenders_the_form(client: Client) -> None:
     resp = client.post("/", {"a": "1"})  # missing b → form invalid
     assert resp.status_code == 200
-    assert "This field is required" in resp.content.decode()
+    assert "This field is required." in resp.content.decode()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -47,7 +47,7 @@ def test_add_fails_on_non_numeric_input(
     assert "Failed:" in body
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 def test_task_detail_shows_working_before_the_task_runs(client: Client) -> None:
     resp = client.post("/", {"a": "2", "b": "3"})
     body = client.get(resp.headers["Location"]).content.decode()
@@ -71,7 +71,7 @@ def test_workflow_get_renders_the_form(client: Client) -> None:
 def test_workflow_post_invalid_rerenders_the_form(client: Client) -> None:
     resp = client.post("/workflow/", {"order": ""})
     assert resp.status_code == 200
-    assert "This field is required" in resp.content.decode()
+    assert "This field is required." in resp.content.decode()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -96,9 +96,17 @@ def test_workflow_suspends_on_event_then_completes_after_pack(
     assert "notified: order-7" in done
 
 
-def test_pack_view_get_does_not_emit_and_redirects_to_default_next(
-    client: Client,
+@pytest.mark.django_db(transaction=True)
+def test_pack_view_get_does_not_emit_the_event(
+    absurd_drain_queue: t.Callable[..., None], client: Client
 ) -> None:
-    resp = client.get("/workflow/order-x/pack/")
+    task_url = client.post("/workflow/", {"order": "order-get"}).headers["Location"]
+    absurd_drain_queue()  # suspends on await_event
+
+    resp = client.get("/workflow/order-get/pack/")  # GET must NOT emit
     assert resp.status_code == 302
-    assert resp.headers["Location"] == "/"
+    assert resp.headers["Location"] == "/"  # default next
+
+    absurd_drain_queue()
+    body = client.get(task_url).content.decode()
+    assert "Working" in body  # still suspended — the GET delivered no event

--- a/examples/web/tests/test_views.py
+++ b/examples/web/tests/test_views.py
@@ -1,0 +1,104 @@
+"""High-level HTTP tests for the web demo — drive the real nanodjango views through
+the Django test client, asserting observable responses. The `add` task and the
+`fulfill_order` workflow are exercised end-to-end via `absurd_drain_queue`."""
+
+import typing as t
+import uuid
+
+import pytest
+from django.test import Client
+
+
+def test_index_get_renders_the_add_form(client: Client) -> None:
+    body = client.get("/").content.decode()
+    assert "django-absurd demo" in body
+    assert 'name="a"' in body
+    assert 'name="b"' in body
+
+
+def test_index_post_invalid_rerenders_the_form(client: Client) -> None:
+    resp = client.post("/", {"a": "1"})  # missing b → form invalid
+    assert resp.status_code == 200
+    assert "This field is required" in resp.content.decode()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_add_succeeds_and_the_result_page_shows_the_value(
+    absurd_drain_queue: t.Callable[..., None], client: Client
+) -> None:
+    resp = client.post("/", {"a": "2", "b": "3"})
+    assert resp.status_code == 302
+    task_url = resp.headers["Location"]
+    absurd_drain_queue()
+    body = client.get(task_url).content.decode()
+    assert "SUCCESSFUL" in body
+    assert "5.0" in body
+
+
+@pytest.mark.django_db(transaction=True)
+def test_add_fails_on_non_numeric_input(
+    absurd_drain_queue: t.Callable[..., None], client: Client
+) -> None:
+    resp = client.post("/", {"a": "x", "b": "3"})
+    task_url = resp.headers["Location"]
+    absurd_drain_queue()
+    body = client.get(task_url).content.decode()
+    assert "FAILED" in body
+    assert "Failed:" in body
+
+
+@pytest.mark.django_db(transaction=True)
+def test_task_detail_shows_working_before_the_task_runs(client: Client) -> None:
+    resp = client.post("/", {"a": "2", "b": "3"})
+    body = client.get(resp.headers["Location"]).content.decode()
+    assert "Working" in body
+    assert 'http-equiv="refresh"' in body
+
+
+@pytest.mark.django_db
+def test_task_detail_unknown_id_returns_404(client: Client) -> None:
+    resp = client.get(f"/tasks/default:{uuid.uuid4()}/")
+    assert resp.status_code == 404
+    assert "Unknown task" in resp.content.decode()
+
+
+def test_workflow_get_renders_the_form(client: Client) -> None:
+    body = client.get("/workflow/").content.decode()
+    assert "Order-fulfillment workflow" in body
+    assert 'name="order"' in body
+
+
+def test_workflow_post_invalid_rerenders_the_form(client: Client) -> None:
+    resp = client.post("/workflow/", {"order": ""})
+    assert resp.status_code == 200
+    assert "This field is required" in resp.content.decode()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_workflow_suspends_on_event_then_completes_after_pack(
+    absurd_drain_queue: t.Callable[..., None], client: Client
+) -> None:
+    resp = client.post("/workflow/", {"order": "order-7"})
+    assert resp.status_code == 302
+    task_url = resp.headers["Location"]
+
+    absurd_drain_queue()  # charge + reserve, then suspends on await_event
+    waiting = client.get(task_url).content.decode()
+    assert "Working" in waiting
+    assert 'action="/workflow/order-7/pack/' in waiting  # pack button present
+
+    pack = client.post("/workflow/order-7/pack/?next=/")
+    assert pack.status_code == 302
+
+    absurd_drain_queue()  # event delivered → resumes, runs notify, completes
+    done = client.get(task_url).content.decode()
+    assert "SUCCESSFUL" in done
+    assert "notified: order-7" in done
+
+
+def test_pack_view_get_does_not_emit_and_redirects_to_default_next(
+    client: Client,
+) -> None:
+    resp = client.get("/workflow/order-x/pack/")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/"


### PR DESCRIPTION
Application tests for the three nanodjango example apps, wired into Codecov.

- web: high-level HTTP tests through the real views (add success/failure, the await_event workflow completed via emit_event, 404).
- beat / pg_cron: enqueue+drain the scheduled task + index redirect. The schedulers themselves stay lib-tested.
- Coverage now measures each `app.py` (was tests-only); all three suites at 100% (statement + branch).
- CI: the web-only job becomes a matrix over web/beat/pg_cron, each uploading coverage + results under an `examples-<name>` flag.
- pg_cron's test DB is pinned to `cron.database_name` so its migration's CREATE EXTENSION is permitted.