### PR TITLE
ci: validate PR titles as Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+---
+name: PR Title
+
+"on":
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  # Abort pending builds if there's an update.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      # Squash-merge puts the PR title on main, so a Conventional Commits title is
+      # what makes the release notes readable.
+      # yamllint disable-line rule:line-length
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
+  # The job id is the status-check context, so name it for what it gates — it has to
+  # be picked out of a list when added as a required check, and renaming it later
+  # would break that requirement.
+  pr-title:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
Squash is the only merge method here, so the PR title lands on `main`. Enforcing Conventional Commits on it is what makes the history usable as release notes.

Mirrors `ll-claude-skills`: same SHA-pinned `amannn/action-semantic-pull-request`, no `with:` block (default types, scope optional). Renovate keeps the digest current.