### PR TITLE
ci: make Renovate PR titles Conventional Commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["helpers:pinGitHubActionDigests", ":configMigration"],
+  "description": "Conventional Commits titles are required by the pr-title workflow, so semanticCommits is pinned on rather than left to auto-detection.",
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
`semanticCommits` was left at `auto`; history detection resolved to non-semantic, so Renovate titles failed the `pr-title` check. Pin it on with `chore(deps)` prefix.