### PR TITLE
refactor(tests): import fixture task modules and qualify

### DIFF
--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -8,8 +8,8 @@ from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 from django_absurd.models import Run
+from tests import tasks
 from tests.core.test_admin.utils import parse_html, result_rows, seed_mixed
-from tests.tasks import add, sawait_event_once
 
 if t.TYPE_CHECKING:
     from bs4 import Tag
@@ -36,9 +36,9 @@ def test_changelist_shows_dates_ordered_by_recent_activity(
     client: Client,
 ) -> None:
     call_command("absurd_sync_queues")
-    older = add.enqueue(1, 1)
+    older = tasks.add.enqueue(1, 1)
     call_command("absurd_worker", queue="default", burst=True)  # older run starts
-    newer = add.enqueue(2, 2)
+    newer = tasks.add.enqueue(2, 2)
     call_command("absurd_worker", queue="default", burst=True)  # newer run starts later
     client.force_login(admin_user)
     response = client.get(CHANGELIST)
@@ -103,7 +103,7 @@ def test_changelist_and_detail_survive_indefinite_available_at(
     # un-guarded available_at column crashes both the changelist and the detail
     # page with a DataError before anything renders.
     call_command("absurd_sync_queues")
-    sawait_event_once.enqueue("admin-infinity-check")
+    tasks.sawait_event_once.enqueue("admin-infinity-check")
     call_command("absurd_worker", queue="default", burst=True)  # suspends indefinitely
 
     client.force_login(admin_user)

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -12,7 +12,7 @@ from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.queues import get_absurd_client
-from tests.atasks import DURABLE_STEP_CALLS, asleep_for_once
+from tests import atasks, tasks
 from tests.core.test_admin.utils import (
     BACKEND,
     parse_html,
@@ -20,7 +20,6 @@ from tests.core.test_admin.utils import (
     seed,
     seed_mixed,
 )
-from tests.tasks import add, sawait_event_once
 
 if t.TYPE_CHECKING:
     from bs4 import ResultSet, Tag
@@ -114,8 +113,8 @@ def test_changelist_shows_dates_ordered_by_recent_activity(
     admin_user: User, client: Client
 ) -> None:
     call_command("absurd_sync_queues")  # index the default queue
-    older = add.enqueue(1, 1)
-    newer = add.enqueue(2, 2)  # enqueued later → more recent activity
+    older = tasks.add.enqueue(1, 1)
+    newer = tasks.add.enqueue(2, 2)  # enqueued later → more recent activity
     client.force_login(admin_user)
     resp = client.get(CHANGELIST)
     soup = parse_html(resp)
@@ -227,8 +226,8 @@ def test_detail_inlines_checkpoints_and_run_available_at(
     admin_user: User, client: Client
 ) -> None:
     call_command("absurd_sync_queues")
-    DURABLE_STEP_CALLS["n"] = 0
-    asleep_for_once.enqueue("admin-k")
+    atasks.DURABLE_STEP_CALLS["n"] = 0
+    atasks.asleep_for_once.enqueue("admin-k")
     call_command("absurd_worker", queue="default", burst=True)  # suspends
     client.force_login(admin_user)
 
@@ -258,7 +257,7 @@ def test_detail_inlines_waits_for_a_suspended_await_event(
     admin_user: User, client: Client
 ) -> None:
     call_command("absurd_sync_queues")
-    sawait_event_once.enqueue("wait-admin-demo")
+    tasks.sawait_event_once.enqueue("wait-admin-demo")
     call_command("absurd_worker", queue="default", burst=True)  # suspends
     client.force_login(admin_user)
 
@@ -335,7 +334,7 @@ def test_partitioned_queue_appears_in_changelist(
         }
     }
     call_command("absurd_sync_queues")
-    add.using(queue_name="part").enqueue(1, 1)
+    tasks.add.using(queue_name="part").enqueue(1, 1)
     call_command("absurd_worker", queue="part", burst=True)
     client.force_login(admin_user)
     resp = client.get(CHANGELIST)

--- a/tests/core/test_admin/utils.py
+++ b/tests/core/test_admin/utils.py
@@ -11,7 +11,7 @@ from django.urls import clear_url_caches
 
 from django_absurd.admin import register_absurd_admin
 from django_absurd.params import AbsurdSpawnParams
-from tests.tasks import add, boom
+from tests import tasks
 from tests.utils import HasContent
 
 if t.TYPE_CHECKING:
@@ -36,9 +36,9 @@ def register_admin() -> None:
 
 def seed() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(2, 3)
-    add.using(queue_name="other").enqueue(7, 8)
-    boom.enqueue()
+    tasks.add.enqueue(2, 3)
+    tasks.add.using(queue_name="other").enqueue(7, 8)
+    tasks.boom.enqueue()
     call_command("absurd_worker", queue="default", burst=True)
     call_command("absurd_worker", queue="other", burst=True)
 
@@ -48,10 +48,10 @@ def seed_mixed() -> tuple[
 ]:
     """Three default-queue tasks in distinct terminal/queued states."""
     call_command("absurd_sync_queues")
-    completed = add.enqueue(2, 3)
-    failed = boom.enqueue(  # type: ignore[call-arg]
+    completed = tasks.add.enqueue(2, 3)
+    failed = tasks.boom.enqueue(  # type: ignore[call-arg]
         absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)
     )
     call_command("absurd_worker", queue="default", burst=True)
-    pending = add.enqueue(5, 6)  # enqueued after the burst → never claimed
+    pending = tasks.add.enqueue(5, 6)  # enqueued after the burst → never claimed
     return completed, failed, pending

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -13,7 +13,7 @@ from django_absurd.admin_views import (
     rebuild_admin_view,
 )
 from django_absurd.queues import get_absurd_client
-from tests.tasks import add
+from tests import tasks
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -24,8 +24,8 @@ CHECKS_SPEC: EntitySpec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "check
 
 def seed_two_queues() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(2, 3)
-    add.using(queue_name="other").enqueue(7, 8)
+    tasks.add.enqueue(2, 3)
+    tasks.add.using(queue_name="other").enqueue(7, 8)
     call_command("absurd_worker", queue="default", burst=True)
     call_command("absurd_worker", queue="other", burst=True)
 

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -9,16 +9,8 @@ from django.tasks import TaskResultStatus
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.params import AbsurdSpawnParams
-from tests.atasks import (
-    aboom,
-    acreate_payload,
-    aecho,
-    aread_payload,
-    areport_attempt,
-    asleeper,
-)
+from tests import atasks, tasks
 from tests.models import Payload
-from tests.tasks import create_payload, echo  # sync ORM task + sync echo
 from tests.utils import get_task_result, run_absurd_worker
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -30,7 +22,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 )
 def test_async_return_value_round_trips(value: JsonValue) -> None:
     call_command("absurd_sync_queues")
-    r = aecho.enqueue(value)
+    r = atasks.aecho.enqueue(value)
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -40,7 +32,7 @@ def test_async_return_value_round_trips(value: JsonValue) -> None:
 
 def test_async_failure_recorded() -> None:
     call_command("absurd_sync_queues")
-    r = aboom.enqueue(  # type: ignore[call-arg]
+    r = atasks.aboom.enqueue(  # type: ignore[call-arg]
         absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)
     )
     run_absurd_worker()
@@ -51,7 +43,7 @@ def test_async_failure_recorded() -> None:
 
 def test_async_takes_context_attempt_is_one() -> None:
     call_command("absurd_sync_queues")
-    r = areport_attempt.enqueue()
+    r = atasks.areport_attempt.enqueue()
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -61,7 +53,7 @@ def test_async_takes_context_attempt_is_one() -> None:
 def test_sync_orm_jsonfield_round_trips() -> None:
     # ORM in a SYNC task (executor path) — matched pair with the async-ORM test below
     call_command("absurd_sync_queues")
-    r = create_payload.enqueue({"sync": True, "x": [9, 8]})
+    r = tasks.create_payload.enqueue({"sync": True, "x": [9, 8]})
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -72,7 +64,7 @@ def test_sync_orm_jsonfield_round_trips() -> None:
 def test_async_orm_jsonfield_round_trips() -> None:
     # ORM in an ASYNC task (loop path) — matched pair with the sync-ORM test above
     call_command("absurd_sync_queues")
-    r = acreate_payload.enqueue({"async": True, "y": {"z": None}})
+    r = atasks.acreate_payload.enqueue({"async": True, "y": {"z": None}})
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -84,7 +76,7 @@ def test_async_task_queries_payload() -> None:
     # async QUERY path: a row created in the test, read back by an async task (aget)
     call_command("absurd_sync_queues")
     obj = Payload.objects.create(data={"q": [1, {"x": None}], "u": "ünï"})
-    r = aread_payload.enqueue(obj.pk)
+    r = atasks.aread_payload.enqueue(obj.pk)
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -96,7 +88,7 @@ def test_aenqueue_async_task_runs_end_to_end() -> None:
     # exercise the aenqueue (produce) path for an async task, end-to-end
     # through the worker
     call_command("absurd_sync_queues")
-    r = asyncio.run(aecho.aenqueue("via-aenqueue"))
+    r = asyncio.run(atasks.aecho.aenqueue("via-aenqueue"))
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -106,7 +98,7 @@ def test_aenqueue_async_task_runs_end_to_end() -> None:
 def test_aenqueue_sync_task_runs_end_to_end() -> None:
     # aenqueue a SYNC task too — runs via the worker's executor path
     call_command("absurd_sync_queues")
-    r = asyncio.run(echo.aenqueue({"via": "aenqueue-sync"}))
+    r = asyncio.run(tasks.echo.aenqueue({"via": "aenqueue-sync"}))
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -117,7 +109,7 @@ def test_full_async_workflow_aenqueue_to_aget_result() -> None:
     # The whole async pipeline in one flow: aenqueue (async produce) -> async task
     # on the loop doing async ORM (acreate) -> aget_result (async read of the result).
     call_command("absurd_sync_queues")
-    r = asyncio.run(acreate_payload.aenqueue({"full": "async", "n": [1, 2]}))
+    r = asyncio.run(atasks.acreate_payload.aenqueue({"full": "async", "n": [1, 2]}))
     run_absurd_worker()
     got = asyncio.run(get_absurd_backends()["default"].aget_result(r.id))
     assert got.status == TaskResultStatus.SUCCESSFUL
@@ -126,8 +118,8 @@ def test_full_async_workflow_aenqueue_to_aget_result() -> None:
 
 def test_sync_and_async_in_one_worker_run() -> None:
     call_command("absurd_sync_queues")
-    rs = echo.enqueue({"mixed": "sync"})
-    ra = aecho.enqueue({"mixed": "async"})
+    rs = tasks.echo.enqueue({"mixed": "sync"})
+    ra = atasks.aecho.enqueue({"mixed": "async"})
     run_absurd_worker()
     snap_s = get_task_result(rs.id)
     snap_a = get_task_result(ra.id)
@@ -142,7 +134,7 @@ def test_worker_does_not_poison_jsonfield_reads() -> None:
     # JSONField read on the shared connection after a worker run must still
     # decode (no SP6-style poison).
     call_command("absurd_sync_queues")
-    aecho.enqueue("x")
+    atasks.aecho.enqueue("x")
     run_absurd_worker()
     obj = Payload.objects.create(data={"k": "v", "n": 7})
     assert Payload.objects.get(pk=obj.pk).data == {"k": "v", "n": 7}
@@ -151,7 +143,7 @@ def test_worker_does_not_poison_jsonfield_reads() -> None:
 def test_async_concurrency_is_not_serial() -> None:
     call_command("absurd_sync_queues")
     for _ in range(4):
-        asleeper.enqueue(0.5)
+        atasks.asleeper.enqueue(0.5)
     start = time.monotonic()
     run_absurd_worker(concurrency=4)  # burst now drains CONCURRENTLY (gather)
     elapsed = time.monotonic() - start

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -18,7 +18,7 @@ from django_absurd.backends import get_absurd_backends
 from django_absurd.cleanup import QueueCleanup, cleanup_queues
 from django_absurd.queues import get_absurd_client
 from django_absurd.scheduler import run_beat
-from tests.tasks import add, routed
+from tests import tasks
 
 if t.TYPE_CHECKING:
     import pytest_django.fixtures
@@ -105,7 +105,7 @@ def test_cleanup_deletes_aged_terminal_tasks(
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     sync_queue(settings)
-    add.enqueue(2, 3)
+    tasks.add.enqueue(2, 3)
     drain()
     assert cleanup() == [
         {"queue_name": "default", "tasks_deleted": 1, "events_deleted": 0}
@@ -117,7 +117,7 @@ def test_cleanup_skips_non_terminal_tasks(
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     sync_queue(settings)
-    add.enqueue(2, 3)  # pending — worker not run, so not terminal
+    tasks.add.enqueue(2, 3)  # pending — worker not run, so not terminal
     assert cleanup() == [
         {"queue_name": "default", "tasks_deleted": 0, "events_deleted": 0}
     ]
@@ -133,7 +133,7 @@ def test_cleanup_respects_batch_limit(
 ) -> None:
     sync_queue(settings, cleanup_limit=2)
     for _ in range(3):
-        add.enqueue(2, 3)
+        tasks.add.enqueue(2, 3)
     drain()
     assert cleanup() == [
         {"queue_name": "default", "tasks_deleted": 2, "events_deleted": 0}
@@ -151,8 +151,8 @@ def test_cleanup_targets_specific_queue(
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     sync_queue(settings, names=("default", "other"))
-    add.enqueue(2, 3)  # default
-    routed.enqueue()  # routed is @task(queue_name="other")
+    tasks.add.enqueue(2, 3)  # default
+    tasks.routed.enqueue()  # routed is @task(queue_name="other")
     drain("default")
     drain("other")
     assert cleanup(["default"]) == [
@@ -169,7 +169,7 @@ def test_cleanup_command_reports_per_queue_counts(
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     sync_queue(settings)
-    add.enqueue(2, 3)
+    tasks.add.enqueue(2, 3)
     drain()
     capsys.readouterr()  # discard sync/worker output
     call_command("absurd_cleanup")
@@ -277,7 +277,7 @@ def test_beat_fires_cleanup_on_cadence(
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
-    add.enqueue(2, 3)
+    tasks.add.enqueue(2, 3)
     drain()  # completed → aged-terminal (cleanup_ttl="0 seconds")
     run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
     assert cleanup() == [
@@ -325,7 +325,7 @@ def test_beat_fires_cleanup_and_task_same_slot(
         }
     }
     call_command("absurd_sync_queues")
-    add.enqueue(2, 3)
+    tasks.add.enqueue(2, 3)
     drain()  # completed → aged-terminal, cleanup-eligible
     backend = get_absurd_backends()["default"]
     run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -14,7 +14,7 @@ from pytest_django.fixtures import SettingsWrapper
 from django_absurd.connection import register_jsonb_loader
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.queues import get_absurd_client
-from tests.tasks import add, make_group, with_default_attempts
+from tests import tasks
 
 pytestmark = [
     pytest.mark.django_db(transaction=True),
@@ -30,7 +30,7 @@ def claim_one() -> list[ClaimedTask]:
 
 def test_enqueue_lands_and_returns_taskresult() -> None:
     call_command("absurd_sync_queues")
-    result = add.enqueue(1, 2)
+    result = tasks.add.enqueue(1, 2)
     assert isinstance(result.id, str)
     assert result.id
     assert result.status == TaskResultStatus.READY
@@ -45,7 +45,7 @@ def test_enqueue_lands_and_returns_taskresult() -> None:
 
 def test_enqueue_preserves_kwargs() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(a=1, b=2)
+    tasks.add.enqueue(a=1, b=2)
     assert claim_one()[0]["params"] == {"args": [], "kwargs": {"a": 1, "b": 2}}
 
 
@@ -57,7 +57,7 @@ def test_enqueue_rides_django_transaction() -> None:
 
     def enqueue_then_roll_back() -> t.Never:
         with transaction.atomic():
-            add.enqueue(1, 2)
+            tasks.add.enqueue(1, 2)
             raise BoomError
 
     with pytest.raises(BoomError):
@@ -68,19 +68,19 @@ def test_enqueue_rides_django_transaction() -> None:
 def test_undeclared_queue_rejected() -> None:
     call_command("absurd_sync_queues")
     with pytest.raises(InvalidTask):
-        add.using(queue_name="nope").enqueue(1, 2)
+        tasks.add.using(queue_name="nope").enqueue(1, 2)
 
 
 def test_aenqueue_lands() -> None:
     call_command("absurd_sync_queues")
-    asyncio.run(add.aenqueue(1, 2))
+    asyncio.run(tasks.add.aenqueue(1, 2))
     assert len(claim_one()) == 1
 
 
 def test_enqueue_auto_creates_declared_queue_and_runs() -> None:
     # 'default' declared but unprovisioned (no absurd_sync_queues). Enqueue auto-creates
     # it; the worker then runs the task end-to-end.
-    make_group.enqueue("auto")
+    tasks.make_group.enqueue("auto")
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="auto").exists()
 
@@ -88,7 +88,7 @@ def test_enqueue_auto_creates_declared_queue_and_runs() -> None:
 def test_enqueue_to_undeclared_queue_raises() -> None:
     # 'ghost' is not in TASKS QUEUES; validate_task raises InvalidTask naming the queue.
     with pytest.raises(InvalidTask, match="ghost"):
-        add.using(queue_name="ghost").enqueue(1, 2)
+        tasks.add.using(queue_name="ghost").enqueue(1, 2)
 
 
 def test_enqueue_with_empty_queues_reports_undeclared(
@@ -102,12 +102,12 @@ def test_enqueue_with_empty_queues_reports_undeclared(
         }
     }
     with pytest.raises(ImproperlyConfigured, match="not declared"):
-        add.enqueue(1, 2)
+        tasks.add.enqueue(1, 2)
 
 
 def test_enqueue_auto_create_survives_outer_atomic() -> None:
     with transaction.atomic():
-        make_group.enqueue("inatomic")
+        tasks.make_group.enqueue("inatomic")
         assert Group.objects.count() == 0  # nothing committed yet
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="inatomic").exists()
@@ -118,7 +118,7 @@ def test_enqueue_with_absent_schema_raises_clear_error() -> None:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
         with pytest.raises(ImproperlyConfigured, match="migrate"):
-            add.enqueue(1, 2)
+            tasks.add.enqueue(1, 2)
     finally:
         call_command("migrate", "django_absurd", "zero", verbosity=0)
         call_command("migrate", verbosity=0)  # restore absurd schema
@@ -126,19 +126,19 @@ def test_enqueue_with_absent_schema_raises_clear_error() -> None:
 
 def test_max_attempts_uses_backend_default_when_unset() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
     assert claim_one()[0]["max_attempts"] == 5
 
 
 def test_max_attempts_uses_decorator_default() -> None:
     call_command("absurd_sync_queues")
-    with_default_attempts.enqueue(1, 2)
+    tasks.with_default_attempts.enqueue(1, 2)
     assert claim_one()[0]["max_attempts"] == 7
 
 
 def test_per_call_max_attempts_overrides_decorator_and_backend() -> None:
     call_command("absurd_sync_queues")
-    with_default_attempts.enqueue(  # type: ignore[call-arg]
+    tasks.with_default_attempts.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(max_attempts=9)
     )
     assert claim_one()[0]["max_attempts"] == 9
@@ -146,7 +146,7 @@ def test_per_call_max_attempts_overrides_decorator_and_backend() -> None:
 
 def test_headers_reach_spawn() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(  # type: ignore[call-arg]
+    tasks.add.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(headers={"trace": "abc"})
     )
     assert claim_one()[0]["headers"] == {"trace": "abc"}
@@ -160,7 +160,7 @@ def test_retry_strategy_reaches_spawn() -> None:
         "factor": 2.0,
         "max_seconds": 10.0,
     }
-    add.enqueue(  # type: ignore[call-arg]
+    tasks.add.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(retry_strategy=strategy)
     )
     assert claim_one()[0]["retry_strategy"] == strategy
@@ -168,10 +168,10 @@ def test_retry_strategy_reaches_spawn() -> None:
 
 def test_idempotency_key_dedups() -> None:
     call_command("absurd_sync_queues")
-    r1 = add.enqueue(  # type: ignore[call-arg]
+    r1 = tasks.add.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="dup")
     )
-    r2 = add.enqueue(  # type: ignore[call-arg]
+    r2 = tasks.add.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="dup")
     )
     assert r1.id == r2.id
@@ -185,7 +185,7 @@ def test_idempotency_key_dedups() -> None:
 
 def test_spawn_params_not_passed_to_task_func() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(  # type: ignore[call-arg]
+    tasks.add.enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="x")
     )
     assert claim_one()[0]["params"] == {"args": [1, 2], "kwargs": {}}
@@ -193,6 +193,6 @@ def test_spawn_params_not_passed_to_task_func() -> None:
 
 def test_result_id_encodes_queue() -> None:
     call_command("absurd_sync_queues")
-    result = add.enqueue(1, 2)
+    result = tasks.add.enqueue(1, 2)
     task_id = str(claim_one()[0]["task_id"])
     assert result.id == f"default:{task_id}"

--- a/tests/core/test_orm_models.py
+++ b/tests/core/test_orm_models.py
@@ -17,7 +17,7 @@ from django_absurd.admin_views import (
 from django_absurd.exceptions import QueueReadOnlyError
 from django_absurd.models import Checkpoint, Event, Run, Task, Wait
 from django_absurd.params import AbsurdSpawnParams
-from tests.tasks import add, boom
+from tests import tasks
 
 
 def test_models_importable_and_view_backed() -> None:
@@ -66,9 +66,9 @@ def test_admin_uses_the_models_py_classes() -> None:
 
 def seed_two_queues() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(2, 3)
-    add.using(queue_name="other").enqueue(7, 8)
-    boom.enqueue(  # type: ignore[call-arg]
+    tasks.add.enqueue(2, 3)
+    tasks.add.using(queue_name="other").enqueue(7, 8)
+    tasks.boom.enqueue(  # type: ignore[call-arg]
         absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)
     )
     call_command("absurd_worker", queue="default", burst=True)

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -16,7 +16,7 @@ from django_absurd.apps import provision_queues_after_migrate
 from django_absurd.exceptions import ViewNotProvisionedError
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
-from tests.tasks import add
+from tests import tasks
 
 if t.TYPE_CHECKING:
     from django.apps.config import AppConfig
@@ -94,7 +94,7 @@ def test_sync_command_rebuilds_views_with_new_queue() -> None:
     task_model: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
-    add.using(queue_name="other").enqueue(1, 1)
+    tasks.add.using(queue_name="other").enqueue(1, 1)
     call_command("absurd_worker", queue="other", burst=True)
     qs = task_model.objects.values_list("queue", flat=True).distinct()
     assert "other" in set(qs)
@@ -113,7 +113,7 @@ def test_worker_start_rebuilds_when_it_created_queue() -> None:
     get_absurd_client().drop_queue("other")
     call_command("absurd_sync_queues")
     call_command("absurd_worker", queue="other", burst=True)
-    add.using(queue_name="other").enqueue(7, 8)
+    tasks.add.using(queue_name="other").enqueue(7, 8)
     call_command("absurd_worker", queue="other", burst=True)
     assert task_model.objects.filter(queue="other").count() >= 1
 

--- a/tests/core/test_params.py
+++ b/tests/core/test_params.py
@@ -8,7 +8,7 @@ from django_absurd.params import (
     AbsurdSpawnParams,
     absurd_default_params,
 )
-from tests.tasks import add
+from tests import tasks
 
 
 # Module-level: validate_task rejects a @task with a "<locals>" qualname.
@@ -40,4 +40,4 @@ def test_decorator_attaches_default_to_task_func() -> None:
 
 def test_decorator_above_task_raises() -> None:
     with pytest.raises(TypeError):
-        absurd_default_params(max_attempts=7)(add)  # add is a Task -> wrong order
+        absurd_default_params(max_attempts=7)(tasks.add)  # add is a Task -> wrong order

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -17,8 +17,7 @@ from django_absurd.flush import flush_absurd_state
 from django_absurd.models import Queue, Task
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.test import install_absurd_cleanup
-from tests import utils
-from tests.tasks import add
+from tests import tasks, utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -30,7 +29,7 @@ TxnCase: t.Any = TransactionTestCase
 
 def test_flush_absurd_state_truncates_rows_by_default() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
     task_model: t.Any = Task
     assert task_model.objects.filter(queue="default").count() == 1
 
@@ -50,7 +49,7 @@ def test_flush_absurd_state_truncates_a_partitioned_queues_idempotency_table(
         queues={"part": {"storage_mode": "partitioned"}}
     )
     call_command("absurd_sync_queues")
-    add.using(queue_name="part").enqueue(  # type: ignore[call-arg]
+    tasks.add.using(queue_name="part").enqueue(  # type: ignore[call-arg]
         1, 2, absurd_spawn_params=AbsurdSpawnParams(idempotency_key="k")
     )
     task_model: t.Any = Task
@@ -64,7 +63,7 @@ def test_flush_absurd_state_truncates_a_partitioned_queues_idempotency_table(
 
 def test_flush_absurd_state_drops_schema_when_requested() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
 
     flush_absurd_state(drop_schema=True)
 
@@ -91,7 +90,7 @@ def test_flush_absurd_state_is_a_noop_on_an_unmigrated_schema(
 
 def test_post_teardown_hook_truncates_absurd_state() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
     task_model: t.Any = Task
     assert task_model.objects.filter(queue="default").count() == 1
 
@@ -107,7 +106,7 @@ def test_post_teardown_hook_truncates_absurd_state() -> None:
 
 def test_post_teardown_hook_skips_undeclared_absurd_alias() -> None:
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
 
     class NoDatabasesCase(TransactionTestCase):
         databases = set[str]()
@@ -125,7 +124,7 @@ def test_post_teardown_hook_skips_without_an_absurd_backend(
     # Seed under the real Absurd backend, then swap TASKS to a non-Absurd backend so
     # the hook's unconfigured-backend guard (no AbsurdBackend) fires and skips flushing.
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
     task_model: t.Any = Task
     assert task_model.objects.filter(queue="default").count() == 1
 
@@ -167,7 +166,7 @@ def test_absurd_drain_queue_processes_an_enqueued_task(
     absurd_drain_queue: "collections.abc.Callable[..., None]",
 ) -> None:
     call_command("absurd_sync_queues")
-    result = add.enqueue(3, 4)
+    result = tasks.add.enqueue(3, 4)
     absurd_drain_queue()
     snap = utils.get_task_result(result.id)
     assert snap is not None

--- a/tests/core/test_pytest_plugin_no_db.py
+++ b/tests/core/test_pytest_plugin_no_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.tasks import add
+from tests import tasks
 
 
 @pytest.fixture(autouse=True)
@@ -10,7 +10,7 @@ def _enable_db() -> None:
 
 def test_absurd_access_blocked_without_db() -> None:
     with pytest.raises(RuntimeError) as excinfo:
-        add.enqueue(1, 2)
+        tasks.add.enqueue(1, 2)
     assert str(excinfo.value) == (
         'Database access not allowed, use the "django_db" mark, or the "db" or '
         '"transactional_db" fixtures to enable it.'

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -13,8 +13,8 @@ from django.tasks.exceptions import TaskResultDoesNotExist
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.params import AbsurdSpawnParams
 from django_absurd.queues import get_absurd_client
+from tests import tasks
 from tests.models import Payload
-from tests.tasks import add, boom, echo, sawait_event_once
 
 pytestmark = [
     pytest.mark.django_db(transaction=True),
@@ -32,7 +32,7 @@ def run_absurd_worker(queue: str = "default") -> None:
 
 def test_get_result_pending() -> None:
     call_command("absurd_sync_queues")
-    r = add.enqueue(2, 3)
+    r = tasks.add.enqueue(2, 3)
     got = backend().get_result(r.id)
     assert got.id == r.id
     assert got.status == TaskResultStatus.READY
@@ -44,7 +44,7 @@ def test_get_result_pending() -> None:
 
 def test_get_result_successful() -> None:
     call_command("absurd_sync_queues")
-    r = add.enqueue(2, 3)
+    r = tasks.add.enqueue(2, 3)
     run_absurd_worker()
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
@@ -56,7 +56,7 @@ def test_get_result_successful() -> None:
 
 def test_get_result_suspended_on_indefinite_await_event() -> None:
     call_command("absurd_sync_queues")
-    r = sawait_event_once.enqueue("get-result-infinity-check")
+    r = tasks.sawait_event_once.enqueue("get-result-infinity-check")
     run_absurd_worker()
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.RUNNING
@@ -64,7 +64,7 @@ def test_get_result_suspended_on_indefinite_await_event() -> None:
 
 def test_refresh_round_trip() -> None:
     call_command("absurd_sync_queues")
-    r = add.enqueue(2, 3)
+    r = tasks.add.enqueue(2, 3)
     assert r.status == TaskResultStatus.READY  # prior to running
     run_absurd_worker()
     r.refresh()
@@ -74,7 +74,7 @@ def test_refresh_round_trip() -> None:
 
 def test_get_result_failed_has_errors() -> None:
     call_command("absurd_sync_queues")
-    r = boom.enqueue(
+    r = tasks.boom.enqueue(
         absurd_spawn_params=AbsurdSpawnParams(max_attempts=1)  # type: ignore[call-arg]
     )
     run_absurd_worker()
@@ -87,8 +87,8 @@ def test_get_result_failed_has_errors() -> None:
 
 def test_via_task_get_result() -> None:
     call_command("absurd_sync_queues")
-    r = add.enqueue(2, 3)
-    got = add.get_result(r.id)  # public path; must not raise TaskResultMismatch
+    r = tasks.add.enqueue(2, 3)
+    got = tasks.add.get_result(r.id)  # public path; must not raise TaskResultMismatch
     assert got.id == r.id
 
 
@@ -137,7 +137,7 @@ def test_injection_in_queue_segment_is_safe() -> None:
 
 def test_aget_result_matches_get_result() -> None:
     call_command("absurd_sync_queues")
-    r = add.enqueue(2, 3)
+    r = tasks.add.enqueue(2, 3)
     got = asyncio.run(backend().aget_result(r.id))
     assert got.id == r.id
     assert got.status == TaskResultStatus.READY
@@ -179,7 +179,7 @@ def test_enqueue_does_not_poison_jsonfield_reads() -> None:
     # shared Django connection. A JSONField read on the same connection after any
     # enqueue call would raise TypeError. This test fails pre-fix.
     call_command("absurd_sync_queues")
-    add.enqueue(1, 2)
+    tasks.add.enqueue(1, 2)
     payload = Payload.objects.create(data={"key": "value", "n": 99})
     loaded = Payload.objects.get(pk=payload.pk)
     assert loaded.data == {"key": "value", "n": 99}
@@ -199,7 +199,7 @@ def test_enqueue_does_not_poison_jsonfield_reads() -> None:
 )
 def test_echo_return_value_round_trips(value: JsonValue) -> None:
     call_command("absurd_sync_queues")
-    r = echo.enqueue(value)
+    r = tasks.echo.enqueue(value)
     run_absurd_worker()
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
@@ -209,7 +209,7 @@ def test_echo_return_value_round_trips(value: JsonValue) -> None:
 def test_echo_args_round_trip() -> None:
     call_command("absurd_sync_queues")
     nested = {"items": [1, None, False, "ünïçødé"], "sub": {"x": 0}}
-    r = echo.enqueue(nested)
+    r = tasks.echo.enqueue(nested)
     run_absurd_worker()
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
@@ -218,7 +218,7 @@ def test_echo_args_round_trip() -> None:
 
 def test_echo_kwargs_round_trip() -> None:
     call_command("absurd_sync_queues")
-    r = echo.using(queue_name="default").enqueue(value={"k": [True, None, 42]})
+    r = tasks.echo.using(queue_name="default").enqueue(value={"k": [True, None, 42]})
     run_absurd_worker()
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
@@ -230,4 +230,4 @@ def test_non_json_serializable_arg_rejected_at_enqueue() -> None:
     # time rather than silently producing a broken task row.
     call_command("absurd_sync_queues")
     with pytest.raises((TypeError, ValueError)):
-        echo.enqueue(dt.datetime.now(tz=dt.UTC))
+        tasks.echo.enqueue(dt.datetime.now(tz=dt.UTC))

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -23,8 +23,8 @@ from django_absurd.scheduler import (
     run_beat,
     spawn_scheduled,
 )
+from tests import tasks
 from tests.models import Payload
-from tests.tasks import make_group as make_group_task
 from tests.utils import make_tasks_settings
 
 pytestmark = [
@@ -686,7 +686,7 @@ def test_plain_worker_runs_blocking_worker(
         }
     )
     call_command("absurd_sync_queues")
-    make_group_task.enqueue("plain-worker")
+    tasks.make_group.enqueue("plain-worker")
 
     def watch() -> None:
         deadline = time.monotonic() + 15

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -19,9 +19,8 @@ from django_absurd.worker import (
     run_blocking_worker,
     run_burst_worker,
 )
-from tests.atasks import aecho
+from tests import atasks, tasks
 from tests.jobs import record_from_jobs
-from tests.tasks import boom, make_group, report_args, report_attempt, routed
 from tests.utils import get_task_result, run_absurd_worker
 
 pytestmark = [
@@ -86,7 +85,7 @@ def test_worker_client_absent_schema_errors() -> None:
 
 def test_end_to_end_executes_and_records_result() -> None:
     call_command("absurd_sync_queues")
-    result = make_group.enqueue("alpha")
+    result = tasks.make_group.enqueue("alpha")
     run_absurd_worker()
     assert Group.objects.filter(name="alpha").exists()
     snap = get_task_result(result.id)
@@ -97,7 +96,7 @@ def test_end_to_end_executes_and_records_result() -> None:
 
 def test_failing_task_records_failure() -> None:
     call_command("absurd_sync_queues")
-    result = boom.enqueue()
+    result = tasks.boom.enqueue()
     run_absurd_worker()
     snap = get_task_result(result.id)
     assert snap is not None
@@ -106,7 +105,7 @@ def test_failing_task_records_failure() -> None:
 
 def test_takes_context_attempt_is_one_on_first_run() -> None:
     call_command("absurd_sync_queues")
-    result = report_attempt.enqueue()
+    result = tasks.report_attempt.enqueue()
     run_absurd_worker()
     snap = get_task_result(result.id)
     assert snap is not None
@@ -115,7 +114,7 @@ def test_takes_context_attempt_is_one_on_first_run() -> None:
 
 def test_takes_context_task_result_carries_real_args() -> None:
     call_command("absurd_sync_queues")
-    result = report_args.enqueue("x", "y")
+    result = tasks.report_args.enqueue("x", "y")
     run_absurd_worker()
     snap = get_task_result(result.id)
     assert snap is not None
@@ -124,14 +123,14 @@ def test_takes_context_task_result_carries_real_args() -> None:
 
 def test_using_queue_name_routes_to_worker_queue() -> None:
     call_command("absurd_sync_queues")
-    routed.using(queue_name="default").enqueue()
+    tasks.routed.using(queue_name="default").enqueue()
     run_absurd_worker()
     assert Group.objects.filter(name="routed").exists()
 
 
 def test_handler_logs_task_outcome(caplog: pytest.LogCaptureFixture) -> None:
     call_command("absurd_sync_queues")
-    make_group.enqueue("logged")
+    tasks.make_group.enqueue("logged")
     with caplog.at_level(logging.INFO, logger="django_absurd"):
         run_absurd_worker()
     assert "tests.tasks.make_group" in caplog.text
@@ -170,7 +169,7 @@ def test_queue_defaults_to_default(
             "QUEUES": ["default"],
         }
     }
-    make_group.enqueue("dflt")  # auto-creates the default queue
+    tasks.make_group.enqueue("dflt")  # auto-creates the default queue
     call_command("absurd_worker", burst=True)  # no --queue -> "default"
     out = capsys.readouterr().out
     assert out == "Started worker on queue 'default'.\n"
@@ -248,7 +247,7 @@ def test_command_parses_all_flags_with_defaults() -> None:
 
 def test_command_burst_runs_task_end_to_end() -> None:
     call_command("absurd_sync_queues")
-    result = make_group.enqueue("via-command")
+    result = tasks.make_group.enqueue("via-command")
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="via-command").exists()
     snap = get_task_result(result.id)
@@ -398,7 +397,7 @@ def test_worker_non_burst_command_schema_absent_errors_migrate() -> None:
 def test_start_worker_drains_concurrently() -> None:
     call_command("absurd_sync_queues")
     for i in range(5):
-        make_group.enqueue(f"g{i}")
+        tasks.make_group.enqueue(f"g{i}")
 
     run_absurd_worker()
     assert Group.objects.filter(name__startswith="g").count() == 5
@@ -406,7 +405,7 @@ def test_start_worker_drains_concurrently() -> None:
 
 def test_async_task_runs_end_to_end() -> None:
     call_command("absurd_sync_queues")
-    r = aecho.enqueue("hi-async")
+    r = atasks.aecho.enqueue("hi-async")
     run_absurd_worker()
     snap = get_task_result(r.id)
     assert snap is not None
@@ -420,7 +419,7 @@ def test_blocking_worker_drains_then_stops() -> None:
     # THEN calls stop_worker() (the flag start_worker's loop polls).
     # run_blocking_worker returns once stopped.
     call_command("absurd_sync_queues")
-    results = [make_group.enqueue(f"blk-{i}") for i in range(3)]
+    results = [tasks.make_group.enqueue(f"blk-{i}") for i in range(3)]
     task_ids = [r.id.rsplit(":", 1)[-1] for r in results]
 
     async def drive() -> None:
@@ -443,7 +442,7 @@ def test_blocking_worker_drains_then_stops() -> None:
 def test_run_burst_worker_processes_a_task_and_returns_sync_result() -> None:
 
     call_command("absurd_sync_queues")
-    result = make_group.enqueue("via-function")
+    result = tasks.make_group.enqueue("via-function")
     sync_result = run_burst_worker("default")
     assert Group.objects.filter(name="via-function").exists()
     snap = get_task_result(result.id)

--- a/tests/pg_cron/test_run_scheduled_fn.py
+++ b/tests/pg_cron/test_run_scheduled_fn.py
@@ -5,18 +5,18 @@ from django.core.management import call_command
 from django.db import connection
 
 from django_absurd.pg_cron.models import ScheduledTask
+from tests import tasks
 from tests.models import Payload
-from tests.tasks import capped, on_reports
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_capped_task_returns_sum() -> None:
-    assert capped.func(3, 4) == 7
+    assert tasks.capped.func(3, 4) == 7
 
 
 def test_on_reports_task_returns_string() -> None:
-    assert on_reports.func() == "on_reports"
+    assert tasks.on_reports.func() == "on_reports"
 
 
 def fire_wrapper(source: str, name: str) -> None:


### PR DESCRIPTION
`from tests.tasks import routed` puts a bare adjective at the call site. `tasks.routed.enqueue()` reads because the module supplies the noun.

16 files, 99 references. No fixture task renamed. `test_scheduler.py`'s `make_group as make_group_task` workaround alias is gone.

Mechanical: rewritten by token type, so dotted-path string literals (`task="tests.tasks.capped"`) are byte-identical.