### PR TITLE
feat(test): dj_absurd fixture — freeze durable time, drain, emit, read

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: check-github-workflows
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,34 @@ duplicate that material here.
 - `msg` states the PROBLEM only; `hint` states the RESOLUTION. Never duplicate fix text
   in both.
 
+## Exception hierarchy
+
+- django-absurd raises its **own** exception types for its own failure modes, all under
+  `DjangoAbsurdError`, defined in `django_absurd/exceptions.py`. Prefer a specific type
+  over a bare stdlib/Django one when the condition is specific to this package.
+- The type name carries the condition (`QueueNotDeclaredError`,
+  `QueueNotProvisionedError`), and **the exception owns its message** — constructors
+  take the data, callers never assemble text and no `format_*` helper is imported to
+  build one.
+- Named for the distributing package, not the upstream SDK: `DjangoAbsurdError`, never
+  `AbsurdError`, because modules import from both `absurd_sdk` and `django_absurd` and
+  the short name reads as the SDK's.
+- Be honest about coverage: `except DjangoAbsurdError` catches the typed errors, not
+  every error the package can raise — plain `ImproperlyConfigured`/`RuntimeError`/
+  `TypeError` remain in `checks.py`, `connection.py`, `queues.py`, and `test.py`'s
+  guards for now.
+
+## Exception chaining
+
+- Re-raising a curated error inside an `except` always chains with `from exc` — never
+  `from None`. Add `as exc` to the handler if it doesn't already bind a name.
+  `from None` hides the real cause exactly when the curated message turns out to be the
+  wrong guess.
+- Pair this with narrowing the catch: classify first, re-raise the original untouched
+  when the error isn't about what your curated message claims, chain with `from exc`
+  when it is. `from exc` is not a licence to relabel broadly — see `names_a_queue_table`
+  in `django_absurd/queues.py` for the worked example of both together.
+
 ## Testing conventions
 
 - pytest, **function-based only** (never class-based).
@@ -61,6 +89,12 @@ duplicate that material here.
   access — do NOT decorate tests with `@pytest.mark.django_db`. Only add
   `@pytest.mark.django_db(transaction=True)` (or markers for multi-DB / reset-sequences)
   when a test needs transactions/commits or DDL (`migrate`, `create_queue`).
+- **A durable test (sleep, `await_event` timeout, retry backoff, a chain of several
+  sleeps) uses the `dj_absurd` pytest fixture's clock** —
+  `with dj_absurd.freeze_time() as frozen_time:`, then
+  `frozen_time.shift(Δ)`/`move_to(instant)`, enqueueing INSIDE the block — **never
+  `time.sleep`**. See
+  [Testing — the `dj_absurd` fixture](docs/web/testing.md#the-dj_absurd-fixture-durable-time-drain-and-read).
 - **No monkeypatching / `unittest.mock.patch`.** Test observable behavior, not
   internals. If a test needs to patch our own functions to reach a branch, restructure
   so a real input drives that branch instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ duplicate that material here.
   `with dj_absurd.freeze_time() as frozen_time:`, then
   `frozen_time.shift(Δ)`/`move_to(instant)`, enqueueing INSIDE the block — **never
   `time.sleep`**. See
-  [Testing — the `dj_absurd` fixture](docs/web/testing.md#the-dj_absurd-fixture-durable-time-drain-and-read).
+  [Testing — the `dj_absurd` fixture](docs/web/testing.md#the-dj_absurd-fixture).
 - **No monkeypatching / `unittest.mock.patch`.** Test observable behavior, not
   internals. If a test needs to patch our own functions to reach a branch, restructure
   so a real input drives that branch instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,25 @@ duplicate that material here.
   access — do NOT decorate tests with `@pytest.mark.django_db`. Only add
   `@pytest.mark.django_db(transaction=True)` (or markers for multi-DB / reset-sequences)
   when a test needs transactions/commits or DDL (`migrate`, `create_queue`).
-- **A durable test (sleep, `await_event` timeout, retry backoff, a chain of several
-  sleeps) uses the `dj_absurd` pytest fixture's clock** —
+- **Any test that EXECUTES anything — enqueue, drain, a worker, cleanup deleting rows —
+  freezes time through the `dj_absurd` fixture**, not through time-machine directly:
   `with dj_absurd.freeze_time() as frozen_time:`, then
   `frozen_time.shift(Δ)`/`move_to(instant)`, enqueueing INSIDE the block — **never
-  `time.sleep`**. See
+  `time.sleep`**. It moves Postgres and Python together, which is mandatory: Postgres
+  ahead of Python is an unkillable deadlock for a sync task. The fixture works unchanged
+  in an `async def` test. See
   [Testing — the `dj_absurd` fixture](docs/web/testing.md#the-dj_absurd-fixture).
+- **`time_machine.travel(..., tick=False)` directly is for pure-Python math only** —
+  cron arithmetic (`get_next_datetime`) and the like, where no row, worker, or Absurd
+  deadline is involved. Reaching for the fixture there would write a database GUC for
+  nothing; reaching for time-machine on an executing test leaves Postgres on real time
+  (that mistake shipped once — `test_cleanup.py` passed only because `cleanup_ttl` was
+  0). The one sanctioned ticking use is `tests/core/test_scheduler.py`'s live worker
+  crossing a `*/1` boundary, which needs real time to pass.
+- **freezegun is banned** — it patches `time.monotonic`, which IS asyncio's event-loop
+  clock, so a frozen freezegun deadlocks the burst drain unkillably. Do not reintroduce
+  it. `pytest-asyncio` is a dev dependency for writing `async def` tests; nothing in
+  `django_absurd/` may depend on it.
 - **No monkeypatching / `unittest.mock.patch`.** Test observable behavior, not
   internals. If a test needs to patch our own functions to reach a branch, restructure
   so a real input drives that branch instead.

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -792,6 +792,10 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
         assert snapshot.state == "completed"
 ```
 
+All six members work unchanged from an `async def` test — same names, nothing to `await`
+on the fixture, no separate API. Enqueue with Django's own `await task.aenqueue()`
+there, since `enqueue()` is synchronous.
+
 **`sync_queues()`** provisions every declared queue — the runtime counterpart of
 `manage.py absurd_sync_queues`. Rarely needed: `migrate` already provisions the declared
 catalog, so reach for this only when the test itself changed queue topology — a

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -675,6 +675,8 @@ all subclasses of `django_absurd.exceptions.DjangoAbsurdError`:
   provisioned.
 - `TaskIdQueueMismatchError` — the test fixture's `get_result(task_id, queue=...)` was
   given a `"queue:uuid"` id and an explicit `queue=` that name different queues.
+- `TaskNotFoundError` — the test fixture's `get_result(task_id, queue=...)` found no
+  task by that id on that queue.
 
 Catch `DjangoAbsurdError` to handle any of django-absurd's own typed errors generically;
 other failures (schema-not-installed, config validation, clock misuse) still raise plain
@@ -752,22 +754,23 @@ completes" or a [durable sleep](#sleep), an [`await_event` timeout](#timeout), a
 backoff, or a chain of several sleeps. It returns an `AbsurdTestRuntime` with six
 members:
 
-| Member                                      | Does                                                              |
-| ------------------------------------------- | ----------------------------------------------------------------- |
-| `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry) |
-| `now`                                       | virtual now, timezone-aware, as Postgres itself reports it        |
-| `sync_queues()`                             | provision every declared queue (rarely needed; see below)         |
-| `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                |
-| `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`     |
-| `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot \| None` (see below)    |
+| Member                                      | Does                                                                                         |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry)                            |
+| `now`                                       | virtual now, timezone-aware, as Postgres itself reports it                                   |
+| `sync_queues()`                             | provision every declared queue (rarely needed; see below)                                    |
+| `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                                           |
+| `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`                                |
+| `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot` (raises `TaskNotFoundError` on a miss; see below) |
 
-`freeze_time` yields a `FrozenTime` handle (importable from `django_absurd.test`, for
-annotating helpers) whose `move_to(datetime)` and `shift(timedelta)` are the only way
-durable time moves — `shift` by absolute elapsed time, `move_to` to an absolute aware
-instant. Leaving the block releases both halves of the clock, so windows can be
-sequential; opening one inside another raises, since two frozen instants cannot both be
-"now", and a mover used after its own block exited raises rather than silently
-re-freezing from real now.
+`freeze_time` yields a `FrozenTime` handle. `FrozenTime`, `AbsurdTestRuntime` (what
+`dj_absurd` itself is typed as), `TaskSnapshot`, and `RunSnapshot` are all importable
+from `django_absurd.test`, for annotating helpers and fixture parameters.
+`move_to(datetime)` and `shift(timedelta)` are the only way durable time moves — `shift`
+by absolute elapsed time, `move_to` to an absolute aware instant. Leaving the block
+releases both halves of the clock, so windows can be sequential; opening one inside
+another raises, since two frozen instants cannot both be "now", and a mover used after
+its own block exited raises rather than silently re-freezing from real now.
 
 ```python
 import datetime as dt
@@ -786,7 +789,6 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
         assert [run.state for run in dj_absurd.drain()] == ["completed"]
 
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.state == "completed"
 ```
 
@@ -807,10 +809,27 @@ declares by overriding `TASKS` needs `dj_absurd.sync_queues()` first or `drain()
 raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above for the full
 typed-error taxonomy.
 
-**`get_result()` honours a prefixed id's own queue.** `task_id` accepts either a bare
-uuid or Django's own `TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed
-back. When it carries a queue prefix, that prefix is what gets queried, not `queue`'s
-default:
+**`RunSnapshot` fields:** `queue`/`task_id` (which task this run belongs to), `run_id`
+(this run's id — the same value appears twice for a re-armed `await_event` waiter),
+`task_name` (dotted task path), `args`/`kwargs` (decoded from the enqueued params),
+`attempt` (1-based attempt number), `state` (see below), `result` (the task's return
+value, once `completed`), `failure`
+(`{"message": str, "name"?: str, "traceback"?: str}`, once `failed`).
+
+**Observable `state` values:** `pending` (claimable, not yet run), `sleeping` (suspended
+— a durable [sleep](#sleep), an `await_event` wait, or a retry backoff,
+indistinguishable from a `RunSnapshot` alone), `completed` (finished successfully),
+`failed` (raised, and out of retries), `cancelled` (cancelled before or during
+execution).
+
+**`get_result()` honours a prefixed id's own queue.** Where `my_task.get_result(id)`
+([Retrieving results](#retrieving-results) above) reads Django's own
+`TaskResult.status`, `dj_absurd.get_result` reads Absurd's own states directly —
+including `sleeping`, a state `TaskResult.status` can't show — and skips the worker
+round-trip; like Django's own method, it raises on a miss (`TaskNotFoundError`).
+`task_id` accepts either a bare uuid or Django's own `TaskResult.id` (`"queue:uuid"`) —
+whatever `enqueue()` handed back. When it carries a queue prefix, that prefix is what
+gets queried, not `queue`'s default:
 
 ```python
 result = reports_task.enqueue()   # id is "reports:<uuid>"
@@ -841,6 +860,13 @@ bundled with django-absurd and not one of its extras (`pip install time-machine`
 `sync_queues`/`drain`/`emit`/`get_result`/`now` work without it; only `freeze_time`
 imports it, lazily, on first use, and raises `ImproperlyConfigured` naming the install
 command if it's missing.
+
+**`TaskSnapshot` fields:** `queue`/`task_id` (which task this is; no queue prefix on
+`task_id`), `task_name` (dotted task path), `args`/`kwargs` (decoded from the enqueued
+params), `state` (see the state vocabulary above), `attempts` (created, not completed —
+see caveats below), `enqueued_at` (when `enqueue()` ran), `result` (the task's return
+value, once `completed`), `failure` (`None` except on a terminal failure — see caveats
+below).
 
 **`TaskSnapshot` caveats — use `RunSnapshot` for an in-flight retry.** `get_result`
 returns a task-level view, which cannot express an in-flight

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -676,10 +676,9 @@ all subclasses of `django_absurd.exceptions.DjangoAbsurdError`:
 - `TaskIdQueueMismatchError` — the test fixture's `get_result(task_id, queue=...)` was
   given a `"queue:uuid"` id and an explicit `queue=` that name different queues.
 
-Catch `DjangoAbsurdError` to handle any of django-absurd's own typed errors generically.
-It is not exhaustive, though: plenty of call sites in this package still raise a plain
-`ImproperlyConfigured`, `RuntimeError`, or `TypeError` directly (schema-not-installed,
-config validation, clock misuse) and are not (yet) part of this hierarchy.
+Catch `DjangoAbsurdError` to handle any of django-absurd's own typed errors generically;
+other failures (schema-not-installed, config validation, clock misuse) still raise plain
+`ImproperlyConfigured`/`RuntimeError`/`TypeError` outside the hierarchy.
 
 ## Testing
 
@@ -796,16 +795,13 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
 **`drain()`** runs every currently-claimable task on `queue` to completion, in-process —
 no [worker](#workers) subprocess, no polling loop to manage. It's the fixture
 counterpart of `absurd_worker --burst`: it drains the backlog present at call time, then
-returns one `RunSnapshot` per run executed, in claim order. It takes no `concurrency`
-parameter — the burst drain runs lockstep batches rather than a rolling window, so the
-parameter would be a misnomer; worker concurrency stays covered through the
-`absurd_worker` CLI. It provisions nothing (unlike the CLI, which provisions declared
-queues on start): `migrate` provisions every declared queue already, so a test database
-arrives ready, but a queue a single test declares by overriding `TASKS` needs
-`call_command("absurd_sync_queues")` first or `drain()` raises
-`QueueNotProvisionedError` naming that command (a queue that isn't declared at all
-raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above for the full
-typed-error taxonomy.
+returns one `RunSnapshot` per run executed, in claim order. It provisions nothing
+(unlike the CLI, which provisions declared queues on start): `migrate` provisions every
+declared queue already, so a test database arrives ready, but a queue a single test
+declares by overriding `TASKS` needs `call_command("absurd_sync_queues")` first or
+`drain()` raises `QueueNotProvisionedError` naming that command (a queue that isn't
+declared at all raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above
+for the full typed-error taxonomy.
 
 **`get_result()` honours a prefixed id's own queue.** `task_id` accepts either a bare
 uuid or Django's own `TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed
@@ -813,32 +809,28 @@ back. When it carries a queue prefix, that prefix is what gets queried, not `que
 default:
 
 ```python
-result = reports_task.enqueue()          # id is "reports:<uuid>"
-dj_absurd.get_result(result.id)             # queries the "reports" queue, correctly
+result = reports_task.enqueue()   # id is "reports:<uuid>"
+dj_absurd.get_result(result.id)   # queries the "reports" queue
 ```
 
-Passing `queue=` explicitly — including `queue="default"` — is detectable (it defaults
-to an internal sentinel, not the literal string `"default"`); one that disagrees with a
-prefixed id's own queue raises `TaskIdQueueMismatchError` naming both instead of
-silently picking one. A bare uuid (no prefix) resolves an unpassed `queue` to
-`"default"`, same as always.
+An explicit `queue=` — even `queue="default"` — that disagrees with a prefixed id's own
+queue raises `TaskIdQueueMismatchError` naming both. A bare uuid resolves an unpassed
+`queue` to `"default"`, same as always.
 
 **Requires `transaction=True`**: Absurd's own work runs on a connection separate from
-the test's. Under a plain `db` test the enqueued row is invisible to that connection, so
-a drain silently no-ops, `get_result` returns `None`, and an `emit` never wakes its
-waiter; `drain`, `emit`, and `get_result` each detect the open transaction and raise
-rather than letting that confusing silence land far from its cause. In a multi-DB
-project, declare the Absurd alias in that same test's `databases` too — draining commits
-real state via the worker's own connection, and an undeclared alias means the cleanup
-guard above skips it, leaking that state into the next test.
+the test's; under a plain `db` test the enqueued row is invisible to it. `drain`,
+`emit`, and `get_result` detect the open transaction and raise rather than silently
+no-opping. In a multi-DB project, declare the Absurd alias in that same test's
+`databases` too — draining commits real state via the worker's own connection, and an
+undeclared alias means the cleanup guard above skips it, leaking that state into the
+next test.
 
 **Freeze BEFORE enqueueing.** `freeze_time` and its movers move both Python's clock (via
 [time-machine](https://github.com/adamchainz/time-machine)) and Postgres's
 `absurd.fake_now` GUC. Freezing to a PAST instant after rows already exist leaves those
 rows' deadlines in the database's future relative to the new frozen now, so nothing is
-claimable until a later `move_to`/`shift` passes them. Durable time only moves inside a
-`freeze_time` block — `drain`, `emit`, `get_result`, and `now` all work without ever
-touching the clock, and a test that never opens one pays nothing.
+claimable until a later `move_to`/`shift` passes them. A test that never opens a
+`freeze_time` block pays nothing: the other members never touch the clock.
 
 **Install time-machine yourself** — it is a dev/test dependency of _your_ project, not
 bundled with django-absurd and not one of its extras (`pip install time-machine`).

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -749,13 +749,14 @@ Then point your project's `TEST_RUNNER` at it. `install_absurd_cleanup()` is ide
 Running a task, moving Absurd's own notion of "now", and inspecting what actually ran
 all go through one fixture, `dj_absurd` — whether the test is a one-line "my task
 completes" or a [durable sleep](#sleep), an [`await_event` timeout](#timeout), a retry
-backoff, or a chain of several sleeps. It returns an `AbsurdTestRuntime` with five
+backoff, or a chain of several sleeps. It returns an `AbsurdTestRuntime` with six
 members:
 
 | Member                                      | Does                                                              |
 | ------------------------------------------- | ----------------------------------------------------------------- |
 | `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry) |
 | `now`                                       | virtual now, timezone-aware, as Postgres itself reports it        |
+| `sync_queues()`                             | provision every declared queue (rarely needed; see below)         |
 | `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                |
 | `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`     |
 | `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot \| None` (see below)    |
@@ -772,14 +773,11 @@ re-freezing from real now.
 import datetime as dt
 
 import pytest
-from django.core.management import call_command
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
-    call_command("absurd_sync_queues")
-
     with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
         result = my_weekly_followup_task.enqueue()  # enqueue INSIDE the block
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
@@ -792,16 +790,22 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
         assert snapshot.state == "completed"
 ```
 
+**`sync_queues()`** provisions every declared queue — the runtime counterpart of
+`manage.py absurd_sync_queues`. Rarely needed: `migrate` already provisions the declared
+catalog, so reach for this only when the test itself changed queue topology — a
+`settings` override declaring a queue the migration never saw, or a fixture that dropped
+the queues.
+
 **`drain()`** runs every currently-claimable task on `queue` to completion, in-process —
 no [worker](#workers) subprocess, no polling loop to manage. It's the fixture
 counterpart of `absurd_worker --burst`: it drains the backlog present at call time, then
 returns one `RunSnapshot` per run executed, in claim order. It provisions nothing
 (unlike the CLI, which provisions declared queues on start): `migrate` provisions every
 declared queue already, so a test database arrives ready, but a queue a single test
-declares by overriding `TASKS` needs `call_command("absurd_sync_queues")` first or
-`drain()` raises `QueueNotProvisionedError` naming that command (a queue that isn't
-declared at all raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above
-for the full typed-error taxonomy.
+declares by overriding `TASKS` needs `dj_absurd.sync_queues()` first or `drain()` raises
+`QueueNotProvisionedError` naming that command (a queue that isn't declared at all
+raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above for the full
+typed-error taxonomy.
 
 **`get_result()` honours a prefixed id's own queue.** `task_id` accepts either a bare
 uuid or Django's own `TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed
@@ -834,9 +838,9 @@ claimable until a later `move_to`/`shift` passes them. A test that never opens a
 
 **Install time-machine yourself** — it is a dev/test dependency of _your_ project, not
 bundled with django-absurd and not one of its extras (`pip install time-machine`).
-`drain`/`emit`/`get_result`/`now` work without it; only `freeze_time` imports it,
-lazily, on first use, and raises `ImproperlyConfigured` naming the install command if
-it's missing.
+`sync_queues`/`drain`/`emit`/`get_result`/`now` work without it; only `freeze_time`
+imports it, lazily, on first use, and raises `ImproperlyConfigured` naming the install
+command if it's missing.
 
 **`TaskSnapshot` caveats — use `RunSnapshot` for an in-flight retry.** `get_result`
 returns a task-level view, which cannot express an in-flight

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -650,6 +650,37 @@ send_report.get_result(result.id)              # fetch by id (sync)
 await send_report.aget_result(result.id)       # async variant
 ```
 
+## Exceptions
+
+django-absurd raises its own exception types for conditions specific to this package,
+all subclasses of `django_absurd.exceptions.DjangoAbsurdError`:
+
+- `QueueNotDeclaredError` — a queue name doesn't match any queue declared for the
+  backend. Raised by `emit_event` and the test fixture's `drain()`. `enqueue` raises it
+  too, but only when the backend's `QUEUES` option is empty/unset; with `QUEUES`
+  configured, a typo'd queue name at enqueue is instead rejected earlier as Django's own
+  `InvalidTask`.
+- `QueueNotProvisionedError` — a queue is declared but its Absurd table hasn't been
+  provisioned yet (run `manage.py absurd_sync_queues`). Raised by `emit_event` and
+  `drain()`.
+- `BackendNotConfiguredError` — no `AbsurdBackend`, or more than one, is configured in
+  `TASKS`. The `absurd_worker`/`absurd_beat`/`absurd_sync_crons` commands translate it
+  to a `CommandError`; `emit_event` and the test fixture's `drain()` propagate it
+  untranslated.
+- `QueueReadOnlyError` — an attempt to `.save()`/`.delete()` one of the read-only admin
+  models mapping Absurd's own tables (`Queue`, and the admin entity views over
+  tasks/runs/waits/etc.).
+- `ViewNotProvisionedError` — one of those admin entity views (a `UNION` over every
+  declared queue's own Absurd table) hits a missing relation because a queue was never
+  provisioned.
+- `TaskIdQueueMismatchError` — the test fixture's `get_result(task_id, queue=...)` was
+  given a `"queue:uuid"` id and an explicit `queue=` that name different queues.
+
+Catch `DjangoAbsurdError` to handle any of django-absurd's own typed errors generically.
+It is not exhaustive, though: plenty of call sites in this package still raise a plain
+`ImproperlyConfigured`, `RuntimeError`, or `TypeError` directly (schema-not-installed,
+config validation, clock misuse) and are not (yet) part of this hierarchy.
+
 ## Testing
 
 Installing django-absurd registers a
@@ -714,28 +745,141 @@ class MyTestRunner(DiscoverRunner):
 Then point your project's `TEST_RUNNER` at it. `install_absurd_cleanup()` is idempotent
 — calling it again where pytest's plugin already installed it is a no-op.
 
-### `absurd_drain_queue`
+### The `dj_absurd` fixture: durable time, drain, and read
+
+Running a task, moving Absurd's own notion of "now", and inspecting what actually ran
+all go through one fixture, `dj_absurd` — whether the test is a one-line "my task
+completes" or a [durable sleep](#sleep), an [`await_event` timeout](#timeout), a retry
+backoff, or a chain of several sleeps. It returns an `AbsurdTestRuntime` with five
+members:
+
+| Member                                      | Does                                                              |
+| ------------------------------------------- | ----------------------------------------------------------------- |
+| `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry) |
+| `now`                                       | virtual now, timezone-aware, as Postgres itself reports it        |
+| `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                |
+| `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`     |
+| `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot \| None` (see below)    |
+
+`freeze_time` yields a `FrozenTime` handle (importable from `django_absurd.test`, for
+annotating helpers) whose `move_to(datetime)` and `shift(timedelta)` are the only way
+durable time moves — `shift` by absolute elapsed time, `move_to` to an absolute aware
+instant. Leaving the block releases both halves of the clock, so windows can be
+sequential; opening one inside another raises, since two frozen instants cannot both be
+"now", and a mover used after its own block exited raises rather than silently
+re-freezing from real now.
 
 ```python
-@pytest.mark.django_db(transaction=True)
-def test_task_runs(absurd_drain_queue):
-    my_task.enqueue()
-    absurd_drain_queue()
-    ...
+import datetime as dt
+
+import pytest
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
+    call_command("absurd_sync_queues")
+
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
+        result = my_weekly_followup_task.enqueue()  # enqueue INSIDE the block
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=7))
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.state == "completed"
 ```
 
-Returns a callable `drain(queue: str = "default", *, concurrency: int = 1) -> None` that
-runs every currently-claimable task on `queue` to completion, in-process — no
-[worker](#workers) subprocess, no polling loop to manage. It's the fixture equivalent of
-`absurd_worker --burst`: drains the backlog present at call time, then returns.
+**`drain()`** runs every currently-claimable task on `queue` to completion, in-process —
+no [worker](#workers) subprocess, no polling loop to manage. It's the fixture
+counterpart of `absurd_worker --burst`: it drains the backlog present at call time, then
+returns one `RunSnapshot` per run executed, in claim order. It takes no `concurrency`
+parameter — the burst drain runs lockstep batches rather than a rolling window, so the
+parameter would be a misnomer; worker concurrency stays covered through the
+`absurd_worker` CLI. It provisions nothing (unlike the CLI, which provisions declared
+queues on start): `migrate` provisions every declared queue already, so a test database
+arrives ready, but a queue a single test declares by overriding `TASKS` needs
+`call_command("absurd_sync_queues")` first or `drain()` raises
+`QueueNotProvisionedError` naming that command (a queue that isn't declared at all
+raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above for the full
+typed-error taxonomy.
 
-The worker opens its own database connection, separate from the test's — so a test using
-`absurd_drain_queue` needs `transaction=True` (not plain `db`): under an uncommitted
-`db` transaction the enqueue is invisible to that second connection and the task never
-gets claimed. In a multi-DB project, declare the Absurd alias in that same test's
-`databases` too — draining commits real state via the worker's own connection, and an
-undeclared alias means the cleanup guard above skips it, leaking that state into the
-next test.
+**`get_result()` honours a prefixed id's own queue.** `task_id` accepts either a bare
+uuid or Django's own `TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed
+back. When it carries a queue prefix, that prefix is what gets queried, not `queue`'s
+default:
+
+```python
+result = reports_task.enqueue()          # id is "reports:<uuid>"
+dj_absurd.get_result(result.id)             # queries the "reports" queue, correctly
+```
+
+Passing `queue=` explicitly — including `queue="default"` — is detectable (it defaults
+to an internal sentinel, not the literal string `"default"`); one that disagrees with a
+prefixed id's own queue raises `TaskIdQueueMismatchError` naming both instead of
+silently picking one. A bare uuid (no prefix) resolves an unpassed `queue` to
+`"default"`, same as always.
+
+**Requires `transaction=True`**: Absurd's own work runs on a connection separate from
+the test's. Under a plain `db` test the enqueued row is invisible to that connection, so
+a drain silently no-ops, `get_result` returns `None`, and an `emit` never wakes its
+waiter; `drain`, `emit`, and `get_result` each detect the open transaction and raise
+rather than letting that confusing silence land far from its cause. In a multi-DB
+project, declare the Absurd alias in that same test's `databases` too — draining commits
+real state via the worker's own connection, and an undeclared alias means the cleanup
+guard above skips it, leaking that state into the next test.
+
+**Freeze BEFORE enqueueing.** `freeze_time` and its movers move both Python's clock (via
+[time-machine](https://github.com/adamchainz/time-machine)) and Postgres's
+`absurd.fake_now` GUC. Freezing to a PAST instant after rows already exist leaves those
+rows' deadlines in the database's future relative to the new frozen now, so nothing is
+claimable until a later `move_to`/`shift` passes them. Durable time only moves inside a
+`freeze_time` block — `drain`, `emit`, `get_result`, and `now` all work without ever
+touching the clock, and a test that never opens one pays nothing.
+
+**Install time-machine yourself** — it is a dev/test dependency of _your_ project, not
+bundled with django-absurd and not one of its extras (`pip install time-machine`).
+`drain`/`emit`/`get_result`/`now` work without it; only `freeze_time` imports it,
+lazily, on first use, and raises `ImproperlyConfigured` naming the install command if
+it's missing.
+
+**`TaskSnapshot` caveats — use `RunSnapshot` for an in-flight retry.** `get_result`
+returns a task-level view, which cannot express an in-flight
+[retry](https://github.com/lincolnloop/django-absurd/blob/main/docs/web/tasks.md#retries--spawn-options):
+
+- `attempts` counts attempts CREATED, not completed — a task with one failed attempt and
+  a pending backoff already reads `attempts=2`, before the second attempt has run.
+- `state="sleeping"` covers a retry backoff as well as a durable [sleep](#sleep) — a
+  test asserting "my workflow is asleep" would pass just as readily on a task that
+  crashed and is waiting to retry.
+- `failure` is `None` mid-backoff — `last_attempt_run` already points at the fresh
+  pending run by the time the backoff is showing.
+
+`drain()`'s `RunSnapshot` tells these apart: it reports each run's own state right after
+that run executes, so a retry sequence reads attempt-by-attempt instead of collapsing to
+one ambiguous final read.
+
+**Hazards:**
+
+- A `manage.py absurd_worker` subprocess is only half-frozen: `ALTER DATABASE` reaches
+  its Postgres session, but its own Python clock is real — frozen-ahead-of-real is the
+  deadlock direction. The `dj_absurd` fixture's `drain` only ever runs the in-process
+  burst worker; a real subprocess worker under a freeze is out of scope.
+- A savepoint rollback inside a `freeze_time` block can make a later `enqueue()` stamp
+  stale time: Django's own connection only ever sees the frozen instant via a
+  session-level `SET` (a database-level default reaches only new sessions), and a
+  savepoint rollback reverts that `SET`. `dj_absurd.now` still reports the frozen
+  instant correctly — it reads through its own fresh connection — so `now` cannot itself
+  flag the mismatch.
+- Moving durable time cannot make a [pg_cron](#pg_cron-backend) schedule fire: its
+  launcher runs in the central `cron.database_name` database (see
+  [Test databases](#pg_cron-backend) above), on its own real clock, and interprets
+  schedules in the [`cron.timezone`](https://github.com/citusdata/pg_cron#parameters)
+  GUC — none of which a test-database GUC can reach. Testing a pg_cron schedule stays
+  "reconcile it in, then inspect `cron.job`", exactly as `tests/pg_cron` already does.
 
 ### Getting a `SCHEDULE` into pg_cron for a test
 
@@ -936,9 +1080,11 @@ freed) → the warehouse system POSTs the webhook → the view emits the event o
 queue → the task's next claim finds it → resumes with the payload.
 
 `queue` must match the queue the waiting task actually runs on — it targets the
-client-level `emit_event`'s `queue_name`, not a database alias. An unknown queue raises
-`ImproperlyConfigured` immediately (fail fast on a typo). `emit_event` is sync; from an
-async view, wrap it in `sync_to_async`.
+client-level `emit_event`'s `queue_name`, not a database alias. An undeclared queue
+raises `QueueNotDeclaredError` immediately (fail fast on a typo); a declared but
+unprovisioned queue raises `QueueNotProvisionedError` naming
+`manage.py absurd_sync_queues` (see [Exceptions](#exceptions) above). `emit_event` is
+sync; from an async view, wrap it in `sync_to_async`.
 
 #### Sync
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -886,22 +886,12 @@ one ambiguous final read.
 
 **Hazards:**
 
-- A `manage.py absurd_worker` subprocess is only half-frozen: `ALTER DATABASE` reaches
-  its Postgres session, but its own Python clock is real — frozen-ahead-of-real is the
-  deadlock direction. The `dj_absurd` fixture's `drain` only ever runs the in-process
-  burst worker; a real subprocess worker under a freeze is out of scope.
-- A savepoint rollback inside a `freeze_time` block can make a later `enqueue()` stamp
-  stale time: Django's own connection only ever sees the frozen instant via a
-  session-level `SET` (a database-level default reaches only new sessions), and a
-  savepoint rollback reverts that `SET`. `dj_absurd.now` still reports the frozen
-  instant correctly — it reads through its own fresh connection — so `now` cannot itself
-  flag the mismatch.
-- Moving durable time cannot make a [pg_cron](#pg_cron-backend) schedule fire: its
-  launcher runs in the central `cron.database_name` database (see
-  [Test databases](#pg_cron-backend) above), on its own real clock, and interprets
-  schedules in the [`cron.timezone`](https://github.com/citusdata/pg_cron#parameters)
-  GUC — none of which a test-database GUC can reach. Testing a pg_cron schedule stays
-  "reconcile it in, then inspect `cron.job`", exactly as `tests/pg_cron` already does.
+- A freeze doesn't reach [pg_cron](#pg_cron-backend): its launcher runs in another
+  database on its own clock, so moving durable time cannot make a schedule fire. Testing
+  one stays "reconcile it in, then inspect `cron.job`", as `tests/pg_cron` does.
+- A savepoint rollback inside the block reverts Django's session clock, so a later
+  `enqueue()` stamps real time and won't look claimable. Don't enqueue across a rollback
+  boundary.
 
 ### Getting a `SCHEDULE` into pg_cron for a test
 

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -8,6 +8,7 @@ from django.db.utils import OperationalError, ProgrammingError
 
 from django_absurd.admin_views import PRIVATE_ADMIN_APPS
 from django_absurd.backends import get_absurd_backends
+from django_absurd.queues import provision_backend
 
 
 class AbsurdConfig(AppConfig):
@@ -16,6 +17,10 @@ class AbsurdConfig(AppConfig):
     verbose_name = "Absurd"
 
     def ready(self) -> None:
+        # Side-effect import: running the module registers its @register'd checks. In
+        # here, not at module level — this module runs during app-registry population,
+        # before models load, and django_absurd.checks imports django_absurd.models, so
+        # a module-level import raises AppRegistryNotReady.
         import django_absurd.checks  # noqa: F401, PLC0415
 
         # The synthesized admin models live in PRIVATE_ADMIN_APPS, so their
@@ -34,8 +39,6 @@ def provision_queues_after_migrate(
     stdout: t.IO[str] | None = None,
     **kwargs: object,
 ) -> None:
-    from django_absurd.queues import provision_backend  # noqa: PLC0415
-
     style = color_style()
     for alias, backend in get_absurd_backends().items():
         try:

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -17,10 +17,9 @@ class AbsurdConfig(AppConfig):
     verbose_name = "Absurd"
 
     def ready(self) -> None:
-        # Side-effect import: running the module registers its @register'd checks. In
-        # here, not at module level — this module runs during app-registry population,
-        # before models load, and django_absurd.checks imports django_absurd.models, so
-        # a module-level import raises AppRegistryNotReady.
+        # Side-effect import: registers the @register'd checks. In-function
+        # because checks imports models and ready() runs before models load
+        # (AppRegistryNotReady).
         import django_absurd.checks  # noqa: F401, PLC0415
 
         # The synthesized admin models live in PRIVATE_ADMIN_APPS, so their

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -17,6 +17,7 @@ from django.utils.module_loading import import_string
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
+from django_absurd.exceptions import QueueNotDeclaredError
 from django_absurd.tasks import AbsurdTask, build_merged_spawn_options
 
 if t.TYPE_CHECKING:
@@ -49,24 +50,41 @@ class TaskModel(t.Protocol):
 
     These models are built dynamically per queue (build_queue_table_model), so
     django-stubs cannot type their fields; this Protocol names the subset we read.
+
+    Optional here means NULLABLE IN ABSURD'S OWN SCHEMA, not merely nullable on the
+    dynamic model: build_queue_table_model declares every non-pk column null=True
+    because it cannot know better, while t_<queue> itself constrains task_id,
+    task_name, params, enqueue_at, state and attempts NOT NULL.
     """
 
+    task_id: uuid.UUID
     task_name: str
     params: TaskParams
-    enqueue_at: dt.datetime | None
+    enqueue_at: dt.datetime
     first_started_at: dt.datetime | None
     state: str
+    attempts: int
     completed_payload: JsonValue
     cancelled_at: dt.datetime | None
     last_attempt_run: uuid.UUID | None
 
 
 class RunModel(t.Protocol):
-    """The fields read off a per-queue Absurd run model instance."""
+    """The fields read off a per-queue Absurd run model instance.
 
+    Optional means nullable in ``r_<queue>`` itself, as on ``TaskModel``; ``state`` is
+    the one field below that Absurd constrains NOT NULL.
+
+    ``available_at`` is deliberately absent, and every read of this model defers it: an
+    indefinite ``await_event`` parks a run at Postgres's ``'infinity'``, which psycopg
+    refuses to decode.
+    """
+
+    state: str
     started_at: dt.datetime | None
     completed_at: dt.datetime | None
     failed_at: dt.datetime | None
+    result: JsonValue
     failure_reason: FailureReason | None
 
 
@@ -129,25 +147,23 @@ class AbsurdBackend(BaseTaskBackend):
             psycopg.errors.UndefinedTable,
             psycopg.errors.UndefinedFunction,
             psycopg.errors.InvalidSchemaName,
-        ):
+        ) as exc:
             declared = get_declared_queues(self)
             # validate_task() rejects an undeclared queue (InvalidTask) when the
             # backend declares queues. This guards the empty-QUEUES config (where
             # that check is skipped) and the declared[...] access below from KeyError.
             if task.queue_name not in declared:
-                msg = (
-                    f"Queue '{task.queue_name}' is not declared in TASKS QUEUES. "
-                    "Add it to the QUEUES list in your TASKS backend settings."
-                )
-                raise ImproperlyConfigured(msg) from None
+                raise QueueNotDeclaredError(
+                    task.queue_name, self.alias, self.queues
+                ) from exc
             try:
                 client.create_queue(task.queue_name, **declared[task.queue_name])
             except (
                 psycopg.errors.UndefinedFunction,
                 psycopg.errors.InvalidSchemaName,
-            ):
+            ) as exc:
                 msg = "Absurd schema is not installed. Run: manage.py migrate"
-                raise ImproperlyConfigured(msg) from None
+                raise ImproperlyConfigured(msg) from exc
             with transaction.atomic(using=self.database, savepoint=True):
                 spawn_result = client.spawn(
                     task.module_path,
@@ -216,8 +232,8 @@ def fetch_task_and_run(
             task: TaskModel | None = (
                 task_model.objects.using(database).filter(pk=task_id).first()
             )
-    except ProgrammingError:
-        raise TaskResultDoesNotExist(result_id) from None
+    except ProgrammingError as exc:
+        raise TaskResultDoesNotExist(result_id) from exc
     if task is None:
         raise TaskResultDoesNotExist(result_id)
     run: RunModel | None = None
@@ -233,8 +249,8 @@ def fetch_task_and_run(
                     .defer("available_at")
                     .first()
                 )
-        except ProgrammingError:
-            raise TaskResultDoesNotExist(result_id) from None
+        except ProgrammingError as exc:
+            raise TaskResultDoesNotExist(result_id) from exc
     try:
         with transaction.atomic(using=database, savepoint=True):
             worker_ids = list(
@@ -243,8 +259,8 @@ def fetch_task_and_run(
                 .order_by("attempt")
                 .values_list("claimed_by", flat=True)
             )
-    except ProgrammingError:
-        raise TaskResultDoesNotExist(result_id) from None
+    except ProgrammingError as exc:
+        raise TaskResultDoesNotExist(result_id) from exc
     return task, run, worker_ids
 
 
@@ -269,9 +285,9 @@ def build_task_result(
     failure_reason = run.failure_reason if run else None
     try:
         task_obj = import_string(task_name)
-    except ImportError:
+    except ImportError as exc:
         msg = f"task '{task_name}' is no longer importable"
-        raise ImproperlyConfigured(msg) from None
+        raise ImproperlyConfigured(msg) from exc
     if task_obj.queue_name != queue:
         task_obj = task_obj.using(queue_name=queue)
     status = map_state_to_status(state)

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -236,31 +236,28 @@ def fetch_task_and_run(
         raise TaskResultDoesNotExist(result_id) from exc
     if task is None:
         raise TaskResultDoesNotExist(result_id)
+    # Only the task read above translates a missing relation: past it the queue's
+    # schema demonstrably exists, so a ProgrammingError here is a broken database, not
+    # an absent task, and must not be relabelled as one.
     run: RunModel | None = None
     if task.last_attempt_run is not None:
-        try:
-            with transaction.atomic(using=database, savepoint=True):
-                run = (
-                    run_model.objects.using(database)
-                    .filter(pk=task.last_attempt_run)
-                    # An indefinite await_event can leave available_at as Postgres's
-                    # 'infinity' sentinel, which psycopg can't decode — defer it since
-                    # build_task_result() below never reads it.
-                    .defer("available_at")
-                    .first()
-                )
-        except ProgrammingError as exc:
-            raise TaskResultDoesNotExist(result_id) from exc
-    try:
         with transaction.atomic(using=database, savepoint=True):
-            worker_ids = list(
+            run = (
                 run_model.objects.using(database)
-                .filter(task_id=task_id, claimed_by__isnull=False)
-                .order_by("attempt")
-                .values_list("claimed_by", flat=True)
+                .filter(pk=task.last_attempt_run)
+                # An indefinite await_event can leave available_at as Postgres's
+                # 'infinity' sentinel, which psycopg can't decode — defer it since
+                # build_task_result() below never reads it.
+                .defer("available_at")
+                .first()
             )
-    except ProgrammingError as exc:
-        raise TaskResultDoesNotExist(result_id) from exc
+    with transaction.atomic(using=database, savepoint=True):
+        worker_ids = list(
+            run_model.objects.using(database)
+            .filter(task_id=task_id, claimed_by__isnull=False)
+            .order_by("attempt")
+            .values_list("claimed_by", flat=True)
+        )
     return task, run, worker_ids
 
 

--- a/django_absurd/connection.py
+++ b/django_absurd/connection.py
@@ -31,8 +31,7 @@ def register_jsonb_loader(context: psycopg.abc.AdaptContext) -> None:
     # absurd-sdk returns jsonb columns as raw strings unless we register a loader;
     # psycopg3's built-in loader is jsonb-type-OID only and doesn't cover the
     # un-typed bytea path the SDK's claim_tasks cursor uses. Typed as an AdaptContext
-    # because that is what psycopg scopes a loader to; every caller registers on a
-    # Connection, the SDK's own execution path.
+    # because that is what psycopg scopes a loader to.
     set_json_loads(json.loads, context)
 
 

--- a/django_absurd/connection.py
+++ b/django_absurd/connection.py
@@ -30,9 +30,9 @@ def validate_backend(using: str) -> None:
 def register_jsonb_loader(context: psycopg.abc.AdaptContext) -> None:
     # absurd-sdk returns jsonb columns as raw strings unless we register a loader;
     # psycopg3's built-in loader is jsonb-type-OID only and doesn't cover the
-    # un-typed bytea path the SDK's claim_tasks cursor uses.
-    # Accepts either a Connection (for the SDK path) or a Cursor (for get_result,
-    # where cursor-scope avoids poisoning Django's shared connection adapters).
+    # un-typed bytea path the SDK's claim_tasks cursor uses. Typed as an AdaptContext
+    # because that is what psycopg scopes a loader to; every caller registers on a
+    # Connection, the SDK's own execution path.
     set_json_loads(json.loads, context)
 
 

--- a/django_absurd/events.py
+++ b/django_absurd/events.py
@@ -3,8 +3,18 @@
 import typing as t
 
 import psycopg.errors
-from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
+
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+)
+from django_absurd.queues import (
+    get_absurd_backend,
+    get_absurd_client,
+    names_a_queue_table,
+)
 
 if t.TYPE_CHECKING:
     from absurd_sdk import JsonValue
@@ -13,30 +23,16 @@ if t.TYPE_CHECKING:
 def emit_event(
     event_name: str, payload: "JsonValue | None" = None, *, queue: str = "default"
 ) -> None:
-    from django_absurd.backends import get_declared_queues  # noqa: PLC0415
-    from django_absurd.queues import (  # noqa: PLC0415
-        get_absurd_backend,
-        get_absurd_client,
-    )
-
     backend = get_absurd_backend()
     if backend is None:
-        msg = "django-absurd: no Absurd backend configured."
-        raise ImproperlyConfigured(msg)
-    declared = get_declared_queues(backend)
-    if queue not in declared:
-        msg = (
-            f"Queue '{queue}' is not declared in TASKS QUEUES. "
-            "Add it to the QUEUES list in your TASKS backend settings."
-        )
-        raise ImproperlyConfigured(msg)
+        raise BackendNotConfiguredError(0)
+    if queue not in backend.queues:
+        raise QueueNotDeclaredError(queue, backend.alias, backend.queues)
     client = get_absurd_client()
     try:
         with transaction.atomic(using=backend.database, savepoint=True):
             client.emit_event(event_name, payload, queue_name=queue)
-    except psycopg.errors.UndefinedTable:
-        msg = (
-            f"Queue '{queue}' is declared but its Absurd table is not provisioned. "
-            "Run: manage.py absurd_sync_queues"
-        )
-        raise ImproperlyConfigured(msg) from None
+    except psycopg.errors.UndefinedTable as exc:
+        if not names_a_queue_table(exc, queue):
+            raise
+        raise QueueNotProvisionedError(queue) from exc

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -1,3 +1,5 @@
+import typing as t
+
 QUEUE_READONLY_MSG = (
     "Queue is read-only; manage queues via the AbsurdBackend QUEUES option + "
     "'manage.py absurd_sync_queues', or the absurd-sdk."
@@ -8,9 +10,106 @@ ADMIN_VIEW_READONLY_MSG = (
 )
 
 
-class QueueReadOnlyError(Exception):
+class DjangoAbsurdError(Exception):
+    """Base for every typed error this package raises.
+
+    Named for the distributing package, deliberately not ``AbsurdError``: the
+    upstream ``absurd_sdk`` is the confusing name to anchor on here, since
+    ``worker.py`` imports from both it and ``django_absurd``, and the SDK's own
+    exceptions (``SuspendTask``, ``CancelledTask``, ``FailedTask``, plus a
+    ``TimeoutError`` that shadows the builtin) share no base of their own.
+
+    Deliberately not also a ``ValueError``/``ImproperlyConfigured`` subclass — alpha
+    status means no external compatibility to preserve, and the class name already
+    carries the condition (``QueueNotDeclaredError`` over a bare ``ValueError``).
+
+    Covers only the exceptions defined in this module — ``except DjangoAbsurdError``
+    is "anything this package raised as a typed error," not every error the package
+    can raise. Plenty of call sites still raise a plain
+    ``ImproperlyConfigured``/``RuntimeError``/``TypeError`` directly and are
+    unaffected by this base.
+    """
+
+
+class QueueReadOnlyError(DjangoAbsurdError):
     pass
 
 
-class ViewNotProvisionedError(Exception):
+class ViewNotProvisionedError(DjangoAbsurdError):
     pass
+
+
+class QueueNotDeclaredError(DjangoAbsurdError):
+    """A queue name doesn't match any queue declared for the backend.
+
+    Raised unconditionally by ``worker.drain_queue`` and ``events.emit_event`` for any
+    undeclared queue name. ``AbsurdBackend.enqueue`` raises it too, but only when the
+    backend's ``QUEUES`` option is empty/unset; with ``QUEUES`` configured, an
+    undeclared queue name at enqueue is rejected earlier as Django's own
+    ``InvalidTask``, from ``validate_task``.
+    """
+
+    def __init__(self, queue: str, alias: str, valid_queues: t.Iterable[str]) -> None:
+        sorted_queues = sorted(valid_queues)
+        valid = ", ".join(sorted_queues) if sorted_queues else "(none)"
+        msg = (
+            f"Queue '{queue}' is not declared for backend '{alias}'. "
+            f"Valid queues: {valid}. "
+            "Add it to the QUEUES list in your TASKS backend settings."
+        )
+        super().__init__(msg)
+
+
+class QueueNotProvisionedError(DjangoAbsurdError):
+    """A queue is declared but its Absurd table has not been provisioned.
+
+    Raised by ``worker.drain_queue`` and ``events.emit_event`` when a claim/emit hits
+    a missing relation that names one of the queue's own Absurd tables.
+    """
+
+    def __init__(self, queue: str) -> None:
+        msg = (
+            f"Queue '{queue}' is declared but its Absurd table is not provisioned. "
+            "Run: manage.py absurd_sync_queues"
+        )
+        super().__init__(msg)
+
+
+class TaskIdQueueMismatchError(DjangoAbsurdError):
+    """A ``"queue:uuid"`` task id's own queue prefix disagrees with an explicit
+    ``queue=`` argument passed alongside it.
+
+    Raised by ``AbsurdTestRuntime.get_result`` when ``task_id`` carries a queue prefix
+    (as Django's own ``TaskResult.id`` always does) and the caller ALSO passed a
+    ``queue=`` naming a different queue — an ambiguous request, not one this package
+    will silently resolve by picking either side.
+    """
+
+    def __init__(self, task_id: str, prefix_queue: str, queue: str) -> None:
+        msg = (
+            f"get_result(): task id '{task_id}' names queue '{prefix_queue}', but "
+            f"queue='{queue}' was also passed and disagrees. Pass only one, or make "
+            "them agree."
+        )
+        super().__init__(msg)
+
+
+class BackendNotConfiguredError(DjangoAbsurdError):
+    """No single Absurd backend could be resolved.
+
+    Raised by ``management.base.resolve_backend`` on zero or on several configured
+    backends, and by ``events.emit_event`` on the same zero-backends condition.
+    One type for both counts — this package supports exactly one Absurd backend per
+    project, so "zero" and "several" both boil down to the same fact for the caller:
+    there is no single backend to act on.
+    """
+
+    def __init__(self, backend_count: int) -> None:
+        if backend_count == 0:
+            msg = "No Absurd backend configured."
+        else:
+            msg = (
+                "django-absurd supports one Absurd backend per project; "
+                "configure exactly one AbsurdBackend in TASKS."
+            )
+        super().__init__(msg)

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -106,7 +106,10 @@ class BackendNotConfiguredError(DjangoAbsurdError):
 
     def __init__(self, backend_count: int) -> None:
         if backend_count == 0:
-            msg = "No Absurd backend configured."
+            msg = (
+                "No Absurd backend configured. Add a "
+                "django_absurd.backends.AbsurdBackend entry to TASKS."
+            )
         else:
             msg = (
                 "django-absurd supports one Absurd backend per project; "

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -13,21 +13,13 @@ ADMIN_VIEW_READONLY_MSG = (
 class DjangoAbsurdError(Exception):
     """Base for every typed error this package raises.
 
-    Named for the distributing package, deliberately not ``AbsurdError``: the
-    upstream ``absurd_sdk`` is the confusing name to anchor on here, since
-    ``worker.py`` imports from both it and ``django_absurd``, and the SDK's own
-    exceptions (``SuspendTask``, ``CancelledTask``, ``FailedTask``, plus a
-    ``TimeoutError`` that shadows the builtin) share no base of their own.
-
-    Deliberately not also a ``ValueError``/``ImproperlyConfigured`` subclass — alpha
-    status means no external compatibility to preserve, and the class name already
-    carries the condition (``QueueNotDeclaredError`` over a bare ``ValueError``).
-
-    Covers only the exceptions defined in this module — ``except DjangoAbsurdError``
-    is "anything this package raised as a typed error," not every error the package
-    can raise. Plenty of call sites still raise a plain
-    ``ImproperlyConfigured``/``RuntimeError``/``TypeError`` directly and are
-    unaffected by this base.
+    Named for the distributing package, not ``AbsurdError`` — modules import from
+    both ``absurd_sdk`` and ``django_absurd``, and the short name reads as the SDK's
+    (whose own exceptions share no base). Deliberately not also a
+    ``ValueError``/``ImproperlyConfigured`` subclass: alpha status, and the class
+    name carries the condition. ``except DjangoAbsurdError`` covers only this
+    module's typed errors — plain ``ImproperlyConfigured``/``RuntimeError``/
+    ``TypeError`` raised elsewhere in the package are unaffected.
     """
 
 
@@ -76,13 +68,9 @@ class QueueNotProvisionedError(DjangoAbsurdError):
 
 
 class TaskIdQueueMismatchError(DjangoAbsurdError):
-    """A ``"queue:uuid"`` task id's own queue prefix disagrees with an explicit
-    ``queue=`` argument passed alongside it.
-
-    Raised by ``AbsurdTestRuntime.get_result`` when ``task_id`` carries a queue prefix
-    (as Django's own ``TaskResult.id`` always does) and the caller ALSO passed a
-    ``queue=`` naming a different queue — an ambiguous request, not one this package
-    will silently resolve by picking either side.
+    """An explicit ``queue=`` disagrees with the queue prefix inside a
+    ``"queue:uuid"`` task id — ambiguous, so ``AbsurdTestRuntime.get_result`` raises
+    rather than silently picking a side.
     """
 
     def __init__(self, task_id: str, prefix_queue: str, queue: str) -> None:
@@ -95,13 +83,9 @@ class TaskIdQueueMismatchError(DjangoAbsurdError):
 
 
 class BackendNotConfiguredError(DjangoAbsurdError):
-    """No single Absurd backend could be resolved.
-
-    Raised by ``management.base.resolve_backend`` on zero or on several configured
-    backends, and by ``events.emit_event`` on the same zero-backends condition.
-    One type for both counts — this package supports exactly one Absurd backend per
-    project, so "zero" and "several" both boil down to the same fact for the caller:
-    there is no single backend to act on.
+    """No single Absurd backend could be resolved — zero or several configured. One
+    type for both counts: the package supports exactly one Absurd backend per
+    project, so either way there is no single backend to act on.
     """
 
     def __init__(self, backend_count: int) -> None:

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -82,6 +82,22 @@ class TaskIdQueueMismatchError(DjangoAbsurdError):
         super().__init__(msg)
 
 
+class TaskNotFoundError(DjangoAbsurdError):
+    """``AbsurdTestRuntime.get_result`` found no task by that id on that queue.
+
+    Raised in place of a ``None`` return so a typo'd id, or a bare uuid resolved
+    against the wrong queue, names both instead of surfacing as an
+    ``AttributeError`` on a ``None`` read.
+    """
+
+    def __init__(self, task_id: str, queue: str) -> None:
+        msg = (
+            f"No task '{task_id}' found on queue '{queue}'. A bare uuid resolves "
+            "to queue 'default'; pass queue=... if the task ran on another queue."
+        )
+        super().__init__(msg)
+
+
 class BackendNotConfiguredError(DjangoAbsurdError):
     """No single Absurd backend could be resolved — zero or several configured. One
     type for both counts: the package supports exactly one Absurd backend per

--- a/django_absurd/flush.py
+++ b/django_absurd/flush.py
@@ -3,8 +3,20 @@
 Backs both the automatic test cleanup (``django_absurd.test.install_absurd_cleanup``,
 which wraps ``TransactionTestCase._post_teardown``) and the ``absurd_flush`` management
 command — a plain, always-Django-dependent module.
+
+Both in-function imports below reach into ``django_absurd.pg_cron``, the OPTIONAL app,
+and stay in-function on purpose: core must not import it at module level, since the
+``apps.is_installed(PG_CRON_APP_NAME)`` guard is what decides whether it is in play at
+all. ``pg_cron.reconcile`` additionally imports ``pg_cron.models``, so a module-level
+import of it would make THIS module settings-dependent — and this module is imported at
+module level by ``django_absurd.test``, which pytest's plugin bootstrap imports on every
+run in every venv (see that module's import-safety note).
 """
 
+import contextlib
+import typing as t
+
+import psycopg
 import psycopg.sql
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
@@ -16,8 +28,9 @@ from django_absurd.queues import get_absurd_client, resolve_absurd_database
 
 
 def flush_absurd_state(*, drop_schema: bool = False) -> None:
-    """Reset Absurd state: drop or truncate every queue's tables, then (if
-    ``django_absurd.pg_cron`` is installed) clear its scheduled-task state.
+    """Reset Absurd state: release a stranded durable clock, drop or truncate every
+    queue's tables, then (if ``django_absurd.pg_cron`` is installed) clear its
+    scheduled-task state.
 
     ``drop_schema=True`` drops each queue's schema (catalog row + tables) and clears
     this app database's pg_cron state (its ``cron.job`` jobs + its
@@ -28,6 +41,11 @@ def flush_absurd_state(*, drop_schema: bool = False) -> None:
     ``cron.job_run_details``. Both steps are independently no-ops on an unmigrated /
     absent schema.
     """
+    # Tolerant like the steps below: an unreachable database or an unconfigured Absurd
+    # backend means there is no clock to release.
+    with contextlib.suppress(OperationalError, ProgrammingError, ImproperlyConfigured):
+        reset_fake_now(resolve_absurd_database())
+
     clear_queues(drop_schema=drop_schema)
 
     if apps.is_installed(PG_CRON_APP_NAME):
@@ -38,6 +56,43 @@ def flush_absurd_state(*, drop_schema: bool = False) -> None:
                 teardown_owned_pg_cron_jobs()
         except (OperationalError, ProgrammingError, ImproperlyConfigured):
             pass  # pg_cron schema not present (unmigrated / schema-absent)
+
+
+def reset_fake_now(alias: str) -> None:
+    """Clear ``alias``'s database-level ``absurd.fake_now`` — the one implementation of
+    that statement, shared by the ``dj_absurd`` fixture's clock release, the post-test
+    flush, and the session-start sweep.
+
+    The GUC outlives the process that set it and every NEW session inherits it, so an
+    unreleased one silently moves durable time for the whole reused test database.
+
+    Targeted ``RESET`` of the one parameter, never ``RESET ALL`` — that would clobber
+    unrelated database-level settings. ``ALTER DATABASE`` rejects bind parameters, hence
+    the composed identifier, read at runtime so xdist's per-worker databases each get
+    their own.
+
+    On a DEDICATED autocommit connection, mirroring the freeze that set it
+    (``django_absurd.test.AbsurdTestRuntime._write_fake_now``): a caller can be inside
+    an open transaction — a test that froze the clock without
+    ``django_db(transaction=True)`` — where an ``ALTER DATABASE`` on Django's own
+    connection is rolled back with the test, stranding exactly the GUC this clears.
+    """
+    statement = psycopg.sql.SQL("alter database {name} reset absurd.fake_now").format(
+        name=psycopg.sql.Identifier(connections[alias].settings_dict["NAME"])
+    )
+    params: dict[str, t.Any] = connections[alias].get_connection_params()
+    params.pop("cursor_factory", None)
+    # ``context`` (Django's adapters) is kept, unlike in
+    # ``django_absurd.test.open_test_connection``, which drops it because its
+    # timestamptz loader relabels rather than converts. This connection is write-only —
+    # one ``ALTER DATABASE ... RESET`` — so no timestamptz is ever read back through it.
+    with connections[alias].wrap_database_errors:
+        conn = psycopg.connect(**params, autocommit=True)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(statement)
+        finally:
+            conn.close()
 
 
 def clear_queues(*, drop_schema: bool) -> None:
@@ -58,6 +113,7 @@ def clear_queues(*, drop_schema: bool) -> None:
 def teardown_owned_pg_cron_jobs() -> None:
     # Scoped clear (drop_schema=False) — the existing, already-tested
     # teardown_crons(include_admin=True), never a hand-rolled parallel implementation.
+    # In-function: optional app, AND reconcile imports pg_cron.models (see docstring).
     from django_absurd.pg_cron.reconcile import teardown_crons  # noqa: PLC0415
 
     teardown_crons(include_admin=True)
@@ -84,6 +140,7 @@ def truncate_queue_tables(queue: str) -> None:
 
 
 def drop_pg_cron_state() -> None:
+    # In-function: optional app (see module docstring). catalog itself is settings-free.
     from django_absurd.pg_cron import catalog  # noqa: PLC0415
 
     # Scoped clear — this app database's own jobs + run history in the shared central

--- a/django_absurd/flush.py
+++ b/django_absurd/flush.py
@@ -4,13 +4,10 @@ Backs both the automatic test cleanup (``django_absurd.test.install_absurd_clean
 which wraps ``TransactionTestCase._post_teardown``) and the ``absurd_flush`` management
 command — a plain, always-Django-dependent module.
 
-Both in-function imports below reach into ``django_absurd.pg_cron``, the OPTIONAL app,
-and stay in-function on purpose: core must not import it at module level, since the
-``apps.is_installed(PG_CRON_APP_NAME)`` guard is what decides whether it is in play at
-all. ``pg_cron.reconcile`` additionally imports ``pg_cron.models``, so a module-level
-import of it would make THIS module settings-dependent — and this module is imported at
-module level by ``django_absurd.test``, which pytest's plugin bootstrap imports on every
-run in every venv (see that module's import-safety note).
+Both in-function imports below reach ``django_absurd.pg_cron``, the OPTIONAL app
+gated by ``apps.is_installed``; ``pg_cron.reconcile`` also imports models, which
+would make this module settings-dependent — and ``django_absurd.test`` imports it
+at module level during pytest bootstrap (see that module's import-safety note).
 """
 
 import contextlib
@@ -24,7 +21,11 @@ from django.db import connections
 from django.db.utils import OperationalError, ProgrammingError
 
 from django_absurd.backends import PG_CRON_APP_NAME
-from django_absurd.queues import get_absurd_client, resolve_absurd_database
+from django_absurd.queues import (
+    QUEUE_TABLE_PREFIXES,
+    get_absurd_client,
+    resolve_absurd_database,
+)
 
 
 def flush_absurd_state(*, drop_schema: bool = False) -> None:
@@ -59,33 +60,25 @@ def flush_absurd_state(*, drop_schema: bool = False) -> None:
 
 
 def reset_fake_now(alias: str) -> None:
-    """Clear ``alias``'s database-level ``absurd.fake_now`` — the one implementation of
-    that statement, shared by the ``dj_absurd`` fixture's clock release, the post-test
-    flush, and the session-start sweep.
+    """Clear ``alias``'s database-level ``absurd.fake_now`` — the one implementation
+    of that statement, shared by the fixture's clock release, the post-test flush,
+    and the session-start sweep.
 
-    The GUC outlives the process that set it and every NEW session inherits it, so an
-    unreleased one silently moves durable time for the whole reused test database.
-
-    Targeted ``RESET`` of the one parameter, never ``RESET ALL`` — that would clobber
-    unrelated database-level settings. ``ALTER DATABASE`` rejects bind parameters, hence
-    the composed identifier, read at runtime so xdist's per-worker databases each get
-    their own.
-
-    On a DEDICATED autocommit connection, mirroring the freeze that set it
-    (``django_absurd.test.AbsurdTestRuntime._write_fake_now``): a caller can be inside
-    an open transaction — a test that froze the clock without
-    ``django_db(transaction=True)`` — where an ``ALTER DATABASE`` on Django's own
-    connection is rolled back with the test, stranding exactly the GUC this clears.
+    The GUC outlives the process that set it and every NEW session inherits it.
+    Targeted ``RESET`` of the one parameter, never ``RESET ALL`` (would clobber
+    unrelated database-level settings); ``ALTER DATABASE`` rejects bind parameters,
+    hence the composed identifier, read at runtime for xdist's per-worker databases.
+    Dedicated autocommit connection, mirroring the freeze that set it: on Django's
+    connection inside a test transaction the ``ALTER`` rolls back with the test,
+    stranding exactly the GUC this clears.
     """
     statement = psycopg.sql.SQL("alter database {name} reset absurd.fake_now").format(
         name=psycopg.sql.Identifier(connections[alias].settings_dict["NAME"])
     )
     params: dict[str, t.Any] = connections[alias].get_connection_params()
     params.pop("cursor_factory", None)
-    # ``context`` (Django's adapters) is kept, unlike in
-    # ``django_absurd.test.open_test_connection``, which drops it because its
-    # timestamptz loader relabels rather than converts. This connection is write-only —
-    # one ``ALTER DATABASE ... RESET`` — so no timestamptz is ever read back through it.
+    # ``context`` kept (unlike ``open_test_connection``): this connection is
+    # write-only, so its relabeling timestamptz loader can never fire.
     with connections[alias].wrap_database_errors:
         conn = psycopg.connect(**params, autocommit=True)
         try:
@@ -113,7 +106,6 @@ def clear_queues(*, drop_schema: bool) -> None:
 def teardown_owned_pg_cron_jobs() -> None:
     # Scoped clear (drop_schema=False) — the existing, already-tested
     # teardown_crons(include_admin=True), never a hand-rolled parallel implementation.
-    # In-function: optional app, AND reconcile imports pg_cron.models (see docstring).
     from django_absurd.pg_cron.reconcile import teardown_crons  # noqa: PLC0415
 
     teardown_crons(include_admin=True)
@@ -122,7 +114,7 @@ def teardown_owned_pg_cron_jobs() -> None:
 def truncate_queue_tables(queue: str) -> None:
     tables = [
         psycopg.sql.Identifier("absurd", f"{prefix}_{queue}")
-        for prefix in ("t", "r", "c", "e", "w")
+        for prefix in QUEUE_TABLE_PREFIXES
     ]
     with connections[resolve_absurd_database()].cursor() as cur:
         # `i_<queue>` only exists for a `partitioned` queue (see

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -1,6 +1,7 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
+from django_absurd.exceptions import BackendNotConfiguredError
 from django_absurd.queues import SyncResult
 
 BEAT_DISABLED_UNDER_PG_CRON = (
@@ -15,14 +16,7 @@ def resolve_backend() -> AbsurdBackend:
     backends = get_absurd_backends()
     if len(backends) == 1:
         return next(iter(backends.values()))
-    if len(backends) == 0:
-        msg = "No Absurd backend configured."
-        raise CommandError(msg)
-    msg = (
-        "django-absurd supports one Absurd backend per project; "
-        "configure exactly one AbsurdBackend in TASKS."
-    )
-    raise CommandError(msg)
+    raise BackendNotConfiguredError(len(backends))
 
 
 class AbsurdReportCommand(BaseCommand):

--- a/django_absurd/management/commands/absurd_beat.py
+++ b/django_absurd/management/commands/absurd_beat.py
@@ -5,6 +5,7 @@ from types import FrameType
 
 from django.core.management.base import BaseCommand, CommandError
 
+from django_absurd.exceptions import BackendNotConfiguredError
 from django_absurd.management.base import BEAT_DISABLED_UNDER_PG_CRON, resolve_backend
 from django_absurd.scheduler import get_settings_schedules, run_beat
 
@@ -13,7 +14,10 @@ class Command(BaseCommand):
     help = "Start the Absurd beat scheduler."
 
     def handle(self, *args: t.Any, **options: t.Any) -> None:
-        backend = resolve_backend()
+        try:
+            backend = resolve_backend()
+        except BackendNotConfiguredError as exc:
+            raise CommandError(str(exc)) from exc
 
         if backend.scheduler == "pg_cron":
             raise CommandError(BEAT_DISABLED_UNDER_PG_CRON)

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -6,13 +6,14 @@ from django.core.management.base import CommandError
 if t.TYPE_CHECKING:
     from django.core.management.base import CommandParser
 
+from django_absurd.exceptions import BackendNotConfiguredError, QueueNotDeclaredError
 from django_absurd.management.base import (
     BEAT_DISABLED_UNDER_PG_CRON,
     AbsurdReportCommand,
     resolve_backend,
 )
 from django_absurd.queues import provision_backend
-from django_absurd.worker import WorkerOptions, run_burst_worker, run_worker
+from django_absurd.worker import WorkerOptions, run_worker
 
 
 class Command(AbsurdReportCommand):
@@ -71,7 +72,10 @@ class Command(AbsurdReportCommand):
         )
 
     def handle(self, *args: t.Any, **options: t.Any) -> None:
-        backend = resolve_backend()
+        try:
+            backend = resolve_backend()
+        except BackendNotConfiguredError as exc:
+            raise CommandError(str(exc)) from exc
         queue = options["queue"]
 
         if options["burst"] and options["beat"]:
@@ -89,19 +93,10 @@ class Command(AbsurdReportCommand):
             worker_id=options["worker_id"],
         )
 
-        if options["burst"]:
-            result = run_burst_worker(queue, options=worker_options)
-            self.report_sync_result(result)
-            self.stdout.write(f"Started worker on queue '{queue}'.")
-            return
-
         if queue not in backend.queues:
-            valid = ", ".join(sorted(backend.queues))
-            msg = (
-                f"Queue '{queue}' is not declared for backend '{backend.alias}'."
-                f" Valid queues: {valid}"
+            raise CommandError(
+                str(QueueNotDeclaredError(queue, backend.alias, backend.queues))
             )
-            raise CommandError(msg)
 
         try:
             # Full provision on start so the admin views reflect every declared
@@ -115,6 +110,7 @@ class Command(AbsurdReportCommand):
         run_worker(
             backend,
             queue,
+            burst=options["burst"],
             run_beat=options["beat"],
             options=worker_options,
         )

--- a/django_absurd/pg_cron/apps.py
+++ b/django_absurd/pg_cron/apps.py
@@ -36,6 +36,9 @@ class PgCronConfig(AppConfig):
             )
 
         # Side-effect import: running the module registers its @register'd E007 checks.
+        # In here, not at module level: this module runs during app-registry population,
+        # before models load, and pg_cron.checks reaches django_absurd.models via
+        # django_absurd.checks — a module-level import raises AppRegistryNotReady.
         import django_absurd.pg_cron.checks  # noqa: F401, PLC0415
 
         scheduled_task = apps.get_model("django_absurd_pg_cron", "ScheduledTask")
@@ -73,6 +76,9 @@ def reconcile_crons_after_migrate(
     stdout: t.TextIO | None = None,
     **kwargs: object,
 ) -> None:
+    # In-function for the same reason as the checks import in ready(): reconcile imports
+    # pg_cron.models, and this module is executed during app-registry population, so a
+    # module-level import raises AppRegistryNotReady.
     from django_absurd.pg_cron.reconcile import (  # noqa: PLC0415
         sync_admin_crons,
         sync_crons,

--- a/django_absurd/pg_cron/apps.py
+++ b/django_absurd/pg_cron/apps.py
@@ -35,10 +35,9 @@ class PgCronConfig(AppConfig):
                 db_alias, str(db_config["NAME"])
             )
 
-        # Side-effect import: running the module registers its @register'd E007 checks.
-        # In here, not at module level: this module runs during app-registry population,
-        # before models load, and pg_cron.checks reaches django_absurd.models via
-        # django_absurd.checks — a module-level import raises AppRegistryNotReady.
+        # Side-effect import: registers the @register'd checks. In-function
+        # because checks imports models and ready() runs before models load
+        # (AppRegistryNotReady).
         import django_absurd.pg_cron.checks  # noqa: F401, PLC0415
 
         scheduled_task = apps.get_model("django_absurd_pg_cron", "ScheduledTask")

--- a/django_absurd/pg_cron/management/commands/absurd_sync_crons.py
+++ b/django_absurd/pg_cron/management/commands/absurd_sync_crons.py
@@ -2,6 +2,7 @@ import typing as t
 
 from django.core.management.base import BaseCommand, CommandError
 
+from django_absurd.exceptions import BackendNotConfiguredError
 from django_absurd.management.base import resolve_backend
 from django_absurd.pg_cron.detection import is_pg_cron_inert
 from django_absurd.pg_cron.reconcile import (
@@ -32,7 +33,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: t.Any, **options: t.Any) -> str | None:
-        backend = resolve_backend()
+        try:
+            backend = resolve_backend()
+        except BackendNotConfiguredError as exc:
+            raise CommandError(str(exc)) from exc
 
         if is_pg_cron_inert(backend.database):
             msg = (

--- a/django_absurd/pg_cron/signals.py
+++ b/django_absurd/pg_cron/signals.py
@@ -34,6 +34,8 @@ import psycopg
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError, transaction
 
+from django_absurd.queues import resolve_absurd_database
+
 if t.TYPE_CHECKING:
     from django_absurd.pg_cron.models import ScheduledTask
 
@@ -49,7 +51,7 @@ def reject_cross_database_save(
     if is_foreign_database(using):
         msg = (
             f"ScheduledTask was written to database {using!r}, but Absurd schedules "
-            f"live only on {resolve_absurd_database_lazily()!r} "
+            f"live only on {resolve_absurd_database()!r} "
             "(the run-wrapper reads there). "
             "Cross-database schedule writes are not supported."
         )
@@ -104,10 +106,4 @@ def emit_schedule_change(catalog_op: t.Callable[[], None]) -> None:
 
 def is_foreign_database(using: str | None) -> bool:
     """True when a save/delete targeted a database other than the single absurd one."""
-    return using is not None and using != resolve_absurd_database_lazily()
-
-
-def resolve_absurd_database_lazily() -> str:
-    from django_absurd.queues import resolve_absurd_database  # noqa: PLC0415
-
-    return resolve_absurd_database()
+    return using is not None and using != resolve_absurd_database()

--- a/django_absurd/pytest_plugin.py
+++ b/django_absurd/pytest_plugin.py
@@ -1,29 +1,45 @@
-"""django-absurd's ``pytest11`` plugin: auto Absurd cleanup + ``absurd_drain_queue``.
+"""django-absurd's ``pytest11`` plugin: auto Absurd cleanup plus the ``dj_absurd``
+fixture.
 
 ``pytest_configure`` installs ``django_absurd.test.install_absurd_cleanup``, which
 patches ``TransactionTestCase._post_teardown`` so every DB-backed test flushes leftover
 Absurd state after it runs — no per-test fixture or marker to opt into. The
-``absurd_drain_queue`` fixture burst-drains a queue synchronously in-process.
+``dj_absurd`` fixture yields an ``AbsurdTestRuntime`` — the read/drain/clock facade for
+durable tests.
 
 **Import-safety constraint**: this module is imported by pytest's own plugin bootstrap
 (the ``pytest11`` entry point) before pytest-django configures Django, for EVERY pytest
-run in ANY project with django-absurd installed — Django project or not. A top-level
-``django``/``django_absurd`` import would chain into model definitions and raise
-``AppRegistryNotReady``/``ImproperlyConfigured`` outright. So only ``typing`` and
-``pytest`` are imported at module level; everything Django-touching is imported lazily
-inside the function bodies. ``pytest_configure`` therefore imports ``django.test`` (via
-``django_absurd.test``) on every pytest run in any venv with django-absurd installed —
-an import-safe, verified pre-configuration step, but a small universal startup cost.
+run in ANY project with django-absurd installed — Django project or not. So every
+module imported below, transitively, must be importable with Django UNCONFIGURED.
+Reaching ``django_absurd.models`` (or ``.checks``/``.admin``, which do) defines model
+classes and raises ``ImproperlyConfigured: Requested setting INSTALLED_APPS`` — an
+``INTERNALERROR`` before collection, in every non-Django project in the venv, from one
+module-level import.
+
+That constraint has ONE choke point, not a rule spread over this file: the only
+model-touching import in the whole graph reachable from here lives inside
+``django_absurd.queues.reconcile_queue``'s function body (see the comment there), which
+is what keeps ``queues``, ``flush``, ``events`` and ``django_absurd.test`` settings-free
+and so importable at module level here. ``tests/core/test_pytest_plugin.py``'s
+``test_a_pytest_run_with_no_django_settings_still_collects`` runs a real settings-less
+subprocess and is the guard; in-function imports here would add no protection, since
+``pytest_configure`` imports ``django_absurd.test`` on every such run regardless.
 """
 
 import typing as t
 
 import pytest
+from django.apps import apps
+from django.conf import settings
+from django.db import connections
+
+from django_absurd import backends
+from django_absurd.flush import reset_fake_now
+from django_absurd.queues import resolve_absurd_database
+from django_absurd.test import AbsurdTestRuntime, install_absurd_cleanup
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    from django_absurd.test import install_absurd_cleanup  # noqa: PLC0415
-
     install_absurd_cleanup()
 
 
@@ -46,40 +62,110 @@ def _sweep_orphaned_pg_cron_jobs(request: pytest.FixtureRequest) -> None:
     pulling the DB fixtures lazily via ``getfixturevalue`` keeps this a clean no-op for
     a non-Django or unconfigured project. When the pg_cron app is present but scheduling
     is inert (opt-in off), ``flush_database_jobs`` itself no-ops, so it's free too.
+
+    Same unprovisioned-session guard as ``_sweep_stranded_fake_now``, in the same
+    shape: forcing ``django_db_setup`` costs nothing beyond ordering — it builds only
+    the aliases the COLLECTED tests need, so a session with no DB-backed test in it
+    builds nothing FOR THIS ALIAS, and ``NAME`` stays whatever the developer
+    configured — the live database, never swapped to a test one. This sweep's blast
+    radius there isn't an ``ALTER DATABASE`` ownership failure but a central-catalog
+    ``DELETE``/unschedule scoped by ``database = <live NAME>``: sweeping in that case
+    would unschedule and delete run history for real jobs that happen to share that
+    live database name. So this compares ``NAME`` before and after forcing setup and
+    skips silently — a session that provisions nothing for this alias has nothing
+    orphaned to sweep, by definition.
     """
-    from django.apps import apps  # noqa: PLC0415
-    from django.conf import settings  # noqa: PLC0415
-
-    from django_absurd.backends import PG_CRON_APP_NAME  # noqa: PLC0415
-
-    if not settings.configured or not apps.is_installed(PG_CRON_APP_NAME):
+    if not settings.configured or not apps.is_installed(backends.PG_CRON_APP_NAME):
         return
 
+    alias = resolve_absurd_database()
+    unswapped_name = connections[alias].settings_dict["NAME"]
+
     request.getfixturevalue("django_db_setup")  # force test-DB setup ordering
+
+    if connections[alias].settings_dict["NAME"] == unswapped_name:
+        return  # nothing was provisioned for this alias; nothing orphaned to sweep
+
     django_db_blocker = request.getfixturevalue("django_db_blocker")
 
+    # Layering, not import-safety: ``django_absurd.pg_cron`` is an OPTIONAL app, so core
+    # never imports it at module level — the ``is_installed`` guard above decides
+    # whether it is in play at all.
     from django_absurd.pg_cron import catalog  # noqa: PLC0415
-    from django_absurd.queues import resolve_absurd_database  # noqa: PLC0415
 
     with django_db_blocker.unblock():
-        catalog.flush_database_jobs(resolve_absurd_database())
+        catalog.flush_database_jobs(alias)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _sweep_stranded_fake_now(request: pytest.FixtureRequest) -> None:
+    """Once per xdist worker, clear an ``absurd.fake_now`` stranded on the reused test
+    database by a previous run that died mid-freeze.
+
+    Recovery has to happen BEFORE any test, not only after one. The per-test clock
+    teardown and the post-test flush are both scheduled after a test body, so neither
+    protects the first casualty of a poisoned ``--reuse-db`` database: the GUC outlives
+    the process that set it, every NEW session inherits it, and so this run's first
+    draining test can hang on a task whose wake time is already in the frozen past —
+    before any resetting code executes.
+
+    Session-autouse, not lazily hung off the ``dj_absurd`` fixture, and the difference
+    is load-bearing: a draining test need not use that fixture at all (one that calls
+    the worker directly hangs on the same stranded clock), so only a scope covering the
+    whole session covers every casualty. Forcing ``django_db_setup`` costs nothing
+    beyond ordering — it builds only the aliases the COLLECTED tests need, so a session
+    with no DB-backed test in it builds nothing FOR THIS ALIAS: pytest-django computes
+    which aliases to provision from the ``django_db`` markers across the WHOLE
+    collected session, not from this fixture forcing the call, so ``NAME`` stays
+    whatever the developer configured — the live database, never swapped to a test
+    one. Sweeping in that case would run ``ALTER DATABASE`` against that live database,
+    and ``ALTER DATABASE`` generally needs OWNERSHIP of the target — a privilege the
+    application role commonly lacks on managed Postgres. Left unguarded, a plain
+    ``pytest tests/test_utils.py`` in a project that merely has an Absurd backend
+    configured, with no ``django_db``-marked test in the file, would error the whole
+    session on a permissions failure before a single test ran. So this compares
+    ``NAME`` before and after forcing setup and skips silently — a session that
+    provisions nothing for this alias has nothing stranded to sweep, by definition.
+
+    Import-safe in the same shape as ``_sweep_orphaned_pg_cron_jobs``: takes ONLY
+    ``request`` so the guard runs BEFORE any Django/DB fixture is resolved. In a project
+    that isn't a fully-configured Django + pytest-django stack, resolving
+    ``django_db_setup`` either skips the whole session or errors; in one that is
+    configured but has no Absurd backend, there is no Absurd database, and the resolver
+    would fall back to ``default`` and issue an ``ALTER DATABASE`` against a project
+    database that has nothing to do with us. Guarding first, then pulling the DB
+    fixtures lazily via ``getfixturevalue``, keeps both cases a clean no-op.
+    """
+    if not settings.configured or not backends.get_absurd_backends():
+        return
+
+    alias = resolve_absurd_database()
+    unswapped_name = connections[alias].settings_dict["NAME"]
+
+    request.getfixturevalue("django_db_setup")  # force test-DB setup ordering
+
+    if connections[alias].settings_dict["NAME"] == unswapped_name:
+        return  # nothing was provisioned for this alias; nothing stranded to sweep
+
+    django_db_blocker = request.getfixturevalue("django_db_blocker")
+
+    with django_db_blocker.unblock():
+        reset_fake_now(alias)
 
 
 @pytest.fixture
-def absurd_drain_queue() -> t.Callable[..., None]:
-    """Burst-drain a queue synchronously, in-process.
+def dj_absurd() -> t.Iterator[AbsurdTestRuntime]:
+    """Read/drain/clock facade for durable tests: snapshot task/run state, burst-drain a
+    queue, and freeze Absurd's durable clock with ``freeze_time``.
 
-    Returns a callable ``drain(queue: str = "default", *, concurrency: int = 1) ->
-    None`` that runs every currently-claimable task on the given queue to completion,
-    then returns — no persistent worker process, no subprocess.
+    Requires ``@pytest.mark.django_db(transaction=True)`` — its reads run on a
+    separate connection, so an enqueue left inside an open transaction is invisible to
+    it (see ``django_absurd.test.guard_against_open_transaction``).
+
+    A ``freeze_time`` block releases both clock halves on the way out, so the runtime is
+    entered for the test's duration purely as the crash net: a test that dies INSIDE the
+    block still gets real time restored, function-scoped, before the next test runs. A
+    test that never froze releases nothing.
     """
-
-    def drain(queue: str = "default", *, concurrency: int = 1) -> None:
-        from django_absurd.worker import (  # noqa: PLC0415
-            WorkerOptions,
-            run_burst_worker,
-        )
-
-        run_burst_worker(queue, options=WorkerOptions(concurrency=concurrency))
-
-    return drain
+    with AbsurdTestRuntime(alias=resolve_absurd_database()) as runtime:
+        yield runtime

--- a/django_absurd/pytest_plugin.py
+++ b/django_absurd/pytest_plugin.py
@@ -63,29 +63,15 @@ def _sweep_orphaned_pg_cron_jobs(request: pytest.FixtureRequest) -> None:
     a non-Django or unconfigured project. When the pg_cron app is present but scheduling
     is inert (opt-in off), ``flush_database_jobs`` itself no-ops, so it's free too.
 
-    Same unprovisioned-session guard as ``_sweep_stranded_fake_now``, in the same
-    shape: forcing ``django_db_setup`` costs nothing beyond ordering — it builds only
-    the aliases the COLLECTED tests need, so a session with no DB-backed test in it
-    builds nothing FOR THIS ALIAS, and ``NAME`` stays whatever the developer
-    configured — the live database, never swapped to a test one. This sweep's blast
-    radius there isn't an ``ALTER DATABASE`` ownership failure but a central-catalog
-    ``DELETE``/unschedule scoped by ``database = <live NAME>``: sweeping in that case
-    would unschedule and delete run history for real jobs that happen to share that
-    live database name. So this compares ``NAME`` before and after forcing setup and
-    skips silently — a session that provisions nothing for this alias has nothing
-    orphaned to sweep, by definition.
+    Skips via ``resolve_provisioned_alias`` like ``_sweep_stranded_fake_now`` — here
+    the unguarded blast radius is a central-catalog DELETE/unschedule scoped by the
+    LIVE database name, killing real jobs that share it.
     """
     if not settings.configured or not apps.is_installed(backends.PG_CRON_APP_NAME):
         return
-
-    alias = resolve_absurd_database()
-    unswapped_name = connections[alias].settings_dict["NAME"]
-
-    request.getfixturevalue("django_db_setup")  # force test-DB setup ordering
-
-    if connections[alias].settings_dict["NAME"] == unswapped_name:
-        return  # nothing was provisioned for this alias; nothing orphaned to sweep
-
+    alias = resolve_provisioned_alias(request)
+    if alias is None:
+        return
     django_db_blocker = request.getfixturevalue("django_db_blocker")
 
     # Layering, not import-safety: ``django_absurd.pg_cron`` is an OPTIONAL app, so core
@@ -102,51 +88,24 @@ def _sweep_stranded_fake_now(request: pytest.FixtureRequest) -> None:
     """Once per xdist worker, clear an ``absurd.fake_now`` stranded on the reused test
     database by a previous run that died mid-freeze.
 
-    Recovery has to happen BEFORE any test, not only after one. The per-test clock
-    teardown and the post-test flush are both scheduled after a test body, so neither
-    protects the first casualty of a poisoned ``--reuse-db`` database: the GUC outlives
-    the process that set it, every NEW session inherits it, and so this run's first
-    draining test can hang on a task whose wake time is already in the frozen past —
-    before any resetting code executes.
+    Must run BEFORE any test: the GUC outlives the process that set it and every NEW
+    session inherits it, so this run's FIRST draining test can hang on a frozen-past
+    wake time before any resetting code executes. Session-autouse, not hung off
+    ``dj_absurd`` — a draining test need not use that fixture at all.
 
-    Session-autouse, not lazily hung off the ``dj_absurd`` fixture, and the difference
-    is load-bearing: a draining test need not use that fixture at all (one that calls
-    the worker directly hangs on the same stranded clock), so only a scope covering the
-    whole session covers every casualty. Forcing ``django_db_setup`` costs nothing
-    beyond ordering — it builds only the aliases the COLLECTED tests need, so a session
-    with no DB-backed test in it builds nothing FOR THIS ALIAS: pytest-django computes
-    which aliases to provision from the ``django_db`` markers across the WHOLE
-    collected session, not from this fixture forcing the call, so ``NAME`` stays
-    whatever the developer configured — the live database, never swapped to a test
-    one. Sweeping in that case would run ``ALTER DATABASE`` against that live database,
-    and ``ALTER DATABASE`` generally needs OWNERSHIP of the target — a privilege the
-    application role commonly lacks on managed Postgres. Left unguarded, a plain
-    ``pytest tests/test_utils.py`` in a project that merely has an Absurd backend
-    configured, with no ``django_db``-marked test in the file, would error the whole
-    session on a permissions failure before a single test ran. So this compares
-    ``NAME`` before and after forcing setup and skips silently — a session that
-    provisions nothing for this alias has nothing stranded to sweep, by definition.
-
-    Import-safe in the same shape as ``_sweep_orphaned_pg_cron_jobs``: takes ONLY
-    ``request`` so the guard runs BEFORE any Django/DB fixture is resolved. In a project
-    that isn't a fully-configured Django + pytest-django stack, resolving
-    ``django_db_setup`` either skips the whole session or errors; in one that is
-    configured but has no Absurd backend, there is no Absurd database, and the resolver
-    would fall back to ``default`` and issue an ``ALTER DATABASE`` against a project
-    database that has nothing to do with us. Guarding first, then pulling the DB
-    fixtures lazily via ``getfixturevalue``, keeps both cases a clean no-op.
+    Import-safe in the same shape as ``_sweep_orphaned_pg_cron_jobs``: takes only
+    ``request``, guards first, pulls DB fixtures via ``getfixturevalue``. The backend
+    guard also keeps a configured-but-Absurd-free project from an ``ALTER DATABASE``
+    against its own ``default`` database. ``resolve_provisioned_alias`` skips a
+    session that provisioned nothing — unguarded, that sweep would need OWNERSHIP of
+    the LIVE database and would error a plain ``pytest tests/test_utils.py`` on
+    permissions before a single test ran.
     """
     if not settings.configured or not backends.get_absurd_backends():
         return
-
-    alias = resolve_absurd_database()
-    unswapped_name = connections[alias].settings_dict["NAME"]
-
-    request.getfixturevalue("django_db_setup")  # force test-DB setup ordering
-
-    if connections[alias].settings_dict["NAME"] == unswapped_name:
-        return  # nothing was provisioned for this alias; nothing stranded to sweep
-
+    alias = resolve_provisioned_alias(request)
+    if alias is None:
+        return
     django_db_blocker = request.getfixturevalue("django_db_blocker")
 
     with django_db_blocker.unblock():
@@ -169,3 +128,19 @@ def dj_absurd() -> t.Iterator[AbsurdTestRuntime]:
     """
     with AbsurdTestRuntime(alias=resolve_absurd_database()) as runtime:
         yield runtime
+
+
+def resolve_provisioned_alias(request: pytest.FixtureRequest) -> str | None:
+    """The Absurd alias, or ``None`` when this session provisioned no test database
+    for it — then ``NAME`` is still the developer's LIVE database, and a sweep there
+    is an ``ALTER DATABASE``/catalog-DELETE against production state. pytest-django
+    provisions aliases from the whole session's ``django_db`` markers, not from this
+    forced setup call, so an unswapped ``NAME`` after forcing ``django_db_setup``
+    means nothing was provisioned — and nothing stranded to sweep, by definition.
+    """
+    alias = resolve_absurd_database()
+    unswapped_name = connections[alias].settings_dict["NAME"]
+    request.getfixturevalue("django_db_setup")  # force test-DB setup ordering
+    if connections[alias].settings_dict["NAME"] == unswapped_name:
+        return None
+    return alias

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -1,7 +1,9 @@
 import datetime as dt
+import re
 import typing as t
 from dataclasses import dataclass, field
 
+import psycopg.errors
 from absurd_sdk import Absurd, QueuePolicyOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
@@ -10,7 +12,14 @@ from django.db.utils import ProgrammingError
 from django_absurd import backends
 from django_absurd.admin_views import rebuild_views
 from django_absurd.connection import build_absurd_client, validate_backend
-from django_absurd.models import Queue
+
+if t.TYPE_CHECKING:
+    from django_absurd.models import Queue
+
+# Per-queue table prefixes, as absurd.create_queue names them: tasks, runs, checkpoints,
+# events, waiters. (``i_<queue>`` exists for a partitioned queue too, but only spawn and
+# cleanup touch it — nothing a drain runs can miss it.)
+QUEUE_TABLE_PREFIXES = ("t", "r", "c", "e", "w")
 
 MUTABLE_OPTION_KEYS = (
     "partition_lookahead",
@@ -56,7 +65,39 @@ def get_absurd_client(using: str | None = None) -> Absurd:
     return build_absurd_client(using or resolve_absurd_database())
 
 
+def names_a_queue_table(exc: psycopg.errors.UndefinedTable, queue: str) -> bool:
+    """Report whether ``exc`` is about one of ``queue``'s own Absurd tables.
+
+    Read off ``diag.message_primary`` (``relation "absurd.r_default" does not exist``),
+    not ``diag.table_name``: Postgres populates no table field for SQLSTATE 42P01 —
+    verified, it is always ``None`` — since a relation that does not exist has no OID to
+    name. The match is on the relation NAME, which Postgres never translates, so a
+    server running a localised ``lc_messages`` classifies the same way an English one
+    does.
+
+    Word-bounded, so an unrelated ``audit_default`` is not read as this queue's
+    ``t_default``. ``message_primary`` alone, never ``str(exc)``: the latter carries
+    the failing statement as CONTEXT, and the claim statement names every queue table,
+    so an unrelated failure inside it would look like a provisioning problem.
+    """
+    message = exc.diag.message_primary or ""
+    return any(
+        re.search(rf"\b{re.escape(prefix)}_{re.escape(queue)}\b", message)
+        for prefix in QUEUE_TABLE_PREFIXES
+    )
+
+
 def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncResult:
+    # The ONE import that would make this module settings-dependent at load time:
+    # ``django_absurd.models`` defines model classes (``build_admin_model``), so
+    # importing it reads INSTALLED_APPS. Keeping it in here is what lets
+    # ``django_absurd.pytest_plugin``/``.test``/``.flush`` import this module at their
+    # own top level during pytest's bootstrap, in any venv, before Django is configured.
+    # Move it to the top of this module and every pytest run in a non-Django project
+    # dies with INTERNALERROR (see tests/core/test_pytest_plugin.py's
+    # test_a_pytest_run_with_no_django_settings_still_collects).
+    from django_absurd.models import Queue  # noqa: PLC0415
+
     db = backend.database
     validate_backend(db)
     opts = backends.get_declared_queues(backend)[queue_name]
@@ -116,7 +157,7 @@ def parse_interval(using: str, interval_str: str) -> dt.timedelta:
 
 
 def check_mutable_options_drifted(
-    using: str, opts: QueuePolicyOptions, existing: Queue
+    using: str, opts: QueuePolicyOptions, existing: "Queue"
 ) -> bool:
     for key, declared_value in opts.items():
         db_value = getattr(existing, key)

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -544,12 +544,11 @@ class AbsurdTestRuntime:
         databases.
 
         Both writes go through ``run_off_event_loop`` together, so under a running loop
-        they land on ONE off-loop connection rather than the session write landing on a
-        second one. Under a loop the session half reaches only that off-loop session
-        (closed on the way out) — an ``async def`` test cannot use Django's sync ORM on
-        its own connection anyway, and every session its work DOES use (``aenqueue``'s
-        ``sync_to_async`` thread, the SDK's own connection per drain) either opens after
-        this write or is opened fresh, inheriting the database-level default.
+        they land on ONE off-loop connection instead of two. There the session half
+        reaches only that off-loop session, which the hop then closes — the sessions an
+        ``async def`` test's work actually uses are covered by the hop's own recycling
+        of asgiref's thread-sensitive connection, so they reconnect and inherit the
+        database-level default just written.
         """
         statement = psycopg.sql.SQL(
             "alter database {name} set absurd.fake_now = {instant}"
@@ -769,9 +768,11 @@ def run_off_event_loop[T](work: t.Callable[[], T]) -> T:
     own in the worker thread.
 
     Callers keep their guards on THEIR OWN thread and call this for the DB work only:
-    ``in_atomic_block`` is per-connection and ``connections`` is thread-local, so a
-    transaction guard evaluated over here would inspect a connection the test never
-    used and pass every time.
+    ``in_atomic_block`` is per-connection and ``connections`` is thread-critical, so
+    ``guard_against_open_transaction`` evaluated over here would inspect a connection
+    the test never used and pass every time. The one guard that does hop is
+    ``guard_against_blocked_database``, which cannot run on the calling thread at all
+    and keeps its fidelity for the reason given there.
 
     Two sets of Django connections are closed on the way out, both of them sessions no
     test-runner teardown reaches, and one stranded session is enough to fail teardown's

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -26,7 +26,7 @@ run in any venv with django-absurd installed, so its top level must stay setting
 import asyncio
 import datetime as dt
 import functools
-import importlib.util
+import importlib
 import typing as t
 import uuid
 from collections.abc import Mapping
@@ -505,12 +505,9 @@ class AbsurdTestRuntime:
     def _move_python_clock(self, instant: dt.datetime) -> None:
         """Hold Python's clock at ``instant`` via time-machine, ``tick=False``.
 
-        time-machine is a test-time dependency of the PROJECT UNDER TEST, never bundled
-        and never an extra, so the import is lazy: a ``drain``-only test must not need
-        the package, and Python caches the module so only the first move pays for it.
-        ``_apply_clock_move`` has already called ``require_time_machine()`` before
-        either clock moved, so this import is expected to succeed — the ``except``
-        below is a defence-in-depth translation, not the primary guard.
+        The import is lazy because time-machine is optional — a ``drain``-only test
+        must not need it. ``require_time_machine()`` has already run, so it can't fail
+        here.
 
         ``tick=False`` is a correctness requirement: ``absurd.fake_now`` is a static
         literal, so Postgres never ticks, and a ticking Python clock would drift out of
@@ -519,10 +516,7 @@ class AbsurdTestRuntime:
         Both fields are assigned only once ``start()`` has returned, so a failed start
         leaves nothing for the release to ``stop()``.
         """
-        try:
-            import time_machine  # noqa: PLC0415
-        except ImportError as err:
-            raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE) from err
+        import time_machine  # noqa: PLC0415
 
         if self.traveller is None:
             time_travel = time_machine.travel(instant, tick=False)
@@ -739,19 +733,13 @@ def require_time_machine() -> None:
     """Raise ``ImproperlyConfigured`` before either clock moves, if time-machine is not
     installed.
 
-    Called from ``_apply_clock_move`` ahead of both the Postgres GUC write and the
-    Python clock move, so a project without the optional dependency fails atomically —
-    neither clock is touched. ``importlib.util.find_spec`` rather than a bare
-    ``import time_machine``: a probe-only import with no later use of the bound name is
-    exactly what a linter flags as unused, and ``_move_python_clock`` already performs
-    the real import once it has actual work for the module to do.
+    Runs ahead of both clock writes, so a project without it fails with neither clock
+    touched.
     """
     try:
-        installed = importlib.util.find_spec("time_machine") is not None
+        importlib.import_module("time_machine")
     except ImportError as err:
         raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE) from err
-    if not installed:
-        raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE)
 
 
 def run_off_event_loop[T](work: t.Callable[[], T]) -> T:

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -1,4 +1,5 @@
-"""Auto Absurd state cleanup for Django's test runner.
+"""Auto Absurd state cleanup for Django's test runner, plus the ``dj_absurd`` test
+fixture.
 
 ``install_absurd_cleanup()`` monkeypatches ``TransactionTestCase._post_teardown`` so
 that every DB-backed test case flushes leftover Absurd state (per-queue tables,
@@ -10,13 +11,54 @@ so the flush executes while the DB is unblocked.
 The project's no-monkeypatch rule governs test-code hygiene; this is library test-infra
 integration (pytest-django itself patches ``BaseDatabaseWrapper.ensure_connection``),
 so the patch here is deliberate.
+
+``AbsurdTestRuntime`` (returned by the ``dj_absurd`` pytest fixture in
+``django_absurd.pytest_plugin``) is the read/drain/clock facade for durable tests:
+``sync_queues``, ``get_result``, ``drain``, ``emit``, the transaction guard all four
+share, plus clock control (``freeze_time``, which yields a ``FrozenTime``, and
+``now``). Every other
+METHOD on that class is an internal and carries a leading underscore; its dataclass
+fields are plain state, not part of the public surface.
+
+**Import-safety constraint**: ``django_absurd.pytest_plugin.pytest_configure`` imports
+this module on EVERY pytest run in ANY venv that has django-absurd installed — Django
+project or not — so this module's top level must stay settings-free. Everything
+imported above is: the one import that would read ``INSTALLED_APPS`` is
+``django_absurd.models``, and it is confined to ``queues.reconcile_queue``'s own
+function body (see the comment there). Never add a module-level import here that
+reaches ``django_absurd.models``, ``.checks`` or ``.admin`` — the run would die with
+``INTERNALERROR: ImproperlyConfigured`` before collecting anything, in every non-Django
+project in the venv. ``tests/core/test_pytest_plugin.py``'s
+``test_a_pytest_run_with_no_django_settings_still_collects`` guards exactly that.
 """
 
+import datetime as dt
 import functools
+import typing as t
+import uuid
+from collections.abc import Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
 
+import psycopg
+import psycopg.sql
+from django.core.exceptions import ImproperlyConfigured
+from django.db import connections
+from django.db.utils import ProgrammingError
 from django.test import TestCase, TransactionTestCase
 
-from django_absurd import backends  # import-safe: touches no settings at module load
+from django_absurd import admin_views, backends, flush, queues
+from django_absurd.events import emit_event
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueNotProvisionedError,
+    TaskIdQueueMismatchError,
+)
+from django_absurd.params import NOT_SET, NotSet
+
+if t.TYPE_CHECKING:
+    import time_machine  # dev/test-only dependency, imported lazily at runtime
+    from absurd_sdk import JsonValue
 
 CLEANUP_MARKER = "absurd_cleanup_installed"
 
@@ -65,12 +107,653 @@ def flush_absurd_after_teardown(instance: TransactionTestCase) -> None:
     if not backends.get_absurd_backends():
         return
 
-    from django_absurd.queues import resolve_absurd_database  # noqa: PLC0415
-
     databases = instance.databases
-    if databases != "__all__" and resolve_absurd_database() not in databases:
+    if databases != "__all__" and queues.resolve_absurd_database() not in databases:
         return
 
-    from django_absurd.flush import flush_absurd_state  # noqa: PLC0415
+    flush.flush_absurd_state()
 
-    flush_absurd_state()
+
+@dataclass(frozen=True)
+class TaskSnapshot:
+    """Where one task stands: one row from ``t_<queue>``, left-joined to its last
+    attempt's run for ``failure``.
+
+    Caveats, measured (see the design doc for the full reasoning):
+
+    - ``attempts`` counts attempts CREATED, not completed — a task retried once (one
+      failure, one pending replacement) already reads ``attempts=2`` before the second
+      attempt has run.
+    - ``state="sleeping"`` covers both a durable sleep and a retry backoff; it cannot
+      tell them apart.
+    - ``failure`` is populated only when ``last_attempt_run`` still points at the failed
+      run (a terminal failure) — mid-backoff it already points at the fresh pending
+      run, so ``failure`` reads ``None`` even though the previous attempt raised.
+    """
+
+    queue: str
+    task_id: uuid.UUID
+    task_name: str
+    args: list[t.Any]
+    kwargs: dict[str, t.Any]
+    state: str
+    attempts: int
+    enqueued_at: dt.datetime
+    result: t.Any | None
+    failure: t.Any | None
+
+
+@dataclass(frozen=True)
+class RunSnapshot:
+    """One run executed during a ``drain()``, in claim order.
+
+    ``drain()`` reports what RUNS did; ``get_result()`` reports where a TASK stands —
+    conflating the two is what makes ``TaskSnapshot`` unable to express an in-flight
+    retry (see its own caveats). Per-run state is read right after THAT run's own
+    execution, never batched at drain end: a run that suspends (``sleeping``) or fails
+    (``failed``, with its own ``failure``) reports honestly, and a retry sequence reads
+    attempt-by-attempt instead of collapsing to one final verdict.
+
+    The same ``run_id`` can legitimately appear twice in one drain: an ``await_event``
+    waiter re-arms its own run, so it first appears ``sleeping`` and later
+    ``completed``.
+    """
+
+    queue: str
+    run_id: uuid.UUID
+    task_id: uuid.UUID
+    task_name: str
+    args: list[t.Any]
+    kwargs: dict[str, t.Any]
+    attempt: int
+    state: str
+    result: t.Any | None
+    failure: t.Any | None
+
+
+@dataclass(frozen=True)
+class FrozenTime:
+    """The handle ``AbsurdTestRuntime.freeze_time`` yields: durable time's two movers.
+
+    ``move_to``/``shift`` are time-machine's own ``Coordinates`` vocabulary, and the
+    absence of a ``travel`` is deliberate — travelling implies ticking, while both
+    halves of this clock are frozen: ``absurd.fake_now`` is a static literal, so
+    Postgres never ticks, and a ticking Python clock would drift out of lockstep with
+    it.
+
+    ``move_to`` and ``shift`` are the whole surface. ``_apply_move`` behind them is the
+    window's own two-clock apply, bound when the freeze opened, so the handle carries no
+    clock state of its own — the runtime stays the single owner of what has to be
+    released. It also holds the window open/closed, so BOTH movers raise once the block
+    has exited rather than silently re-freezing real time behind the test's back.
+    """
+
+    _apply_move: t.Callable[[dt.datetime, dt.datetime | None], None]
+
+    def move_to(self, dest: dt.datetime) -> None:
+        """Move durable time to ``dest``, a timezone-aware ``datetime``.
+
+        Valid only while the ``freeze_time`` block that yielded this handle is open.
+        """
+        self._apply_move(dest, None)
+
+    def shift(self, delta: dt.timedelta) -> None:
+        """Move durable time forward by ``delta`` of ABSOLUTE elapsed time.
+
+        Absolute, not wall-clock: a seven-day shift across a US spring-forward gap
+        lands 7 * 24 hours later as an INSTANT, which is the only thing a durable
+        deadline is measured in. The destination is read back from ``datetime.now``
+        — already the frozen instant while time-machine holds the process clock — so
+        there is one source of truth instead of bookkeeping of our own that could
+        disagree with it.
+
+        That same reading is also passed through as the direction reference, so
+        ``_apply_clock_move`` decides forward-vs-backward against the exact ``now()``
+        this method took, not a second, later one of its own.
+
+        Valid only while the ``freeze_time`` block that yielded this handle is open.
+        """
+        now = dt.datetime.now(dt.UTC)
+        self._apply_move(now + delta, now)
+
+
+@dataclass
+class AbsurdTestRuntime:
+    """Read/drain/clock facade returned by the ``dj_absurd`` pytest fixture.
+
+    Holds the Django database alias the Absurd backend runs on, and — for as long as a
+    ``freeze_time`` block is open — the time-machine coordinate driving Python's half of
+    the clock. Every per-queue method resolves its queue name from its own argument,
+    defaulting to ``"default"`` — except ``get_result``, which prefers a prefixed id's
+    own queue over an unpassed ``queue`` argument (see its own docstring), and
+    ``sync_queues``, which is whole-catalog and takes no queue at all.
+
+    Public surface: ``freeze_time``, ``now``, ``sync_queues``, ``drain``, ``emit``,
+    ``get_result``.
+
+    ``time_travel`` is what release stops; ``traveller`` is what later moves take. Both
+    stay ``None`` outside a ``freeze_time`` block, which is how a drain-only test pays
+    nothing and cannot leak a frozen clock, and a live ``time_travel`` is what makes a
+    nested freeze detectable.
+    """
+
+    alias: str
+    time_travel: "time_machine.travel | None" = None
+    traveller: "time_machine.Traveller | None" = None
+
+    def __enter__(self) -> "t.Self":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Release a clock a test left frozen — the crash net behind ``freeze_time``.
+
+        ``freeze_time`` releases its own window on the way out, so this only ever has
+        work to do when a test died without leaving the block. The ``dj_absurd`` fixture
+        drives it by entering the runtime for the test's duration.
+        """
+        self._release_clock()
+
+    def sync_queues(self) -> None:
+        """Provision every queue declared on the Absurd backend — the runtime
+        counterpart of ``manage.py absurd_sync_queues``.
+
+        **Rarely needed, so don't reach for it defensively.** django-absurd provisions
+        the declared catalog from its own ``post_migrate`` receiver, and pytest-django
+        migrates the test database, so a test that enqueues on a declared queue already
+        has its tables. What needs this is a test that CHANGED the topology: a
+        ``settings`` override declaring a queue the migration never saw, or a fixture
+        that dropped the queues to isolate itself.
+
+        Whole-catalog, hence no ``queue`` argument — provisioning also rebuilds the
+        admin views over the FULL catalog, which reconciling one queue cannot express.
+
+        Transaction-guarded like the reads, for a different reason: ``create_queue`` is
+        DDL, so a sync inside an open transaction is invisible to the worker's own
+        connection and is rolled back with the test — provisioning that looks like it
+        happened and didn't.
+        """
+        guard_against_open_transaction(self.alias, "sync_queues")
+        backend = queues.get_absurd_backend()
+        if backend is None:
+            raise BackendNotConfiguredError(0)
+        queues.provision_backend(backend)
+
+    def get_result(
+        self, task_id: str | uuid.UUID, queue: str | NotSet = NOT_SET
+    ) -> TaskSnapshot | None:
+        """Look up one task by id, returning ``None`` if it doesn't exist.
+
+        ``task_id`` accepts either a Django ``TaskResult.id`` (``"queue:uuid"``) or a
+        bare uuid. A ``"queue:uuid"`` id's own prefix is HONOURED as the queue to
+        query when ``queue`` is left unpassed. ``queue`` defaults to the ``NOT_SET``
+        sentinel rather than the literal string ``"default"`` precisely so an
+        EXPLICITLY passed ``queue=`` — including ``queue="default"`` — is
+        distinguishable from an omitted one: pass one that disagrees with a prefixed
+        id's own queue and this raises ``TaskIdQueueMismatchError`` naming both,
+        instead of silently picking one. A bare uuid (no prefix) resolves ``queue`` to
+        ``"default"`` when left unpassed, same as always.
+
+        A declared-but-unprovisioned queue raises ``QueueNotProvisionedError`` —
+        the same facade ``drain()`` and ``emit()`` give that condition, rather than
+        Django's own ``ProgrammingError`` leaking through this one read. The ORM
+        wraps the underlying ``psycopg.errors.UndefinedTable``, so the classifier
+        reads it off ``exc.__cause__``, not the wrapper. Only a relation of THIS
+        queue's own earns the translation; an unrelated missing relation re-raises
+        as itself, chained, same as ``drain_queue``/``emit_event``.
+        """
+        guard_against_open_transaction(self.alias, "get_result")
+        raw_task_id = str(task_id)
+        if ":" in raw_task_id:
+            prefix_queue, _, raw_task_id = raw_task_id.rpartition(":")
+            if queue is not NOT_SET and queue != prefix_queue:
+                raise TaskIdQueueMismatchError(
+                    task_id=str(task_id), prefix_queue=prefix_queue, queue=queue
+                )
+            resolved_queue = prefix_queue
+        else:
+            resolved_queue = "default" if queue is NOT_SET else queue
+        try:
+            task, run = read_task_and_last_run(self.alias, resolved_queue, raw_task_id)
+        except ProgrammingError as exc:
+            cause = exc.__cause__
+            if not isinstance(
+                cause, psycopg.errors.UndefinedTable
+            ) or not queues.names_a_queue_table(cause, resolved_queue):
+                raise
+            raise QueueNotProvisionedError(resolved_queue) from exc
+        if task is None:
+            return None
+        args, kwargs = decode_params(task.params)
+        return TaskSnapshot(
+            queue=resolved_queue,
+            task_id=task.task_id,
+            task_name=task.task_name,
+            args=args,
+            kwargs=kwargs,
+            state=task.state,
+            attempts=task.attempts,
+            enqueued_at=task.enqueue_at,
+            result=task.completed_payload,
+            failure=None if run is None else run.failure_reason,
+        )
+
+    def emit(
+        self, name: str, payload: "JsonValue | None" = None, queue: str = "default"
+    ) -> None:
+        """Emit ``name`` on ``queue``, delegating to ``events.emit_event``.
+
+        Resolves a task suspended in ``await_event(name)`` on the next ``drain()`` — it
+        does not itself run anything. Prefer this over enqueuing a one-off task that
+        calls ``django_absurd.events.emit_event`` from inside a run: it puts the emit on
+        the SAME timeline the assertions read, at the point the test chooses.
+
+        Transaction-guarded like the reads: an event written inside an open transaction
+        is invisible to the worker's own connection, so the waiting task would simply
+        never wake — a silent no-op instead of a loud error.
+        """
+        guard_against_open_transaction(self.alias, "emit")
+        emit_event(name, payload, queue=queue)
+
+    def drain(self, queue: str = "default") -> list[RunSnapshot]:
+        """Burst-drain ``queue`` synchronously, returning one ``RunSnapshot`` per run
+        executed, in claim order.
+
+        A run that suspended (durable sleep, ``await_event``) is still returned, with
+        ``state="sleeping"`` — the honest reading. The same run can appear twice: an
+        ``await_event`` waiter re-arms its own run when a same-drain emit wakes it, so
+        it first appears ``sleeping`` then ``completed``. Spawned children run in the
+        SAME drain (the burst loop claims until nothing is claimable), so they appear
+        too. ``drain() == []`` does not mean nothing happened — cancellation rules run
+        inside claiming itself and produce no claim row; use ``get_result`` for those.
+
+        The worker import stays in-function for COST and CONTAINMENT, not import-safety
+        (it is settings-free, verified): ``pytest_configure`` imports THIS module on
+        every pytest run in any venv with django-absurd installed, and
+        ``django_absurd.worker`` is the runtime execution engine — asyncio bridge,
+        thread pool, signal handling, and Django 6's brand-new ``django.tasks``. Only
+        ``drain()`` needs any of it, so a project that never drains should not load it
+        at pytest bootstrap, and a future ``django.tasks`` that reads settings at import
+        cannot break unrelated projects' test runs from here.
+        """
+        guard_against_open_transaction(self.alias, "drain")
+        from django_absurd import worker  # noqa: PLC0415
+
+        drained = worker.drain_queue(queue)
+        snapshots: list[RunSnapshot] = []
+        for run in drained:
+            args, kwargs = decode_params(run.params)
+            snapshots.append(
+                RunSnapshot(
+                    queue=queue,
+                    run_id=run.run_id,
+                    task_id=run.task_id,
+                    task_name=run.task_name,
+                    args=args,
+                    kwargs=kwargs,
+                    attempt=run.attempt,
+                    state=run.state,
+                    result=run.result,
+                    failure=run.failure,
+                )
+            )
+        return snapshots
+
+    @contextmanager
+    def freeze_time(self, instant: dt.datetime | None = None) -> t.Iterator[FrozenTime]:
+        """Pin BOTH clocks — Python's and Postgres's — for the duration of the block.
+
+        ``instant`` is a timezone-aware ``datetime``, or ``None`` for real now at
+        entry. Freeze BEFORE enqueueing: freezing to a PAST instant once rows exist
+        leaves their ``available_at`` in the database's future, so nothing is claimable
+        until a move passes it.
+
+        The yielded ``FrozenTime`` is the only way to move durable time, and it moves it
+        only while this block is open. Leaving the block releases both halves, restoring
+        real time, so a test can open several windows in sequence; the fixture's own
+        teardown stays as the crash net for a test that dies inside one.
+
+        Nesting raises instead of stacking: two frozen instants cannot both be "now",
+        and an inner block's exit would restore real time under the outer one rather
+        than the instant it froze.
+        """
+        if self.time_travel is not None:
+            msg = (
+                "django-absurd: freeze_time() is already active, and two frozen "
+                "instants cannot both be 'now'. Move the open freeze with "
+                "move_to()/shift(), or leave its with-block before opening another."
+            )
+            raise RuntimeError(msg)
+        window_open = True
+
+        def move_within_window(
+            dest: dt.datetime, reference: dt.datetime | None
+        ) -> None:
+            """Apply a mover's destination, or refuse once the window has closed.
+
+            An escaped handle would otherwise re-freeze silently — the first move after
+            the block starts a FRESH travel from real now and rewrites the GUC, cleaned
+            up invisibly by the fixture's crash net. That is the exact failure shape
+            this whole facade exists to convert into a loud one.
+
+            ``reference`` passes through the SAME ``now()`` reading a caller already
+            took to build ``dest`` (a bare entry, ``shift()``), so direction is decided
+            against that one reading rather than a second, later one. ``None`` means
+            the caller had no such reading to reuse (an explicit ``move_to()``/entry
+            instant isn't derived from ``now()`` at all), and ``_apply_clock_move``
+            takes its own single reading in that case.
+            """
+            if not window_open:
+                msg = (
+                    "django-absurd: this freeze_time() block has already exited, so "
+                    "durable time is real again. Open a new freeze_time() window to "
+                    "move durable time again."
+                )
+                raise RuntimeError(msg)
+            self._apply_clock_move(dest, reference)
+
+        try:
+            now = dt.datetime.now(dt.UTC)
+            if instant is None:
+                move_within_window(now, now)
+            else:
+                move_within_window(instant, None)
+            yield FrozenTime(_apply_move=move_within_window)
+        finally:
+            window_open = False
+            self._release_clock()
+
+    @property
+    def now(self) -> dt.datetime:
+        """Virtual now, UTC-aware, as POSTGRES reports it.
+
+        Read through a fresh UTC-pinned connection: not Django's session (it can hold a
+        stale or rolled-back ``SET``, and never sees a database-level default applied
+        after it opened) and not Python-side bookkeeping (that would report what we
+        meant to apply, so it could never reveal a Python/Postgres desync — the failure
+        this most needs visible).
+        """
+        with open_test_connection(self.alias) as cursor:
+            cursor.execute("select absurd.current_time()")
+            (instant,) = t.cast("tuple[dt.datetime]", cursor.fetchone())
+        return instant
+
+    def _apply_clock_move(
+        self, when: dt.datetime, reference: dt.datetime | None = None
+    ) -> None:
+        """Move BOTH clocks to ``when``, ordered by DIRECTION so an interrupted move
+        always lands ahead-on-Python — the benign side — never ahead-on-Postgres.
+
+        Postgres ahead of Python is the one unrecoverable direction: the run is
+        claimed, the SDK re-checks the wake on replay and re-suspends, and the burst
+        drain re-arms the same wake forever. Python ahead of Postgres just leaves a
+        sleeping run unclaimed — a merely-incomplete move, not a deadlock. Which order
+        lands which side ahead flips with the direction of the move itself:
+
+        - FORWARD (``when`` at or after the reference instant — the entry freeze to
+          real now, and every ``shift``): Python moves first, Postgres second. A
+          failure in between leaves Python ahead — benign. EQUAL counts as forward, so
+          a bare ``freeze_time()`` entry always takes this branch.
+        - BACKWARD (``when`` strictly before the reference instant — a ``move_to``
+          earlier than the current instant, entry to an explicit past instant
+          included): moving Python first would invert it — Postgres, left at the OLDER
+          instant, would end up ahead once Python jumped back. So Postgres moves first
+          here, Python second, keeping a failure in between on the same benign side.
+
+        ``reference`` is a SINGLE ``now()`` reading, taken once by whichever caller
+        needed one to build ``when`` in the first place (a bare entry, ``shift()``) and
+        passed straight through — never re-read here. A second, later read would let
+        direction resolve by OS clock resolution instead of intent: at a bare entry,
+        ``when`` and the comparison instant would be built from two independent
+        ``now()`` calls, tying or not by chance rather than by rule. ``None`` means the
+        caller had no such reading to reuse (an explicit ``move_to()``/entry instant
+        isn't derived from ``now()`` at all), so this takes its own single reading —
+        still only one read total for that call.
+
+        Both validation arms matter. A non-``datetime`` would otherwise reach
+        ``astimezone`` and die with an unhelpful ``AttributeError``, and a string that
+        survived to the GUC is accepted by ``ALTER DATABASE`` only to explode inside
+        ``absurd.current_time()`` on every NEW session — far from the call that caused
+        it. A naive ``datetime`` is worse than useless: ``absurd.current_time()`` casts
+        the GUC text using the READING session's ``TimeZone``, and the worker's
+        connection inherits the server default, so on a server west of UTC a naive
+        instant puts Postgres ahead of Python — the deadlock direction.
+        """
+        if not isinstance(when, dt.datetime) or when.utcoffset() is None:
+            msg = (
+                "django-absurd: freeze_time() and move_to() need a timezone-aware "
+                "datetime; a naive one is ambiguous and would desynchronise Postgres "
+                "from Python. Pass tzinfo=datetime.UTC (or any zone)."
+            )
+            raise TypeError(msg)
+        guard_against_blocked_database(self.alias)
+        instant = when.astimezone(dt.UTC)
+        current = reference if reference is not None else dt.datetime.now(dt.UTC)
+        if instant < current:
+            self._write_fake_now(instant)
+            self._move_python_clock(instant)
+        else:
+            self._move_python_clock(instant)
+            self._write_fake_now(instant)
+
+    def _move_python_clock(self, instant: dt.datetime) -> None:
+        """Hold Python's clock at ``instant`` via time-machine, ``tick=False``.
+
+        time-machine is a test-time dependency of the PROJECT UNDER TEST, never bundled
+        and never an extra, so the import is lazy and its failure is translated: a
+        ``drain``-only test must not need the package, and Python caches the module so
+        only the first move pays for it.
+
+        ``tick=False`` is a correctness requirement: ``absurd.fake_now`` is a static
+        literal, so Postgres never ticks, and a ticking Python clock would drift out of
+        lockstep with it.
+
+        Both fields are assigned only once ``start()`` has returned, so a failed start
+        leaves nothing for the release to ``stop()``.
+        """
+        try:
+            import time_machine  # noqa: PLC0415
+        except ImportError as err:
+            msg = (
+                "django-absurd: freezing durable time needs the time-machine package. "
+                "Install it in your test environment: pip install time-machine."
+            )
+            raise ImproperlyConfigured(msg) from err
+
+        if self.traveller is None:
+            time_travel = time_machine.travel(instant, tick=False)
+            traveller = time_travel.start()
+            self.time_travel, self.traveller = time_travel, traveller
+        else:
+            self.traveller.move_to(instant)
+
+    def _write_fake_now(self, instant: dt.datetime) -> None:
+        """Set ``absurd.fake_now`` at DATABASE level, then on Django's live session.
+
+        Database level because the burst worker opens its OWN connection per drain and
+        only a database default reaches it; session level as well because a database
+        default reaches only NEW sessions, so an ``enqueue()`` on Django's already-open
+        connection would keep stamping real time.
+
+        ``ALTER DATABASE`` rejects bind parameters, hence the composed literal — and the
+        literal always carries its UTC offset, so the cast inside
+        ``absurd.current_time()`` cannot depend on the reading session's ``TimeZone``.
+        The database name is read at runtime, so xdist's per-worker databases work.
+
+        ``_apply_clock_move`` has already run ``guard_against_blocked_database`` before
+        either clock moves, so a test with no earned DB access never reaches this
+        method's own raw connection at all.
+        """
+        statement = psycopg.sql.SQL(
+            "alter database {name} set absurd.fake_now = {instant}"
+        ).format(
+            name=psycopg.sql.Identifier(connections[self.alias].settings_dict["NAME"]),
+            instant=psycopg.sql.Literal(instant.isoformat()),
+        )
+        with open_test_connection(self.alias) as cursor:
+            cursor.execute(statement)
+        with connections[self.alias].cursor() as session_cursor:
+            session_cursor.execute(
+                "select set_config('absurd.fake_now', %s, false)",
+                [instant.isoformat()],
+            )
+
+    def _release_clock(self) -> None:
+        """Restore real time on both clocks — every ``freeze_time`` block's own exit,
+        and the fixture teardown behind a test that never reached it.
+
+        A runtime with no open freeze touches nothing, which is what makes the two
+        callers safe to chain: whichever runs first releases, the other returns. The
+        Postgres half is released even if stopping time-machine raises — a stopped
+        Python clock over a live ``absurd.fake_now`` is the deadlock direction, and
+        unlike the Python half the GUC outlives the process that set it.
+        """
+        if self.time_travel is None:
+            return
+        time_travel, self.time_travel, self.traveller = self.time_travel, None, None
+        try:
+            time_travel.stop()
+        finally:
+            self._reset_fake_now()
+
+    def _reset_fake_now(self) -> None:
+        """Unset ``absurd.fake_now`` at database level, then on Django's session.
+
+        The database-level half is ``django_absurd.flush.reset_fake_now``, the single
+        implementation of that targeted ``RESET`` (never ``RESET ALL``), shared with the
+        post-test flush and the session-start sweep. The session-level half is a
+        different statement on a different connection — Django's own live session, which
+        a database-level default never reaches.
+        """
+        flush.reset_fake_now(self.alias)
+        with connections[self.alias].cursor() as session_cursor:
+            session_cursor.execute("reset absurd.fake_now")
+
+
+def read_task_and_last_run(
+    alias: str, queue: str, task_id: str
+) -> "tuple[backends.TaskModel | None, backends.RunModel | None]":
+    """Read ``queue``'s task row and its last attempt's run, through Django's ORM.
+
+    The same per-queue dynamic models the production read uses
+    (``backends.fetch_task_and_run``), so the two cannot drift on column names or on
+    jsonb/timestamptz decoding — and no hand-written SQL to keep in step with Absurd's
+    own schema. Not ``fetch_task_and_run`` itself: that one raises
+    ``TaskResultDoesNotExist`` where this must report a missing task as ``None``, and it
+    folds a missing per-queue table into that same error where ``get_result`` lets the
+    original missing-relation error surface.
+
+    Two queries rather than one left join, matching the production read: the run is
+    needed only for its ``failure_reason``, and reading it separately is what lets the
+    ``available_at`` deferral below apply to the run alone.
+    """
+    tasks_spec = next(s for s in admin_views.ADMIN_ENTITY_SPECS if s.name == "tasks")
+    task_model: type[t.Any] = admin_views.build_queue_table_model(tasks_spec, queue)
+    task: backends.TaskModel | None = (
+        task_model.objects.using(alias).filter(pk=task_id).first()
+    )
+    if task is None or task.last_attempt_run is None:
+        return task, None
+    runs_spec = next(s for s in admin_views.ADMIN_ENTITY_SPECS if s.name == "runs")
+    run_model: type[t.Any] = admin_views.build_queue_table_model(runs_spec, queue)
+    run: backends.RunModel | None = (
+        run_model.objects.using(alias)
+        .filter(pk=task.last_attempt_run)
+        # An indefinite await_event parks a run at Postgres's 'infinity' available_at,
+        # which psycopg refuses to decode ("timestamp too large (after year 10K)") —
+        # defer it, since a TaskSnapshot never reads it.
+        .defer("available_at")
+        .first()
+    )
+    return task, run
+
+
+def decode_params(params: t.Any) -> tuple[list[t.Any], dict[str, t.Any]]:
+    """Split raw ``params`` jsonb into ``(args, kwargs)``, defensively.
+
+    Our own ``enqueue()`` always writes both keys under a mapping, even for a
+    zero-arg task, and schedules and task-spawned children take the same path — but a
+    queue shared with raw-SDK producers can hold anything (a bare list, proven). Fall
+    back to empty rather than raising, or one foreign row takes down the whole read.
+    """
+    if isinstance(params, Mapping):
+        return params.get("args", []), params.get("kwargs", {})
+    return [], {}
+
+
+@contextmanager
+def open_test_connection(alias: str) -> t.Iterator[psycopg.Cursor[t.Any]]:
+    """Open a DEDICATED, short-lived, UTC-pinned connection for a test read.
+
+    Built from ``get_connection_params()`` with BOTH ``cursor_factory`` and
+    ``context`` dropped — ``context`` carries Django's psycopg adapters, whose
+    timestamptz loader relabels rather than converts (``replace(tzinfo=...)``), which
+    is only correct when the session's ``TimeZone`` is already UTC. Inherited unpinned
+    on a non-UTC server it silently yields wall-clock digits mislabeled UTC — a
+    different instant. So the session is pinned to UTC itself right after connecting,
+    making every value read back through this connection UTC-aware by construction.
+
+    Not Django's own connection: a held connection never sees a database-level GUC
+    default applied after it opened, and a fresh one is needed on every read anyway
+    (mirrors ``django_absurd/connection.py:open_central_connection``).
+
+    Every remaining caller reads the CLOCK or writes the GUC that fakes it — ``now``,
+    ``_write_fake_now``, and the GUC oracles in ``tests/utils.py``. Nothing here reads a
+    jsonb column any more (task and run state come through the ORM), which is why this
+    registers no json loader of its own.
+    """
+    params: dict[str, t.Any] = connections[alias].get_connection_params()
+    params.pop("cursor_factory", None)
+    params.pop("context", None)
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        with connections[alias].wrap_database_errors, conn.cursor() as cursor:
+            cursor.execute("SET TIME ZONE 'UTC'")
+            yield cursor
+    finally:
+        conn.close()
+
+
+def guard_against_open_transaction(alias: str, operation: str) -> None:
+    """Raise if called from inside an open transaction on ``alias``.
+
+    Checked at CALL time, not fixture setup — a plain ``db`` test, a legitimate
+    ``django_db(transaction=True)`` test that happens to call from inside
+    ``transaction.atomic()``, a ``transactional_db``-only test, and a class-based
+    ``TestCase`` are all covered by ``in_atomic_block``, which a marker/fixture-name
+    check would miss. Uncommitted rows in an open transaction are invisible to
+    Absurd's own connection (worker, or this module's own fresh reads), so the
+    alternative is a confusing, silent wrong answer instead of a loud one.
+    """
+    if connections[alias].in_atomic_block:
+        msg = (
+            f"django-absurd: {operation}() ran inside an open transaction, where "
+            "uncommitted rows are invisible to Absurd's own connection. Use "
+            "@pytest.mark.django_db(transaction=True) and call outside "
+            "transaction.atomic()."
+        )
+        raise RuntimeError(msg)
+
+
+def guard_against_blocked_database(alias: str) -> None:
+    """Raise before ``freeze_time()`` opens its own raw connection, if a test never
+    earned real access to ``alias`` in the first place.
+
+    Touches Django's OWN connection first — ``ensure_connection()``, the exact call
+    pytest-django's DB blocker patches to refuse a test with no ``django_db`` marker —
+    before any raw psycopg connection gets a chance to run. Forcing ``django_db_setup``
+    ourselves would not be enough: pytest-django computes which aliases to provision
+    from the markers across the WHOLE collected session, so a session with no OTHER
+    ``django_db``-marked test touching ``alias`` would leave it unswapped from the live
+    settings database no matter how eagerly this fixture asked for setup. Reusing
+    pytest-django's own per-test block instead catches every such session shape, not
+    just the common one.
+    """
+    try:
+        connections[alias].ensure_connection()
+    except RuntimeError as exc:
+        msg = (
+            "django-absurd: freeze_time() needs real Django database access to pin "
+            f"Postgres's clock on '{alias}', and this test has none. Mark it "
+            "@pytest.mark.django_db(transaction=True)."
+        )
+        raise RuntimeError(msg) from exc

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -23,17 +23,20 @@ run in any venv with django-absurd installed, so its top level must stay setting
 ``django_absurd.pytest_plugin``'s module docstring and ``queues.reconcile_queue``.
 """
 
+import asyncio
 import datetime as dt
 import functools
 import importlib.util
 import typing as t
 import uuid
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 
 import psycopg
 import psycopg.sql
+from asgiref.sync import sync_to_async
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.utils import ProgrammingError
@@ -212,7 +215,10 @@ class AbsurdTestRuntime:
     """Read/drain/clock facade returned by the ``dj_absurd`` pytest fixture.
 
     Public surface: ``freeze_time``, ``now``, ``sync_queues``, ``drain``, ``emit``,
-    ``get_result``. Holds the Absurd backend's database alias and, while a
+    ``get_result``. Every one of them works unchanged — same name, no ``await`` — from
+    an ``async def`` test: the blocking Django/Absurd work each one does goes through
+    ``run_off_event_loop``, which steps off a running event loop when there is one.
+    Holds the Absurd backend's database alias and, while a
     ``freeze_time`` block is open, the time-machine coordinate driving Python's half
     of the clock. ``time_travel``/``traveller`` stay ``None`` outside a freeze — a
     drain-only test pays nothing and cannot leak a frozen clock, and a live
@@ -252,7 +258,7 @@ class AbsurdTestRuntime:
         backend = queues.get_absurd_backend()
         if backend is None:
             raise BackendNotConfiguredError(0)
-        queues.provision_backend(backend)
+        run_off_event_loop(functools.partial(queues.provision_backend, backend))
 
     def get_result(
         self, task_id: str | uuid.UUID, queue: str | NotSet = NOT_SET
@@ -284,7 +290,11 @@ class AbsurdTestRuntime:
         else:
             resolved_queue = "default" if queue is NOT_SET else queue
         try:
-            task, run = read_task_and_last_run(self.alias, resolved_queue, raw_task_id)
+            task, run = run_off_event_loop(
+                functools.partial(
+                    read_task_and_last_run, self.alias, resolved_queue, raw_task_id
+                )
+            )
         except ProgrammingError as exc:
             cause = exc.__cause__
             if not isinstance(
@@ -323,7 +333,7 @@ class AbsurdTestRuntime:
         never wake — a silent no-op instead of a loud error.
         """
         guard_against_open_transaction(self.alias, "emit")
-        emit_event(name, payload, queue=queue)
+        run_off_event_loop(functools.partial(emit_event, name, payload, queue=queue))
 
     def drain(self, queue: str = "default") -> list[RunSnapshot]:
         """Burst-drain ``queue`` synchronously, one ``RunSnapshot`` per run, in claim
@@ -338,13 +348,13 @@ class AbsurdTestRuntime:
 
         The worker import is in-function for cost and containment, not import-safety
         (verified settings-free): only ``drain()`` needs the execution engine, so
-        pytest bootstrap in a non-draining project never loads the asyncio bridge,
-        thread pool, or ``django.tasks``.
+        pytest bootstrap in a non-draining project never loads the absurd SDK's async
+        client or ``django.tasks``.
         """
         guard_against_open_transaction(self.alias, "drain")
         from django_absurd import worker  # noqa: PLC0415
 
-        drained = worker.drain_queue(queue)
+        drained = run_off_event_loop(functools.partial(worker.drain_queue, queue))
         snapshots: list[RunSnapshot] = []
         for run in drained:
             args, kwargs = decode_params(run.params)
@@ -532,6 +542,14 @@ class AbsurdTestRuntime:
         the cast inside ``absurd.current_time()`` cannot depend on the reading
         session's ``TimeZone``. Name read at runtime for xdist's per-worker
         databases.
+
+        Both writes go through ``run_off_event_loop`` together, so under a running loop
+        they land on ONE off-loop connection rather than the session write landing on a
+        second one. Under a loop the session half reaches only that off-loop session
+        (closed on the way out) — an ``async def`` test cannot use Django's sync ORM on
+        its own connection anyway, and every session its work DOES use (``aenqueue``'s
+        ``sync_to_async`` thread, the SDK's own connection per drain) either opens after
+        this write or is opened fresh, inheriting the database-level default.
         """
         statement = psycopg.sql.SQL(
             "alter database {name} set absurd.fake_now = {instant}"
@@ -539,13 +557,17 @@ class AbsurdTestRuntime:
             name=psycopg.sql.Identifier(connections[self.alias].settings_dict["NAME"]),
             instant=psycopg.sql.Literal(instant.isoformat()),
         )
-        with open_test_connection(self.alias) as cursor:
-            cursor.execute(statement)
-        with connections[self.alias].cursor() as session_cursor:
-            session_cursor.execute(
-                "select set_config('absurd.fake_now', %s, false)",
-                [instant.isoformat()],
-            )
+
+        def write_both_clock_levels() -> None:
+            with open_test_connection(self.alias) as cursor:
+                cursor.execute(statement)
+            with connections[self.alias].cursor() as session_cursor:
+                session_cursor.execute(
+                    "select set_config('absurd.fake_now', %s, false)",
+                    [instant.isoformat()],
+                )
+
+        run_off_event_loop(write_both_clock_levels)
 
     def _release_clock(self) -> None:
         """Restore real time on both clocks; a runtime with no open freeze touches
@@ -568,10 +590,19 @@ class AbsurdTestRuntime:
         """Unset at database level via ``flush.reset_fake_now`` (the single
         implementation), then on Django's own live session, which a database-level
         default never reaches.
+
+        Paired with ``_write_fake_now``'s hop so the two halves release wherever they
+        were set: a ``freeze_time`` block exited inside an ``async def`` test releases
+        off the loop, while the fixture's own teardown runs after the loop has closed
+        and releases in place.
         """
-        flush.reset_fake_now(self.alias)
-        with connections[self.alias].cursor() as session_cursor:
-            session_cursor.execute("reset absurd.fake_now")
+
+        def reset_both_clock_levels() -> None:
+            flush.reset_fake_now(self.alias)
+            with connections[self.alias].cursor() as session_cursor:
+                session_cursor.execute("reset absurd.fake_now")
+
+        run_off_event_loop(reset_both_clock_levels)
 
 
 def read_task_and_last_run(
@@ -679,9 +710,23 @@ def guard_against_blocked_database(alias: str) -> None:
     the WHOLE session's markers, so an unmarked-elsewhere session leaves ``alias``
     unswapped. Reusing pytest-django's own per-test block instead catches every such
     session shape, not just the common one.
+
+    Off the loop when there is one, because ``ensure_connection`` is exactly what
+    Django's ``async_unsafe`` decorator refuses outright — so under a running loop the
+    guard could not run at all on the calling thread. It loses nothing by changing
+    threads: BOTH blocks it relies on are patched onto ``BaseDatabaseWrapper`` ITSELF
+    (pytest-django's ``_blocking_wrapper``, and Django's undeclared-alias
+    ``mock.patch.object``), so they fire for whichever thread's connection asks. The
+    alias is re-resolved INSIDE the hop rather than the calling thread's wrapper being
+    handed over: connecting stamps ``_thread_ident``, and a test connection first
+    opened by the hop thread would then refuse the test's own later cursors.
     """
-    try:
+
+    def ensure_the_test_can_reach_the_database() -> None:
         connections[alias].ensure_connection()
+
+    try:
+        run_off_event_loop(ensure_the_test_can_reach_the_database)
     except RuntimeError as exc:
         msg = (
             "django-absurd: freeze_time() needs real Django database access to pin "
@@ -708,3 +753,69 @@ def require_time_machine() -> None:
         raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE) from err
     if not installed:
         raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE)
+
+
+def run_off_event_loop[T](work: t.Callable[[], T]) -> T:
+    """Run ``work`` somewhere Django's synchronous API is legal, and block for its
+    result — which is what lets one facade serve both a plain ``def test_`` and an
+    ``async def`` one with no second API and no ``await``.
+
+    With no loop running in this thread, ``work`` is simply called: the sync path is
+    untouched, same thread, same connection, same traceback. Under a running loop it
+    goes to a worker thread, where there IS no running loop, so both Django's
+    ``async_unsafe`` guards and ``asyncio.run`` inside the burst worker are legal
+    again. Blocking the loop is safe here because a test is the only thing on it and
+    ``work`` never awaits it back — ``drain()``'s ``arun_worker`` builds a loop of its
+    own in the worker thread.
+
+    Callers keep their guards on THEIR OWN thread and call this for the DB work only:
+    ``in_atomic_block`` is per-connection and ``connections`` is thread-local, so a
+    transaction guard evaluated over here would inspect a connection the test never
+    used and pass every time.
+
+    Two sets of Django connections are closed on the way out, both of them sessions no
+    test-runner teardown reaches, and one stranded session is enough to fail teardown's
+    ``DROP DATABASE`` (the trap ``worker.aworker_client`` already closes for):
+
+    - the worker thread's own, opened by ``work`` — ``connections`` is thread-critical,
+      so these are objects the test itself never saw;
+    - asgiref's thread-sensitive session, where ``aenqueue`` and Django's own async ORM
+      (``aget``, ``acreate``, …) run their synchronous halves. That one is a
+      process-wide thread whose session inherits ``absurd.fake_now`` at CONNECT time,
+      and a session-level ``SET`` can only ever reach the thread it runs on — so a
+      connection opened before a freeze, or before the last clock move, keeps stamping
+      the wrong instant, and does so for every LATER test too. Measured, before this
+      close: one preceding ``await Model.objects.acount()`` was enough to make a frozen
+      week-long sleep enqueue at real time and never wake. Recycling costs one
+      reconnect and leaves the next session to inherit whatever the clock now says.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return work()
+
+    def run_then_close_connections() -> T:
+        try:
+            return work()
+        finally:
+            connections.close_all()
+            # A loop of this thread's own, so asgiref resolves thread-sensitive work to
+            # its process-wide thread rather than back here — the same dispatch
+            # ``worker.aworker_client``'s own closing hop already relies on.
+            asyncio.run(sync_to_async(connections.close_all)())
+
+    return get_off_loop_executor().submit(run_then_close_connections).result()
+
+
+@functools.cache
+def get_off_loop_executor() -> ThreadPoolExecutor:
+    """The one worker thread every ``run_off_event_loop`` hop shares, built on first
+    use.
+
+    Cached, not per call or per fixture: a fresh executor per call would leak a thread
+    per drain across a suite, and the runtime that owns the fixture is function-scoped,
+    so hanging it there would leak one per test instead. One worker is enough because
+    each hop blocks until it returns, and a nested call inside the worker thread finds
+    no running loop and never queues behind itself.
+    """
+    return ThreadPoolExecutor(max_workers=1, thread_name_prefix="dj-absurd-test")

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -25,6 +25,7 @@ run in any venv with django-absurd installed, so its top level must stay setting
 
 import datetime as dt
 import functools
+import importlib.util
 import typing as t
 import uuid
 from collections.abc import Mapping
@@ -52,6 +53,11 @@ if t.TYPE_CHECKING:
     from absurd_sdk import JsonValue
 
 CLEANUP_MARKER = "absurd_cleanup_installed"
+
+TIME_MACHINE_MISSING_MESSAGE = (
+    "django-absurd: freezing durable time needs the time-machine package. Install it "
+    "in your test environment: pip install time-machine."
+)
 
 
 def install_absurd_cleanup() -> None:
@@ -456,6 +462,15 @@ class AbsurdTestRuntime:
         cause. A NAIVE one is worse — the GUC text is cast with the READING session's
         ``TimeZone``, so a server west of UTC lands Postgres-ahead: the deadlock
         direction.
+
+        ``require_time_machine()`` runs before either clock write below — both clocks
+        move together or neither does. Without it, the BACKWARD branch would write
+        Postgres's GUC first and only discover the missing dependency once
+        ``_move_python_clock`` ran, so a project without time-machine would see the
+        GUC written and then stranded: ``self.time_travel`` was never assigned (the
+        failed ``_move_python_clock`` call raises before either field is set), so
+        ``_release_clock`` treats the freeze as never having opened and leaves the
+        database-level GUC in place.
         """
         if not isinstance(when, dt.datetime) or when.utcoffset() is None:
             msg = (
@@ -465,6 +480,7 @@ class AbsurdTestRuntime:
             )
             raise TypeError(msg)
         guard_against_blocked_database(self.alias)
+        require_time_machine()
         instant = when.astimezone(dt.UTC)
         current = reference if reference is not None else dt.datetime.now(dt.UTC)
         if instant < current:
@@ -478,9 +494,11 @@ class AbsurdTestRuntime:
         """Hold Python's clock at ``instant`` via time-machine, ``tick=False``.
 
         time-machine is a test-time dependency of the PROJECT UNDER TEST, never bundled
-        and never an extra, so the import is lazy and its failure is translated: a
-        ``drain``-only test must not need the package, and Python caches the module so
-        only the first move pays for it.
+        and never an extra, so the import is lazy: a ``drain``-only test must not need
+        the package, and Python caches the module so only the first move pays for it.
+        ``_apply_clock_move`` has already called ``require_time_machine()`` before
+        either clock moved, so this import is expected to succeed — the ``except``
+        below is a defence-in-depth translation, not the primary guard.
 
         ``tick=False`` is a correctness requirement: ``absurd.fake_now`` is a static
         literal, so Postgres never ticks, and a ticking Python clock would drift out of
@@ -492,11 +510,7 @@ class AbsurdTestRuntime:
         try:
             import time_machine  # noqa: PLC0415
         except ImportError as err:
-            msg = (
-                "django-absurd: freezing durable time needs the time-machine package. "
-                "Install it in your test environment: pip install time-machine."
-            )
-            raise ImproperlyConfigured(msg) from err
+            raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE) from err
 
         if self.traveller is None:
             time_travel = time_machine.travel(instant, tick=False)
@@ -673,3 +687,22 @@ def guard_against_blocked_database(alias: str) -> None:
             "@pytest.mark.django_db(transaction=True)."
         )
         raise RuntimeError(msg) from exc
+
+
+def require_time_machine() -> None:
+    """Raise ``ImproperlyConfigured`` before either clock moves, if time-machine is not
+    installed.
+
+    Called from ``_apply_clock_move`` ahead of both the Postgres GUC write and the
+    Python clock move, so a project without the optional dependency fails atomically —
+    neither clock is touched. ``importlib.util.find_spec`` rather than a bare
+    ``import time_machine``: a probe-only import with no later use of the bound name is
+    exactly what a linter flags as unused, and ``_move_python_clock`` already performs
+    the real import once it has actual work for the module to do.
+    """
+    try:
+        installed = importlib.util.find_spec("time_machine") is not None
+    except ImportError as err:
+        raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE) from err
+    if not installed:
+        raise ImproperlyConfigured(TIME_MACHINE_MISSING_MESSAGE)

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -45,6 +45,7 @@ from django_absurd.exceptions import (
     BackendNotConfiguredError,
     QueueNotProvisionedError,
     TaskIdQueueMismatchError,
+    TaskNotFoundError,
 )
 from django_absurd.params import NOT_SET, NotSet
 
@@ -255,8 +256,8 @@ class AbsurdTestRuntime:
 
     def get_result(
         self, task_id: str | uuid.UUID, queue: str | NotSet = NOT_SET
-    ) -> TaskSnapshot | None:
-        """Look up one task by id, returning ``None`` if it doesn't exist.
+    ) -> TaskSnapshot:
+        """Look up one task by id, raising ``TaskNotFoundError`` if it doesn't exist.
 
         ``task_id`` is a Django ``TaskResult.id`` (``"queue:uuid"``) or a bare uuid.
         A prefixed id's own queue wins when ``queue`` is unpassed; the default is the
@@ -271,7 +272,8 @@ class AbsurdTestRuntime:
         missing relation re-raises as itself, chained.
         """
         guard_against_open_transaction(self.alias, "get_result")
-        raw_task_id = str(task_id)
+        original_task_id = str(task_id)
+        raw_task_id = original_task_id
         if ":" in raw_task_id:
             prefix_queue, _, raw_task_id = raw_task_id.rpartition(":")
             if queue is not NOT_SET and queue != prefix_queue:
@@ -291,7 +293,7 @@ class AbsurdTestRuntime:
                 raise
             raise QueueNotProvisionedError(resolved_queue) from exc
         if task is None:
-            return None
+            raise TaskNotFoundError(task_id=original_task_id, queue=resolved_queue)
         args, kwargs = decode_params(task.params)
         return TaskSnapshot(
             queue=resolved_queue,

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -12,24 +12,15 @@ The project's no-monkeypatch rule governs test-code hygiene; this is library tes
 integration (pytest-django itself patches ``BaseDatabaseWrapper.ensure_connection``),
 so the patch here is deliberate.
 
-``AbsurdTestRuntime`` (returned by the ``dj_absurd`` pytest fixture in
-``django_absurd.pytest_plugin``) is the read/drain/clock facade for durable tests:
-``sync_queues``, ``get_result``, ``drain``, ``emit``, the transaction guard all four
-share, plus clock control (``freeze_time``, which yields a ``FrozenTime``, and
-``now``). Every other
-METHOD on that class is an internal and carries a leading underscore; its dataclass
-fields are plain state, not part of the public surface.
+``AbsurdTestRuntime`` (yielded by the ``dj_absurd`` fixture in
+``django_absurd.pytest_plugin``) is the read/drain/clock facade for durable tests;
+underscore-prefixed methods are internal, and its dataclass fields are plain state.
 
-**Import-safety constraint**: ``django_absurd.pytest_plugin.pytest_configure`` imports
-this module on EVERY pytest run in ANY venv that has django-absurd installed — Django
-project or not — so this module's top level must stay settings-free. Everything
-imported above is: the one import that would read ``INSTALLED_APPS`` is
-``django_absurd.models``, and it is confined to ``queues.reconcile_queue``'s own
-function body (see the comment there). Never add a module-level import here that
-reaches ``django_absurd.models``, ``.checks`` or ``.admin`` — the run would die with
-``INTERNALERROR: ImproperlyConfigured`` before collecting anything, in every non-Django
-project in the venv. ``tests/core/test_pytest_plugin.py``'s
-``test_a_pytest_run_with_no_django_settings_still_collects`` guards exactly that.
+**Import-safety constraint**: ``pytest_configure`` imports this module on every pytest
+run in any venv with django-absurd installed, so its top level must stay settings-free
+— never add a module-level import reaching ``django_absurd.models``/``.checks``/
+``.admin``. Full constraint and the one sanctioned choke point:
+``django_absurd.pytest_plugin``'s module docstring and ``queues.reconcile_queue``.
 """
 
 import datetime as dt
@@ -119,7 +110,7 @@ class TaskSnapshot:
     """Where one task stands: one row from ``t_<queue>``, left-joined to its last
     attempt's run for ``failure``.
 
-    Caveats, measured (see the design doc for the full reasoning):
+    Caveats, measured:
 
     - ``attempts`` counts attempts CREATED, not completed — a task retried once (one
       failure, one pending replacement) already reads ``attempts=2`` before the second
@@ -148,15 +139,11 @@ class RunSnapshot:
     """One run executed during a ``drain()``, in claim order.
 
     ``drain()`` reports what RUNS did; ``get_result()`` reports where a TASK stands —
-    conflating the two is what makes ``TaskSnapshot`` unable to express an in-flight
-    retry (see its own caveats). Per-run state is read right after THAT run's own
-    execution, never batched at drain end: a run that suspends (``sleeping``) or fails
-    (``failed``, with its own ``failure``) reports honestly, and a retry sequence reads
-    attempt-by-attempt instead of collapsing to one final verdict.
-
-    The same ``run_id`` can legitimately appear twice in one drain: an ``await_event``
-    waiter re-arms its own run, so it first appears ``sleeping`` and later
-    ``completed``.
+    which is why ``TaskSnapshot`` cannot express an in-flight retry (see its
+    caveats). State is read right after each run's own execution, never batched at
+    drain end, so a retry sequence reads attempt-by-attempt. The same ``run_id`` can
+    appear twice: an ``await_event`` waiter re-arms its own run — first ``sleeping``,
+    later ``completed``.
     """
 
     queue: str
@@ -173,19 +160,15 @@ class RunSnapshot:
 
 @dataclass(frozen=True)
 class FrozenTime:
-    """The handle ``AbsurdTestRuntime.freeze_time`` yields: durable time's two movers.
+    """Handle yielded by ``AbsurdTestRuntime.freeze_time``: durable time's only
+    movers.
 
-    ``move_to``/``shift`` are time-machine's own ``Coordinates`` vocabulary, and the
-    absence of a ``travel`` is deliberate — travelling implies ticking, while both
-    halves of this clock are frozen: ``absurd.fake_now`` is a static literal, so
-    Postgres never ticks, and a ticking Python clock would drift out of lockstep with
-    it.
-
-    ``move_to`` and ``shift`` are the whole surface. ``_apply_move`` behind them is the
-    window's own two-clock apply, bound when the freeze opened, so the handle carries no
-    clock state of its own — the runtime stays the single owner of what has to be
-    released. It also holds the window open/closed, so BOTH movers raise once the block
-    has exited rather than silently re-freezing real time behind the test's back.
+    ``move_to``/``shift`` are time-machine's ``Coordinates`` vocabulary; no ``travel``
+    because travelling implies ticking, and ``absurd.fake_now`` is a static literal —
+    a ticking Python clock would drift out of lockstep. ``_apply_move`` is the open
+    window's two-clock apply: the handle carries no clock state (the runtime owns
+    release) and both movers raise once the block has exited rather than silently
+    re-freezing real time.
     """
 
     _apply_move: t.Callable[[dt.datetime, dt.datetime | None], None]
@@ -207,9 +190,9 @@ class FrozenTime:
         there is one source of truth instead of bookkeeping of our own that could
         disagree with it.
 
-        That same reading is also passed through as the direction reference, so
+        That same reading passes through as the direction reference, so
         ``_apply_clock_move`` decides forward-vs-backward against the exact ``now()``
-        this method took, not a second, later one of its own.
+        this method took.
 
         Valid only while the ``freeze_time`` block that yielded this handle is open.
         """
@@ -221,20 +204,13 @@ class FrozenTime:
 class AbsurdTestRuntime:
     """Read/drain/clock facade returned by the ``dj_absurd`` pytest fixture.
 
-    Holds the Django database alias the Absurd backend runs on, and — for as long as a
-    ``freeze_time`` block is open — the time-machine coordinate driving Python's half of
-    the clock. Every per-queue method resolves its queue name from its own argument,
-    defaulting to ``"default"`` — except ``get_result``, which prefers a prefixed id's
-    own queue over an unpassed ``queue`` argument (see its own docstring), and
-    ``sync_queues``, which is whole-catalog and takes no queue at all.
-
     Public surface: ``freeze_time``, ``now``, ``sync_queues``, ``drain``, ``emit``,
-    ``get_result``.
-
-    ``time_travel`` is what release stops; ``traveller`` is what later moves take. Both
-    stay ``None`` outside a ``freeze_time`` block, which is how a drain-only test pays
-    nothing and cannot leak a frozen clock, and a live ``time_travel`` is what makes a
-    nested freeze detectable.
+    ``get_result``. Holds the Absurd backend's database alias and, while a
+    ``freeze_time`` block is open, the time-machine coordinate driving Python's half
+    of the clock. ``time_travel``/``traveller`` stay ``None`` outside a freeze — a
+    drain-only test pays nothing and cannot leak a frozen clock, and a live
+    ``time_travel`` is what makes a nested freeze detectable. ``time_travel`` is what
+    release stops; ``traveller`` is what later moves take.
     """
 
     alias: str
@@ -254,23 +230,16 @@ class AbsurdTestRuntime:
         self._release_clock()
 
     def sync_queues(self) -> None:
-        """Provision every queue declared on the Absurd backend — the runtime
-        counterpart of ``manage.py absurd_sync_queues``.
+        """Provision every declared queue — the runtime counterpart of ``manage.py
+        absurd_sync_queues``.
 
-        **Rarely needed, so don't reach for it defensively.** django-absurd provisions
-        the declared catalog from its own ``post_migrate`` receiver, and pytest-django
-        migrates the test database, so a test that enqueues on a declared queue already
-        has its tables. What needs this is a test that CHANGED the topology: a
-        ``settings`` override declaring a queue the migration never saw, or a fixture
-        that dropped the queues to isolate itself.
-
-        Whole-catalog, hence no ``queue`` argument — provisioning also rebuilds the
-        admin views over the FULL catalog, which reconciling one queue cannot express.
-
-        Transaction-guarded like the reads, for a different reason: ``create_queue`` is
-        DDL, so a sync inside an open transaction is invisible to the worker's own
-        connection and is rolled back with the test — provisioning that looks like it
-        happened and didn't.
+        Rarely needed: migrate already provisions the declared catalog. Reach for it
+        only when the test CHANGED topology — a ``settings`` override declaring a
+        queue the migration never saw, or a fixture that dropped the queues.
+        Whole-catalog (no ``queue`` argument) because provisioning also rebuilds the
+        admin views over the full catalog. Transaction-guarded because the DDL would
+        be invisible to the worker's connection and rolled back with the test —
+        provisioning that looks like it happened and didn't.
         """
         guard_against_open_transaction(self.alias, "sync_queues")
         backend = queues.get_absurd_backend()
@@ -283,23 +252,17 @@ class AbsurdTestRuntime:
     ) -> TaskSnapshot | None:
         """Look up one task by id, returning ``None`` if it doesn't exist.
 
-        ``task_id`` accepts either a Django ``TaskResult.id`` (``"queue:uuid"``) or a
-        bare uuid. A ``"queue:uuid"`` id's own prefix is HONOURED as the queue to
-        query when ``queue`` is left unpassed. ``queue`` defaults to the ``NOT_SET``
-        sentinel rather than the literal string ``"default"`` precisely so an
-        EXPLICITLY passed ``queue=`` — including ``queue="default"`` — is
-        distinguishable from an omitted one: pass one that disagrees with a prefixed
-        id's own queue and this raises ``TaskIdQueueMismatchError`` naming both,
-        instead of silently picking one. A bare uuid (no prefix) resolves ``queue`` to
-        ``"default"`` when left unpassed, same as always.
+        ``task_id`` is a Django ``TaskResult.id`` (``"queue:uuid"``) or a bare uuid.
+        A prefixed id's own queue wins when ``queue`` is unpassed; the default is the
+        ``NOT_SET`` sentinel (not ``"default"``) so an EXPLICITLY passed ``queue=`` —
+        even ``queue="default"`` — that disagrees with the prefix raises
+        ``TaskIdQueueMismatchError`` instead of silently picking a side. A bare uuid
+        resolves an unpassed ``queue`` to ``"default"``.
 
-        A declared-but-unprovisioned queue raises ``QueueNotProvisionedError`` —
-        the same facade ``drain()`` and ``emit()`` give that condition, rather than
-        Django's own ``ProgrammingError`` leaking through this one read. The ORM
-        wraps the underlying ``psycopg.errors.UndefinedTable``, so the classifier
-        reads it off ``exc.__cause__``, not the wrapper. Only a relation of THIS
-        queue's own earns the translation; an unrelated missing relation re-raises
-        as itself, chained, same as ``drain_queue``/``emit_event``.
+        A declared-but-unprovisioned queue raises ``QueueNotProvisionedError``, the
+        same facade ``drain()``/``emit()`` give it. The ORM wraps the underlying
+        ``UndefinedTable``, so the classifier reads ``exc.__cause__``; an unrelated
+        missing relation re-raises as itself, chained.
         """
         guard_against_open_transaction(self.alias, "get_result")
         raw_task_id = str(task_id)
@@ -355,25 +318,20 @@ class AbsurdTestRuntime:
         emit_event(name, payload, queue=queue)
 
     def drain(self, queue: str = "default") -> list[RunSnapshot]:
-        """Burst-drain ``queue`` synchronously, returning one ``RunSnapshot`` per run
-        executed, in claim order.
+        """Burst-drain ``queue`` synchronously, one ``RunSnapshot`` per run, in claim
+        order.
 
-        A run that suspended (durable sleep, ``await_event``) is still returned, with
-        ``state="sleeping"`` — the honest reading. The same run can appear twice: an
-        ``await_event`` waiter re-arms its own run when a same-drain emit wakes it, so
-        it first appears ``sleeping`` then ``completed``. Spawned children run in the
-        SAME drain (the burst loop claims until nothing is claimable), so they appear
-        too. ``drain() == []`` does not mean nothing happened — cancellation rules run
-        inside claiming itself and produce no claim row; use ``get_result`` for those.
+        A suspended run (durable sleep, ``await_event``) is returned with
+        ``state="sleeping"``. The same run can appear twice — an ``await_event``
+        waiter re-arms when a same-drain emit wakes it: first ``sleeping``, later
+        ``completed``. Spawned children run in the SAME drain. ``drain() == []`` does
+        not mean nothing happened — cancellation rules run inside claiming itself and
+        produce no claim row; use ``get_result`` for those.
 
-        The worker import stays in-function for COST and CONTAINMENT, not import-safety
-        (it is settings-free, verified): ``pytest_configure`` imports THIS module on
-        every pytest run in any venv with django-absurd installed, and
-        ``django_absurd.worker`` is the runtime execution engine — asyncio bridge,
-        thread pool, signal handling, and Django 6's brand-new ``django.tasks``. Only
-        ``drain()`` needs any of it, so a project that never drains should not load it
-        at pytest bootstrap, and a future ``django.tasks`` that reads settings at import
-        cannot break unrelated projects' test runs from here.
+        The worker import is in-function for cost and containment, not import-safety
+        (verified settings-free): only ``drain()`` needs the execution engine, so
+        pytest bootstrap in a non-draining project never loads the asyncio bridge,
+        thread pool, or ``django.tasks``.
         """
         guard_against_open_transaction(self.alias, "drain")
         from django_absurd import worker  # noqa: PLC0415
@@ -430,17 +388,11 @@ class AbsurdTestRuntime:
         ) -> None:
             """Apply a mover's destination, or refuse once the window has closed.
 
-            An escaped handle would otherwise re-freeze silently — the first move after
-            the block starts a FRESH travel from real now and rewrites the GUC, cleaned
-            up invisibly by the fixture's crash net. That is the exact failure shape
-            this whole facade exists to convert into a loud one.
-
-            ``reference`` passes through the SAME ``now()`` reading a caller already
-            took to build ``dest`` (a bare entry, ``shift()``), so direction is decided
-            against that one reading rather than a second, later one. ``None`` means
-            the caller had no such reading to reuse (an explicit ``move_to()``/entry
-            instant isn't derived from ``now()`` at all), and ``_apply_clock_move``
-            takes its own single reading in that case.
+            An escaped handle would otherwise re-freeze silently — a FRESH travel
+            from real now plus a rewritten GUC, cleaned up invisibly by the crash
+            net: the exact failure shape this facade exists to make loud.
+            ``reference`` is the ``now()`` reading the caller built ``dest`` from
+            (entry, ``shift``); ``None`` when ``dest`` wasn't derived from ``now()``.
             """
             if not window_open:
                 msg = (
@@ -478,45 +430,32 @@ class AbsurdTestRuntime:
         return instant
 
     def _apply_clock_move(
-        self, when: dt.datetime, reference: dt.datetime | None = None
+        self, when: dt.datetime, reference: dt.datetime | None
     ) -> None:
-        """Move BOTH clocks to ``when``, ordered by DIRECTION so an interrupted move
-        always lands ahead-on-Python — the benign side — never ahead-on-Postgres.
+        """Move BOTH clocks to ``when``, ordered by direction so an interrupted move
+        always lands Python-ahead — the benign side.
 
-        Postgres ahead of Python is the one unrecoverable direction: the run is
-        claimed, the SDK re-checks the wake on replay and re-suspends, and the burst
-        drain re-arms the same wake forever. Python ahead of Postgres just leaves a
-        sleeping run unclaimed — a merely-incomplete move, not a deadlock. Which order
-        lands which side ahead flips with the direction of the move itself:
+        Postgres-ahead is unrecoverable: the run is claimed, the SDK re-suspends on
+        replay, and the burst drain re-arms the same wake forever. Python-ahead just
+        leaves a sleeping run unclaimed. Which order lands which side ahead flips with
+        the move's direction:
 
-        - FORWARD (``when`` at or after the reference instant — the entry freeze to
-          real now, and every ``shift``): Python moves first, Postgres second. A
-          failure in between leaves Python ahead — benign. EQUAL counts as forward, so
-          a bare ``freeze_time()`` entry always takes this branch.
-        - BACKWARD (``when`` strictly before the reference instant — a ``move_to``
-          earlier than the current instant, entry to an explicit past instant
-          included): moving Python first would invert it — Postgres, left at the OLDER
-          instant, would end up ahead once Python jumped back. So Postgres moves first
-          here, Python second, keeping a failure in between on the same benign side.
+        - FORWARD (``when`` at/after ``reference``; entry and every ``shift``): Python
+          first, Postgres second. Equal counts as forward, so a bare ``freeze_time()``
+          entry takes this branch.
+        - BACKWARD (``when`` strictly before ``reference``): Postgres first — moving
+          Python first would leave Postgres at the older instant, i.e. ahead.
 
-        ``reference`` is a SINGLE ``now()`` reading, taken once by whichever caller
-        needed one to build ``when`` in the first place (a bare entry, ``shift()``) and
-        passed straight through — never re-read here. A second, later read would let
-        direction resolve by OS clock resolution instead of intent: at a bare entry,
-        ``when`` and the comparison instant would be built from two independent
-        ``now()`` calls, tying or not by chance rather than by rule. ``None`` means the
-        caller had no such reading to reuse (an explicit ``move_to()``/entry instant
-        isn't derived from ``now()`` at all), so this takes its own single reading —
-        still only one read total for that call.
+        ``reference`` is the caller's single ``now()`` reading, never re-read here — a
+        second read would let direction resolve by OS clock resolution instead of
+        intent. ``None``: the caller had no reading (explicit ``move_to``/entry
+        instant), so take one now.
 
-        Both validation arms matter. A non-``datetime`` would otherwise reach
-        ``astimezone`` and die with an unhelpful ``AttributeError``, and a string that
-        survived to the GUC is accepted by ``ALTER DATABASE`` only to explode inside
-        ``absurd.current_time()`` on every NEW session — far from the call that caused
-        it. A naive ``datetime`` is worse than useless: ``absurd.current_time()`` casts
-        the GUC text using the READING session's ``TimeZone``, and the worker's
-        connection inherits the server default, so on a server west of UTC a naive
-        instant puts Postgres ahead of Python — the deadlock direction.
+        Aware-or-raise: a non-``datetime`` would die later in ``astimezone`` or
+        explode inside ``absurd.current_time()`` on every NEW session, far from the
+        cause. A NAIVE one is worse — the GUC text is cast with the READING session's
+        ``TimeZone``, so a server west of UTC lands Postgres-ahead: the deadlock
+        direction.
         """
         if not isinstance(when, dt.datetime) or when.utcoffset() is None:
             msg = (
@@ -569,19 +508,14 @@ class AbsurdTestRuntime:
     def _write_fake_now(self, instant: dt.datetime) -> None:
         """Set ``absurd.fake_now`` at DATABASE level, then on Django's live session.
 
-        Database level because the burst worker opens its OWN connection per drain and
-        only a database default reaches it; session level as well because a database
-        default reaches only NEW sessions, so an ``enqueue()`` on Django's already-open
-        connection would keep stamping real time.
-
-        ``ALTER DATABASE`` rejects bind parameters, hence the composed literal — and the
-        literal always carries its UTC offset, so the cast inside
-        ``absurd.current_time()`` cannot depend on the reading session's ``TimeZone``.
-        The database name is read at runtime, so xdist's per-worker databases work.
-
-        ``_apply_clock_move`` has already run ``guard_against_blocked_database`` before
-        either clock moves, so a test with no earned DB access never reaches this
-        method's own raw connection at all.
+        Database level because the burst worker opens its OWN connection per drain —
+        only a database default reaches it; session level too because a default
+        reaches only NEW sessions, so ``enqueue()`` on Django's already-open
+        connection would keep stamping real time. ``ALTER DATABASE`` rejects bind
+        parameters, hence the composed literal; it always carries its UTC offset, so
+        the cast inside ``absurd.current_time()`` cannot depend on the reading
+        session's ``TimeZone``. Name read at runtime for xdist's per-worker
+        databases.
         """
         statement = psycopg.sql.SQL(
             "alter database {name} set absurd.fake_now = {instant}"
@@ -598,14 +532,13 @@ class AbsurdTestRuntime:
             )
 
     def _release_clock(self) -> None:
-        """Restore real time on both clocks — every ``freeze_time`` block's own exit,
-        and the fixture teardown behind a test that never reached it.
+        """Restore real time on both clocks; a runtime with no open freeze touches
+        nothing, so block exit and fixture teardown chain safely.
 
-        A runtime with no open freeze touches nothing, which is what makes the two
-        callers safe to chain: whichever runs first releases, the other returns. The
-        Postgres half is released even if stopping time-machine raises — a stopped
-        Python clock over a live ``absurd.fake_now`` is the deadlock direction, and
-        unlike the Python half the GUC outlives the process that set it.
+        The Postgres half is released even if stopping time-machine raises — a
+        stopped Python clock over a live ``absurd.fake_now`` is the deadlock
+        direction, and unlike the Python half the GUC outlives the process that set
+        it.
         """
         if self.time_travel is None:
             return
@@ -616,13 +549,9 @@ class AbsurdTestRuntime:
             self._reset_fake_now()
 
     def _reset_fake_now(self) -> None:
-        """Unset ``absurd.fake_now`` at database level, then on Django's session.
-
-        The database-level half is ``django_absurd.flush.reset_fake_now``, the single
-        implementation of that targeted ``RESET`` (never ``RESET ALL``), shared with the
-        post-test flush and the session-start sweep. The session-level half is a
-        different statement on a different connection — Django's own live session, which
-        a database-level default never reaches.
+        """Unset at database level via ``flush.reset_fake_now`` (the single
+        implementation), then on Django's own live session, which a database-level
+        default never reaches.
         """
         flush.reset_fake_now(self.alias)
         with connections[self.alias].cursor() as session_cursor:
@@ -636,8 +565,7 @@ def read_task_and_last_run(
 
     The same per-queue dynamic models the production read uses
     (``backends.fetch_task_and_run``), so the two cannot drift on column names or on
-    jsonb/timestamptz decoding — and no hand-written SQL to keep in step with Absurd's
-    own schema. Not ``fetch_task_and_run`` itself: that one raises
+    jsonb/timestamptz decoding. Not ``fetch_task_and_run`` itself: that one raises
     ``TaskResultDoesNotExist`` where this must report a missing task as ``None``, and it
     folds a missing per-queue table into that same error where ``get_result`` lets the
     original missing-relation error surface.
@@ -682,24 +610,16 @@ def decode_params(params: t.Any) -> tuple[list[t.Any], dict[str, t.Any]]:
 
 @contextmanager
 def open_test_connection(alias: str) -> t.Iterator[psycopg.Cursor[t.Any]]:
-    """Open a DEDICATED, short-lived, UTC-pinned connection for a test read.
+    """Open a dedicated, short-lived, UTC-pinned connection for a test read.
 
-    Built from ``get_connection_params()`` with BOTH ``cursor_factory`` and
-    ``context`` dropped — ``context`` carries Django's psycopg adapters, whose
-    timestamptz loader relabels rather than converts (``replace(tzinfo=...)``), which
-    is only correct when the session's ``TimeZone`` is already UTC. Inherited unpinned
-    on a non-UTC server it silently yields wall-clock digits mislabeled UTC — a
-    different instant. So the session is pinned to UTC itself right after connecting,
-    making every value read back through this connection UTC-aware by construction.
-
-    Not Django's own connection: a held connection never sees a database-level GUC
-    default applied after it opened, and a fresh one is needed on every read anyway
-    (mirrors ``django_absurd/connection.py:open_central_connection``).
-
-    Every remaining caller reads the CLOCK or writes the GUC that fakes it — ``now``,
-    ``_write_fake_now``, and the GUC oracles in ``tests/utils.py``. Nothing here reads a
-    jsonb column any more (task and run state come through the ORM), which is why this
-    registers no json loader of its own.
+    BOTH ``cursor_factory`` and ``context`` are dropped: ``context`` carries Django's
+    psycopg adapters, whose timestamptz loader RELABELS rather than converts
+    (``replace(tzinfo=...)``) — correct only when the session zone is UTC, so the
+    session is pinned to UTC right after connecting. Not Django's own connection: a
+    held session never sees a database-level GUC default applied after it opened, and
+    a fresh one is needed per read anyway (mirrors ``connection.py``'s
+    ``open_central_connection``). Callers read the clock or write the GUC — nothing
+    reads jsonb through this, hence no json loader.
     """
     params: dict[str, t.Any] = connections[alias].get_connection_params()
     params.pop("cursor_factory", None)
@@ -716,13 +636,11 @@ def open_test_connection(alias: str) -> t.Iterator[psycopg.Cursor[t.Any]]:
 def guard_against_open_transaction(alias: str, operation: str) -> None:
     """Raise if called from inside an open transaction on ``alias``.
 
-    Checked at CALL time, not fixture setup — a plain ``db`` test, a legitimate
-    ``django_db(transaction=True)`` test that happens to call from inside
-    ``transaction.atomic()``, a ``transactional_db``-only test, and a class-based
-    ``TestCase`` are all covered by ``in_atomic_block``, which a marker/fixture-name
-    check would miss. Uncommitted rows in an open transaction are invisible to
-    Absurd's own connection (worker, or this module's own fresh reads), so the
-    alternative is a confusing, silent wrong answer instead of a loud one.
+    Checked at CALL time, not fixture setup — every legitimate call shape is
+    covered by ``in_atomic_block``, which a marker/fixture-name check would miss.
+    Uncommitted rows in an open transaction are invisible to Absurd's own connection
+    (worker, or this module's own fresh reads), so the alternative is a confusing,
+    silent wrong answer instead of a loud one.
     """
     if connections[alias].in_atomic_block:
         msg = (
@@ -740,13 +658,11 @@ def guard_against_blocked_database(alias: str) -> None:
 
     Touches Django's OWN connection first — ``ensure_connection()``, the exact call
     pytest-django's DB blocker patches to refuse a test with no ``django_db`` marker —
-    before any raw psycopg connection gets a chance to run. Forcing ``django_db_setup``
-    ourselves would not be enough: pytest-django computes which aliases to provision
-    from the markers across the WHOLE collected session, so a session with no OTHER
-    ``django_db``-marked test touching ``alias`` would leave it unswapped from the live
-    settings database no matter how eagerly this fixture asked for setup. Reusing
-    pytest-django's own per-test block instead catches every such session shape, not
-    just the common one.
+    before any raw psycopg connection gets a chance to run. Forcing
+    ``django_db_setup`` would not be enough — pytest-django provisions aliases from
+    the WHOLE session's markers, so an unmarked-elsewhere session leaves ``alias``
+    unswapped. Reusing pytest-django's own per-test block instead catches every such
+    session shape, not just the common one.
     """
     try:
         connections[alias].ensure_connection()

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -55,12 +55,10 @@ class WorkerOptions:
 class DrainedRun:
     """One run executed during a burst drain, in claim order.
 
-    Identity (``run_id``/``task_id``/``task_name``/``attempt``/``params``) rides free
-    from the claim row the SDK's ``ClaimedTask`` already returns; ``state``/``result``/
-    ``failure`` cost one read per run, taken immediately after THAT run executes — never
-    batched at drain end, so a run that re-arms itself (an ``await_event`` waiter) keeps
-    its earlier ``sleeping`` appearance honest instead of it being overwritten by the
-    same run's later ``completed`` one.
+    ``state``/``result``/``failure`` cost one read per run, taken immediately after
+    THAT run executes — never batched at drain end, so a run that re-arms itself (an
+    ``await_event`` waiter) keeps its earlier ``sleeping`` appearance honest instead
+    of it being overwritten by the same run's later ``completed`` one.
 
     ``run_id``/``task_id`` are ``uuid.UUID`` at runtime even though the SDK's
     ``ClaimedTask`` stub types them ``str`` — psycopg deserializes the uuid columns.
@@ -119,21 +117,14 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
 def drain_queue(queue: str = "default") -> list[DrainedRun]:
     """Burst-drain ``queue`` in-process, one ``DrainedRun`` per run, in claim order.
 
-    The entry point behind ``AbsurdTestRuntime.drain``, so it resolves the backend
-    itself and takes no ``WorkerOptions``: the fixture exposes no worker knobs, and
-    concurrency is covered through the ``absurd_worker`` CLI instead.
-
-    It provisions nothing. ``migrate`` already provisions every declared queue (see
-    ``apps.provision_queues_after_migrate``), so a test database arrives ready; a queue
-    declared mid-test through changed settings has no table yet, and that surfaces as
-    the same curated error ``events.emit_event`` raises for the condition rather than as
-    schema mutation from a call tests read results through.
-
-    Only a relation of THIS queue's own earns that translation. Any other missing
-    relation — a user's audit trigger pointing at a dropped table, a schema half
-    migrated — is re-raised as itself, because "run absurd_sync_queues" would send the
-    reader to the wrong door and would not fix it. The curated error chains the original
-    either way, so the failing relation stays visible in the traceback.
+    The entry point behind ``AbsurdTestRuntime.drain``: resolves the backend itself
+    and takes no ``WorkerOptions`` — worker knobs live on the ``absurd_worker`` CLI.
+    Provisions nothing: migrate already provisions every declared queue, so a queue
+    declared mid-test surfaces as the same ``QueueNotProvisionedError``
+    ``events.emit_event`` raises — not as schema DDL from a call tests read results
+    through. Only a relation of THIS queue's own earns that translation; any other
+    missing relation re-raises as itself (chained, so it stays visible), because
+    "run absurd_sync_queues" would send the reader to the wrong door.
     """
     backend = resolve_backend()
     if queue not in backend.queues:
@@ -226,15 +217,12 @@ async def aworker_client(
         yield client
     finally:
         await conn.close()
-        # fetch_run_outcome's ORM read runs through asgiref's THREAD-SENSITIVE
-        # executor — one process-wide thread, whatever the concurrency — so it opens a
-        # Django connection in a thread nothing else ever tears down, and that session
-        # would outlive the whole worker run. One session is enough to fail a
-        # ``DROP DATABASE``: measured, a pytest run without ``--reuse-db`` ends in
-        # "database ... is being accessed by other users" and strands the test database.
-        # Closing here rather than per read keeps it to one hop per run, and lands it in
-        # that same thread (both calls resolve the same executor, which is what
-        # thread_sensitive means). The blocking worker reads nothing, so it is free.
+        # fetch_run_outcome's ORM read runs on asgiref's thread-sensitive executor —
+        # one process-wide thread nothing else tears down — so its Django session
+        # would outlive the whole worker run, and one session fails DROP DATABASE
+        # (measured: a run without --reuse-db dies with "database ... is being
+        # accessed by other users"). Close once per run, here, in that same thread
+        # (both calls resolve the same executor). The blocking worker reads nothing.
         await sync_to_async(close_old_connections)()
 
 
@@ -290,24 +278,15 @@ async def execute_claimed_run(
 async def fetch_run_outcome(
     database: str, queue: str, run_id: str
 ) -> tuple[str, t.Any, t.Any]:
-    """Read one run's own current ``state``/``result``/``failure_reason``.
+    """Read one run's current ``state``/``result``/``failure_reason``.
 
-    No public SDK accessor keys a read by ``run_id`` (only by ``task_id``, which would
-    collapse a retry's several runs into one), so this reads the run row itself —
-    through the same per-queue dynamic model ``backends.fetch_task_and_run`` and
-    ``AbsurdTestRuntime.get_result`` read, rather than SQL of its own.
-
-    Django's ORM, so on DJANGO's connection rather than the worker's own async one:
-    ``aget`` is ``sync_to_async(get)``, a hop into a worker thread. That cost is only
-    ever paid by a BURST drain — ``execute_claimed_run`` is unreachable from the
-    blocking worker, which hands its whole loop to the SDK's ``start_worker`` — and next
-    to executing the task itself it is noise. The row is visible from another session
-    because the SDK writes it on an autocommit connection, so it is committed by the
-    time ``_execute_task`` returns.
-
-    ``aget``, not ``afirst``: the run was just claimed and executed, so a missing row is
-    a broken invariant that should raise, not read as ``None`` and fail later on an
-    attribute.
+    No public SDK accessor keys a read by ``run_id`` (only ``task_id``, which
+    collapses a retry's several runs), so read the run row through the same
+    per-queue dynamic model the other reads use — no SQL of its own. ORM means
+    Django's connection via a ``sync_to_async`` hop; only burst drains pay it, and
+    next to executing the task it is noise. The row is committed by the time
+    ``_execute_task`` returns (the SDK writes on autocommit). ``aget``, not
+    ``afirst``: a missing just-executed run is a broken invariant that should raise.
     """
     runs_spec = next(s for s in admin_views.ADMIN_ENTITY_SPECS if s.name == "runs")
     run_model: type[t.Any] = admin_views.build_queue_table_model(runs_spec, queue)

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -5,6 +5,7 @@ import signal
 import threading
 import time
 import typing as t
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -15,22 +16,25 @@ from absurd_sdk import (
     AsyncAbsurd,
     AsyncTaskContext,
     CancelledTask,
+    ClaimedTask,
     FailedTask,
     JsonValue,
     SuspendTask,
 )
+from asgiref.sync import sync_to_async
 from django.core.exceptions import ImproperlyConfigured
-from django.core.management.base import CommandError
 from django.db import close_old_connections, connections
 from django.tasks import Task, TaskContext, TaskResult, TaskResultStatus
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
-from django_absurd.backends import AbsurdBackend, TaskParams
+from django_absurd import admin_views
+from django_absurd.backends import AbsurdBackend, RunModel, TaskParams
 from django_absurd.connection import register_jsonb_loader, validate_backend
 from django_absurd.context import WORKER_LOOP
+from django_absurd.exceptions import QueueNotDeclaredError, QueueNotProvisionedError
 from django_absurd.management.base import resolve_backend
-from django_absurd.queues import SyncResult, provision_backend
+from django_absurd.queues import names_a_queue_table
 from django_absurd.scheduler import run_beat
 
 logger = logging.getLogger("django_absurd")
@@ -45,6 +49,31 @@ class WorkerOptions:
     poll_interval: float = 0.25
     batch_size: int | None = None
     worker_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DrainedRun:
+    """One run executed during a burst drain, in claim order.
+
+    Identity (``run_id``/``task_id``/``task_name``/``attempt``/``params``) rides free
+    from the claim row the SDK's ``ClaimedTask`` already returns; ``state``/``result``/
+    ``failure`` cost one read per run, taken immediately after THAT run executes — never
+    batched at drain end, so a run that re-arms itself (an ``await_event`` waiter) keeps
+    its earlier ``sleeping`` appearance honest instead of it being overwritten by the
+    same run's later ``completed`` one.
+
+    ``run_id``/``task_id`` are ``uuid.UUID`` at runtime even though the SDK's
+    ``ClaimedTask`` stub types them ``str`` — psycopg deserializes the uuid columns.
+    """
+
+    run_id: uuid.UUID
+    task_id: uuid.UUID
+    task_name: str
+    params: t.Any
+    attempt: int
+    state: str
+    result: t.Any | None
+    failure: t.Any | None
 
 
 class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
@@ -87,28 +116,35 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
         return super().get(name, default)
 
 
-def run_burst_worker(
-    queue: str = "default",
-    *,
-    options: WorkerOptions | None = None,
-) -> SyncResult:
-    options = options or WorkerOptions()
+def drain_queue(queue: str = "default") -> list[DrainedRun]:
+    """Burst-drain ``queue`` in-process, one ``DrainedRun`` per run, in claim order.
+
+    The entry point behind ``AbsurdTestRuntime.drain``, so it resolves the backend
+    itself and takes no ``WorkerOptions``: the fixture exposes no worker knobs, and
+    concurrency is covered through the ``absurd_worker`` CLI instead.
+
+    It provisions nothing. ``migrate`` already provisions every declared queue (see
+    ``apps.provision_queues_after_migrate``), so a test database arrives ready; a queue
+    declared mid-test through changed settings has no table yet, and that surfaces as
+    the same curated error ``events.emit_event`` raises for the condition rather than as
+    schema mutation from a call tests read results through.
+
+    Only a relation of THIS queue's own earns that translation. Any other missing
+    relation — a user's audit trigger pointing at a dropped table, a schema half
+    migrated — is re-raised as itself, because "run absurd_sync_queues" would send the
+    reader to the wrong door and would not fix it. The curated error chains the original
+    either way, so the failing relation stays visible in the traceback.
+    """
     backend = resolve_backend()
     if queue not in backend.queues:
-        valid = ", ".join(sorted(backend.queues))
-        msg = (
-            f"Queue '{queue}' is not declared for backend '{backend.alias}'."
-            f" Valid queues: {valid}"
-        )
-        raise CommandError(msg)
+        raise QueueNotDeclaredError(queue, backend.alias, backend.queues)
 
     try:
-        result = provision_backend(backend)
-    except ImproperlyConfigured as exc:
-        raise CommandError(str(exc)) from exc
-
-    run_worker(backend, queue, burst=True, options=options)
-    return result
+        return run_worker(backend, queue, burst=True)
+    except psycopg.errors.UndefinedTable as exc:
+        if not names_a_queue_table(exc, queue):
+            raise
+        raise QueueNotProvisionedError(queue) from exc
 
 
 def run_worker(
@@ -118,10 +154,10 @@ def run_worker(
     burst: bool = False,
     run_beat: bool = False,
     options: WorkerOptions | None = None,
-) -> None:
+) -> list[DrainedRun]:
     options = options or WorkerOptions()
     validate_backend(backend.database)
-    asyncio.run(
+    return asyncio.run(
         arun_worker(backend, queue, burst=burst, run_beat=run_beat, options=options)
     )
 
@@ -133,7 +169,7 @@ async def arun_worker(
     burst: bool = False,
     run_beat: bool = False,
     options: WorkerOptions,
-) -> None:
+) -> list[DrainedRun]:
     with ThreadPoolExecutor(max_workers=options.concurrency) as executor:
         loop = asyncio.get_running_loop()
         loop.set_default_executor(executor)
@@ -148,17 +184,12 @@ async def arun_worker(
                 options.concurrency,
             )
             if burst:
-                await drain_queue(
-                    client,
-                    concurrency=options.concurrency,
-                    claim_timeout=options.claim_timeout,
-                    batch_size=options.batch_size,
-                    worker_id=options.worker_id,
-                )
-            elif run_beat:
+                return await adrain_queue(backend.database, client, queue, options)
+            if run_beat:
                 await run_worker_with_beat(client, options, backend)
             else:
                 await run_blocking_worker(client, options)
+            return []
 
 
 @asynccontextmanager
@@ -168,6 +199,8 @@ async def aworker_client(
     # DEDICATED async connection (built from Django's DB config, NOT Django's registered
     # connection). cursor_factory from Django's params is fatal for AsyncConnection
     # (sync cursor factory incompatible with async execute) — pop it before connecting.
+    # The connection stays private to the client built on it: every read django-absurd
+    # makes for itself goes through the ORM instead.
     params: dict[str, t.Any] = connections[backend.database].get_connection_params()
     params.pop("cursor_factory", None)
     conn: psycopg.AsyncConnection = await psycopg.AsyncConnection.connect(
@@ -193,28 +226,95 @@ async def aworker_client(
         yield client
     finally:
         await conn.close()
+        # fetch_run_outcome's ORM read runs through asgiref's THREAD-SENSITIVE
+        # executor — one process-wide thread, whatever the concurrency — so it opens a
+        # Django connection in a thread nothing else ever tears down, and that session
+        # would outlive the whole worker run. One session is enough to fail a
+        # ``DROP DATABASE``: measured, a pytest run without ``--reuse-db`` ends in
+        # "database ... is being accessed by other users" and strands the test database.
+        # Closing here rather than per read keeps it to one hop per run, and lands it in
+        # that same thread (both calls resolve the same executor, which is what
+        # thread_sensitive means). The blocking worker reads nothing, so it is free.
+        await sync_to_async(close_old_connections)()
 
 
-async def drain_queue(
+async def adrain_queue(
+    database: str,
     client: AsyncAbsurd,
-    *,
-    concurrency: int = 1,
-    claim_timeout: int = 120,
-    batch_size: int | None = None,
-    worker_id: str | None = None,
-) -> int:
-    count = 0
+    queue: str,
+    options: WorkerOptions,
+) -> list[DrainedRun]:
+    drained: list[DrainedRun] = []
     while True:
         claimed = await client.claim_tasks(
-            batch_size or concurrency, claim_timeout, worker_id or "worker"
+            options.batch_size or options.concurrency,
+            options.claim_timeout,
+            options.worker_id or "worker",
         )
         if not claimed:
             break
-        await asyncio.gather(
-            *[client._execute_task(t_, claim_timeout) for t_ in claimed]  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
+        drained.extend(
+            await asyncio.gather(
+                *[
+                    execute_claimed_run(
+                        database, client, queue, claimed_task, options.claim_timeout
+                    )
+                    for claimed_task in claimed
+                ]
+            )
         )
-        count += len(claimed)
-    return count
+    return drained
+
+
+async def execute_claimed_run(
+    database: str,
+    client: AsyncAbsurd,
+    queue: str,
+    claimed: ClaimedTask,
+    claim_timeout: int,
+) -> DrainedRun:
+    await client._execute_task(claimed, claim_timeout)  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
+    state, result, failure = await fetch_run_outcome(database, queue, claimed["run_id"])
+    return DrainedRun(
+        run_id=t.cast("uuid.UUID", claimed["run_id"]),
+        task_id=t.cast("uuid.UUID", claimed["task_id"]),
+        task_name=claimed["task_name"],
+        params=claimed["params"],
+        attempt=claimed["attempt"],
+        state=state,
+        result=result,
+        failure=failure,
+    )
+
+
+async def fetch_run_outcome(
+    database: str, queue: str, run_id: str
+) -> tuple[str, t.Any, t.Any]:
+    """Read one run's own current ``state``/``result``/``failure_reason``.
+
+    No public SDK accessor keys a read by ``run_id`` (only by ``task_id``, which would
+    collapse a retry's several runs into one), so this reads the run row itself —
+    through the same per-queue dynamic model ``backends.fetch_task_and_run`` and
+    ``AbsurdTestRuntime.get_result`` read, rather than SQL of its own.
+
+    Django's ORM, so on DJANGO's connection rather than the worker's own async one:
+    ``aget`` is ``sync_to_async(get)``, a hop into a worker thread. That cost is only
+    ever paid by a BURST drain — ``execute_claimed_run`` is unreachable from the
+    blocking worker, which hands its whole loop to the SDK's ``start_worker`` — and next
+    to executing the task itself it is noise. The row is visible from another session
+    because the SDK writes it on an autocommit connection, so it is committed by the
+    time ``_execute_task`` returns.
+
+    ``aget``, not ``afirst``: the run was just claimed and executed, so a missing row is
+    a broken invariant that should raise, not read as ``None`` and fail later on an
+    attribute.
+    """
+    runs_spec = next(s for s in admin_views.ADMIN_ENTITY_SPECS if s.name == "runs")
+    run_model: type[t.Any] = admin_views.build_queue_table_model(runs_spec, queue)
+    run: RunModel = (
+        await run_model.objects.using(database).defer("available_at").aget(pk=run_id)
+    )
+    return run.state, run.result, run.failure_reason
 
 
 def build_task_context(

--- a/docs/plans/2026-07-29-durable-test-clock.md
+++ b/docs/plans/2026-07-29-durable-test-clock.md
@@ -1,0 +1,1280 @@
+# Durable test clock — `absurd` fixture: implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement task-by-task. Steps use checkbox (`- [ ]`)
+> syntax.
+
+**Goal:** ship an `absurd` pytest fixture that advances durable time deterministically,
+so sleep / event-timeout / retry-backoff / claim-expiry / cancellation behavior is
+testable without wall-clock waiting.
+
+**Architecture:** pin BOTH clocks that gate a sleeping run — Postgres via Absurd's own
+`absurd.fake_now` GUC set at DATABASE level (the worker opens its own connection per
+drain), and Python via time-machine `tick=False`. `fake_now` never ticks, so Python must
+be frozen too. Reads happen on fresh UTC-pinned connections. `drain()` returns per-run
+records; `get_result()` returns a task-level record.
+
+**Tech stack:** Django 6.0, psycopg 3, absurd-sdk, pytest + pytest-django, time-machine
+(runtime-detected, NOT bundled).
+
+**Spec:** `docs/specs/2026-07-28-durable-test-clock-design.md`. Read it before starting;
+it carries the reasoning and the measured evidence behind every rule below.
+
+## Global constraints
+
+- Floor Django 6.0 / Python 3.12. psycopg (v3) backend only.
+- `import typing as t` — never `from typing import X`. Absolute imports only.
+- Functions contain a verb. No leading-underscore module constants/helpers. Helpers go
+  BELOW their public callers.
+- pytest, function-based only. Autouse `_enable_db` gives DB access — do NOT add
+  `@pytest.mark.django_db`; add `(transaction=True)` only when commits/DDL needed.
+- No monkeypatching / `unittest.mock.patch`. ONE deliberate exception, spec-sanctioned:
+  the `sys.meta_path` finder in Task 3's missing-dependency test.
+- Assert the COMPLETE error message, never a fragment.
+- Alphabetize `@pytest.mark.parametrize` values and each test's own fixture parameters.
+- mypy strict. Narrow `# type: ignore[...]` allowed only where a test deliberately
+  passes something the checker rejects.
+- No ruff ignore / `noqa` without asking first.
+- 100% statement+branch coverage on lines this patch adds.
+- Gates before a behavior commit: `uvx --with tox-uv tox -e dev` and
+  `uv run pre-commit run --all-files`. Iterating: `uv run pytest <path> -v`.
+- Compose services must be up: `docker compose up -d db db_pg_cron`.
+- Every new test file: `pytestmark = pytest.mark.django_db(transaction=True)` — the
+  fixture requires it and refuses otherwise.
+
+## File structure
+
+| File                                                                   | Responsibility                                                                                                                                                           |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `django_absurd/test.py` (modify)                                       | public test surface: `RunSnapshot`, `TaskSnapshot`, the runtime object, fresh-connection reader. Already hosts `install_absurd_cleanup` / `flush_absurd_after_teardown`. |
+| `django_absurd/flush.py` (modify)                                      | `flush_absurd_state` gains the defensive GUC reset — it lives HERE, not in `test.py`                                                                                     |
+| `django_absurd/pytest_plugin.py` (modify)                              | `absurd` fixture, `absurd_drain_queue` delegate, session-start GUC sweep                                                                                                 |
+| `django_absurd/worker.py` (modify)                                     | widen `drain_queue` / `run_burst_worker` to return claim rows                                                                                                            |
+| `tests/tasks.py` (modify)                                              | new fixture tasks the new tests execute                                                                                                                                  |
+| `tests/core/test_absurd_fixture.py` (create)                           | read surface, drain return, transaction guard, emit, alias                                                                                                               |
+| `tests/core/test_durable_clock.py` (create)                            | freeze/advance against real durable primitives                                                                                                                           |
+| `tests/core/test_pytest_plugin.py` (modify)                            | teardown reset + session-start sweep                                                                                                                                     |
+| `docs/web/testing.md`, `django_absurd/AGENTS.md`, `CLAUDE.md` (modify) | user + maintainer docs                                                                                                                                                   |
+
+Phase 2 (own plan, NOT this one): freezegun→time-machine migration, converting
+`tests/core/test_durable.py`'s four `time.sleep(2)` recipes, raising the fixture tasks'
+1.5s sleeps, and replacing 24 `utils.get_task_result` call sites. Spec section "Adopt in
+the existing suite".
+
+---
+
+## Task 1: read surface — snapshots on a fresh UTC-pinned connection
+
+Delivers `absurd.get_result()` plus the transaction guard. No clock yet.
+
+**Files:**
+
+- Modify: `django_absurd/test.py`
+- Modify: `django_absurd/pytest_plugin.py`
+- Modify: `tests/tasks.py`
+- Test: `tests/core/test_absurd_fixture.py` (create)
+
+**Interfaces:**
+
+- Consumes: `django_absurd.connection.register_jsonb_loader`, `django.db.connections`,
+  existing `tests.utils.run_absurd_worker`.
+- Produces:
+  - `django_absurd.test.TaskSnapshot` — frozen dataclass, fields `queue: str`,
+    `task_id: uuid.UUID`, `task_name: str`, `args: list[t.Any]`,
+    `kwargs: dict[str, t.Any]`, `state: str`, `attempts: int`,
+    `enqueued_at: dt.datetime`, `result: t.Any | None`, `failure: t.Any | None`.
+  - `django_absurd.test.AbsurdTestRuntime` with
+    `get_result(task_id: str | uuid.UUID, queue: str = "default") -> TaskSnapshot | None`.
+  - `absurd` pytest fixture yielding `AbsurdTestRuntime`.
+  - `django_absurd.test.open_test_connection(alias: str)` — context manager yielding a
+    cursor on a fresh UTC-pinned connection.
+
+- [ ] **Step 1: add the fixture tasks these tests execute**
+
+No new fixture tasks are needed. `tests/tasks.py` already has `add` (completes) and
+`boom` (raises `ValueError("boom")` under the default retry policy) — use those. Do NOT
+add a near-duplicate of either.
+
+- [ ] **Step 2: write the failing tests**
+
+Create `tests/core/test_absurd_fixture.py`:
+
+```python
+import typing as t
+import uuid
+
+import psycopg
+import pytest
+from django.core.management import call_command
+from django.db import connections, transaction
+
+from django_absurd.test import AbsurdTestRuntime, TaskSnapshot
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_get_result_reports_a_completed_task(absurd: AbsurdTestRuntime) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+
+    snapshot = absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.queue == "default"
+    assert snapshot.task_name == "tests.tasks.add"
+    assert snapshot.args == [2, 3]
+    assert snapshot.kwargs == {}
+    assert snapshot.state == "completed"
+    assert snapshot.result == 5
+    assert snapshot.failure is None
+    assert snapshot.attempts == 1
+    assert isinstance(snapshot.task_id, uuid.UUID)
+
+
+def test_get_result_reports_a_failed_task_with_its_failure(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.boom.enqueue()
+    utils.run_absurd_worker()
+
+    snapshot = absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.state == "failed"
+    assert snapshot.result is None
+    assert snapshot.failure is not None
+    assert snapshot.failure["name"] == "ValueError"
+    assert snapshot.failure["message"] == "boom"
+
+
+def test_get_result_decodes_jsonb_to_python_objects(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.create_payload.enqueue({"k": "v", "n": 7})
+    utils.run_absurd_worker()
+
+    snapshot = absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.args == [{"k": "v", "n": 7}]
+    assert not isinstance(snapshot.args[0], str)
+    assert isinstance(snapshot.result, int)
+
+
+def test_get_result_returns_none_for_an_unknown_task(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+
+    assert absurd.get_result(uuid.uuid4()) is None
+
+
+def test_get_result_tolerates_params_that_are_not_our_shape(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    """A queue shared with raw-SDK producers can hold any JSON in params."""
+    call_command("absurd_sync_queues")
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+    task_id = str(result.id).rsplit(":", 1)[-1]
+    params = connections["default"].get_connection_params()
+    params.pop("cursor_factory", None)
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "update absurd.t_default set params = %s where task_id = %s",
+                ["[1, 2, 3]", task_id],
+            )
+    finally:
+        conn.close()
+
+    snapshot = absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.args == []
+    assert snapshot.kwargs == {}
+
+
+def test_get_result_accepts_a_bare_uuid(absurd: AbsurdTestRuntime) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+    bare = str(result.id).rsplit(":", 1)[-1]
+
+    snapshot = absurd.get_result(bare)
+
+    assert snapshot is not None
+    assert snapshot.state == "completed"
+
+
+def test_get_result_inside_an_open_transaction_raises(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+
+    with (
+        transaction.atomic(),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                r"django-absurd: get_result\(\) ran inside an open transaction, where "
+                r"uncommitted rows are invisible to Absurd's own connection\. Use "
+                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+                r"transaction\.atomic\(\)\."
+            ),
+        ),
+    ):
+        absurd.get_result(result.id)
+```
+
+Add a non-transactional guard test in the same file — it needs its own marker, so give
+it an explicit override:
+
+```python
+@pytest.mark.django_db(transaction=False)
+def test_get_result_in_a_plain_db_test_raises(absurd: AbsurdTestRuntime) -> None:
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"django-absurd: get_result\(\) ran inside an open transaction, where "
+            r"uncommitted rows are invisible to Absurd's own connection\. Use "
+            r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+            r"transaction\.atomic\(\)\."
+        ),
+    ):
+        absurd.get_result(uuid.uuid4())
+```
+
+- [ ] **Step 3: run the tests, confirm they fail**
+
+Run: `uv run pytest tests/core/test_absurd_fixture.py -v` Expected: collection error —
+`cannot import name 'AbsurdTestRuntime' from 'django_absurd.test'`.
+
+- [ ] **Step 4: implement the fresh-connection reader**
+
+In `django_absurd/test.py`, add a context manager that opens a short-lived connection
+for reads. Build params from `connections[alias].get_connection_params()`, then remove
+BOTH `cursor_factory` and `context`. Dropping `context` is load-bearing, not tidiness:
+Django's adapter relabels timestamptz with `replace(tzinfo=...)`, which is only correct
+when the session is already UTC — inherited unpinned on a non-UTC server it yields
+wall-clock digits mislabeled UTC, a different instant. Connect autocommit,
+`SET TIME ZONE 'UTC'`, apply `register_jsonb_loader`, yield a cursor, close in
+`finally`. Mirror the shape of `django_absurd/connection.py:open_central_connection`.
+
+- [ ] **Step 5: implement `TaskSnapshot` and `get_result`**
+
+Add the frozen dataclass with the fields from Interfaces. Add `AbsurdTestRuntime`
+holding the backend alias and queue defaults.
+
+`get_result` accepts either a Django `TaskResult.id` (`queue:uuid`) or a bare uuid —
+split on the last `:` as `tests/utils.py` already does. It checks the transaction guard
+first (Task 1 step 6), then runs ONE query against `t_<q>` left-joining `r_<q>` on
+`last_attempt_run` for `failure_reason`, on the fresh connection. Compose table names
+with `psycopg.sql.Identifier`. Decode `params` defensively with exactly ONE branch — an
+`isinstance(params, Mapping)` guard around `params.get("args", [])` /
+`params.get("kwargs", {})`. Two nested conditions (mapping AND carries-the-keys) leave
+the mapping-without-keys arm unreachable by any test, and the patch-coverage gate fails
+on it. Return `None` when no row.
+
+- [ ] **Step 6: implement the transaction guard**
+
+A module-level function in `django_absurd/test.py`, called at the top of every public
+read/drain method — call time, never fixture setup. At setup the check would be
+unreliable in a user project with no autouse db fixture; a method body always runs after
+every db fixture. Condition: `connections[alias].in_atomic_block`. Raise `RuntimeError`
+with the message the tests assert verbatim, naming the operation. Word it as "ran inside
+an open transaction", never "the marker is missing" — a legitimate `transaction=True`
+test calling inside `atomic()` hits the same invisibility.
+
+- [ ] **Step 7: expose the `absurd` fixture**
+
+In `django_absurd/pytest_plugin.py`, add a function-scoped `absurd` fixture that
+constructs `AbsurdTestRuntime`. Keep the module's import-safety rule: imports of
+anything Django-touching stay INSIDE the function body (this module is imported by
+pytest's plugin bootstrap in every project that has django-absurd installed).
+
+- [ ] **Step 8: run the tests, confirm they pass**
+
+Run: `uv run pytest tests/core/test_absurd_fixture.py -v` Expected: PASS, 8 tests.
+
+- [ ] **Step 9: gates + commit**
+
+```bash
+uv run pre-commit run --all-files
+uvx --with tox-uv tox -e dev
+git add django_absurd/test.py django_absurd/pytest_plugin.py tests/tasks.py tests/core/test_absurd_fixture.py
+git commit -m "feat(test): absurd fixture with get_result snapshots"
+```
+
+---
+
+## Task 2: `drain()` returning per-run records
+
+**Files:**
+
+- Modify: `django_absurd/worker.py`
+- Modify: `django_absurd/test.py`
+- Modify: `django_absurd/pytest_plugin.py`
+- Modify: `django_absurd/management/commands/absurd_worker.py:93` — consumes the return
+- Modify: `tests/core/test_worker.py:442-446` — asserts the return
+- Modify: `tests/tasks.py`
+- Test: `tests/core/test_absurd_fixture.py`
+
+**Interfaces:**
+
+- Consumes: Task 1's `open_test_connection`, transaction guard, `AbsurdTestRuntime`.
+- Produces:
+  - `django_absurd.test.RunSnapshot` — frozen dataclass, fields `queue: str`,
+    `run_id: uuid.UUID`, `task_id: uuid.UUID`, `task_name: str`, `args: list[t.Any]`,
+    `kwargs: dict[str, t.Any]`, `attempt: int`, `state: str`, `result: t.Any | None`,
+    `failure: t.Any | None`.
+  - `AbsurdTestRuntime.drain(queue: str = "default") -> list[RunSnapshot]`.
+  - `django_absurd.worker.run_burst_worker(queue, *, options) -> tuple[SyncResult, list[DrainedRun]]`
+    — now a tuple, so both existing consumers need a one-line update (Step 4).
+  - `django_absurd.worker.DrainedRun` — frozen dataclass, fields `run_id: uuid.UUID`,
+    `task_id: uuid.UUID`, `task_name: str`, `params: t.Any`, `attempt: int`,
+    `state: str`, `result: t.Any | None`, `failure: t.Any | None`. Lives in `worker.py`,
+    NOT in `test.py`: `test.py` imports `django.test`, which production code must not
+    pull in. `drain_queue` returns `list[DrainedRun]`; `run_burst_worker` returns them
+    alongside its existing `SyncResult`.
+
+- [ ] **Step 1: add the fixture tasks these tests execute**
+
+`tests/tasks.py`:
+
+```python
+@task
+def spawn_child_then_return(value: int) -> str:
+    run_child.enqueue(value)
+    return "spawned"
+
+
+@task
+def run_child(value: int) -> int:
+    return value * 2
+
+
+@task
+@absurd_params(retry_strategy=RetryStrategy(kind="fixed", base_seconds=0))
+def fail_twice_then_succeed() -> str:
+    RETRY_CALLS["n"] += 1
+    if RETRY_CALLS["n"] < 3:
+        msg = f"attempt {RETRY_CALLS['n']} fails"
+        raise ValueError(msg)
+    return "third-time-lucky"
+```
+
+Add `RETRY_CALLS: dict[str, int] = {"n": 0}` beside the existing `SYNC_STEP_CALLS`
+counter and reset it in each test that uses it (the existing `SYNC_STEP_CALLS` tests
+show the pattern).
+
+- [ ] **Step 2: write the failing tests**
+
+Append to `tests/core/test_absurd_fixture.py`:
+
+```python
+def test_drain_returns_nothing_when_the_queue_is_empty(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+
+    assert absurd.drain() == []
+
+
+def test_drain_returns_one_record_per_run_in_claim_order(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    tasks.add.enqueue(2, 3)
+    tasks.add.enqueue(4, 5)
+
+    drained = absurd.drain()
+
+    assert [(run.task_name, run.args, run.attempt, run.state) for run in drained] == [
+        ("tests.tasks.add", [2, 3], 1, "completed"),
+        ("tests.tasks.add", [4, 5], 1, "completed"),
+    ]
+    assert [run.result for run in drained] == [5, 9]
+
+
+def test_drain_reports_a_suspended_run_as_sleeping(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    tasks.ssleep_for_once.enqueue("k")
+
+    drained = absurd.drain()
+
+    assert [(run.task_name, run.state) for run in drained] == [
+        ("tests.tasks.ssleep_for_once", "sleeping")
+    ]
+
+
+def test_drain_returns_a_spawned_child_in_the_same_drain(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    tasks.spawn_child_then_return.enqueue(21)
+
+    drained = absurd.drain()
+
+    assert [run.task_name for run in drained] == [
+        "tests.tasks.spawn_child_then_return",
+        "tests.tasks.run_child",
+    ]
+    assert drained[1].result == 42
+    assert absurd.drain() == []
+
+
+def test_drain_returns_every_attempt_of_a_default_retry_burn(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.boom.enqueue()
+
+    drained = absurd.drain()
+
+    assert [run.attempt for run in drained] == [1, 2, 3, 4, 5]
+    assert {run.state for run in drained} == {"failed"}
+    assert drained[0].failure is not None
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.state == "failed"
+    assert snapshot.attempts == 5
+
+
+def test_drain_reports_each_attempt_of_a_retry_sequence(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    tasks.RETRY_CALLS["n"] = 0
+    tasks.fail_twice_then_succeed.enqueue()
+
+    drained = absurd.drain()
+
+    assert [(run.attempt, run.state) for run in drained] == [
+        (1, "failed"),
+        (2, "failed"),
+        (3, "completed"),
+    ]
+    assert [
+        None if run.failure is None else run.failure["message"] for run in drained
+    ] == ["attempt 1 fails", "attempt 2 fails", None]
+    assert drained[2].result == "third-time-lucky"
+
+
+def test_drain_returns_the_same_run_twice_when_an_emit_wakes_it(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    tasks.sawait_event_once.enqueue("order.packed:same-drain")
+    tasks.semit_event_once.enqueue("order.packed:same-drain", {"tracking": "abc"})
+
+    drained = absurd.drain()
+
+    waiter_runs = [run for run in drained if run.task_name.endswith("sawait_event_once")]
+    assert [run.state for run in waiter_runs] == ["sleeping", "completed"]
+    assert waiter_runs[0].run_id == waiter_runs[1].run_id
+
+
+def test_drain_inside_an_open_transaction_raises(absurd: AbsurdTestRuntime) -> None:
+    call_command("absurd_sync_queues")
+
+    with (
+        transaction.atomic(),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                r"django-absurd: drain\(\) ran inside an open transaction, where "
+                r"uncommitted rows are invisible to Absurd's own connection\. Use "
+                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+                r"transaction\.atomic\(\)\."
+            ),
+        ),
+    ):
+        absurd.drain()
+```
+
+- [ ] **Step 3: run the tests, confirm they fail**
+
+Run: `uv run pytest tests/core/test_absurd_fixture.py -v -k drain` Expected: FAIL —
+`AttributeError: 'AbsurdTestRuntime' object has no attribute 'drain'`.
+
+- [ ] **Step 4: widen the worker's burst path**
+
+`drain_queue` currently counts runs and returns an `int`; `run_burst_worker` discards it
+and returns the provisioning `SyncResult`. Change `drain_queue` to accumulate, for each
+claimed row it executes, the identity the SDK's `ClaimedTask` already carries
+(`run_id`/`task_id`/`task_name`/`attempt`/`params`) — no extra query for identity. Read
+each run's own `state`/`result`/`failure_reason` immediately AFTER that run executes,
+never in one batch at drain end: an `await_event` waiter re-arms its own run, so a
+final-state batch read would rewrite history for an earlier appearance of the same
+`run_id` (the test in Step 2 covers this).
+
+Have `run_burst_worker` return `tuple[SyncResult, list[DrainedRun]]`. Two callers
+consume the old single return and MUST be updated in this task, or the management
+command breaks and a sibling test fails with no obvious cause:
+
+- `django_absurd/management/commands/absurd_worker.py:93` —
+  `result = run_burst_worker(...)` becomes `result, _ = run_burst_worker(...)`, feeding
+  `report_sync_result` unchanged.
+- `tests/core/test_worker.py:446` in
+  `test_run_burst_worker_processes_a_task_and_returns_sync_result` — unpack the tuple,
+  keeping its existing `SyncResult` assertions.
+
+- [ ] **Step 5: implement `RunSnapshot` and `drain`**
+
+Add the frozen dataclass. `drain` checks the guard, calls the widened burst path for the
+queue, and maps each collected row to a `RunSnapshot`, decoding `params` with the same
+defensive helper Task 1 added. Preserve claim order.
+
+- [ ] **Step 6: run the tests, confirm they pass**
+
+Run: `uv run pytest tests/core/test_absurd_fixture.py -v` Expected: PASS, 16 tests.
+
+- [ ] **Step 7: gates + commit**
+
+```bash
+uv run pre-commit run --all-files
+uvx --with tox-uv tox -e dev
+git add django_absurd/worker.py django_absurd/test.py django_absurd/pytest_plugin.py tests/tasks.py tests/core/test_absurd_fixture.py
+git commit -m "feat(test): drain returns per-run snapshots"
+```
+
+---
+
+## Task 3: the clock — `freeze_at`, `advance`, `now`
+
+**Files:**
+
+- Modify: `django_absurd/test.py`
+- Modify: `pyproject.toml` (dev dependency)
+- Modify: `tests/tasks.py` — sync fixture tasks only; the async ones belong to phase 2
+- Test: `tests/core/test_durable_clock.py` (create)
+
+**Interfaces:**
+
+- Consumes: Task 1's `open_test_connection` + guard, Task 2's `drain`.
+- Produces: `AbsurdTestRuntime.freeze_at(when: dt.datetime) -> None`,
+  `AbsurdTestRuntime.advance(delta: dt.timedelta) -> None`, `AbsurdTestRuntime.now`
+  property returning `dt.datetime` (UTC-aware).
+
+- [ ] **Step 1: add the dev dependencies**
+
+Add BOTH `time-machine` and `pytest-timeout` to the dev dependency group in
+`pyproject.toml` (leave `freezegun` alone — its removal is phase 2), then `uv lock`.
+time-machine stays a DEV dep only: never bundled, never an extra. pytest-timeout is not
+housekeeping — every run command below passes `--timeout`, because a half-applied clock
+deadlocks a sync drain permanently, and without the plugin those runs die on
+`pytest: error: unrecognized arguments: --timeout=60`.
+
+- [ ] **Step 2: add the long-sleep fixture tasks**
+
+`tests/tasks.py` — durations long enough that no wall-clock wait could ever satisfy
+them, which is the point:
+
+`tests/tasks.py` also needs a task whose cancellation policy can fire once time moves,
+and `tests/utils.py` a plain function that takes a lease without running the task
+(claiming is two lines — inline the cursor there rather than hiding it further):
+
+```python
+@task
+@absurd_params(cancellation=CancellationPolicy(max_delay=60))
+def cancellable_after_a_minute() -> t.Never:
+    msg = "cancelled before it ever ran"
+    raise NotImplementedError(msg)
+```
+
+`utils.claim_one_run(queue, *, claim_timeout)` calls `absurd.claim_task` through a
+short-lived connection so a run holds a lease that the sweep can later expire.
+`tests/tasks.py` already has `cancellable` with `max_duration=30`, but it carries a
+`NotImplementedError` body and no `max_delay` — leave it alone.
+
+```python
+WEEK_SECONDS = 7 * 24 * 3600
+
+
+@task
+def sleep_a_week() -> str:
+    get_absurd_context().sleep_for("nap", WEEK_SECONDS)
+    return "woke"
+
+
+@task
+def sleep_twice() -> str:
+    context = get_absurd_context()
+    context.sleep_for("first", WEEK_SECONDS)
+    context.sleep_for("second", 3 * 24 * 3600)
+    return "woke-twice"
+
+
+@task
+@absurd_params(retry_strategy=RetryStrategy(kind="fixed", base_seconds=3600))
+def fail_with_long_backoff() -> t.Never:
+    msg = "boom"
+    raise ValueError(msg)
+```
+
+- [ ] **Step 3: write the failing tests**
+
+Create `tests/core/test_durable_clock.py`:
+
+```python
+import datetime as dt
+import importlib.abc
+import importlib.machinery
+import sys
+import typing as t
+import zoneinfo
+
+import psycopg
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command
+from django.db import connections
+
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+FROZEN = dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)
+
+
+def test_a_week_long_sleep_resumes_after_advancing_a_week(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sleep_a_week.enqueue()
+    assert [run.state for run in absurd.drain()] == ["sleeping"]
+
+    absurd.advance(dt.timedelta(days=7))
+
+    assert [run.state for run in absurd.drain()] == ["completed"]
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.result == "woke"
+
+
+def test_advancing_short_of_the_wake_leaves_the_task_sleeping(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sleep_a_week.enqueue()
+    absurd.drain()
+    real_before = dt.datetime.now(dt.UTC)
+
+    absurd.advance(dt.timedelta(days=6))
+
+    # Without this, a no-op advance() would pass the rest of the test.
+    assert absurd.now - real_before >= dt.timedelta(days=6)
+    assert absurd.drain() == []
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.state == "sleeping"
+
+
+def test_a_chain_of_two_sleeps_needs_two_advances(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sleep_twice.enqueue()
+    absurd.drain()
+
+    absurd.advance(dt.timedelta(days=7))
+    assert [run.state for run in absurd.drain()] == ["sleeping"]
+
+    absurd.advance(dt.timedelta(days=3))
+    assert [run.state for run in absurd.drain()] == ["completed"]
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.result == "woke-twice"
+
+
+def test_an_await_event_timeout_fires_after_advancing_past_it(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sawait_event_timeout.enqueue(
+        "order.packed:never-arrives", timeout=tasks.WEEK_SECONDS
+    )
+    assert [run.state for run in absurd.drain()] == ["sleeping"]
+
+    absurd.advance(dt.timedelta(days=8))
+    absurd.drain()
+
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.result == "timed-out"
+
+
+def test_a_retry_backoff_runs_the_next_attempt_after_advancing(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.fail_with_long_backoff.enqueue()
+    assert [run.attempt for run in absurd.drain()] == [1]
+    mid_backoff = absurd.get_result(result.id)
+    assert mid_backoff is not None
+    assert mid_backoff.state == "sleeping"
+    assert mid_backoff.failure is None
+
+    absurd.advance(dt.timedelta(hours=1, seconds=1))
+
+    assert [run.attempt for run in absurd.drain()] == [2]
+
+
+def test_a_cancelled_task_produces_an_empty_drain(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    """Cancellation happens inside claim_task, before anything is claimed."""
+    call_command("absurd_sync_queues")
+    result = tasks.cancellable_after_a_minute.enqueue()
+
+    absurd.advance(dt.timedelta(minutes=2))
+
+    assert absurd.drain() == []
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.state == "cancelled"
+
+
+def test_an_expired_claim_is_swept_after_advancing_past_the_lease(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.add.enqueue(2, 3)
+    utils.claim_one_run("default", claim_timeout=3600)
+
+    absurd.advance(dt.timedelta(hours=2))
+    absurd.drain()
+
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.state == "completed"
+    assert snapshot.attempts == 2
+
+
+def test_freeze_at_stamps_the_frozen_instant_on_enqueue(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    call_command("absurd_sync_queues")
+    absurd.freeze_at(FROZEN)
+
+    result = tasks.add.enqueue(2, 3)
+
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.enqueued_at == FROZEN
+
+
+def test_now_is_real_until_frozen_then_exactly_the_frozen_instant(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    before = absurd.now
+    assert before.utcoffset() == dt.timedelta(0)
+    assert abs(before - dt.datetime.now(dt.UTC)) < dt.timedelta(seconds=30)
+
+    absurd.freeze_at(FROZEN)
+    assert absurd.now == FROZEN
+
+    absurd.advance(dt.timedelta(days=2))
+    assert absurd.now == FROZEN + dt.timedelta(days=2)
+
+
+def test_advance_without_a_prior_freeze_moves_from_real_now(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    real = dt.datetime.now(dt.UTC)
+
+    absurd.advance(dt.timedelta(days=1))
+
+    assert absurd.now - real >= dt.timedelta(days=1)
+
+
+def test_freeze_at_honors_a_non_utc_aware_zone(absurd: AbsurdTestRuntime) -> None:
+    call_command("absurd_sync_queues")
+    chicago = dt.datetime(
+        2026, 3, 8, 1, 30, tzinfo=zoneinfo.ZoneInfo("America/Chicago")
+    )
+    absurd.freeze_at(chicago)
+
+    result = tasks.sleep_a_week.enqueue()
+    absurd.drain()
+    absurd.advance(dt.timedelta(days=7))
+    absurd.drain()
+
+    # advance() moves ABSOLUTE elapsed time; `chicago + timedelta` would be
+    # wall-clock arithmetic, an hour short across the spring-forward gap.
+    assert absurd.now == chicago.astimezone(dt.UTC) + dt.timedelta(days=7)
+    assert absurd.now.utcoffset() == dt.timedelta(0)
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.enqueued_at == chicago
+    assert snapshot.state == "completed"
+
+
+def test_the_clock_is_correct_on_a_server_whose_timezone_is_not_utc(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    """Regression: Django's adapter relabels timestamptz instead of converting it."""
+    dbname = connections["default"].settings_dict["NAME"]
+    params: dict[str, t.Any] = connections["default"].get_connection_params()
+    params.pop("cursor_factory", None)
+    params.pop("context", None)
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                psycopg.sql.SQL("alter database {} set timezone = 'America/Chicago'")
+                .format(psycopg.sql.Identifier(dbname))
+            )
+        call_command("absurd_sync_queues")
+        absurd.freeze_at(FROZEN)
+
+        result = tasks.add.enqueue(2, 3)
+        absurd.drain()
+
+        assert absurd.now == FROZEN
+        assert absurd.now.utcoffset() == dt.timedelta(0)
+        snapshot = absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.enqueued_at == FROZEN
+    finally:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                psycopg.sql.SQL("alter database {} reset timezone").format(
+                    psycopg.sql.Identifier(dbname)
+                )
+            )
+        conn.close()
+
+
+def test_freeze_at_rejects_a_naive_datetime(absurd: AbsurdTestRuntime) -> None:
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"django-absurd: freeze_at\(\) needs a timezone-aware datetime; a naive one "
+            r"is ambiguous and would desynchronise Postgres from Python\. Pass "
+            r"tzinfo=datetime\.UTC \(or any zone\)\."
+        ),
+    ):
+        absurd.freeze_at(dt.datetime(2026, 1, 1, 12, 0))  # type: ignore[arg-type]
+
+
+def test_freeze_at_rejects_a_string(absurd: AbsurdTestRuntime) -> None:
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"django-absurd: freeze_at\(\) needs a timezone-aware datetime; a naive one "
+            r"is ambiguous and would desynchronise Postgres from Python\. Pass "
+            r"tzinfo=datetime\.UTC \(or any zone\)\."
+        ),
+    ):
+        absurd.freeze_at("2026-01-01T12:00:00+00:00")  # type: ignore[arg-type]
+
+
+def test_advancing_without_time_machine_installed_raises(
+    absurd: AbsurdTestRuntime,
+) -> None:
+    class BlockTimeMachine(importlib.abc.MetaPathFinder):
+        def find_spec(
+            self,
+            fullname: str,
+            path: t.Sequence[str] | None = None,
+            target: object | None = None,
+        ) -> importlib.machinery.ModuleSpec | None:
+            if fullname == "time_machine":
+                msg = "blocked for this test"
+                raise ImportError(msg)
+            return None
+
+    blocker = BlockTimeMachine()
+    cached = sys.modules.pop("time_machine", None)
+    sys.meta_path.insert(0, blocker)
+    try:
+        with pytest.raises(
+            ImproperlyConfigured,
+            match=(
+                r"django-absurd: advancing durable time needs the time-machine "
+                r"package\. Install it in your test environment: pip install "
+                r"time-machine\."
+            ),
+        ):
+            absurd.advance(dt.timedelta(days=1))
+    finally:
+        sys.meta_path.remove(blocker)
+        if cached is not None:
+            sys.modules["time_machine"] = cached
+```
+
+- [ ] **Step 4: run the tests, confirm they fail**
+
+Run: `uv run pytest tests/core/test_durable_clock.py -v --timeout=60` Expected: FAIL —
+`AttributeError: 'AbsurdTestRuntime' object has no attribute 'freeze_at'`.
+
+Pass `--timeout` on every run in this task. A half-applied clock (DB ahead of Python)
+deadlocks a sync drain permanently and pytest-timeout cannot rescue it — only SIGKILL.
+If a run hangs, SIGKILL it, then clear the stranded GUC before rerunning:
+
+```bash
+PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres \
+  -c 'alter database "absurd_test_core" reset "absurd.fake_now";'
+```
+
+- [ ] **Step 5: implement the apply path**
+
+One internal function owns every clock move; `freeze_at` and `advance` are its two doors
+(`advance` = apply(current virtual now + Δ), and before any freeze the current virtual
+now is real now).
+
+Order matters and is not arbitrary: move the **Python clock first, then the DB
+literal**. A failure between the two must land Python-AHEAD-of-DB, which merely leaves a
+run unclaimed; DB-ahead-of-Python is the permanent deadlock.
+
+1. Validate: the argument must be a `datetime` AND aware, else `TypeError` with the
+   message the test asserts. Both halves matter — a `str` would otherwise reach
+   `astimezone` and die with an unhelpful `AttributeError`, and a string literal that
+   survived to the GUC is accepted by `ALTER DATABASE` only to explode inside
+   `absurd."current_time"()` on every NEW session, far from the call that caused it.
+   Then normalize with `astimezone(dt.UTC)`.
+2. Python: lazily `import time_machine` (translating `ImportError` to
+   `ImproperlyConfigured` with the install command), then start a
+   `travel(..., tick=False)` coordinate on first use and `move_to(...)` on every later
+   call. `tick=False` is a correctness requirement, not a preference — `absurd.fake_now`
+   is a static literal, so Postgres never ticks, and a ticking Python clock would drift
+   out of lockstep.
+3. DB, database level:
+   `ALTER DATABASE <test_db> SET absurd.fake_now = '<iso with offset>'` on a dedicated
+   autocommit connection. `ALTER DATABASE` rejects bind parameters — compose with
+   `psycopg.sql.Identifier` and `psycopg.sql.Literal`. Database level, not session: the
+   worker opens its own connection per drain, and only a database default reaches it.
+   Read the database name at runtime from `connections[alias].settings_dict["NAME"]` so
+   xdist's per-worker databases work.
+4. DB, session level: also `SET absurd.fake_now` on the Absurd alias' live Django
+   connection, so an `enqueue()` after an advance stamps fake time rather than real (a
+   database default only reaches NEW sessions).
+
+`now` reads `select absurd.current_time()` through Task 1's fresh UTC-pinned connection
+— Postgres owns the instant. Not Django's session (it can hold a stale or rolled-back
+`SET`), not a held connection (one opened before the first freeze never sees the later
+database default), and not Python-side bookkeeping (that reports what we intended, so it
+could never reveal a desync).
+
+- [ ] **Step 6: implement per-test teardown**
+
+The fixture is function-scoped, so its teardown runs per test. Release BOTH halves
+unconditionally — passed, failed, or raised mid-apply — and release the DB GUC even if
+stopping time-machine raises, since a stopped Python clock with a live DB GUC is the
+deadlock direction. Use targeted `ALTER DATABASE <test_db> RESET absurd.fake_now`, never
+`RESET ALL` (that would clobber unrelated database settings). Also `RESET` the
+session-level GUC. A test that never froze must touch nothing.
+
+- [ ] **Step 7: run the tests, confirm they pass**
+
+Run: `uv run pytest tests/core/test_durable_clock.py -v --timeout=60` Expected: PASS, 15
+tests.
+
+Then confirm no GUC leaked:
+
+```bash
+PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -tAc \
+  "select datname, setconfig from pg_db_role_setting s join pg_database d on d.oid = s.setdatabase;"
+```
+
+Expected: no rows.
+
+- [ ] **Step 8: gates + commit**
+
+```bash
+uv run pre-commit run --all-files
+uvx --with tox-uv tox -e dev
+git add pyproject.toml uv.lock django_absurd/test.py tests/tasks.py tests/core/test_durable_clock.py
+git commit -m "feat(test): freeze and advance durable time"
+```
+
+---
+
+## Task 4: leak recovery — session-start sweep and flush integration
+
+Per-test teardown cannot save a run that was SIGKILLed mid-freeze: the GUC survives, and
+with `--reuse-db` the next run's first draining test can hang before any resetting code
+executes. So recovery must also happen BEFORE tests.
+
+**Files:**
+
+- Modify: `django_absurd/pytest_plugin.py`
+- Modify: `django_absurd/flush.py` — `flush_absurd_state`, real signature
+  `(*, drop_schema: bool = False) -> None`
+- Modify: `tests/utils.py`
+- Test: `tests/core/test_pytest_plugin.py`
+
+**Interfaces:**
+
+- Consumes: Task 3's reset helper.
+- Produces: a session-scoped autouse sweep fixture; `flush_absurd_state` additionally
+  resets the GUC; `tests/utils.py` gains `set_database_fake_now`,
+  `read_database_fake_now`, `reset_database_fake_now`.
+
+- [ ] **Step 1: write the failing tests**
+
+Both behaviors need a real session boundary — a session fixture cannot be re-triggered
+inside the session it already ran in, and "a failing test still releases the clock"
+needs a test that genuinely fails. So the inner runs go through `pytester`.
+
+Three things are required, all verified live. Do NOT write a conftest or ini into the
+pytester directory — it is unnecessary and easy to get wrong:
+
+1. `pytest_plugins = ["pytester"]` at the top of `tests/core/test_pytest_plugin.py`.
+2. `monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))` so the inner interpreter can
+   import `tests.core.settings`, with
+   `REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]`. `DJANGO_SETTINGS_MODULE`
+   needs no help — `runpytest_subprocess` inherits `os.environ`, and pytest-django
+   exports it in the outer run.
+3. `--reuse-db` on EVERY inner invocation. Without it the inner session tries to DROP
+   and recreate the outer session's test database:
+   `Got an error creating the test database: database "absurd_test_core" already exists`.
+   Only the outer session's open connection prevents a real drop.
+
+Each planting test needs `try/finally`. These tests MUST fail in step 2, and a stranded
+`absurd.fake_now` would then poison every later test in the outer session, because every
+new connection inherits it.
+
+```python
+def test_a_stranded_fake_now_is_swept_before_the_session_runs(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """A SIGKILLed run leaves the GUC behind; the next session must clear it."""
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    utils.set_database_fake_now("2036-01-01T00:00:00+00:00")
+    try:
+        pytester.makepyfile(
+            inner_test="""
+            import datetime as dt
+
+            import pytest
+
+            pytestmark = pytest.mark.django_db(transaction=True)
+
+
+            def test_clock_is_real(absurd):
+                assert absurd.now.year == dt.datetime.now(dt.UTC).year
+            """
+        )
+
+        outcome = pytester.runpytest_subprocess("--reuse-db")
+
+        outcome.assert_outcomes(passed=1)
+        assert utils.read_database_fake_now() is None
+    finally:
+        utils.reset_database_fake_now()
+
+
+def test_flush_absurd_state_resets_a_stranded_fake_now() -> None:
+    utils.set_database_fake_now("2036-01-01T00:00:00+00:00")
+    try:
+        flush_absurd_state()
+
+        assert utils.read_database_fake_now() is None
+    finally:
+        utils.reset_database_fake_now()
+
+
+def test_a_test_that_raises_mid_advance_still_releases_the_clock(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """Proves recovery by SOME layer — fixture teardown or the flush reset. Both exist by
+    now and both fire after the inner failing test; the sweep test above is the one that
+    isolates the sweep, since it runs before any inner test."""
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    pytester.makepyfile(
+        inner_test="""
+        import datetime as dt
+
+        import pytest
+
+        pytestmark = pytest.mark.django_db(transaction=True)
+
+
+        def test_advances_then_fails(absurd):
+            absurd.advance(dt.timedelta(days=7))
+            pytest.fail("deliberate")
+        """
+    )
+
+    outcome = pytester.runpytest_subprocess("--reuse-db")
+
+    outcome.assert_outcomes(failed=1)
+    assert utils.read_database_fake_now() is None
+```
+
+Add three plain functions to `tests/utils.py` (no fixture — they need nothing beyond a
+connection). `set_database_fake_now(value: str) -> None` and
+`reset_database_fake_now() -> None` issue `ALTER DATABASE <test_db> SET` /
+`RESET absurd.fake_now`; `read_database_fake_now() -> str | None` returns the stored
+value by reading `pg_db_role_setting` joined to `pg_database`, or `None` when unset. All
+three run on a short-lived autocommit connection with the statement composed via
+`psycopg.sql` (`ALTER DATABASE` rejects bind parameters). Read the database name from
+`connections["default"].settings_dict["NAME"]` so xdist workers hit their own database.
+
+`tests/core/test_pytest_plugin.py` already imports `utils`, already imports
+`flush_absurd_state` from `django_absurd.flush`, and already sets
+`pytestmark = pytest.mark.django_db(transaction=True)`.
+
+- [ ] **Step 2: run the tests, confirm they fail**
+
+Run: `uv run pytest tests/core/test_pytest_plugin.py -v --timeout=120` Expected: FAIL —
+the stranded GUC survives the inner session.
+
+- [ ] **Step 3: implement the session-start sweep**
+
+Add a session-scoped autouse fixture to `django_absurd/pytest_plugin.py`, mirroring
+`_sweep_orphaned_pg_cron_jobs` exactly: take ONLY `request` so the guard runs before any
+Django/DB fixture resolves, bail out when settings are unconfigured or no Absurd backend
+is configured, then pull `django_db_setup` and `django_db_blocker` lazily via
+`getfixturevalue`. That ordering is what keeps the plugin a clean no-op in a project
+that merely has django-absurd installed. Issue the targeted `RESET` once. Read the
+database name at runtime so xdist's per-worker databases are each swept.
+
+`ALTER DATABASE ... RESET` works through Django's own connection while connected to that
+same database (session-fixture time is autocommit, no transaction block), so no
+dedicated connection is needed here.
+
+Mirror whatever coverage treatment `_sweep_orphaned_pg_cron_jobs`' early-return arms
+already get — the new sweep has the same unconfigured/no-backend arms, and patch
+coverage will flag them otherwise.
+
+- [ ] **Step 4: add the defensive reset to `flush_absurd_state`**
+
+It lives in `django_absurd/flush.py:18`, NOT in `test.py` (which only imports it). Reset
+the GUC there too, so the existing post-test flush recovers a leak even when the
+fixture's own teardown never ran.
+
+- [ ] **Step 5: run the tests, confirm they pass**
+
+Run: `uv run pytest tests/core/test_pytest_plugin.py -v --timeout=120` Expected: PASS.
+
+- [ ] **Step 6: confirm xdist safety**
+
+Run: `uv run pytest tests/core -q --no-cov -n4 --timeout=120` Expected: all pass. Then
+the `pg_db_role_setting` query from Task 3 returns no rows.
+
+- [ ] **Step 7: gates + commit**
+
+```bash
+uv run pre-commit run --all-files
+uvx --with tox-uv tox -e dev
+git add django_absurd/pytest_plugin.py django_absurd/flush.py tests/utils.py tests/core/test_pytest_plugin.py
+git commit -m "feat(test): sweep stranded fake_now at session start"
+```
+
+## Task 5: `emit`, the `absurd_drain_queue` delegate, and docs
+
+**Files:**
+
+- Modify: `django_absurd/test.py`, `django_absurd/pytest_plugin.py`
+- Modify: `docs/web/testing.md`, `django_absurd/AGENTS.md`, `CLAUDE.md`
+- Test: `tests/core/test_absurd_fixture.py`
+
+**Interfaces:**
+
+- Produces:
+  `AbsurdTestRuntime.emit(name: str, payload: JsonValue | None = None, queue: str = "default") -> None`;
+  `absurd_drain_queue` reimplemented as a delegate whose callable takes `queue` only.
+
+- [ ] **Step 1: write the failing tests**
+
+```python
+def test_emit_resolves_a_waiting_task(absurd: AbsurdTestRuntime) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.sawait_event_once.enqueue("order.packed:via-fixture")
+    assert [run.state for run in absurd.drain()] == ["sleeping"]
+
+    absurd.emit("order.packed:via-fixture", {"tracking": "abc"})
+
+    assert [run.state for run in absurd.drain()] == ["completed"]
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.result == {"tracking": "abc"}
+
+
+def test_absurd_drain_queue_alias_still_drains(
+    absurd_drain_queue: t.Callable[..., None], absurd: AbsurdTestRuntime
+) -> None:
+    call_command("absurd_sync_queues")
+    result = tasks.add.enqueue(2, 3)
+
+    absurd_drain_queue()
+
+    snapshot = absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.state == "completed"
+```
+
+- [ ] **Step 2: run the tests, confirm they fail**
+
+Run: `uv run pytest tests/core/test_absurd_fixture.py -v -k "emit or alias"` Expected:
+FAIL — no `emit` attribute.
+
+- [ ] **Step 3: implement `emit` and re-point the alias**
+
+`emit` delegates to the existing public `django_absurd.events.emit_event`, defaulting
+the queue. Reimplement `absurd_drain_queue` as a thin delegate to
+`AbsurdTestRuntime.drain`, WITHOUT a `concurrency` parameter — the burst drain runs
+lockstep batches rather than a rolling window, nothing in the repo passed it, and worker
+concurrency stays covered through the CLI path.
+
+- [ ] **Step 4: run the tests, confirm they pass**
+
+Run: `uv run pytest tests/core -v --timeout=120` Expected: PASS.
+
+- [ ] **Step 5: write the docs**
+
+`docs/web/testing.md` — new section for the fixture, covering: the six members; that
+`transaction=True` is required; freeze BEFORE enqueueing (freezing to a past instant
+after rows exist leaves their deadlines in the DB's future); "install time-machine
+yourself"; that durable time moves only on `freeze_at`/`advance`; the `TaskSnapshot`
+caveats (`attempts` counts attempts CREATED, `sleeping` covers a retry backoff as well
+as a durable sleep, `failure` is `None` mid-backoff — use the drain's `RunSnapshot` to
+tell them apart); and three hazards: a `manage.py absurd_worker` subprocess is only
+half-frozen, a savepoint rollback after an advance makes a later `enqueue()` stamp stale
+time while `absurd.now` still looks correct, and advancing cannot make a **pg_cron**
+schedule fire (its launcher runs in the central database on its own clock).
+
+`django_absurd/AGENTS.md` — integration note in the testing section; update the
+`absurd_drain_queue` entry, which currently documents a `concurrency` parameter.
+
+`CLAUDE.md` — testing conventions: durable tests use the `absurd` fixture, never
+`time.sleep`.
+
+Cross-link per project convention (Absurd docs, specific Django docs).
+
+- [ ] **Step 6: gates + commit**
+
+```bash
+uv run pre-commit run --all-files
+uvx --with tox-uv tox -e dev
+git add django_absurd/test.py django_absurd/pytest_plugin.py docs/web/testing.md django_absurd/AGENTS.md CLAUDE.md tests/core/test_absurd_fixture.py
+git commit -m "feat(test): emit helper, drain alias, and docs"
+```
+
+---
+
+## Done when
+
+- `uvx --with tox-uv tox -e dev` green; `uv run pre-commit run --all-files` green.
+- `uv run pytest tests/core -n4` green, and `pg_db_role_setting` empty afterwards.
+- 100% patch coverage on the added lines.
+- A 7-day sleep, an `await_event` timeout, a retry backoff, and a two-sleep chain are
+  all tested without a single `time.sleep`.
+
+Phase 2 then follows in its own plan: the freezegun→time-machine migration and the
+existing- suite adoption recorded in the spec.

--- a/docs/specs/2026-07-28-durable-test-clock-design.md
+++ b/docs/specs/2026-07-28-durable-test-clock-design.md
@@ -1,0 +1,726 @@
+# Durable test clock — `absurd` fixture (advance time, emit, drain, inspect)
+
+Issue: <https://github.com/lincolnloop/django-absurd/issues/108>
+
+## Problem
+
+Durable primitives untestable deterministically. Today `tests/core/test_durable.py` pins
+a wall-clock recipe: task sleeps ~1.5s, test does `time.sleep(2)`, drain again. Slow
+(~8s across 4 tests), flake-prone, and can't express a 7-day sleep at all. `await_event`
+timeouts worse — nothing to wait on but wall clock.
+
+## Two clocks, not one
+
+A sleeping run is gated twice:
+
+1. **Postgres** — claim predicate `r_<q>.available_at <= absurd.current_time()`.
+   `absurd.current_time()` (shipped in
+   `django_absurd/migrations/0001_initial_0_4_0.sql:38`, Absurd's own function, used in
+   21 places) returns `clock_timestamp()` unless session GUC `absurd.fake_now` is set.
+   Upstream built it for tests.
+2. **Python SDK** — `sleep_until` recomputes on replay and re-suspends when
+   `_get_current_time() < actual_wake_at` (`absurd_sdk/__init__.py:787`).
+
+Both must move together. Moving only the DB clock does NOT benignly fail: run gets
+claimed, SDK re-suspends, `schedule_run` re-arms same `wake_at`, drain never ends.
+
+Measured during review: with a SYNC sleeping task the drain spins and, when
+pytest-timeout fires, deadlocks permanently in the executor's thread-join — unkillable
+except by SIGKILL, with zero test output. (An async task IS rescued by pytest-timeout,
+so the blast radius depends on task flavor.) The SIGKILL then strands both the database
+GUC and the sleeping rows, and the poisoned reused DB hangs the next run's first
+draining test.
+
+Hence three design consequences: no DB-only knob; advancing is one operation over both
+clocks; and recovery cannot rely on per-test teardown alone — a session-start sweep is
+required, because pytest-randomly can schedule the poisoned test before any resetting
+test runs (see [Isolation](#isolation)).
+
+Python-ahead-of-DB is the safe direction (run merely not claimed yet).
+DB-ahead-of-Python is the deadlock. Design must never produce the latter — which also
+fixes the apply order: **Python clock first, then the DB literal**. A failure between
+the two lands Python-ahead (benign); DB-first would land in the deadlock direction.
+
+## Mechanism
+
+- DB side: `absurd.fake_now` set at **database** level
+  (`ALTER DATABASE <test_db> SET absurd.fake_now = '<iso>'`). Session-level `SET` on
+  Django's connection is not enough — worker opens its OWN connection per drain
+  (`django_absurd/worker.py:171`). DB-level default is inherited by every new session,
+  and the worker connects fresh each drain. Proven: 7-day sleep resumes after one
+  advance. Outlives the test if not undone — reset is per-test and unconditional, see
+  [Isolation](#isolation).
+- `ALTER DATABASE` rejects bind params (`syntax error at or near "$1"`) → compose with
+  `psycopg.sql.Identifier`/`Literal` on a dedicated autocommit connection (same shape as
+  `django_absurd/connection.py:open_central_connection`).
+- Gap: DB-level default only reaches NEW sessions. Django's live connection would stamp
+  real time on a post-advance `enqueue()`. So advancing also issues a session-level
+  `SET` on the Absurd alias' open connection.
+- Python side: **time-machine**, `tick=False`, driven via
+  `move_to(<absolute datetime>)`.
+- `absurd.fake_now` is a static literal → Postgres is FROZEN once set, never ticks.
+  Therefore Python must be frozen too. `tick=False` is a consistency requirement, not a
+  preference: both sides pinned to the same instant, durable time moves only when the
+  test says so.
+- Before any freeze/advance, nothing is set — both sides run real clocks and agree.
+
+### The literal must be aware UTC (deadlock path if not)
+
+`absurd.current_time()` casts the GUC text using the **reading session's** `TimeZone`.
+The worker's connection is raw `psycopg.connect(**params)`
+(`django_absurd/worker.py:171`), so its `TimeZone` is the **server default**, not
+Django's `UTC`. time-machine treats a naive datetime as UTC. On a server defaulting west
+of UTC, a naive `freeze_at` therefore puts the DB AHEAD of Python — the deadlock
+direction. Today it only works because the container defaults to `Etc/UTC`.
+
+Proven live, `absurd.current_time()` against a naive literal vs the same instant written
+with an offset:
+
+| Literal             | Session zone     | Reads as                 | Correct instant |
+| ------------------- | ---------------- | ------------------------ | --------------- |
+| `2030-01-01T12:00Z` | America/New_York | `2030-01-01 07:00:00-05` | yes             |
+| `2030-01-01T12:00Z` | Asia/Tokyo       | `2030-01-01 21:00:00+09` | yes             |
+| `2030-01-01T12:00`  | America/New_York | `2030-01-01 12:00:00-05` | NO              |
+| `2030-01-01T12:00`  | Asia/Tokyo       | `2030-01-01 12:00:00+09` | NO              |
+
+With the offset the session zone changes only the rendering; without it, the same text
+is a different instant per session.
+
+Rules, non-negotiable:
+
+- `freeze_at` takes an aware `datetime`; a naive one raises a curated error telling the
+  caller to attach `tzinfo` (wrong-door case: the value is ambiguous and the failure
+  would land far from its cause). No guessing from Django's current timezone — a wrong
+  guess is the deadlock direction, and `tzinfo=dt.UTC` is a one-token fix.
+- On the WRITE side, normalize with `astimezone(dt.UTC)` and always write the literal
+  WITH its offset, so the cast can never depend on the reading session's `TimeZone`.
+  Reads are pinned to UTC for the same reason — see [Reads](#reads).
+- Any aware zone is accepted; a Chicago-zoned datetime is just an instant. Cron math is
+  unaffected: `get_next_datetime` interprets schedules in Django's `TIME_ZONE`
+  regardless of how the instant was spelled.
+- Never accept a string. A malformed literal is accepted by `ALTER DATABASE` and then
+  fails inside `absurd."current_time"()` on every NEW session
+  (`invalid input syntax for type timestamp with time zone`) — i.e. far from the call
+  that caused it. `datetime`-only makes that unreachable.
+
+### What a freeze does NOT reach: the two schedulers
+
+Three time interpreters exist in this project; the freeze moves two of them.
+
+- **Durable deadlines** (`absurd.current_time()`) — moved. The feature.
+- **beat's slot math** — moved incidentally: `get_next_datetime` works from
+  `timezone.localtime(timezone.now())` (`django_absurd/scheduler.py:37`), i.e. Python's
+  clock, which time-machine freezes. Cron expressions are interpreted in Django's
+  `TIME_ZONE`. Existing beat tests inject `run_beat`'s `now`/`wait` seams, so they are
+  unaffected either way.
+- **pg_cron's launcher** — NOT moved. It runs in the central `cron.database_name`
+  database on its own clock and interprets schedules in the `cron.timezone` GUC (default
+  `GMT`, independent of the server's `TimeZone`; see
+  [Timezone](../web/cron-jobs.md#timezone)). A database-level GUC on the TEST database
+  cannot reach it.
+
+Consequence to document: advancing durable time cannot make a pg_cron schedule fire.
+Testing that stays "reconcile, then inspect `cron.job`", as `tests/pg_cron` already
+does.
+
+### Subprocess workers are only half-frozen
+
+`ALTER DATABASE` reaches a `manage.py absurd_worker` subprocess, but its Python clock is
+real. Frozen-time-ahead-of-real then IS the deadlock condition. The fixture drives the
+in-process burst worker only; a subprocess worker under a freeze is out of scope and
+must be called out in the docs.
+
+### Dependency
+
+time-machine is NOT bundled and NOT an extra. `drain`/`emit`/`get_result`/`now` work
+without it.
+
+Detection = a lazy `import time_machine` in the apply path, i.e. on the first
+`freeze_at`/`advance` call, with `ImportError` translated to `ImproperlyConfigured`
+naming the install command (same shape as the guards in `django_absurd/events.py`). Not
+`importlib.util.find_spec` — a module can be found and still fail to import, and the
+real import is the thing we need to succeed. Not a fixture-setup check either: a
+`drain`-only test must not require the package. Python caches the module, so only the
+first advance pays the import.
+
+## Surface
+
+> **Superseded in part.** Sections below that describe `freeze_at`/`advance`, the
+> "advance before any freeze" rule, `run_burst_worker`'s tuple return, or the
+> `absurd_drain_queue` delegate record the FIRST build. The fixture also shipped as
+> `dj_absurd`, not `absurd`, reserving the `dj_` prefix the way `DjangoAbsurdError` does
+> — read every `absurd` fixture reference below as `dj_absurd`. The
+> [post-review redesign](#post-review-redesign-human-revdiff-2026-07-29) below
+> supersedes them; where the two disagree, that section wins.
+
+One facade fixture, `absurd`, returning a test-runtime object:
+
+| Member                                      | Behavior                                       |
+| ------------------------------------------- | ---------------------------------------------- |
+| `freeze_time(dt=None)`                      | context manager; pins both clocks (None = now) |
+| `clock.move_to(dt)` / `clock.shift(Δ)`      | on the yielded handle; the only movers         |
+| `drain(queue="default")`                    | burst-drain; returns `list[RunSnapshot]`       |
+| (`absurd_drain_queue` is deleted, not kept) | one way in                                     |
+| `emit(name, payload=None, queue="default")` | delegate to `emit_event`                       |
+| `get_result(task_id, queue="default")`      | `TaskSnapshot \| None`                         |
+| `now`                                       | virtual now, aware, as Postgres reports it     |
+
+### Two typed records, ours — not the SDK's and not Django's
+
+`drain()` reports what RUNS did; `get_result()` reports where a TASK stands. Conflating
+the two is what makes a snapshot lie (see the caveats below), so they are separate
+frozen, fully annotated dataclasses.
+
+`RunSnapshot` — one per run executed, in claim order:
+
+| Field       | Source                                          |
+| ----------- | ----------------------------------------------- |
+| `queue`     | the drained queue                               |
+| `run_id`    | claim row                                       |
+| `task_id`   | claim row                                       |
+| `task_name` | claim row                                       |
+| `args`      | decoded from the claim row's `params["args"]`   |
+| `kwargs`    | decoded from the claim row's `params["kwargs"]` |
+| `attempt`   | claim row — THIS run's attempt number           |
+| `state`     | THIS run's own `r_<q>.state` after execution    |
+| `result`    | `r_<q>.result` of this run                      |
+| `failure`   | `r_<q>.failure_reason` of this run              |
+
+Per-run state is what makes the record honest: a run that suspended on a durable sleep
+reads `sleeping`; a run that raised reads `failed` WITH its own `failure_reason`; a
+retry sequence reads attempt-by-attempt instead of collapsing to one final verdict.
+Identity and `attempt` ride along free from the claim select (the SDK's `ClaimedTask`
+carries `run_id`/`task_id`/`task_name`/`attempt`/`params`); only each run's outcome
+costs a read.
+
+`TaskSnapshot` — where one task stands, returned by `get_result`:
+
+| Field         | Source                                                                             |
+| ------------- | ---------------------------------------------------------------------------------- |
+| `queue`       | the queried queue                                                                  |
+| `task_id`     | `t_<q>.task_id`                                                                    |
+| `task_name`   | `t_<q>.task_name`                                                                  |
+| `args`        | decoded from `t_<q>.params["args"]`                                                |
+| `kwargs`      | decoded from `t_<q>.params["kwargs"]`                                              |
+| `state`       | raw durable state: `pending`/`running`/`sleeping`/`completed`/`failed`/`cancelled` |
+| `attempts`    | `t_<q>.attempts`                                                                   |
+| `enqueued_at` | `t_<q>.enqueue_at`, UTC-aware (see [Reads](#reads))                                |
+| `result`      | `t_<q>.completed_payload`                                                          |
+| `failure`     | `r_<q>.failure_reason` of `last_attempt_run`                                       |
+
+`enqueued_at` earns its place: "did `enqueue()` actually stamp fake time?" is
+load-bearing for this design, and without the field it is assertable only by reaching
+into raw SQL — the practice `get_result` exists to end.
+
+Populated by one query per task against `t_<q>`, left-joining `r_<q>` on
+`last_attempt_run` for `failure_reason`, on a fresh UTC-pinned connection with
+`register_jsonb_loader` applied (see [Reads](#reads)). That constructs per-queue table
+names — the same coupling `django_absurd/flush.py:truncate_queue_tables` already
+carries.
+
+#### `TaskSnapshot` caveats, documented on the dataclass
+
+A task-level view cannot express an in-flight retry. Measured: one failed attempt with
+an hour's backoff pending reads `state=sleeping attempts=2 failure=None`, and all three
+mislead.
+
+- **`attempts` counts attempts CREATED, not completed.** `fail_run` records the next
+  attempt immediately, so it reads N+1 before attempt N+1 has run. A never-run pending
+  or cancelled task reads `1`.
+- **`state="sleeping"` covers BOTH a durable sleep and a retry backoff.** A test
+  asserting "my workflow is asleep" would pass on a task that actually crashed. The
+  drain's `RunSnapshot` distinguishes them.
+- **`failure` is the last attempt's `failure_reason` only when no newer run exists**
+  (exhausted retries, terminal failure). Mid-backoff, `last_attempt_run` already points
+  at the fresh pending run, so `failure` is `None` and attempt N's error is invisible
+  here.
+- `max_delay`-cancelled tasks carry no `failure_reason` at all, so `failure=None` —
+  which matches the SDK.
+
+#### Decoding rules
+
+- The snapshot query runs on a connection with `register_jsonb_loader` applied. Proven:
+  on a plain psycopg connection every jsonb column comes back as a raw **string**
+  (`'{"args": [], "kwargs": {}}'`), which would silently type `result` as `str`.
+  `tests/utils.py:get_task_result` already does this.
+- `params` decoding is defensive. Our `enqueue()` always writes both keys, even for a
+  zero-arg task, and schedules and task-spawned children take the same path — but a
+  queue shared with raw-SDK producers can hold anything (proven: `params` as a bare
+  list). Fall back to `args=[]`/`kwargs={}` rather than raising, or one foreign row
+  takes down the entire `drain()` call.
+
+Why our own types rather than Django's `TaskResult`, the SDK's `TaskResultSnapshot`, or
+the admin pseudo-models: Django's status vocabulary folds `sleeping → RUNNING` and
+`cancelled → FAILED`, the SDK type has no identity, and the pseudo-models type as `Any`
+and need `rebuild_views()`. Full reasoning in the
+[appendix](#appendix-rejected-alternatives).
+
+#### Clock operations
+
+- `advance` takes `timedelta` only. No seconds/float overload, no datetime union —
+  `freeze_at` owns absolute.
+- `advance` before any `freeze_at` freezes at real-now-plus-Δ. It does NOT error: the
+  first advance is the freeze, and every existing row's deadline is still interpreted
+  against the same instant.
+- Both funnel into one internal apply: set virtual now → `move_to` + DB literal +
+  session `SET`. `advance` = apply(virtual_now + Δ).
+- No jump-to-next-deadline. Test supplies the amount. Multi-wait workflows are driven
+  explicitly (drain → advance → emit → drain), so every wait is visible in the test and
+  a wrong advance count fails loudly.
+
+#### Reads
+
+`now` reads `select absurd.current_time()`; the snapshot queries read `t_<q>`/`r_<q>`.
+All of them use a FRESH connection built from `get_connection_params()` with
+`cursor_factory` AND `context` removed, `SET TIME ZONE 'UTC'` issued immediately after
+connect, and `register_jsonb_loader` applied. Every facade datetime is therefore
+UTC-aware by construction — no `astimezone` on values, no server-dependent expression.
+
+The UTC pin is not cosmetic. Django's connection params carry its psycopg adapters
+(`context`), whose timestamptz loader does `replace(tzinfo=...)` — a relabel that is
+only correct when the session TimeZone is already UTC. Inherited unpinned, a non-UTC
+server default hands back wall-clock digits mislabeled UTC: proven, the instant
+`12:00 UTC` read back as `07:00+00:00` on an `America/Chicago` session, for `now` and
+`enqueued_at` alike. Dropping `context` also sidesteps `USE_TZ=False`, where Django's
+loader strips tzinfo and returns naive datetimes.
+
+Fresh, not Django's session: that session sees only the session-level `SET`, never the
+database-level default (applied after it opened), and a savepoint rollback reverts the
+`SET` — it could report real time while the worker's next session sees frozen time. Not
+a connection held by the fixture either: one opened before the first `freeze_at` never
+sees the later database-level default (proven — a held connection read real time while a
+fresh one read the frozen instant), and compensating with a session `SET` would turn
+`now` into Python-side bookkeeping. Which is the third rejected option: reporting what
+we intended to apply could never reveal a Python/DB desync, the failure this design most
+needs visible.
+
+Cost ~7 ms per read. Irrelevant in test code.
+
+#### The transaction guard
+
+- Requires `django_db(transaction=True)`. Under a plain `db` test the enqueued row is
+  invisible to the worker's own connection, so a drain no-ops and `get_result` returns
+  `None` — proven, and silently. `drain`/`get_result` therefore detect it and raise a
+  curated error instead of letting a confusing `None` land far from its cause.
+  Mechanism:
+  - `connections[<alias>].in_atomic_block` — the behavioral truth. Proven to separate
+    every case: plain `db` → `True`; `django_db(transaction=True)` marker → `False`;
+    `transactional_db` fixture → `False`; `TestCase` → `True`; `TransactionTestCase` →
+    `False`. Marker/fixture-name introspection is strictly worse — it misses the
+    `transactional_db`-only and class-based paths.
+  - Checked at **call time**, not fixture setup. At setup the check only happens to work
+    here because our autouse `_enable_db` has already opened the atomic; a user project
+    with no autouse db fixture has no such ordering guarantee, and a setup-time check
+    would false-negative. A method body always runs after every db fixture.
+  - Error wording must cover the legitimate-marker-but-inside-`atomic()` case (rows are
+    equally invisible there): say "ran inside an open transaction — use
+    `django_db(transaction=True)` and call outside `atomic()`", never "the marker is
+    missing".
+- The guard covers TWO blind surfaces, not one: reads happen on fresh connections too,
+  so an uncommitted enqueue is invisible to `get_result` for the same reason it is
+  invisible to the worker.
+
+#### Drain semantics
+
+- `get_result` fills a real gap — today our own tests reach raw psycopg
+  (`tests/utils.py`); users writing durable tests have nothing to assert on.
+- `drain` returns one `RunSnapshot` per run executed, in claim order. A run that
+  SUSPENDED was still executed, so it appears with `state="sleeping"` — the honest
+  reading, and what makes a chain assertable. The primary reason to return anything: a
+  workflow that spawns children gives the test no ids, and queue introspection is cut,
+  so `drain` is the only place those surface.
+- **The same task can appear several times in one drain**, and that is the default, not
+  an edge case: with no retry strategy the backoff is 0s and `AbsurdBackend`'s default
+  max attempts is 5, so one drain burns all five attempts under a frozen clock —
+  measured `[('boom', 1), … ('boom', 5)]`. Per-run records make that legible (each
+  carries its own `attempt` and outcome) instead of five entries repeating one final
+  verdict. With a real backoff the next attempt is scheduled at
+  `current_time() + interval`, so it is NOT claimable and the drain ends after one run —
+  advance past the backoff, then drain again.
+- **The same RUN can appear twice too.** An `await_event` waiter re-arms its own run, so
+  a same-drain emit makes the identical `run_id` claimable again — measured
+  `[('sawait_event_once', 'sleeping'), ('semit_event_once', 'completed'), ('sawait_event_once', 'completed')]`.
+  This is why each entry is read right after its own execution and never in one batch at
+  drain end: a final-state batch read would rewrite history for the earlier appearance.
+- **`drain() == []` does not mean "nothing happened".** Cancellation rules and
+  `$ClaimTimeout` sweeps run INSIDE `claim_task` before anything is claimed, so a drain
+  that just cancelled a task produces no claim rows and returns `[]`. Assert task state
+  via `get_result` for those.
+- Spawned children run in the SAME drain, not the next one. The burst loop claims until
+  nothing is claimable, so a child enqueued from a running task body is picked up
+  immediately — measured `DRAIN-1: ['spawn_child_then_return', 'run_child']`,
+  `DRAIN-2: []`.
+- No `concurrency` on `drain`: `drain_queue` runs lockstep batches, not a rolling
+  window; `batch_size or concurrency` meant one argument set two things; nothing in the
+  repo passed it; worker concurrency stays covered via the CLI path. Add an
+  honestly-named `batch_size` later if a test needs multi-claim.
+- Plumbing this needs: `drain_queue` counts runs and returns an `int`, which
+  `run_burst_worker` discards (it returns the provisioning `SyncResult`). Widen that
+  path to hand back the claim rows. Identity and `attempt` cost no extra query — the
+  SDK's `ClaimedTask` TypedDict already carries
+  `run_id`/`task_id`/`task_name`/`attempt`/`params`. Each run's
+  `state`/`result`/`failure` is NOT in the claim row and costs one post-execution read
+  per run. Additive change to `worker.py` — production code, not test-only.
+- `absurd_drain_queue` stays, reimplemented as a delegate to `absurd.drain` — also
+  without `concurrency`, so both spellings agree. Docs show the facade; alias gets one
+  legacy line.
+- Sync only. Facade is unusable from an async test (`drain` calls `asyncio.run`
+  internally). Async twins are a follow-up, not this spec.
+
+#### Naming and errors
+
+- Fixture `absurd`, shipped from `django_absurd/pytest_plugin.py` alongside the existing
+  `absurd_drain_queue`.
+- `RunSnapshot` and `TaskSnapshot` live in `django_absurd/test.py` (which already hosts
+  the public `install_absurd_cleanup`) and are importable — users need them to annotate
+  helpers.
+- Exception types: naive `freeze_at` → `TypeError`; the transaction guard →
+  `RuntimeError`; missing time-machine → `ImproperlyConfigured`. All three carry the
+  full rule + fix in the message.
+- `get_result` accepts whatever `enqueue()` handed back — a Django `TaskResult.id` in
+  `queue:uuid` form or a bare uuid — matching the existing `tests/utils.py` precedent.
+- `run_id`/`task_id` are `uuid.UUID` at runtime even though the SDK's stubs type them
+  `str` (psycopg deserializes the column); the dataclass fields must say `uuid.UUID`.
+
+### Post-review redesign (human revdiff, 2026-07-29)
+
+The branch shipped, then a human review reshaped three things. Recorded here because the
+reasoning is not recoverable from the diff.
+
+**The clock is a context manager, not two imperative calls.** `freeze_at`/`advance` are
+replaced by `absurd.freeze_time(instant=None)` yielding a handle whose `move_to(dest)`
+and `shift(delta)` are the only movers — time-machine's `Coordinates` vocabulary,
+deliberately NOT called `travel` because travelling implies ticking and we freeze.
+`None` means real now. Nesting raises rather than stacking: two frozen instants cannot
+both be "now". Benefits beyond taste: the release point becomes lexical instead of
+depending on fixture teardown (which stays as the crash net), and the "advance before
+any freeze" special case stops existing, along with its rule and its test. `shift` also
+names the semantics better than `advance` did — it is absolute elapsed time, the
+distinction that made the first DST assertion wrong.
+
+**`run_burst_worker` is gone; `worker.py` stops speaking management-command.** It had
+been doing three jobs and returning `tuple[SyncResult, list[DrainedRun]]` purely because
+the command wanted the first half and the fixture the second. The command now inlines
+validate → provision → report → `run_worker(burst=True)`, which is what its blocking
+path already open-coded, so the change deleted duplication rather than moving it. The
+report and the "Started worker" line now print BEFORE the burst drain, matching the
+blocking path. Test-facing entry point is `drain_queue(queue) -> list[DrainedRun]` with
+no `WorkerOptions` (the fixture exposes no knobs), and the async internal became
+`adrain_queue` to match the module's existing `arun_worker`/`aworker_client` convention.
+
+**Error taxonomy on the drain path**, chosen so each failure names the right door:
+
+| Condition                            | Raises                                                                                     |
+| ------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Queue not declared in `TASKS QUEUES` | `ValueError` — a bad argument value, naming the valid queues                               |
+| Declared but table missing           | `ImproperlyConfigured`, reusing `events.emit_event`'s exact wording for the same condition |
+| Called inside an open transaction    | `RuntimeError` from the guard                                                              |
+
+**`drain` provisions nothing.** `apps.provision_queues_after_migrate` already provisions
+declared queues during `migrate`, so a test database arrives ready; the real gap is a
+queue declared mid-test through changed settings, and that must surface as the curated
+error above rather than as schema mutation from a call tests read results through.
+
+**`absurd_drain_queue` is deleted outright**, not kept as a delegate — alpha owes
+nothing, and pytest prints the available fixtures (including `absurd`) when a fixture is
+missing. Its call sites, including four `examples/` suites, moved to `absurd.drain()`.
+
+### Our own exception types (human revdiff, 2026-07-29)
+
+The error taxonomy landed as two conditions mapped onto stdlib/Django types, then a
+second pass made them ours. `django_absurd/exceptions.py` gains `DjangoAbsurdError` as
+the base and `QueueNotDeclaredError` / `QueueNotProvisionedError` under it, with
+`QueueReadOnlyError` and `ViewNotProvisionedError` rebased onto the same root;
+`resolve_backend` raises a typed `BackendNotConfiguredError` and the three commands
+catch that, still translating to `CommandError` so CLI text is unchanged.
+
+Three reasons, in order of how much they mattered:
+
+1. **The exception owns its message.** The first shape had
+   `format_undeclared_queue_message` imported wherever a raise site needed text —
+   including a lazy import in `backends.py` purely to reach it, because the builder sat
+   in `queues.py`, which chains into `models.py`. Encapsulating the message in the class
+   removed the helper AND the lazy import: the raise site already holds the data, so
+   there is nothing to fetch.
+2. **A specific type for a specific edge.** `QueueNotDeclaredError` says what went wrong
+   where `ValueError` only said someone passed something bad. `except DjangoAbsurdError`
+   then means "this package rejected something".
+3. **Named for the distributing package.** `DjangoAbsurdError`, not `AbsurdError`:
+   modules import from both `absurd_sdk` and `django_absurd`, and the SDK's own
+   exceptions (`SuspendTask`, `CancelledTask`, `FailedTask`, a `TimeoutError` shadowing
+   the builtin) share no base, so nothing anchors the short name to the SDK.
+
+Accepted costs, recorded so they are not rediscovered as bugs:
+
+- The Django/stdlib bases are GONE, so an external `except ValueError` around `enqueue`
+  or `except ImproperlyConfigured` around `emit_event` stops catching. Alpha, no
+  CHANGELOG — belongs in the next release notes.
+- `except DjangoAbsurdError` is NOT universal: `checks.py`, `connection.py`,
+  `queues.py`, and `test.py`'s transaction guard and clock validation still raise plain
+  `ImproperlyConfigured`/`RuntimeError`/`TypeError`. Sweeping those is a follow-up; the
+  docs must not overpromise in the meantime. `events.py` IS fully typed — a follow-up
+  pass moved its no-backend case to `BackendNotConfiguredError`, since the same
+  condition reached through `drain_queue` already raised that and one condition gets one
+  type.
+- Nothing in-package caught the two queue errors, so retyping them broke no handler —
+  verified before the change, not after.
+
+### Ordering rule (documented)
+
+Freeze BEFORE enqueueing. Freezing to a past instant after rows exist leaves their
+`available_at` in the DB's future — nothing claimable until an advance passes it.
+
+## Isolation
+
+Real time is restored after EVERY test, not at session end:
+
+- The fixture is function-scoped, so teardown runs per test. Teardown stops travel and
+  issues `ALTER DATABASE <test_db> RESET absurd.fake_now`.
+- Unconditional: teardown runs whether the test passed, failed, or raised mid-`advance`.
+  Both halves are released even if the first raises — a stopped time-machine with a live
+  DB GUC is the livelock direction (DB ahead of Python), so releasing the DB GUC must
+  not depend on the Python half succeeding.
+- A test that never advanced resets nothing — the fixture only touches the clock once
+  `freeze_at`/`advance` is called, so a plain `drain`-only test pays nothing and cannot
+  leak.
+- Targeted `RESET absurd.fake_now`, never `RESET ALL` — the latter would clobber
+  unrelated database-level settings on the test DB.
+- Also `RESET absurd.fake_now` at session level on Django's connection. Proven not
+  strictly required — a session `SET` is reverted by the test's teardown rollback, and
+  Django closes the connection between `transaction=True` tests — but it's one
+  statement, and relying on connection churn for correctness is not worth the coupling.
+- Same reset added defensively to the existing post-test flush (`flush_absurd_state`
+  path).
+- **Session-START sweep, required.** Per-test and post-flush resets are both scheduled
+  AFTER a test body, so neither protects the first casualty of a poisoned reused DB: a
+  SIGKILLed run strands the GUC, and with pytest-randomly the next run's first draining
+  test can hang (no output, unkillable by pytest-timeout — see
+  [Two clocks](#two-clocks-not-one)) before any resetting code runs. Mirror
+  `_sweep_orphaned_pg_cron_jobs` in `django_absurd/pytest_plugin.py`: once per xdist
+  worker, before any test, `ALTER DATABASE <test_db> RESET absurd.fake_now`. Same
+  import-safety constraints as that fixture (takes only `request`, pulls DB fixtures via
+  `getfixturevalue`).
+- xdist-safe: per-worker test DBs (`absurd_test_core_gw0/1`), verified green under `-n2`
+  with an empty `pg_db_role_setting` afterwards. The DB name must be read at runtime
+  from `connections[<alias>].settings_dict["NAME"]`, never hardcoded, or the sweep and
+  reset hit the wrong database under xdist.
+
+## Testing plan (behavioral, through the fixture)
+
+RED first, each test driving the real fixture + real worker; no monkeypatching, no
+helper-unit tests.
+
+- 7-day `sleep_for`: drain → `sleeping`; `advance(timedelta(days=7))`; drain →
+  `completed`, step body ran once across replay.
+- Not-yet-due: `advance` short of the wake → still `sleeping`. Guards against
+  make-everything-due semantics.
+- `sleep_until` with an absolute wake, driven by `freeze_at` + `advance`.
+- Chain: task sleeping twice → advance, drain (re-arms second sleep, still `sleeping`),
+  advance, drain → `completed`.
+- `await_event` timeout: enqueue with week-long timeout → `sleeping`; advance past it;
+  drain → task's timeout branch ran.
+- `emit` resolves a waiter without any advance (already-covered path, now via facade).
+- Retry backoff: failing task with exponential strategy; advance past the backoff; drain
+  → attempt 2 runs.
+- `freeze_at` before enqueue: `get_result(...).enqueued_at` equals the frozen instant.
+- Missing time-machine: assert the complete `ImproperlyConfigured` message naming the
+  install command. The import must genuinely fail, and time-machine IS installed in dev.
+  Drive it with a real `sys.meta_path` finder that raises `ImportError` for
+  `time_machine` — a real import condition, not a patched attribute — installed and
+  removed by the test. Alternative if that proves brittle: a fixture-less subprocess
+  pytest run in an env without the package (rejected by default: slow, and a skipped/
+  env-gated test breaks patch coverage).
+- Teardown resets: a test that advanced, then a following test asserting
+  `pg_db_role_setting` holds no `absurd.fake_now` for the test DB, and that the
+  following test's own `absurd.now` is real time. Cover the failure path too — a test
+  that advances and then raises must still leave the GUC reset (drive via an inner
+  failing test, e.g. `pytester`, rather than a passing test that pretends).
+- `absurd_drain_queue` alias still drains.
+- `drain` return value: a drain that runs two tasks returns both, in claim order, with
+  `task_name`/`args`/`kwargs`/`attempt`/`state` populated; a drain with nothing
+  claimable returns `[]`; a run that suspended appears with `state="sleeping"`.
+- Spawned children surface in the SAME drain that ran the parent — assert both, in
+  order, from one `drain()`. This is the case that has no ids for the test to hold.
+- Retry sequence, per-run: a task failing twice then succeeding returns three
+  `RunSnapshot`s with `attempt` 1/2/3 and states `failed`/`failed`/`completed`, the
+  first two carrying their own `failure` and the third its `result`. This is what
+  per-run records buy over a task-level view.
+- Same RUN twice in one drain: an `await_event` waiter plus a same-drain emit returns
+  the identical `run_id` twice, `sleeping` then `completed` — the reason entries are
+  read per execution rather than batched at drain end.
+- `get_result` echoes identity: `task_name`/`args`/`kwargs` equal what was enqueued.
+- Default-retry burn: a task with no retry strategy returns five runs from ONE drain
+  (`attempt` 1-5), and `get_result` then reads `state="failed"`, `attempts=5`.
+- Long-backoff retry: one run returned, `get_result` reads `state="sleeping"`
+  mid-backoff with `failure=None` (the documented caveat), then `advance` past the
+  backoff and the next drain returns attempt 2.
+- `drain() == []` after a cancellation: the sweep produces no claim rows, yet
+  `get_result` reads `cancelled` — proving the empty list isn't "nothing happened".
+- Foreign `params` shape (a raw-SDK row on a shared queue) does not blow up `drain`.
+- `TaskSnapshot.failure` is populated for a terminally failed task (from the last
+  attempt's `failure_reason`), and `result` for a completed one.
+- jsonb decoding: `result`/`failure`/`args`/`kwargs` come back as Python objects, not
+  strings — the loader is registered.
+- Naive datetime to `freeze_at`: assert the complete curated error text.
+- `freeze_at` with a non-UTC aware zone (e.g. `America/Chicago`): `absurd.now` and
+  `enqueued_at` both equal the frozen instant, UTC-aware. Include a durable sleep
+  advanced ACROSS a US spring-forward gap.
+- Non-UTC SERVER: with `ALTER DATABASE <test_db> SET timezone` to a non-UTC zone, `now`
+  and `enqueued_at` still read the correct instant and still report
+  `utcoffset() == timedelta(0)` — the regression test for the mislabeling trap described
+  in [Reads](#reads).
+- `absurd.now` before any freeze is real time; after `freeze_at` it is exactly the
+  frozen instant.
+- Plain `db` test (no `transaction=True`): assert the complete curated error text, since
+  the silent-`None` alternative is exactly what the guard exists to prevent.
+- Claim-timeout expiry, cancellation `max_delay`, and `max_duration`: advance past the
+  lease and the `$ClaimTimeout` sweep fires; a `max_delay` task lands `cancelled` with
+  its body never run. All three were untestable before.
+- Rewrite the four `time.sleep(2)` recipes in `tests/core/test_durable.py` to advances;
+  delete the host-clock-vs-DB-clock skew comment. Measured: `4 passed in 9.53s` →
+  `4 passed in 1.30s`.
+
+## Adopt in the existing suite (phase 2, after the fixture ships)
+
+**Order is deliberate: build and test the fixture first, migrate the suite second.** The
+sweep below is recorded so nothing is lost between phases.
+
+Measured with `-n4`, `--no-cov`: `tests/core` 374 passed in 32.30s, `tests/pg_cron` 257
+passed in 21.84s.
+
+### Convert
+
+| Site                                                                       | Now                                                                                         | After                                                                     |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `tests/core/test_durable.py` × 4 (`sleep_for`/`sleep_until`, sync + async) | **8.59s combined** — the four slowest tests in `tests/core`, 27% of its aggregate test time | ~1.3s; the `time.sleep(2)` and its host-clock-vs-DB-clock comment both go |
+
+### Make the fixture tasks honest
+
+`tests/tasks.py` `ssleep_for_once` and `tests/atasks.py` `asleep_for_once` sleep
+**1.5s**; `ssleep_until_once`/`asleep_until_once` use `time.time() + 1.5`. Those
+durations exist only so a test could sit and wait for them. Raise them to something like
+7 days: as written, these tests would pass against an implementation that only handles
+sub-second sleeps, so the change buys correctness, not just speed.
+
+### Coverage the fixture unlocks (absent today, not merely slow)
+
+- `tests/core/test_events.py` has exactly one `await_event` timeout test and it passes
+  `timeout=0` — degenerate, never exercises a deadline actually expiring.
+- Nothing covers retry backoff with a real interval, claim-timeout expiry, or
+  cancellation `max_delay`/`max_duration`. All four are reachable once time can be
+  advanced.
+
+### Keep wall-clock — these are timing and race tests, not slow tests
+
+- `test_async_worker.py::test_async_concurrency_is_not_serial` (0.58s): asserts
+  `elapsed < 1.5s` across 4 × `asleeper(0.5)`. The wall clock IS the assertion.
+  Unaffected by a freeze anyway — `asyncio.sleep` plus an unpatched `monotonic`.
+- `test_scheduler.py` live worker/beat tests
+  (`test_worker_with_beat_runs_scheduled_task` 1.23s, the poll-until-row loops with
+  SIGTERM killer threads, and the `time.sleep(0.05)` that lets beat enter `stop.wait`).
+  Real command wiring and thread races.
+- `tests/pg_cron/test_isolation_regression.py` — **14.25s, 65% of that suite**, and out
+  of reach by construction (the launcher runs in the central database on its own clock).
+  Its producer already uses `"1 seconds"`, so the time is scratch-DB creation plus
+  schema install, not waiting. Leave it alone.
+
+### Adjacent cleanup
+
+24 call sites use `tests/utils.py:get_task_result`, which opens a raw psycopg connection
+per call — they become `absurd.get_result`. (58 `run_absurd_worker` sites could become
+`absurd.drain()`, but most have no reason to change.)
+
+## Migrate our own suite off freezegun
+
+One clock library in the repo, not two. In scope here:
+
+- Drop `freezegun==1.5.5` from dev deps (`pyproject.toml:12`), add time-machine, relock.
+- **Every destination becomes an explicit `dt.datetime(..., tzinfo=dt.UTC)`. No
+  strings.** The two libraries disagree on bare strings: proven on a UTC-5 host,
+  freezegun reads `'2026-01-01 12:00:00'` as `12:00 UTC`, time-machine as `17:00 UTC`
+  (process-local). Our suite masks it because Django sets `os.environ["TZ"]` from
+  `TIME_ZONE`, but `override_settings(TIME_ZONE=...)` calls `tzset` live — so a string's
+  meaning would depend on whether the freeze started before or after the override.
+  Host-invisible and fragile; convert, don't "verify".
+- 6 decorator sites in `tests/core/test_scheduler.py:96-141` (cron-math):
+  `@freeze_time("…")` →
+  `@time_machine.travel(dt.datetime(…, tzinfo=dt.UTC), tick=False)`.
+- `tests/core/test_scheduler.py:610` — the 7th site, `freeze_time(…, tick=True)` around
+  a live worker with `beat=True` near a `*/1` boundary. Keeps `tick=True`: that test
+  WANTS real time to reach the next slot. The `tick=False` rule is about the `absurd`
+  fixture keeping two clocks in lockstep; it does not apply to a test that touches no
+  `absurd.fake_now`.
+- `run_beat_until` in `tests/core/test_scheduler.py:147` and
+  `tests/core/test_cleanup.py:261`: `freeze_time(…) as frozen` + `frozen.tick(Δ)` →
+  `travel(…, tick=False) as traveller` + `traveller.shift(Δ)`. Both already inject
+  `run_beat`'s `wait` seam, so every advance is explicit and `tick=False` is correct —
+  no real `threading.Event.wait` is involved.
+- Update the stale comment at `tests/core/test_scheduler.py:144-146` that names
+  freezegun.
+- **Rehearsed end-to-end during review and reverted**: all 9 conversions across the two
+  files, then `tests/core` 374 passed (-n4), `tests/pg_cron` 257 passed, `tests/multidb`
+  6 passed. `traveller.shift(Δ)` is a faithful `frozen.tick(Δ)` substitute and the
+  `tick=True` live-beat test survives. An `ag --hidden` sweep confirms no 8th call site
+  — freezegun appears only in `pyproject.toml`/`uv.lock` and that stale comment.
+
+## Docs
+
+- New `docs/web/testing.md` section: the fixture, the freeze-then-enqueue rule, the
+  `transaction=True` requirement, the explicit "install time-machine yourself" line, and
+  why durable time only moves on `advance`. Plus the `TaskSnapshot` caveats and two
+  hazards: a subprocess worker is only half-frozen, and a savepoint rollback issued
+  mid-test after an `advance` reverts only Django's session GUC (the DB-level default
+  and time-machine survive). Measured consequence, to state plainly: a later `enqueue()`
+  stamps the STALE instant while `absurd.now` still reports the advanced one — `now`
+  reports what the worker will act on, so it cannot flag a stale enqueue stamp.
+- `django_absurd/AGENTS.md` integration note.
+- CLAUDE.md testing conventions: durable tests use the fixture, never `time.sleep`.
+
+## Out of scope / follow-ups
+
+- Async facade twins (`adrain`/`aadvance`/…) for pytest-asyncio users.
+- `settle(result)` auto-advance loop — deliberately not shipped; explicit steps first.
+- Driving the blocking (non-burst) worker, or a `manage.py absurd_worker` subprocess,
+  under a frozen clock — the subprocess case is DB-frozen only, i.e. the deadlock
+  direction.
+- `get_next_wake` / `get_run_counts` introspection. Cut: no public SDK API exposes
+  either, so both would read `r_<q>`/`w_<q>` for assertions no test in the plan needs —
+  every state check goes through `get_result`.
+- Partitioned queues under a freeze. PG18's `uuidv7()` ignores `absurd.fake_now`
+  (proven: `absurd.current_time()` = 2036 while `uuidv7_timestamp(portable_uuidv7())` =
+  real 2026-07-28), so partition routing keys on real time while rows carry fake
+  `available_at`. Harmless for `order by (available_at, run_id)` — ties break by real
+  enqueue order — but unproven for partitioned storage, which no suite currently uses.
+- Non-pytest `manage.py test` parity (existing issue #96 shape).
+
+## Appendix: rejected alternatives
+
+### Rewriting deadline rows instead of the clock
+
+Alternative was SQL UPDATEs pulling `available_at` / `w_<q>.timeout_at` / the paired
+sleep checkpoint in `c_<q>` back by Δ. Works, needs no dependency, reaches a subprocess
+worker. Rejected: couples to Absurd's per-queue table names, needs run↔checkpoint
+pairing heuristics, and gives less for free. One frozen clock also covers retry backoff,
+`claim_expires_at`, cancellation `max_delay`/`max_duration` with zero extra code.
+
+### freezegun as the Python clock
+
+freezegun patches `time.monotonic`; asyncio's loop clock IS `time.monotonic`. Frozen
+freezegun deadlocks the drain — verified, 40s timeout stuck in `KqueueSelector.select`.
+freezegun only works with `tick=True`, which violates the consistency rule above. Out.
+time-machine leaves `monotonic`/`perf_counter` alone.
+
+### Django's `TaskResult`, the SDK snapshot, and the admin pseudo-models
+
+- **Django's `TaskResult`**: the backend's status mapping folds `sleeping → RUNNING` and
+  `cancelled → FAILED`, so through Django's vocabulary you cannot tell "asleep for 7
+  days" from "executing", nor "cancelled by `max_delay`" from "failed" — the exact
+  distinctions this plan asserts. It stays reachable the normal way (`enqueue()` returns
+  one); the facade exists to expose what that type cannot.
+- **The SDK's `TaskResultSnapshot`**: `state`/`result`/`failure` only, no identity, and
+  it would make `absurd_sdk` part of our test-API surface.
+- **The admin pseudo-models**: `build_admin_model` needs `rebuild_views()` to have run,
+  so it breaks in any test that drops the schema (our own `_isolate_queues` does).
+  `build_queue_table_model` avoids the view, but both are built dynamically and type as
+  `Any` — nothing for mypy/pyright users — and both are the stopgap a standing refactor
+  is meant to replace.

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -7,10 +7,176 @@ icon: lucide/flask-conical
 django-absurd ships a [pytest](https://docs.pytest.org/) plugin — installing the package
 registers it automatically via a
 [`pytest11` entry point](https://docs.pytest.org/en/stable/how-to/writing_plugins.html#making-your-plugin-installable-by-others),
-no extra setup required.
+no extra setup required. It builds on
+[pytest-django](https://pytest-django.readthedocs.io/), so install that alongside
+django-absurd (`pip install pytest-django`).
 
-The plugin builds on [pytest-django](https://pytest-django.readthedocs.io/) — install it
-in your test environment (`pip install pytest-django`) alongside django-absurd.
+## The `dj_absurd` fixture
+
+Running a task, moving Absurd's own notion of "now", and inspecting what actually ran
+all go through one fixture — whether the test is a one-line "my task completes" or a
+[durable sleep](workflows.md#sleep), an [`await_event` timeout](workflows.md#timeout), a
+retry backoff, or a chain of several sleeps.
+
+```python
+import datetime as dt
+
+import pytest
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
+    call_command("absurd_sync_queues")
+
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
+        result = my_weekly_followup_task.enqueue()  # enqueue INSIDE the block
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=7))
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.state == "completed"
+```
+
+### Requires `transaction=True`
+
+Absurd's own work runs on a connection separate from the test's. Under a plain
+[`db`](https://pytest-django.readthedocs.io/en/latest/helpers.html#db) test the enqueued
+row is invisible to that connection, so a drain silently no-ops, `get_result` returns
+`None`, and an `emit` never wakes its waiter. All three detect the open transaction and
+raise rather than letting that silence land far from its cause — use
+`@pytest.mark.django_db(transaction=True)`.
+
+!!! warning "Multi-DB: declare the Absurd alias"
+
+    Draining commits real state via the worker's own connection. If that test's
+    `databases` attribute doesn't include the Absurd alias, cleanup skips it afterward
+    and the committed state leaks into the next test. Declare the Absurd alias in
+    `databases` on any `transaction=True` test that runs a worker.
+
+### `freeze_time(instant=None)`
+
+Pins durable time for the block, `None` meaning real now at entry. It yields a
+`FrozenTime` handle whose two movers are the only way durable time ever moves:
+`move_to(datetime)` for an absolute, timezone-aware instant, and `shift(timedelta)` to
+move forward by Δ. Both move Python's clock (via
+[time-machine](https://github.com/adamchainz/time-machine)) and Postgres's
+`absurd.fake_now` GUC together.
+
+**Enter the block before the `enqueue()` calls whose deadlines you want to control.**
+Freezing to a PAST instant after rows already exist leaves those rows' deadlines in the
+database's future relative to the new frozen now, so nothing is claimable until a later
+`move_to`/`shift` passes them.
+
+`shift(Δ)` is absolute elapsed time, not wall-clock arithmetic: shifting seven days from
+`01:30` the morning of a US spring-forward lands 7 × 24 hours later as an instant, which
+is the only thing a durable deadline is measured in.
+
+Both halves of the clock are released when the block ends, so a test can open several
+windows in sequence. Opening one INSIDE another raises instead of stacking — two frozen
+instants cannot both be "now" — and using a `FrozenTime` after its own block exited
+raises rather than silently re-freezing from real now. Durable time moves only inside a
+block; a test that never opens one pays nothing and leaks nothing. `FrozenTime` is
+importable from `django_absurd.test` for annotating your own helpers.
+
+!!! warning "Install time-machine yourself"
+
+    [time-machine](https://github.com/adamchainz/time-machine) is a dev/test
+    dependency of *your* project, not bundled with django-absurd and not one of its
+    extras. `pip install time-machine` in your test environment. `drain`/`emit`/
+    `get_result`/`now` work without it — only `freeze_time` imports it, lazily, on
+    first use, and raises `ImproperlyConfigured` naming the install command if it's
+    missing.
+
+### `drain(queue="default")`
+
+Runs every currently-claimable task on `queue` to completion, in-process — no
+[worker](how-it-works.md#workers) subprocess, no polling loop to manage. It's the
+fixture counterpart of `absurd_worker --burst`: it drains the backlog present at call
+time, then returns one `RunSnapshot` per run executed, in claim order. It takes no
+`concurrency` parameter — the burst drain runs lockstep batches rather than a rolling
+window, so the parameter would be a misnomer; worker concurrency stays covered through
+the `absurd_worker` CLI.
+
+It provisions nothing, unlike the CLI, which provisions declared queues on start.
+`migrate` provisions every declared queue already, so a test database arrives ready. A
+queue a single test declares by overriding `TASKS` has no table yet — call
+`call_command("absurd_sync_queues")` first, or `drain()` raises
+`QueueNotProvisionedError` naming that command. Draining a queue that isn't declared at
+all raises `QueueNotDeclaredError` — see
+[Our own exceptions](workflows.md#our-own-exceptions) for the full typed-error taxonomy.
+
+### `emit(name, payload=None, queue="default")`
+
+Delivers an [event](workflows.md#events), resolving a task suspended in `await_event` —
+the waiter resumes on the next `drain()`. An unprovisioned queue raises
+`QueueNotProvisionedError`, same as `drain()`.
+
+### `get_result(task_id, queue=...)`
+
+Looks up one task, returning `TaskSnapshot | None`. `task_id` accepts either a bare uuid
+or Django's own `TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed back.
+When it carries a queue prefix, that prefix is what gets queried, not `queue`'s default.
+Omit `queue` entirely to let the prefix win:
+
+```python
+result = reports_task.enqueue()   # id is "reports:<uuid>"
+dj_absurd.get_result(result.id)   # queries the "reports" queue, correctly
+```
+
+Passing `queue=` explicitly — including `queue="default"` — is detectable, since it
+defaults to an internal sentinel rather than the literal string `"default"`. If it
+disagrees with a prefixed id's own queue, `get_result` raises `TaskIdQueueMismatchError`
+naming both instead of silently picking one. A bare uuid resolves an unpassed `queue` to
+`"default"`.
+
+A task-level view cannot express an in-flight [retry](tasks.md#retries-spawn-options):
+
+- **`attempts` counts attempts CREATED, not completed.** A task with one failed attempt
+  and a pending backoff already reads `attempts=2`, before the second attempt has run.
+- **`state="sleeping"` covers a retry backoff as well as a durable
+  [sleep](workflows.md#sleep).** A test asserting "my workflow is asleep" would pass
+  just as readily on a task that crashed and is waiting to retry.
+- **`failure` is `None` mid-backoff.** `last_attempt_run` already points at the fresh
+  pending run by the time the backoff is showing, so the failed attempt's reason isn't
+  reachable from this snapshot.
+
+`drain()`'s `RunSnapshot` is how you tell these apart — it reports each run's own state
+right after that run executes, so a retry sequence reads attempt-by-attempt (attempt 1
+failed, attempt 2 failed, attempt 3 completed) instead of collapsing to one ambiguous
+final read.
+
+### `now`
+
+Virtual now, timezone-aware, as Postgres itself reports it — read through the fixture's
+own fresh connection rather than computed in Python.
+
+### Hazards
+
+**A `manage.py absurd_worker` subprocess is only half-frozen.** `ALTER DATABASE` reaches
+its Postgres session, but its own Python clock is real — frozen-ahead-of-real is the
+deadlock direction, since a durable sleep due at the frozen instant looks not-yet-due to
+that process's real clock. `drain` only ever runs the in-process burst worker; a real
+subprocess worker under a freeze is out of scope.
+
+**A savepoint rollback inside a `freeze_time` block can make a later `enqueue()` stamp
+stale time.** Django's own connection only ever sees the frozen instant via a
+session-level `SET` (a database-level default reaches only new sessions, not one Django
+already has open), and a savepoint rollback reverts that `SET`. `dj_absurd.now` still
+reports the frozen instant correctly — it reads through its own fresh connection, which
+sees the database-level default — so `now` cannot itself flag the mismatch. If your test
+rolls back a savepoint inside the block, avoid enqueuing across the rollback boundary.
+
+**Advancing cannot make a [pg_cron](cron-jobs.md#database-side-pg_cron) schedule fire.**
+Its launcher runs in the central `cron.database_name` database
+([Test databases](cron-jobs.md#test-databases)), on its own real clock, and interprets
+schedules in the [`cron.timezone`](cron-jobs.md#timezone) GUC — none of which a
+test-database GUC can reach. Testing a pg_cron schedule stays "reconcile it in, then
+inspect `cron.job`"; `freeze_time` doesn't apply to it.
 
 ## Cleanup is automatic
 
@@ -46,202 +212,6 @@ In a multi-DB project, cleanup only runs for a test whose declared
 attribute includes the Absurd alias (respecting the `"__all__"` sentinel) — an
 undeclared alias is skipped, matching Django's own per-alias flush scoping.
 
-## `manage.py test` (non-pytest)
-
-The pytest wiring above is pytest-specific — Django's own `manage.py test`/
-[`DiscoverRunner`](https://docs.djangoproject.com/en/6.0/topics/testing/advanced/#django.test.runner.DiscoverRunner)
-has no equivalent auto-hook (pytest is django-absurd's primary test surface). Wire the
-same public hook yourself, from a runner subclass:
-
-```python
-from django.test.runner import DiscoverRunner
-
-from django_absurd.test import install_absurd_cleanup
-
-
-class MyTestRunner(DiscoverRunner):
-    def setup_test_environment(self, **kwargs):
-        super().setup_test_environment(**kwargs)
-        install_absurd_cleanup()
-```
-
-Then point your project's `TEST_RUNNER` at it. `install_absurd_cleanup()` is idempotent
-— calling it again where pytest's plugin already installed it is a no-op.
-
-## The `dj_absurd` fixture: durable time, drain, and read
-
-Running a task, moving Absurd's own notion of "now", and inspecting what actually ran
-all go through one fixture, `dj_absurd` — whether the test is a one-line "my task
-completes" or a [durable sleep](workflows.md#sleep), an
-[`await_event` timeout](workflows.md#timeout), a retry backoff, or a chain of several
-sleeps. It returns an `AbsurdTestRuntime` with five members:
-
-| Member                                      | Does                                                              |
-| ------------------------------------------- | ----------------------------------------------------------------- |
-| `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry) |
-| `now`                                       | virtual now, timezone-aware, as Postgres itself reports it        |
-| `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                |
-| `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`     |
-| `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot \| None` (see below)    |
-
-`freeze_time` yields a `FrozenTime` handle, and its two movers are the only way durable
-time ever moves:
-
-| Mover               | Does                                        |
-| ------------------- | ------------------------------------------- |
-| `move_to(datetime)` | move to an absolute, timezone-aware instant |
-| `shift(timedelta)`  | move forward by Δ of absolute elapsed time  |
-
-```python
-import datetime as dt
-
-import pytest
-from django.core.management import call_command
-
-pytestmark = pytest.mark.django_db(transaction=True)
-
-
-def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
-    call_command("absurd_sync_queues")
-
-    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
-        result = my_weekly_followup_task.enqueue()  # enqueue INSIDE the block
-        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
-
-        frozen_time.shift(dt.timedelta(days=7))
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
-
-        snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
-        assert snapshot.state == "completed"
-```
-
-Both halves of the clock are released when the block ends, so real time is back and a
-test can open several windows in sequence. Opening one INSIDE another raises instead of
-stacking: two frozen instants cannot both be "now". Using a `FrozenTime` after its own
-block has exited raises as well, rather than silently re-freezing from real now.
-`FrozenTime` is importable from `django_absurd.test` for annotating your own helpers.
-
-### `drain()`
-
-`drain()` runs every currently-claimable task on `queue` to completion, in-process — no
-[worker](how-it-works.md#workers) subprocess, no polling loop to manage. It's the
-fixture counterpart of `absurd_worker --burst`: it drains the backlog present at call
-time, then returns one `RunSnapshot` per run executed, in claim order. It takes no
-`concurrency` parameter — the burst drain runs lockstep batches rather than a rolling
-window, so the parameter would be a misnomer; worker concurrency stays covered through
-the `absurd_worker` CLI.
-
-It provisions nothing — unlike the CLI, which provisions declared queues on start.
-`migrate` provisions every declared queue already, so a test database arrives ready. A
-queue a single test declares by overriding `TASKS` has no table yet — call
-`call_command("absurd_sync_queues")` first, or `drain()` raises
-`QueueNotProvisionedError` naming that command. Draining a queue that isn't declared at
-all raises `QueueNotDeclaredError` — see
-[Our own exceptions](workflows.md#our-own-exceptions) for the full typed-error taxonomy.
-
-### `get_result()` honours a prefixed id's own queue
-
-`task_id` accepts either a bare uuid or Django's own `TaskResult.id` (`"queue:uuid"`) —
-whatever `enqueue()` handed back. When it carries a queue prefix, that prefix is what
-gets queried, not `queue`'s default. Omit `queue` entirely to let the prefix win:
-
-```python
-result = reports_task.enqueue()          # id is "reports:<uuid>"
-dj_absurd.get_result(result.id)             # queries the "reports" queue, correctly
-```
-
-Passing `queue=` explicitly — including `queue="default"` — is detectable, since it
-defaults to an internal sentinel rather than the literal string `"default"`. If it
-disagrees with a prefixed id's own queue, `get_result` raises `TaskIdQueueMismatchError`
-naming both instead of silently picking one. A bare uuid (no prefix) resolves an
-unpassed `queue` to `"default"`, same as always.
-
-### Requires `transaction=True`
-
-Absurd's own work runs on a connection separate from the test's. Under a plain
-[`db`](https://pytest-django.readthedocs.io/en/latest/helpers.html#db) test the enqueued
-row is invisible to that connection, so a drain silently no-ops, `get_result` returns
-`None`, and an `emit` never wakes its waiter. Every one of `drain`, `emit`, and
-`get_result` detects the open transaction and raises rather than letting that confusing
-silence land far from its cause — use `@pytest.mark.django_db(transaction=True)`.
-
-!!! warning "Multi-DB: declare the Absurd alias"
-
-    Draining commits real state via the worker's own connection. If that test's
-    `databases` attribute doesn't include the Absurd alias, the cleanup guard above
-    skips it afterward — the committed state leaks into the next test. Declare the
-    Absurd alias in `databases` on any `transaction=True` test that runs a worker.
-
-### Freeze BEFORE enqueueing
-
-`freeze_time` and its movers move both Python's clock (via
-[time-machine](https://github.com/adamchainz/time-machine)) and Postgres's
-`absurd.fake_now` GUC. Freezing to a PAST instant after rows already exist leaves those
-rows' deadlines in the database's future relative to the new frozen now, so nothing is
-claimable until a later `move_to`/`shift` passes them. Enter the `freeze_time` block
-before the `enqueue()` calls whose deadlines you want to control.
-
-`shift(Δ)` is absolute elapsed time, not wall-clock arithmetic: shifting seven days from
-`01:30` the morning of a US spring-forward lands 7 × 24 hours later as an instant, which
-is the only thing a durable deadline is measured in.
-
-Durable time only moves inside a `freeze_time` block — a test that never opens one pays
-nothing and leaks nothing; `drain`, `emit`, `get_result`, and `now` all work without
-ever touching the clock.
-
-!!! warning "Install time-machine yourself"
-
-    [time-machine](https://github.com/adamchainz/time-machine) is a dev/test
-    dependency of *your* project, not bundled with django-absurd and not one of its
-    extras. `pip install time-machine` in your test environment. `drain`/`emit`/
-    `get_result`/`now` work without it — only `freeze_time` imports it, lazily, on
-    first use, and raises `ImproperlyConfigured` naming the install command if it's
-    missing.
-
-### `TaskSnapshot` caveats: use `RunSnapshot` for an in-flight retry
-
-`get_result` returns a task-level view, and a task-level view cannot express an
-in-flight [retry](tasks.md#retries-spawn-options):
-
-- **`attempts` counts attempts CREATED, not completed.** A task with one failed attempt
-  and a pending backoff already reads `attempts=2`, before the second attempt has run.
-- **`state="sleeping"` covers a retry backoff as well as a durable
-  [sleep](workflows.md#sleep).** A test asserting "my workflow is asleep" would pass
-  just as readily on a task that crashed and is waiting to retry.
-- **`failure` is `None` mid-backoff.** `last_attempt_run` already points at the fresh
-  pending run by the time the backoff is showing, so the failed attempt's reason isn't
-  reachable from this snapshot.
-
-`drain()`'s `RunSnapshot` is how you tell these apart — it reports each run's own state
-right after that run executes, so a retry sequence reads attempt-by-attempt (attempt 1
-failed, attempt 2 failed, attempt 3 completed) instead of collapsing to one ambiguous
-final read.
-
-### Hazards
-
-**A `manage.py absurd_worker` subprocess is only half-frozen.** `ALTER DATABASE` reaches
-its Postgres session, but its own Python clock is real — frozen-ahead-of-real is the
-deadlock direction, since a durable sleep due at the frozen instant looks not-yet-due to
-that process's real clock. The `dj_absurd` fixture's `drain` only ever runs the
-in-process burst worker; a real subprocess worker under a freeze is out of scope.
-
-**A savepoint rollback inside a `freeze_time` block can make a later `enqueue()` stamp
-stale time.** Django's own connection only ever sees the frozen instant via a
-session-level `SET` (a database-level default reaches only new sessions, not one Django
-already has open); a savepoint rollback reverts that `SET`. `dj_absurd.now` still
-reports the frozen instant correctly — it reads through its own fresh connection, which
-sees the database-level default — so `now` cannot itself flag the mismatch. If your test
-rolls back a savepoint inside the block, avoid enqueuing across the rollback boundary.
-
-**Advancing cannot make a [pg_cron](cron-jobs.md#database-side-pg_cron) schedule fire.**
-Its launcher runs in the central `cron.database_name` database
-([Test databases](cron-jobs.md#test-databases)), on its own real clock, and interprets
-schedules in the [`cron.timezone`](cron-jobs.md#timezone) GUC — none of which a
-test-database GUC can reach. Testing a pg_cron schedule stays "reconcile it in, then
-inspect `cron.job`", exactly as `tests/pg_cron` already does; `freeze_time` doesn't
-apply to it.
-
 ## Getting a `SCHEDULE` into pg_cron for a test
 
 Auto-cleanup only tears down; it has no say over whether a
@@ -258,5 +228,26 @@ requires `OPTIONS["SYNC_SCHEDULES_ON_TEST_DB"] = True`) or call
 `call_command("absurd_sync_crons")` explicitly — without `PG_CRON_ON_TEST_DB`,
 `absurd_sync_crons` refuses to run (`CommandError`) rather than silently doing nothing.
 Either way, cleanup clears whatever ended up in `cron.job` / `ScheduledTask` —
-settings-synced, admin-authored, or created directly by the test itself — it clears
-whatever's present, regardless of how it got there.
+settings-synced, admin-authored, or created directly by the test itself.
+
+## `manage.py test`
+
+Django's own
+[`DiscoverRunner`](https://docs.djangoproject.com/en/6.0/topics/testing/advanced/#django.test.runner.DiscoverRunner)
+has no equivalent auto-hook — pytest is django-absurd's primary test surface. Wire the
+same public hook yourself, from a runner subclass, and point `TEST_RUNNER` at it:
+
+```python
+from django.test.runner import DiscoverRunner
+
+from django_absurd.test import install_absurd_cleanup
+
+
+class MyTestRunner(DiscoverRunner):
+    def setup_test_environment(self, **kwargs):
+        super().setup_test_environment(**kwargs)
+        install_absurd_cleanup()
+```
+
+`install_absurd_cleanup()` is idempotent — calling it where pytest's plugin already
+installed it is a no-op.

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -22,14 +22,11 @@ retry backoff, or a chain of several sleeps.
 import datetime as dt
 
 import pytest
-from django.core.management import call_command
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
-    call_command("absurd_sync_queues")
-
     with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
         result = my_weekly_followup_task.enqueue()  # enqueue INSIDE the block
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
@@ -86,10 +83,18 @@ pays nothing: the other members never touch the clock. `FrozenTime` is importabl
 
     [time-machine](https://github.com/adamchainz/time-machine) is a dev/test
     dependency of *your* project, not bundled with django-absurd and not one of its
-    extras. `pip install time-machine` in your test environment. `drain`/`emit`/
-    `get_result`/`now` work without it — only `freeze_time` imports it, lazily, on
-    first use, and raises `ImproperlyConfigured` naming the install command if it's
+    extras. `pip install time-machine` in your test environment. `sync_queues`/`drain`/
+    `emit`/`get_result`/`now` work without it — only `freeze_time` imports it, lazily,
+    on first use, and raises `ImproperlyConfigured` naming the install command if it's
     missing.
+
+### `sync_queues()`
+
+Provisions every declared queue — the runtime counterpart of
+`manage.py absurd_sync_queues`. Rarely needed: `migrate` already provisions the declared
+catalog, so reach for this only when the test itself changed queue topology — a
+`settings` override declaring a queue the migration never saw, or a fixture that dropped
+the queues.
 
 ### `drain(queue="default")`
 
@@ -101,10 +106,9 @@ time, then returns one `RunSnapshot` per run executed, in claim order.
 It provisions nothing, unlike the CLI, which provisions declared queues on start.
 `migrate` provisions every declared queue already, so a test database arrives ready. A
 queue a single test declares by overriding `TASKS` has no table yet — call
-`call_command("absurd_sync_queues")` first, or `drain()` raises
-`QueueNotProvisionedError` naming that command. Draining a queue that isn't declared at
-all raises `QueueNotDeclaredError` — see
-[Our own exceptions](workflows.md#our-own-exceptions).
+`dj_absurd.sync_queues()` first, or `drain()` raises `QueueNotProvisionedError` naming
+the `absurd_sync_queues` command. Draining a queue that isn't declared at all raises
+`QueueNotDeclaredError` — see [Our own exceptions](workflows.md#our-own-exceptions).
 
 ### `emit(name, payload=None, queue="default")`
 

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -197,27 +197,14 @@ own fresh connection rather than computed in Python.
 
 ### Hazards
 
-**A `manage.py absurd_worker` subprocess is only half-frozen.** `ALTER DATABASE` reaches
-its Postgres session, but its own Python clock is real — frozen-ahead-of-real is the
-deadlock direction, since a durable sleep due at the frozen instant looks not-yet-due to
-that process's real clock. `drain` only ever runs the in-process burst worker; a real
-subprocess worker under a freeze is out of scope.
-
-**A savepoint rollback inside a `freeze_time` block can make a later `enqueue()` stamp
-stale time.** Django's own connection only ever sees the frozen instant via a
-session-level `SET` (a database-level default reaches only new sessions, not one Django
-already has open), and a savepoint rollback reverts that `SET`. `dj_absurd.now` still
-reports the frozen instant correctly — it reads through its own fresh connection, which
-sees the database-level default — so `now` cannot itself flag the mismatch. If your test
-rolls back a savepoint inside the block, avoid enqueuing across the rollback boundary.
-
-**Advancing cannot make a [pg_cron](cron-jobs.md#database-side-pg_cron) schedule fire.**
-Its launcher runs in the central `cron.database_name` database
-([Test databases](cron-jobs.md#test-databases)), on its own real clock, and interprets
-schedules in the [`cron.timezone`](cron-jobs.md#timezone) GUC — none of which a
-test-database GUC can reach. Testing a pg_cron schedule stays "reconcile it in, then
-inspect `cron.job`" — see
+**A freeze doesn't reach [pg_cron](cron-jobs.md#database-side-pg_cron).** Its launcher
+runs in another database on its own clock, so advancing durable time cannot make a
+schedule fire. Test one by reconciling it in and inspecting `cron.job` — see
 [Getting a `SCHEDULE` into pg_cron for a test](#getting-a-schedule-into-pg_cron-for-a-test).
+
+**A savepoint rollback inside the block reverts Django's session clock**, so a later
+`enqueue()` stamps real time and won't look claimable. Don't enqueue across a rollback
+boundary.
 
 ## Cleanup is automatic
 

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -44,11 +44,10 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
 
 ### Requires `transaction=True`
 
-Absurd's own work runs on a connection separate from the test's. Under a plain
+Absurd's own work runs on a connection separate from the test's; under a plain
 [`db`](https://pytest-django.readthedocs.io/en/latest/helpers.html#db) test the enqueued
-row is invisible to that connection, so a drain silently no-ops, `get_result` returns
-`None`, and an `emit` never wakes its waiter. All three detect the open transaction and
-raise rather than letting that silence land far from its cause — use
+row is invisible to it. `drain`, `emit`, and `get_result` detect the open transaction
+and raise rather than silently no-opping — use
 `@pytest.mark.django_db(transaction=True)`.
 
 !!! warning "Multi-DB: declare the Absurd alias"
@@ -79,9 +78,9 @@ is the only thing a durable deadline is measured in.
 Both halves of the clock are released when the block ends, so a test can open several
 windows in sequence. Opening one INSIDE another raises instead of stacking — two frozen
 instants cannot both be "now" — and using a `FrozenTime` after its own block exited
-raises rather than silently re-freezing from real now. Durable time moves only inside a
-block; a test that never opens one pays nothing and leaks nothing. `FrozenTime` is
-importable from `django_absurd.test` for annotating your own helpers.
+raises rather than silently re-freezing from real now. A test that never opens a block
+pays nothing: the other members never touch the clock. `FrozenTime` is importable from
+`django_absurd.test` for annotating your own helpers.
 
 !!! warning "Install time-machine yourself"
 
@@ -97,10 +96,7 @@ importable from `django_absurd.test` for annotating your own helpers.
 Runs every currently-claimable task on `queue` to completion, in-process — no
 [worker](how-it-works.md#workers) subprocess, no polling loop to manage. It's the
 fixture counterpart of `absurd_worker --burst`: it drains the backlog present at call
-time, then returns one `RunSnapshot` per run executed, in claim order. It takes no
-`concurrency` parameter — the burst drain runs lockstep batches rather than a rolling
-window, so the parameter would be a misnomer; worker concurrency stays covered through
-the `absurd_worker` CLI.
+time, then returns one `RunSnapshot` per run executed, in claim order.
 
 It provisions nothing, unlike the CLI, which provisions declared queues on start.
 `migrate` provisions every declared queue already, so a test database arrives ready. A
@@ -108,7 +104,7 @@ queue a single test declares by overriding `TASKS` has no table yet — call
 `call_command("absurd_sync_queues")` first, or `drain()` raises
 `QueueNotProvisionedError` naming that command. Draining a queue that isn't declared at
 all raises `QueueNotDeclaredError` — see
-[Our own exceptions](workflows.md#our-own-exceptions) for the full typed-error taxonomy.
+[Our own exceptions](workflows.md#our-own-exceptions).
 
 ### `emit(name, payload=None, queue="default")`
 
@@ -125,14 +121,12 @@ Omit `queue` entirely to let the prefix win:
 
 ```python
 result = reports_task.enqueue()   # id is "reports:<uuid>"
-dj_absurd.get_result(result.id)   # queries the "reports" queue, correctly
+dj_absurd.get_result(result.id)   # queries the "reports" queue
 ```
 
-Passing `queue=` explicitly — including `queue="default"` — is detectable, since it
-defaults to an internal sentinel rather than the literal string `"default"`. If it
-disagrees with a prefixed id's own queue, `get_result` raises `TaskIdQueueMismatchError`
-naming both instead of silently picking one. A bare uuid resolves an unpassed `queue` to
-`"default"`.
+An explicit `queue=` — even `queue="default"` — that disagrees with a prefixed id's own
+queue raises `TaskIdQueueMismatchError` naming both. A bare uuid resolves an unpassed
+`queue` to `"default"`.
 
 A task-level view cannot express an in-flight [retry](tasks.md#retries-spawn-options):
 
@@ -146,9 +140,8 @@ A task-level view cannot express an in-flight [retry](tasks.md#retries-spawn-opt
   reachable from this snapshot.
 
 `drain()`'s `RunSnapshot` is how you tell these apart — it reports each run's own state
-right after that run executes, so a retry sequence reads attempt-by-attempt (attempt 1
-failed, attempt 2 failed, attempt 3 completed) instead of collapsing to one ambiguous
-final read.
+right after that run executes, so a retry sequence reads attempt-by-attempt instead of
+collapsing to one ambiguous final read.
 
 ### `now`
 
@@ -176,7 +169,8 @@ Its launcher runs in the central `cron.database_name` database
 ([Test databases](cron-jobs.md#test-databases)), on its own real clock, and interprets
 schedules in the [`cron.timezone`](cron-jobs.md#timezone) GUC — none of which a
 test-database GUC can reach. Testing a pg_cron schedule stays "reconcile it in, then
-inspect `cron.job`"; `freeze_time` doesn't apply to it.
+inspect `cron.job`" — see
+[Getting a `SCHEDULE` into pg_cron for a test](#getting-a-schedule-into-pg_cron-for-a-test).
 
 ## Cleanup is automatic
 

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -35,7 +35,6 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
         assert [run.state for run in dj_absurd.drain()] == ["completed"]
 
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.state == "completed"
 ```
 
@@ -76,8 +75,10 @@ Both halves of the clock are released when the block ends, so a test can open se
 windows in sequence. Opening one INSIDE another raises instead of stacking — two frozen
 instants cannot both be "now" — and using a `FrozenTime` after its own block exited
 raises rather than silently re-freezing from real now. A test that never opens a block
-pays nothing: the other members never touch the clock. `FrozenTime` is importable from
-`django_absurd.test` for annotating your own helpers.
+pays nothing: the other members never touch the clock. `FrozenTime`, `AbsurdTestRuntime`
+(what `dj_absurd` itself is typed as), `TaskSnapshot`, and `RunSnapshot` are all
+importable from `django_absurd.test` for annotating your own helpers and fixture
+parameters.
 
 !!! warning "Install time-machine yourself"
 
@@ -110,6 +111,29 @@ queue a single test declares by overriding `TASKS` has no table yet — call
 the `absurd_sync_queues` command. Draining a queue that isn't declared at all raises
 `QueueNotDeclaredError` — see [Our own exceptions](workflows.md#our-own-exceptions).
 
+**`RunSnapshot` fields:**
+
+| Field              | Meaning                                                                          |
+| ------------------ | -------------------------------------------------------------------------------- |
+| `queue`, `task_id` | which task this run belongs to                                                   |
+| `run_id`           | this run's id — the same value appears twice for a re-armed `await_event` waiter |
+| `task_name`        | dotted task path                                                                 |
+| `args`, `kwargs`   | decoded from the enqueued params                                                 |
+| `attempt`          | 1-based attempt number                                                           |
+| `state`            | see state vocabulary below                                                       |
+| `result`           | the task's return value, once `completed`                                        |
+| `failure`          | `{"message": str, "name"?: str, "traceback"?: str}`, once `failed`               |
+
+**Observable `state` values:**
+
+| State       | Meaning                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pending`   | claimable, not yet run                                                                                                                      |
+| `sleeping`  | suspended — a durable [sleep](workflows.md#sleep), an `await_event` wait, or a retry backoff (indistinguishable from a `RunSnapshot` alone) |
+| `completed` | finished successfully                                                                                                                       |
+| `failed`    | raised, and out of retries                                                                                                                  |
+| `cancelled` | cancelled before or during execution                                                                                                        |
+
 ### `emit(name, payload=None, queue="default")`
 
 Delivers an [event](workflows.md#events), resolving a task suspended in `await_event` —
@@ -118,10 +142,16 @@ the waiter resumes on the next `drain()`. An unprovisioned queue raises
 
 ### `get_result(task_id, queue=...)`
 
-Looks up one task, returning `TaskSnapshot | None`. `task_id` accepts either a bare uuid
-or Django's own `TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed back.
-When it carries a queue prefix, that prefix is what gets queried, not `queue`'s default.
-Omit `queue` entirely to let the prefix win:
+Where [`my_task.get_result(result.id)`](tasks.md#read-the-result) reads Django's own
+`TaskResult.status`, `dj_absurd.get_result` reads Absurd's own states directly —
+including `sleeping`, a state `TaskResult.status` can't show — and skips the worker
+round-trip; like Django's own method, it raises on a miss.
+
+Looks up one task, returning a `TaskSnapshot`, or raising `TaskNotFoundError` if none
+exists on that queue. `task_id` accepts either a bare uuid or Django's own
+`TaskResult.id` (`"queue:uuid"`) — whatever `enqueue()` handed back. When it carries a
+queue prefix, that prefix is what gets queried, not `queue`'s default. Omit `queue`
+entirely to let the prefix win:
 
 ```python
 result = reports_task.enqueue()   # id is "reports:<uuid>"
@@ -131,6 +161,19 @@ dj_absurd.get_result(result.id)   # queries the "reports" queue
 An explicit `queue=` — even `queue="default"` — that disagrees with a prefixed id's own
 queue raises `TaskIdQueueMismatchError` naming both. A bare uuid resolves an unpassed
 `queue` to `"default"`.
+
+**`TaskSnapshot` fields:**
+
+| Field              | Meaning                                                 |
+| ------------------ | ------------------------------------------------------- |
+| `queue`, `task_id` | which task this is (no queue prefix on `task_id`)       |
+| `task_name`        | dotted task path                                        |
+| `args`, `kwargs`   | decoded from the enqueued params                        |
+| `state`            | see the state vocabulary under `drain()` above          |
+| `attempts`         | attempts CREATED, not completed (see caveats below)     |
+| `enqueued_at`      | when `enqueue()` ran                                    |
+| `result`           | the task's return value, once `completed`               |
+| `failure`          | `None` except on a terminal failure (see caveats below) |
 
 A task-level view cannot express an in-flight [retry](tasks.md#retries-spawn-options):
 

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -38,6 +38,24 @@ def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
         assert snapshot.state == "completed"
 ```
 
+### Works from `async def` tests
+
+Every member works unchanged from an `async def` test — same names, nothing to `await`
+on the fixture, no separate API. Enqueue with Django's own
+[`await task.aenqueue()`](https://docs.djangoproject.com/en/6.0/topics/tasks/), since
+`enqueue()` is synchronous.
+
+```python
+async def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
+        result = await my_weekly_followup_task.aenqueue()
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=7))
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+        assert dj_absurd.get_result(result.id).state == "completed"
+```
+
 ### Requires `transaction=True`
 
 Absurd's own work runs on a connection separate from the test's; under a plain

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -68,26 +68,103 @@ class MyTestRunner(DiscoverRunner):
 Then point your project's `TEST_RUNNER` at it. `install_absurd_cleanup()` is idempotent
 — calling it again where pytest's plugin already installed it is a no-op.
 
-## `absurd_drain_queue`
+## The `dj_absurd` fixture: durable time, drain, and read
+
+Running a task, moving Absurd's own notion of "now", and inspecting what actually ran
+all go through one fixture, `dj_absurd` — whether the test is a one-line "my task
+completes" or a [durable sleep](workflows.md#sleep), an
+[`await_event` timeout](workflows.md#timeout), a retry backoff, or a chain of several
+sleeps. It returns an `AbsurdTestRuntime` with five members:
+
+| Member                                      | Does                                                              |
+| ------------------------------------------- | ----------------------------------------------------------------- |
+| `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry) |
+| `now`                                       | virtual now, timezone-aware, as Postgres itself reports it        |
+| `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                |
+| `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`     |
+| `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot \| None` (see below)    |
+
+`freeze_time` yields a `FrozenTime` handle, and its two movers are the only way durable
+time ever moves:
+
+| Mover               | Does                                        |
+| ------------------- | ------------------------------------------- |
+| `move_to(datetime)` | move to an absolute, timezone-aware instant |
+| `shift(timedelta)`  | move forward by Δ of absolute elapsed time  |
 
 ```python
-@pytest.mark.django_db(transaction=True)
-def test_task_runs(absurd_drain_queue):
-    my_task.enqueue()
-    absurd_drain_queue()
-    ...
+import datetime as dt
+
+import pytest
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_a_task_sleeps_seven_days_then_completes(dj_absurd):
+    call_command("absurd_sync_queues")
+
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, tzinfo=dt.UTC)) as frozen_time:
+        result = my_weekly_followup_task.enqueue()  # enqueue INSIDE the block
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=7))
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.state == "completed"
 ```
 
-Returns a callable `drain(queue: str = "default", *, concurrency: int = 1) -> None` that
-runs every currently-claimable task on `queue` to completion, in-process — no
-[worker](how-it-works.md#workers) subprocess, no polling loop to manage. It's the
-fixture equivalent of `absurd_worker --burst`: it drains the backlog present at call
-time, then returns.
+Both halves of the clock are released when the block ends, so real time is back and a
+test can open several windows in sequence. Opening one INSIDE another raises instead of
+stacking: two frozen instants cannot both be "now". Using a `FrozenTime` after its own
+block has exited raises as well, rather than silently re-freezing from real now.
+`FrozenTime` is importable from `django_absurd.test` for annotating your own helpers.
 
-The worker opens its own database connection, separate from the test's — so a test using
-`absurd_drain_queue` needs `transaction=True` (not plain `db`): under an uncommitted
-`db` transaction the enqueue is invisible to that second connection and the task never
-gets claimed.
+### `drain()`
+
+`drain()` runs every currently-claimable task on `queue` to completion, in-process — no
+[worker](how-it-works.md#workers) subprocess, no polling loop to manage. It's the
+fixture counterpart of `absurd_worker --burst`: it drains the backlog present at call
+time, then returns one `RunSnapshot` per run executed, in claim order. It takes no
+`concurrency` parameter — the burst drain runs lockstep batches rather than a rolling
+window, so the parameter would be a misnomer; worker concurrency stays covered through
+the `absurd_worker` CLI.
+
+It provisions nothing — unlike the CLI, which provisions declared queues on start.
+`migrate` provisions every declared queue already, so a test database arrives ready. A
+queue a single test declares by overriding `TASKS` has no table yet — call
+`call_command("absurd_sync_queues")` first, or `drain()` raises
+`QueueNotProvisionedError` naming that command. Draining a queue that isn't declared at
+all raises `QueueNotDeclaredError` — see
+[Our own exceptions](workflows.md#our-own-exceptions) for the full typed-error taxonomy.
+
+### `get_result()` honours a prefixed id's own queue
+
+`task_id` accepts either a bare uuid or Django's own `TaskResult.id` (`"queue:uuid"`) —
+whatever `enqueue()` handed back. When it carries a queue prefix, that prefix is what
+gets queried, not `queue`'s default. Omit `queue` entirely to let the prefix win:
+
+```python
+result = reports_task.enqueue()          # id is "reports:<uuid>"
+dj_absurd.get_result(result.id)             # queries the "reports" queue, correctly
+```
+
+Passing `queue=` explicitly — including `queue="default"` — is detectable, since it
+defaults to an internal sentinel rather than the literal string `"default"`. If it
+disagrees with a prefixed id's own queue, `get_result` raises `TaskIdQueueMismatchError`
+naming both instead of silently picking one. A bare uuid (no prefix) resolves an
+unpassed `queue` to `"default"`, same as always.
+
+### Requires `transaction=True`
+
+Absurd's own work runs on a connection separate from the test's. Under a plain
+[`db`](https://pytest-django.readthedocs.io/en/latest/helpers.html#db) test the enqueued
+row is invisible to that connection, so a drain silently no-ops, `get_result` returns
+`None`, and an `emit` never wakes its waiter. Every one of `drain`, `emit`, and
+`get_result` detects the open transaction and raises rather than letting that confusing
+silence land far from its cause — use `@pytest.mark.django_db(transaction=True)`.
 
 !!! warning "Multi-DB: declare the Absurd alias"
 
@@ -95,6 +172,75 @@ gets claimed.
     `databases` attribute doesn't include the Absurd alias, the cleanup guard above
     skips it afterward — the committed state leaks into the next test. Declare the
     Absurd alias in `databases` on any `transaction=True` test that runs a worker.
+
+### Freeze BEFORE enqueueing
+
+`freeze_time` and its movers move both Python's clock (via
+[time-machine](https://github.com/adamchainz/time-machine)) and Postgres's
+`absurd.fake_now` GUC. Freezing to a PAST instant after rows already exist leaves those
+rows' deadlines in the database's future relative to the new frozen now, so nothing is
+claimable until a later `move_to`/`shift` passes them. Enter the `freeze_time` block
+before the `enqueue()` calls whose deadlines you want to control.
+
+`shift(Δ)` is absolute elapsed time, not wall-clock arithmetic: shifting seven days from
+`01:30` the morning of a US spring-forward lands 7 × 24 hours later as an instant, which
+is the only thing a durable deadline is measured in.
+
+Durable time only moves inside a `freeze_time` block — a test that never opens one pays
+nothing and leaks nothing; `drain`, `emit`, `get_result`, and `now` all work without
+ever touching the clock.
+
+!!! warning "Install time-machine yourself"
+
+    [time-machine](https://github.com/adamchainz/time-machine) is a dev/test
+    dependency of *your* project, not bundled with django-absurd and not one of its
+    extras. `pip install time-machine` in your test environment. `drain`/`emit`/
+    `get_result`/`now` work without it — only `freeze_time` imports it, lazily, on
+    first use, and raises `ImproperlyConfigured` naming the install command if it's
+    missing.
+
+### `TaskSnapshot` caveats: use `RunSnapshot` for an in-flight retry
+
+`get_result` returns a task-level view, and a task-level view cannot express an
+in-flight [retry](tasks.md#retries-spawn-options):
+
+- **`attempts` counts attempts CREATED, not completed.** A task with one failed attempt
+  and a pending backoff already reads `attempts=2`, before the second attempt has run.
+- **`state="sleeping"` covers a retry backoff as well as a durable
+  [sleep](workflows.md#sleep).** A test asserting "my workflow is asleep" would pass
+  just as readily on a task that crashed and is waiting to retry.
+- **`failure` is `None` mid-backoff.** `last_attempt_run` already points at the fresh
+  pending run by the time the backoff is showing, so the failed attempt's reason isn't
+  reachable from this snapshot.
+
+`drain()`'s `RunSnapshot` is how you tell these apart — it reports each run's own state
+right after that run executes, so a retry sequence reads attempt-by-attempt (attempt 1
+failed, attempt 2 failed, attempt 3 completed) instead of collapsing to one ambiguous
+final read.
+
+### Hazards
+
+**A `manage.py absurd_worker` subprocess is only half-frozen.** `ALTER DATABASE` reaches
+its Postgres session, but its own Python clock is real — frozen-ahead-of-real is the
+deadlock direction, since a durable sleep due at the frozen instant looks not-yet-due to
+that process's real clock. The `dj_absurd` fixture's `drain` only ever runs the
+in-process burst worker; a real subprocess worker under a freeze is out of scope.
+
+**A savepoint rollback inside a `freeze_time` block can make a later `enqueue()` stamp
+stale time.** Django's own connection only ever sees the frozen instant via a
+session-level `SET` (a database-level default reaches only new sessions, not one Django
+already has open); a savepoint rollback reverts that `SET`. `dj_absurd.now` still
+reports the frozen instant correctly — it reads through its own fresh connection, which
+sees the database-level default — so `now` cannot itself flag the mismatch. If your test
+rolls back a savepoint inside the block, avoid enqueuing across the rollback boundary.
+
+**Advancing cannot make a [pg_cron](cron-jobs.md#database-side-pg_cron) schedule fire.**
+Its launcher runs in the central `cron.database_name` database
+([Test databases](cron-jobs.md#test-databases)), on its own real clock, and interprets
+schedules in the [`cron.timezone`](cron-jobs.md#timezone) GUC — none of which a
+test-database GUC can reach. Testing a pg_cron schedule stays "reconcile it in, then
+inspect `cron.job`", exactly as `tests/pg_cron` already does; `freeze_time` doesn't
+apply to it.
 
 ## Getting a `SCHEDULE` into pg_cron for a test
 

--- a/docs/web/workflows.md
+++ b/docs/web/workflows.md
@@ -219,9 +219,11 @@ freed) → the warehouse system POSTs the webhook → the view emits the event o
 queue → the task's next claim finds it → resumes with the payload.
 
 `queue` must match the queue the waiting task actually runs on — it targets the
-client-level `emit_event`'s `queue_name`, not a database alias. An unknown queue raises
-`ImproperlyConfigured` immediately (fail fast on a typo). `emit_event` is sync; from an
-async view, wrap it in `sync_to_async`.
+client-level `emit_event`'s `queue_name`, not a database alias. An undeclared queue
+raises `QueueNotDeclaredError` immediately (fail fast on a typo); a declared but
+unprovisioned queue raises `QueueNotProvisionedError` naming
+`manage.py absurd_sync_queues` (see [Our own exceptions](#our-own-exceptions) below).
+`emit_event` is sync; from an async view, wrap it in `sync_to_async`.
 
 ### Sync
 
@@ -355,6 +357,19 @@ An event emitted long before a delayed `await_event` can be cleaned up by the qu
 
 `except TimeoutError:` silently catches nothing — `import absurd_sdk` and catch
 `absurd_sdk.TimeoutError`.
+
+### Our own exceptions
+
+django-absurd's own conditions (an undeclared or unprovisioned queue, from `emit_event`
+or the test fixture's `drain()`) raise typed errors under
+`django_absurd.exceptions.DjangoAbsurdError` — `QueueNotDeclaredError` and
+`QueueNotProvisionedError`. `enqueue` raises `QueueNotDeclaredError` too, but only when
+the backend's `QUEUES` option is empty/unset; with `QUEUES` configured, a typo'd queue
+name at enqueue is instead rejected earlier as Django's own `InvalidTask`, from
+`validate_task`. Catch `DjangoAbsurdError` to handle any of them generically. This is
+not every error the package can raise, though: plenty of call sites still raise a plain
+`ImproperlyConfigured`, `RuntimeError`, or `TypeError` directly and are outside this
+hierarchy for now.
 
 ## Enqueue a durable task
 

--- a/docs/web/workflows.md
+++ b/docs/web/workflows.md
@@ -365,11 +365,9 @@ or the test fixture's `drain()`) raise typed errors under
 `django_absurd.exceptions.DjangoAbsurdError` — `QueueNotDeclaredError` and
 `QueueNotProvisionedError`. `enqueue` raises `QueueNotDeclaredError` too, but only when
 the backend's `QUEUES` option is empty/unset; with `QUEUES` configured, a typo'd queue
-name at enqueue is instead rejected earlier as Django's own `InvalidTask`, from
-`validate_task`. Catch `DjangoAbsurdError` to handle any of them generically. This is
-not every error the package can raise, though: plenty of call sites still raise a plain
-`ImproperlyConfigured`, `RuntimeError`, or `TypeError` directly and are outside this
-hierarchy for now.
+name at enqueue is instead rejected earlier as Django's own `InvalidTask`. Catch
+`DjangoAbsurdError` to handle any of them generically; other failures still raise plain
+`ImproperlyConfigured`/`RuntimeError`/`TypeError` outside the hierarchy.
 
 ## Enqueue a durable task
 

--- a/examples/beat/README.md
+++ b/examples/beat/README.md
@@ -18,4 +18,13 @@ docker compose up
 - `docker compose logs worker` — watch for `tock ⏰` each minute
 - `http://localhost:8000/admin/` — Tasks / Runs growing (login: **admin** / **admin**)
 
+Running more than one example at once? Override the published port:
+`APP_PORT=8010 docker compose up`.
+
 Tear down: `docker compose down -v`
+
+## Test
+
+```
+uv run pytest
+```

--- a/examples/beat/compose.yaml
+++ b/examples/beat/compose.yaml
@@ -15,7 +15,7 @@ services:
       - db
     restart: on-failure
     ports:
-      - "8000:8000"
+      - "${APP_PORT:-8000}:8000"
     environment: &env
       - PGHOST=db
       - PGPORT=5432

--- a/examples/beat/tests/test_beat.py
+++ b/examples/beat/tests/test_beat.py
@@ -1,12 +1,13 @@
 """Tests for the beat demo: the index redirect, and the scheduled `tick` task run
-end-to-end through `absurd_drain_queue` (the beat process itself isn't exercised —
-its cadence is time-driven; here we drive the task the beat would enqueue)."""
-
-import typing as t
+end-to-end through the `dj_absurd` fixture's `drain()` (the beat process itself isn't
+exercised — its cadence is time-driven; here we drive the task the beat would
+enqueue)."""
 
 import pytest
 from app import tick
 from django.test import Client
+
+from django_absurd.test import AbsurdTestRuntime
 
 
 def test_index_redirects_to_admin(client: Client) -> None:
@@ -17,11 +18,11 @@ def test_index_redirects_to_admin(client: Client) -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_tick_task_runs_via_drain(
-    absurd_drain_queue: t.Callable[..., None], caplog: pytest.LogCaptureFixture
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
 ) -> None:
     result = tick.enqueue()
     with caplog.at_level("INFO", logger="demo"):
-        absurd_drain_queue()
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
     result.refresh()
     assert result.status == "SUCCESSFUL"
     assert result.return_value is None

--- a/examples/pg_cron/README.md
+++ b/examples/pg_cron/README.md
@@ -25,4 +25,17 @@ docker compose up
 - `docker compose logs worker` — watch for `pong 🏓` each minute
 - `http://localhost:8000/admin/` — Tasks / Runs growing (login: **admin** / **admin**)
 
+Running more than one example at once? Override the published port:
+`APP_PORT=8010 docker compose up`.
+
 Tear down (remove volumes before re-running): `docker compose down -v`
+
+## Test
+
+This suite is only meaningful **in-stack** — a host run reaches the repo's plain
+database on 5432, which has no `pg_cron` extension:
+
+```
+docker compose up -d --build db
+docker compose run --rm --build app sh -c "cd /app && pytest"
+```

--- a/examples/pg_cron/compose.yaml
+++ b/examples/pg_cron/compose.yaml
@@ -29,7 +29,7 @@ services:
       - db
     restart: on-failure
     ports:
-      - "8000:8000"
+      - "${APP_PORT:-8000}:8000"
     environment: &env
       - PGHOST=db
       - PGPORT=5432

--- a/examples/pg_cron/tests/test_pg_cron.py
+++ b/examples/pg_cron/tests/test_pg_cron.py
@@ -1,12 +1,13 @@
 """Tests for the pg_cron demo: the index redirect, and the scheduled `ping` task run
-end-to-end through `absurd_drain_queue`. pg_cron's own firing (Postgres-side, cadence-
-driven) isn't exercised here — we drive the task pg_cron would enqueue."""
-
-import typing as t
+end-to-end through the `dj_absurd` fixture's `drain()`. pg_cron's own firing
+(Postgres-side, cadence-driven) isn't exercised here — we drive the task pg_cron would
+enqueue."""
 
 import pytest
 from app import ping
 from django.test import Client
+
+from django_absurd.test import AbsurdTestRuntime
 
 
 def test_index_redirects_to_admin(client: Client) -> None:
@@ -16,11 +17,9 @@ def test_index_redirects_to_admin(client: Client) -> None:
 
 
 @pytest.mark.django_db(transaction=True)
-def test_ping_task_runs_via_drain(
-    absurd_drain_queue: t.Callable[..., None],
-) -> None:
+def test_ping_task_runs_via_drain(dj_absurd: AbsurdTestRuntime) -> None:
     result = ping.enqueue()
-    absurd_drain_queue()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
     result.refresh()
     assert result.status == "SUCCESSFUL"
     assert result.return_value == "pong"

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -22,4 +22,13 @@ docker compose up
 - `http://localhost:8000/` — enqueue `add(a, b)`
 - `http://localhost:8000/admin/` — read-only queue tables (login: **admin** / **admin**)
 
+Running more than one example at once? Override the published port:
+`APP_PORT=8010 docker compose up`.
+
 Tear down: `docker compose down -v`
+
+## Test
+
+```
+uv run pytest
+```

--- a/examples/web/app.py
+++ b/examples/web/app.py
@@ -29,6 +29,7 @@ from django.shortcuts import redirect
 from django.tasks import TaskResultStatus, default_task_backend, task
 from django.tasks.exceptions import TaskResultDoesNotExist
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from nanodjango import Django
 
 from django_absurd import emit_event, get_absurd_context
@@ -172,6 +173,10 @@ def pack_view(request: HttpRequest, order: str) -> HttpResponse:
             queue="default",
         )
     next_url = request.GET.get("next", "/")
+    if not url_has_allowed_host_and_scheme(
+        next_url, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        next_url = "/"
     return redirect(next_url)
 
 

--- a/examples/web/compose.yaml
+++ b/examples/web/compose.yaml
@@ -15,7 +15,7 @@ services:
       - db
     restart: on-failure
     ports:
-      - "8000:8000"
+      - "${APP_PORT:-8000}:8000"
     environment: &env
       - PGHOST=db
       - PGPORT=5432

--- a/examples/web/tests/test_add.py
+++ b/examples/web/tests/test_add.py
@@ -1,21 +1,19 @@
-import typing as t
-
 import pytest
 from app import add  # app.py's own `add` task
 
+from django_absurd.test import AbsurdTestRuntime
 
-# transaction=True (not plain `db`): absurd_drain_queue's burst worker opens its
+
+# transaction=True (not plain `db`): the `dj_absurd` fixture's burst drain opens its
 # OWN dedicated DB connection (by design — see django_absurd/worker.py's
 # aworker_client), separate from Django's. Under the default `db` fixture the
 # test body runs inside an uncommitted atomic block, so the enqueue is invisible
 # to that second connection and the task never gets claimed (stays READY).
 # transaction=True commits for real, matching tests/core/test_pytest_plugin.py's
-# own drain-queue test.
+# own drain test.
 @pytest.mark.django_db(transaction=True)
-def test_add_task_completes_via_absurd_drain_queue(
-    absurd_drain_queue: t.Callable[..., None],
-) -> None:
+def test_add_task_completes_via_a_burst_drain(dj_absurd: AbsurdTestRuntime) -> None:
     result = add.enqueue("2", "3")
-    absurd_drain_queue()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
     result.refresh()
     assert result.status == "SUCCESSFUL"

--- a/examples/web/tests/test_views.py
+++ b/examples/web/tests/test_views.py
@@ -115,3 +115,9 @@ def test_pack_view_get_does_not_emit_the_event(
     assert dj_absurd.drain() == []  # nothing claimable: no event woke the waiter
     body = client.get(task_url).content.decode()
     assert "Working" in body  # still suspended — the GET delivered no event
+
+
+def test_pack_view_rejects_an_off_site_next(client: Client) -> None:
+    resp = client.get("/workflow/order-x/pack/?next=https://evil.example/steal")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/"

--- a/examples/web/tests/test_views.py
+++ b/examples/web/tests/test_views.py
@@ -1,12 +1,14 @@
 """High-level HTTP tests for the web demo — drive the real nanodjango views through
 the Django test client, asserting observable responses. The `add` task and the
-`fulfill_order` workflow are exercised end-to-end via `absurd_drain_queue`."""
+`fulfill_order` workflow are exercised end-to-end via the `dj_absurd` fixture's
+`drain()`."""
 
-import typing as t
 import uuid
 
 import pytest
 from django.test import Client
+
+from django_absurd.test import AbsurdTestRuntime
 
 
 def test_index_get_renders_the_add_form(client: Client) -> None:
@@ -24,12 +26,12 @@ def test_index_post_invalid_rerenders_the_form(client: Client) -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_add_succeeds_and_the_result_page_shows_the_value(
-    absurd_drain_queue: t.Callable[..., None], client: Client
+    client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     resp = client.post("/", {"a": "2", "b": "3"})
     assert resp.status_code == 302
     task_url = resp.headers["Location"]
-    absurd_drain_queue()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
     body = client.get(task_url).content.decode()
     assert "SUCCESSFUL" in body
     assert "5.0" in body
@@ -37,11 +39,12 @@ def test_add_succeeds_and_the_result_page_shows_the_value(
 
 @pytest.mark.django_db(transaction=True)
 def test_add_fails_on_non_numeric_input(
-    absurd_drain_queue: t.Callable[..., None], client: Client
+    client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     resp = client.post("/", {"a": "x", "b": "3"})
     task_url = resp.headers["Location"]
-    absurd_drain_queue()
+    # Every attempt of the default retry burn is drained, and each one fails.
+    assert {run.state for run in dj_absurd.drain()} == {"failed"}
     body = client.get(task_url).content.decode()
     assert "FAILED" in body
     assert "Failed:" in body
@@ -76,13 +79,14 @@ def test_workflow_post_invalid_rerenders_the_form(client: Client) -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_workflow_suspends_on_event_then_completes_after_pack(
-    absurd_drain_queue: t.Callable[..., None], client: Client
+    client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     resp = client.post("/workflow/", {"order": "order-7"})
     assert resp.status_code == 302
     task_url = resp.headers["Location"]
 
-    absurd_drain_queue()  # charge + reserve, then suspends on await_event
+    # charge + reserve, then suspends on await_event
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
     waiting = client.get(task_url).content.decode()
     assert "Working" in waiting
     assert 'action="/workflow/order-7/pack/' in waiting  # pack button present
@@ -90,7 +94,8 @@ def test_workflow_suspends_on_event_then_completes_after_pack(
     pack = client.post("/workflow/order-7/pack/?next=/")
     assert pack.status_code == 302
 
-    absurd_drain_queue()  # event delivered → resumes, runs notify, completes
+    # event delivered → resumes, runs notify, completes
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
     done = client.get(task_url).content.decode()
     assert "SUCCESSFUL" in done
     assert "notified: order-7" in done
@@ -98,15 +103,15 @@ def test_workflow_suspends_on_event_then_completes_after_pack(
 
 @pytest.mark.django_db(transaction=True)
 def test_pack_view_get_does_not_emit_the_event(
-    absurd_drain_queue: t.Callable[..., None], client: Client
+    client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     task_url = client.post("/workflow/", {"order": "order-get"}).headers["Location"]
-    absurd_drain_queue()  # suspends on await_event
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
 
     resp = client.get("/workflow/order-get/pack/")  # GET must NOT emit
     assert resp.status_code == 302
     assert resp.headers["Location"] == "/"  # default next
 
-    absurd_drain_queue()
+    assert dj_absurd.drain() == []  # nothing claimable: no event woke the waiter
     body = client.get(task_url).content.decode()
     assert "Working" in body  # still suspended — the GET delivered no event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ ignore = [
   "ARG001",  # Unused function argument
   "ARG002",  # Unused method argument
   "COM812",  # Check absence of trailing commas. Made redundant by formatter.
+  "CPY001",  # Missing copyright notice. This project doesn't use file headers.
   "D",  # Missing or badly formatted docstrings
   "FBT",  # Flake Boolean Trap
   "PLR2004",  # Allow "magic values"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,6 @@ skip_covered = true
 
 [tool.coverage.run]
 branch = true
-omit = [
-  "tests/multidb/*",
-]
 patch = ["subprocess"]
 plugins = [
   "django_coverage_plugin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dev = [
   "build==1.5.0",
   "django-coverage-plugin==3.2.2",
   "django-stubs==6.0.7",
-  "freezegun==1.5.5",
   "hatch-vcs==0.5.0",
   "hatchling==1.31.0",
   "mypy==2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,11 @@ dev = [
   "pytest-cov==7.1.0",
   "pytest-django==4.12.0",
   "pytest-socket==0.8.0",
+  "pytest-timeout==2.4.0",
   "pytest-xdist==3.8.0",
   "pytest==9.1.1",
   "ruff==0.16.0",
+  "time-machine==3.2.0",
   "types-croniter==6.2.4.20260711",
   "zensical==0.0.51",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
   "hatchling==1.31.0",
   "mypy==2.3.0",
   "psycopg[binary]==3.3.4",
+  "pytest-asyncio==1.4.0",
   "pytest-cov==7.1.0",
   "pytest-django==4.12.0",
   "pytest-socket==0.8.0",

--- a/tests/atasks.py
+++ b/tests/atasks.py
@@ -6,6 +6,7 @@ from absurd_sdk import JsonValue
 from django.tasks import TaskContext, task
 
 from django_absurd import aget_absurd_context
+from tests import tasks
 from tests.models import Payload
 
 DURABLE_STEP_CALLS: dict[str, int] = {"n": 0}
@@ -75,13 +76,13 @@ async def asleep_for_once(key: str) -> int:
         return DURABLE_STEP_CALLS["n"]
 
     n = await context.step("bump", bump)
-    await context.sleep_for("nap", 1.5)
+    await context.sleep_for("nap", tasks.WEEK_SECONDS)
     return n
 
 
 @task
 async def asleep_until_once(key: str) -> str:
-    await aget_absurd_context().sleep_until("nap", time.time() + 1.5)
+    await aget_absurd_context().sleep_until("nap", time.time() + tasks.WEEK_SECONDS)
     return "woke"
 
 

--- a/tests/core/pytest.toml
+++ b/tests/core/pytest.toml
@@ -19,3 +19,7 @@ markers = [
 ]
 pythonpath = ["../.."]
 testpaths = ["."]
+# Durable waits are frozen-clock now, so nothing here legitimately takes seconds; the
+# slowest test is ~1.2s. A cap this tight turns a reintroduced wall-clock sleep — or a
+# drain deadlocked on a half-moved clock — into a failure instead of a hung run.
+timeout = "10"

--- a/tests/core/pytest.toml
+++ b/tests/core/pytest.toml
@@ -19,7 +19,6 @@ markers = [
 ]
 pythonpath = ["../.."]
 testpaths = ["."]
-# Durable waits are frozen-clock now, so nothing here legitimately takes seconds; the
-# slowest test is ~1.2s. A cap this tight turns a reintroduced wall-clock sleep — or a
-# drain deadlocked on a half-moved clock — into a failure instead of a hung run.
+# Durable waits are frozen-clock now (slowest test ~1.2s); this cap turns a
+# reintroduced wall-clock sleep or a half-moved-clock deadlock into a failure, not a hang.
 timeout = "10"

--- a/tests/core/pytest.toml
+++ b/tests/core/pytest.toml
@@ -11,6 +11,12 @@ addopts = [
   "--reuse-db",
   "--strict-markers",
 ]
+# Explicit, not inherited: strict mode means an `async def test_` runs only with an
+# @pytest.mark.asyncio marker, so pytest-asyncio (installed venv-wide, hence loaded in
+# every suite) stays inert everywhere it isn't asked for. The loop scope is pinned
+# because leaving it unset is a pytest-asyncio deprecation warning.
+asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "strict"
 filterwarnings = [
   "error::bs4.GuessedAtParserWarning",
 ]

--- a/tests/core/test_absurd_fixture.py
+++ b/tests/core/test_absurd_fixture.py
@@ -424,4 +424,7 @@ def test_sync_queues_with_no_absurd_backend_raises(
     with pytest.raises(BackendNotConfiguredError) as exc:
         dj_absurd.sync_queues()
 
-    assert str(exc.value) == "No Absurd backend configured."
+    assert str(exc.value) == (
+        "No Absurd backend configured. Add a django_absurd.backends.AbsurdBackend "
+        "entry to TASKS."
+    )

--- a/tests/core/test_absurd_fixture.py
+++ b/tests/core/test_absurd_fixture.py
@@ -11,6 +11,7 @@ from django_absurd.exceptions import (
     BackendNotConfiguredError,
     QueueNotProvisionedError,
     TaskIdQueueMismatchError,
+    TaskNotFoundError,
 )
 from django_absurd.test import AbsurdTestRuntime
 from tests import tasks, utils
@@ -24,7 +25,6 @@ def test_get_result_reports_a_completed_task(dj_absurd: AbsurdTestRuntime) -> No
 
     snapshot = dj_absurd.get_result(result.id)
 
-    assert snapshot is not None
     assert snapshot.queue == "default"
     assert snapshot.task_name == "tests.tasks.add"
     assert snapshot.args == [2, 3]
@@ -44,7 +44,6 @@ def test_get_result_reports_a_failed_task_with_its_failure(
 
     snapshot = dj_absurd.get_result(result.id)
 
-    assert snapshot is not None
     assert snapshot.state == "failed"
     assert snapshot.result is None
     assert snapshot.failure is not None
@@ -60,7 +59,6 @@ def test_get_result_decodes_jsonb_to_python_objects(
 
     snapshot = dj_absurd.get_result(result.id)
 
-    assert snapshot is not None
     assert snapshot.args == [{"k": "v", "n": 7}]
     assert not isinstance(snapshot.args[0], str)
     assert isinstance(snapshot.result, int)
@@ -78,17 +76,24 @@ def test_get_result_reads_a_task_suspended_on_an_indefinite_await_event(
 
     snapshot = dj_absurd.get_result(result.id)
 
-    assert snapshot is not None
     assert snapshot.state == "sleeping"
     assert snapshot.attempts == 1
     assert snapshot.result is None
     assert snapshot.failure is None
 
 
-def test_get_result_returns_none_for_an_unknown_task(
+def test_get_result_raises_for_an_unknown_task(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:
-    assert dj_absurd.get_result(uuid.uuid4()) is None
+    task_id = uuid.uuid4()
+
+    with pytest.raises(TaskNotFoundError) as exc:
+        dj_absurd.get_result(task_id)
+
+    assert str(exc.value) == (
+        f"No task '{task_id}' found on queue 'default'. A bare uuid resolves to "
+        "queue 'default'; pass queue=... if the task ran on another queue."
+    )
 
 
 def test_get_result_raises_queue_not_provisioned_for_the_queues_own_missing_table(
@@ -178,7 +183,6 @@ def test_get_result_tolerates_params_that_are_not_our_shape(
 
     snapshot = dj_absurd.get_result(result.id)
 
-    assert snapshot is not None
     assert snapshot.args == []
     assert snapshot.kwargs == {}
 
@@ -190,7 +194,6 @@ def test_get_result_accepts_a_bare_uuid(dj_absurd: AbsurdTestRuntime) -> None:
 
     snapshot = dj_absurd.get_result(bare)
 
-    assert snapshot is not None
     assert snapshot.state == "completed"
 
 
@@ -202,7 +205,6 @@ def test_get_result_honours_a_non_default_queue_prefix_on_the_id(
 
     snapshot = dj_absurd.get_result(result.id)  # no queue= passed; the prefix must win
 
-    assert snapshot is not None
     assert snapshot.queue == "reports"
     assert snapshot.state == "completed"
     assert snapshot.result == "on_reports"
@@ -217,7 +219,6 @@ def test_get_result_accepts_a_bare_uuid_with_an_explicit_non_default_queue(
 
     snapshot = dj_absurd.get_result(bare, queue="other")
 
-    assert snapshot is not None
     assert snapshot.queue == "other"
     assert snapshot.state == "completed"
 
@@ -341,7 +342,6 @@ def test_drain_returns_every_attempt_of_a_default_retry_burn(
     assert {run.state for run in drained} == {"failed"}
     assert drained[0].failure is not None
     snapshot = dj_absurd.get_result(result.id)
-    assert snapshot is not None
     assert snapshot.state == "failed"
     assert snapshot.attempts == 5
 
@@ -391,7 +391,6 @@ def test_emit_resolves_a_waiting_task(dj_absurd: AbsurdTestRuntime) -> None:
 
     assert [run.state for run in dj_absurd.drain()] == ["completed"]
     snapshot = dj_absurd.get_result(result.id)
-    assert snapshot is not None
     assert snapshot.result == {"tracking": "abc"}
 
 

--- a/tests/core/test_absurd_fixture.py
+++ b/tests/core/test_absurd_fixture.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 
 import psycopg
@@ -117,14 +116,9 @@ def test_get_result_does_not_relabel_an_unrelated_missing_relation(
 ) -> None:
     """Mirrors ``test_drain_queue_does_not_relabel_an_unrelated_missing_relation``
     (``tests/core/test_worker.py``): a missing relation that is NOT one of this
-    queue's own Absurd tables surfaces as itself, chained, rather than as the
-    curated unprovisioned-queue error.
-
-    ``get_result`` is a plain SELECT — Postgres has no SELECT trigger to hook the
-    way the write-path tests hook an audit trigger on a claim/emit. A view standing
-    in for ``t_default``, computing ``task_id`` through a function whose body reads
-    the missing relation, gets the same real failure: no mocking, landing exactly
-    where ``get_result``'s own query executes.
+    queue's own Absurd tables surfaces as itself, chained, not as the curated
+    unprovisioned-queue error. ``get_result`` is a plain SELECT — Postgres has no
+    SELECT trigger to hook, so a view stands in for ``t_default`` instead.
     """
     result = tasks.add.enqueue(2, 3)
     utils.run_absurd_worker()
@@ -228,62 +222,50 @@ def test_get_result_accepts_a_bare_uuid_with_an_explicit_non_default_queue(
     assert snapshot.state == "completed"
 
 
+@pytest.mark.parametrize("queue", ["default", "other"])
 def test_get_result_raises_when_queue_disagrees_with_the_id_prefix(
-    dj_absurd: AbsurdTestRuntime,
+    dj_absurd: AbsurdTestRuntime, queue: str
 ) -> None:
+    # queue="default" is the case an unpassed argument alone could never catch: the
+    # caller spelled out the same value the parameter would resolve to anyway.
+    # Distinguishing it from "not passed at all" is why queue defaults to the
+    # NOT_SET sentinel, not the literal string "default".
     result = tasks.on_reports.enqueue()  # id prefix is "reports"
 
-    with pytest.raises(
-        TaskIdQueueMismatchError,
-        match=(
-            rf"get_result\(\): task id '{re.escape(str(result.id))}' names queue "
-            r"'reports', but queue='other' was also passed and disagrees\. Pass "
-            r"only one, or make them agree\."
-        ),
-    ):
-        dj_absurd.get_result(result.id, queue="other")
+    with pytest.raises(TaskIdQueueMismatchError) as exc:
+        dj_absurd.get_result(result.id, queue=queue)
+
+    assert str(exc.value) == (
+        f"get_result(): task id '{result.id}' names queue "
+        f"'reports', but queue='{queue}' was also passed and disagrees. Pass "
+        "only one, or make them agree."
+    )
 
 
-def test_get_result_raises_when_an_explicit_default_queue_disagrees_with_the_id_prefix(
-    dj_absurd: AbsurdTestRuntime,
+@pytest.mark.parametrize("operation", ["drain", "emit", "get_result", "sync_queues"])
+def test_an_operation_inside_an_open_transaction_raises(
+    dj_absurd: AbsurdTestRuntime, operation: str
 ) -> None:
-    """The case an unpassed ``queue`` argument alone could never catch: the caller
-    wrote ``queue="default"`` explicitly, spelling out the same value the parameter
-    would resolve to anyway. Distinguishing this from "queue not passed at all" is
-    exactly why ``queue`` defaults to the ``NOT_SET`` sentinel rather than the literal
-    string ``"default"``."""
-    result = tasks.on_reports.enqueue()  # id prefix is "reports"
+    # One guard (guard_against_open_transaction), four real enforcing entrypoints.
+    def invoke() -> None:
+        if operation == "drain":
+            dj_absurd.drain()
+        elif operation == "emit":
+            dj_absurd.emit("order.packed:never-emitted")
+        elif operation == "get_result":
+            dj_absurd.get_result(uuid.uuid4())
+        else:
+            dj_absurd.sync_queues()
 
-    with pytest.raises(
-        TaskIdQueueMismatchError,
-        match=(
-            rf"get_result\(\): task id '{re.escape(str(result.id))}' names queue "
-            r"'reports', but queue='default' was also passed and disagrees\. Pass "
-            r"only one, or make them agree\."
-        ),
-    ):
-        dj_absurd.get_result(result.id, queue="default")
+    with transaction.atomic(), pytest.raises(RuntimeError) as exc:
+        invoke()
 
-
-def test_get_result_inside_an_open_transaction_raises(
-    dj_absurd: AbsurdTestRuntime,
-) -> None:
-    result = tasks.add.enqueue(2, 3)
-    utils.run_absurd_worker()
-
-    with (
-        transaction.atomic(),
-        pytest.raises(
-            RuntimeError,
-            match=(
-                r"django-absurd: get_result\(\) ran inside an open transaction, where "
-                r"uncommitted rows are invisible to Absurd's own connection\. Use "
-                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
-                r"transaction\.atomic\(\)\."
-            ),
-        ),
-    ):
-        dj_absurd.get_result(result.id)
+    assert str(exc.value) == (
+        f"django-absurd: {operation}() ran inside an open transaction, where "
+        "uncommitted rows are invisible to Absurd's own connection. Use "
+        "@pytest.mark.django_db(transaction=True) and call outside "
+        "transaction.atomic()."
+    )
 
 
 @pytest.mark.django_db(transaction=False)
@@ -401,22 +383,6 @@ def test_drain_returns_the_same_run_twice_when_an_emit_wakes_it(
     assert isinstance(waiter_runs[0].run_id, uuid.UUID)
 
 
-def test_drain_inside_an_open_transaction_raises(dj_absurd: AbsurdTestRuntime) -> None:
-    with (
-        transaction.atomic(),
-        pytest.raises(
-            RuntimeError,
-            match=(
-                r"django-absurd: drain\(\) ran inside an open transaction, where "
-                r"uncommitted rows are invisible to Absurd's own connection\. Use "
-                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
-                r"transaction\.atomic\(\)\."
-            ),
-        ),
-    ):
-        dj_absurd.drain()
-
-
 def test_emit_resolves_a_waiting_task(dj_absurd: AbsurdTestRuntime) -> None:
     result = tasks.sawait_event_once.enqueue("order.packed:via-fixture")
     assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
@@ -427,22 +393,6 @@ def test_emit_resolves_a_waiting_task(dj_absurd: AbsurdTestRuntime) -> None:
     snapshot = dj_absurd.get_result(result.id)
     assert snapshot is not None
     assert snapshot.result == {"tracking": "abc"}
-
-
-def test_emit_inside_an_open_transaction_raises(dj_absurd: AbsurdTestRuntime) -> None:
-    with (
-        transaction.atomic(),
-        pytest.raises(
-            RuntimeError,
-            match=(
-                r"django-absurd: emit\(\) ran inside an open transaction, where "
-                r"uncommitted rows are invisible to Absurd's own connection\. Use "
-                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
-                r"transaction\.atomic\(\)\."
-            ),
-        ),
-    ):
-        dj_absurd.emit("order.packed:never-emitted")
 
 
 @pytest.mark.usefixtures("_isolate_queues")
@@ -465,24 +415,6 @@ def test_sync_queues_provisions_the_declared_queues(
     assert dj_absurd.drain() == []
     tasks.on_reports.enqueue()
     assert [run.result for run in dj_absurd.drain("reports")] == ["on_reports"]
-
-
-def test_sync_queues_inside_an_open_transaction_raises(
-    dj_absurd: AbsurdTestRuntime,
-) -> None:
-    with (
-        transaction.atomic(),
-        pytest.raises(
-            RuntimeError,
-            match=(
-                r"django-absurd: sync_queues\(\) ran inside an open transaction, where "
-                r"uncommitted rows are invisible to Absurd's own connection\. Use "
-                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
-                r"transaction\.atomic\(\)\."
-            ),
-        ),
-    ):
-        dj_absurd.sync_queues()
 
 
 def test_sync_queues_with_no_absurd_backend_raises(

--- a/tests/core/test_absurd_fixture.py
+++ b/tests/core/test_absurd_fixture.py
@@ -1,0 +1,496 @@
+import re
+import uuid
+
+import psycopg
+import psycopg.errors
+import pytest
+from django.db import connections, transaction
+from django.db.utils import ProgrammingError
+from pytest_django.fixtures import SettingsWrapper
+
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueNotProvisionedError,
+    TaskIdQueueMismatchError,
+)
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_get_result_reports_a_completed_task(dj_absurd: AbsurdTestRuntime) -> None:
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+
+    snapshot = dj_absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.queue == "default"
+    assert snapshot.task_name == "tests.tasks.add"
+    assert snapshot.args == [2, 3]
+    assert snapshot.kwargs == {}
+    assert snapshot.state == "completed"
+    assert snapshot.result == 5
+    assert snapshot.failure is None
+    assert snapshot.attempts == 1
+    assert isinstance(snapshot.task_id, uuid.UUID)
+
+
+def test_get_result_reports_a_failed_task_with_its_failure(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.boom.enqueue()
+    utils.run_absurd_worker()
+
+    snapshot = dj_absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.state == "failed"
+    assert snapshot.result is None
+    assert snapshot.failure is not None
+    assert snapshot.failure["name"] == "ValueError"
+    assert snapshot.failure["message"] == "boom"
+
+
+def test_get_result_decodes_jsonb_to_python_objects(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.create_payload.enqueue({"k": "v", "n": 7})
+    utils.run_absurd_worker()
+
+    snapshot = dj_absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.args == [{"k": "v", "n": 7}]
+    assert not isinstance(snapshot.args[0], str)
+    assert isinstance(snapshot.result, int)
+
+
+def test_get_result_reads_a_task_suspended_on_an_indefinite_await_event(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """An indefinite ``await_event`` parks the last attempt's run at Postgres's
+    ``'infinity'`` ``available_at`` — a value psycopg cannot decode — so the read must
+    never select that column.
+    """
+    result = tasks.sawait_event_once.enqueue("order.packed:never-arrives")
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+    snapshot = dj_absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.state == "sleeping"
+    assert snapshot.attempts == 1
+    assert snapshot.result is None
+    assert snapshot.failure is None
+
+
+def test_get_result_returns_none_for_an_unknown_task(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    assert dj_absurd.get_result(uuid.uuid4()) is None
+
+
+def test_get_result_raises_queue_not_provisioned_for_the_queues_own_missing_table(
+    dj_absurd: AbsurdTestRuntime, settings: SettingsWrapper
+) -> None:
+    """Same facade ``drain()`` and ``emit()`` give this condition — Django's own
+    ``ProgrammingError`` (chained from the psycopg ``UndefinedTable`` on
+    ``exc.__cause__``) never leaks through this read.
+    """
+    settings.TASKS = utils.make_tasks_settings(
+        queues={**utils.DECLARED_QUEUES, "unsynced": {}}
+    )
+
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        dj_absurd.get_result(f"unsynced:{uuid.uuid4()}")
+
+    assert str(exc.value) == (
+        "Queue 'unsynced' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+
+
+def test_get_result_does_not_relabel_an_unrelated_missing_relation(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """Mirrors ``test_drain_queue_does_not_relabel_an_unrelated_missing_relation``
+    (``tests/core/test_worker.py``): a missing relation that is NOT one of this
+    queue's own Absurd tables surfaces as itself, chained, rather than as the
+    curated unprovisioned-queue error.
+
+    ``get_result`` is a plain SELECT — Postgres has no SELECT trigger to hook the
+    way the write-path tests hook an audit trigger on a claim/emit. A view standing
+    in for ``t_default``, computing ``task_id`` through a function whose body reads
+    the missing relation, gets the same real failure: no mocking, landing exactly
+    where ``get_result``'s own query executes.
+    """
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+    try:
+        with connections["default"].cursor() as cur:
+            cur.execute("alter table absurd.t_default rename to t_default_probe")
+            cur.execute(
+                "create function absurd.record_get_result_probe(p_task_id uuid) "
+                "returns uuid language plpgsql as $$ begin "
+                "perform 1 from absurd.audit_probe where run_id = p_task_id; "
+                "return p_task_id; end; $$"
+            )
+            cur.execute(
+                "create view absurd.t_default as select "
+                "absurd.record_get_result_probe(task_id) as task_id, task_name, "
+                "params, headers, retry_strategy, max_attempts, cancellation, "
+                "enqueue_at, first_started_at, state, attempts, last_attempt_run, "
+                "completed_payload, cancelled_at, idempotency_key "
+                "from absurd.t_default_probe"
+            )
+
+        with pytest.raises(ProgrammingError) as exc:
+            dj_absurd.get_result(result.id)
+
+        cause = exc.value.__cause__
+        assert isinstance(cause, psycopg.errors.UndefinedTable)
+        assert (
+            cause.diag.message_primary == 'relation "absurd.audit_probe" does not exist'
+        )
+    finally:
+        with connections["default"].cursor() as cur:
+            cur.execute("drop view if exists absurd.t_default")
+            cur.execute("alter table absurd.t_default_probe rename to t_default")
+            cur.execute(
+                "drop function if exists absurd.record_get_result_probe(uuid) cascade"
+            )
+
+
+def test_get_result_tolerates_params_that_are_not_our_shape(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """A queue shared with raw-SDK producers can hold any JSON in params."""
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+    task_id = str(result.id).rsplit(":", 1)[-1]
+    params = connections["default"].get_connection_params()
+    params.pop("cursor_factory", None)
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "update absurd.t_default set params = %s where task_id = %s",
+                ["[1, 2, 3]", task_id],
+            )
+    finally:
+        conn.close()
+
+    snapshot = dj_absurd.get_result(result.id)
+
+    assert snapshot is not None
+    assert snapshot.args == []
+    assert snapshot.kwargs == {}
+
+
+def test_get_result_accepts_a_bare_uuid(dj_absurd: AbsurdTestRuntime) -> None:
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+    bare = str(result.id).rsplit(":", 1)[-1]
+
+    snapshot = dj_absurd.get_result(bare)
+
+    assert snapshot is not None
+    assert snapshot.state == "completed"
+
+
+def test_get_result_honours_a_non_default_queue_prefix_on_the_id(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.on_reports.enqueue()  # on_reports is @task(queue_name="reports")
+    utils.run_absurd_worker(queue="reports")
+
+    snapshot = dj_absurd.get_result(result.id)  # no queue= passed; the prefix must win
+
+    assert snapshot is not None
+    assert snapshot.queue == "reports"
+    assert snapshot.state == "completed"
+    assert snapshot.result == "on_reports"
+
+
+def test_get_result_accepts_a_bare_uuid_with_an_explicit_non_default_queue(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.routed.enqueue()  # routed is @task(queue_name="other")
+    utils.run_absurd_worker(queue="other")
+    bare = str(result.id).rsplit(":", 1)[-1]
+
+    snapshot = dj_absurd.get_result(bare, queue="other")
+
+    assert snapshot is not None
+    assert snapshot.queue == "other"
+    assert snapshot.state == "completed"
+
+
+def test_get_result_raises_when_queue_disagrees_with_the_id_prefix(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.on_reports.enqueue()  # id prefix is "reports"
+
+    with pytest.raises(
+        TaskIdQueueMismatchError,
+        match=(
+            rf"get_result\(\): task id '{re.escape(str(result.id))}' names queue "
+            r"'reports', but queue='other' was also passed and disagrees\. Pass "
+            r"only one, or make them agree\."
+        ),
+    ):
+        dj_absurd.get_result(result.id, queue="other")
+
+
+def test_get_result_raises_when_an_explicit_default_queue_disagrees_with_the_id_prefix(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """The case an unpassed ``queue`` argument alone could never catch: the caller
+    wrote ``queue="default"`` explicitly, spelling out the same value the parameter
+    would resolve to anyway. Distinguishing this from "queue not passed at all" is
+    exactly why ``queue`` defaults to the ``NOT_SET`` sentinel rather than the literal
+    string ``"default"``."""
+    result = tasks.on_reports.enqueue()  # id prefix is "reports"
+
+    with pytest.raises(
+        TaskIdQueueMismatchError,
+        match=(
+            rf"get_result\(\): task id '{re.escape(str(result.id))}' names queue "
+            r"'reports', but queue='default' was also passed and disagrees\. Pass "
+            r"only one, or make them agree\."
+        ),
+    ):
+        dj_absurd.get_result(result.id, queue="default")
+
+
+def test_get_result_inside_an_open_transaction_raises(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.add.enqueue(2, 3)
+    utils.run_absurd_worker()
+
+    with (
+        transaction.atomic(),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                r"django-absurd: get_result\(\) ran inside an open transaction, where "
+                r"uncommitted rows are invisible to Absurd's own connection\. Use "
+                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+                r"transaction\.atomic\(\)\."
+            ),
+        ),
+    ):
+        dj_absurd.get_result(result.id)
+
+
+@pytest.mark.django_db(transaction=False)
+def test_get_result_in_a_plain_db_test_raises(dj_absurd: AbsurdTestRuntime) -> None:
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"django-absurd: get_result\(\) ran inside an open transaction, where "
+            r"uncommitted rows are invisible to Absurd's own connection\. Use "
+            r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+            r"transaction\.atomic\(\)\."
+        ),
+    ):
+        dj_absurd.get_result(uuid.uuid4())
+
+
+def test_drain_returns_nothing_when_the_queue_is_empty(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    assert dj_absurd.drain() == []
+
+
+def test_drain_returns_one_record_per_run_in_claim_order(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    tasks.add.enqueue(2, 3)
+    tasks.add.enqueue(4, 5)
+
+    drained = dj_absurd.drain()
+
+    assert [(run.task_name, run.args, run.attempt, run.state) for run in drained] == [
+        ("tests.tasks.add", [2, 3], 1, "completed"),
+        ("tests.tasks.add", [4, 5], 1, "completed"),
+    ]
+    assert [run.result for run in drained] == [5, 9]
+
+
+def test_drain_reports_a_suspended_run_as_sleeping(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    tasks.ssleep_for_once.enqueue("k")
+
+    drained = dj_absurd.drain()
+
+    assert [(run.task_name, run.state) for run in drained] == [
+        ("tests.tasks.ssleep_for_once", "sleeping")
+    ]
+
+
+def test_drain_returns_a_spawned_child_in_the_same_drain(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    tasks.spawn_child_then_return.enqueue(21)
+
+    drained = dj_absurd.drain()
+
+    assert [run.task_name for run in drained] == [
+        "tests.tasks.spawn_child_then_return",
+        "tests.tasks.run_child",
+    ]
+    assert drained[1].result == 42
+    assert dj_absurd.drain() == []
+
+
+def test_drain_returns_every_attempt_of_a_default_retry_burn(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.boom.enqueue()
+
+    drained = dj_absurd.drain()
+
+    assert [run.attempt for run in drained] == [1, 2, 3, 4, 5]
+    assert {run.state for run in drained} == {"failed"}
+    assert drained[0].failure is not None
+    snapshot = dj_absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.state == "failed"
+    assert snapshot.attempts == 5
+
+
+def test_drain_reports_each_attempt_of_a_retry_sequence(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    tasks.RETRY_CALLS["n"] = 0
+    tasks.fail_twice_then_succeed.enqueue()
+
+    drained = dj_absurd.drain()
+
+    assert [(run.attempt, run.state) for run in drained] == [
+        (1, "failed"),
+        (2, "failed"),
+        (3, "completed"),
+    ]
+    assert [
+        None if run.failure is None else run.failure["message"] for run in drained
+    ] == ["attempt 1 fails", "attempt 2 fails", None]
+    assert drained[2].result == "third-time-lucky"
+
+
+def test_drain_returns_the_same_run_twice_when_an_emit_wakes_it(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    tasks.sawait_event_once.enqueue("order.packed:same-drain")
+    tasks.semit_event_once.enqueue("order.packed:same-drain", {"tracking": "abc"})
+
+    drained = dj_absurd.drain()
+
+    waiter_runs = [
+        run for run in drained if run.task_name.endswith("sawait_event_once")
+    ]
+    assert [run.state for run in waiter_runs] == ["sleeping", "completed"]
+    assert waiter_runs[0].run_id == waiter_runs[1].run_id
+    # The SDK's ClaimedTask stub types run_id ``str``; psycopg deserializes the column,
+    # so the identity above is a uuid comparison, not a string one.
+    assert isinstance(waiter_runs[0].run_id, uuid.UUID)
+
+
+def test_drain_inside_an_open_transaction_raises(dj_absurd: AbsurdTestRuntime) -> None:
+    with (
+        transaction.atomic(),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                r"django-absurd: drain\(\) ran inside an open transaction, where "
+                r"uncommitted rows are invisible to Absurd's own connection\. Use "
+                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+                r"transaction\.atomic\(\)\."
+            ),
+        ),
+    ):
+        dj_absurd.drain()
+
+
+def test_emit_resolves_a_waiting_task(dj_absurd: AbsurdTestRuntime) -> None:
+    result = tasks.sawait_event_once.enqueue("order.packed:via-fixture")
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+    dj_absurd.emit("order.packed:via-fixture", {"tracking": "abc"})
+
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
+    snapshot = dj_absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.result == {"tracking": "abc"}
+
+
+def test_emit_inside_an_open_transaction_raises(dj_absurd: AbsurdTestRuntime) -> None:
+    with (
+        transaction.atomic(),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                r"django-absurd: emit\(\) ran inside an open transaction, where "
+                r"uncommitted rows are invisible to Absurd's own connection\. Use "
+                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+                r"transaction\.atomic\(\)\."
+            ),
+        ),
+    ):
+        dj_absurd.emit("order.packed:never-emitted")
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_queues_provisions_the_declared_queues(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """``_isolate_queues`` has dropped every queue's topology, so the drain that opens
+    this test is the proof the sync below is what puts it back — the common case needs
+    no sync at all, since ``migrate`` already provisions the declared catalog.
+    """
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        dj_absurd.drain()
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+
+    dj_absurd.sync_queues()
+
+    assert dj_absurd.drain() == []
+    tasks.on_reports.enqueue()
+    assert [run.result for run in dj_absurd.drain("reports")] == ["on_reports"]
+
+
+def test_sync_queues_inside_an_open_transaction_raises(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with (
+        transaction.atomic(),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                r"django-absurd: sync_queues\(\) ran inside an open transaction, where "
+                r"uncommitted rows are invisible to Absurd's own connection\. Use "
+                r"@pytest\.mark\.django_db\(transaction=True\) and call outside "
+                r"transaction\.atomic\(\)\."
+            ),
+        ),
+    ):
+        dj_absurd.sync_queues()
+
+
+def test_sync_queues_with_no_absurd_backend_raises(
+    dj_absurd: AbsurdTestRuntime, settings: SettingsWrapper
+) -> None:
+    settings.TASKS = {"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}}
+
+    with pytest.raises(BackendNotConfiguredError) as exc:
+        dj_absurd.sync_queues()
+
+    assert str(exc.value) == "No Absurd backend configured."

--- a/tests/core/test_absurd_fixture_async.py
+++ b/tests/core/test_absurd_fixture_async.py
@@ -1,0 +1,77 @@
+"""The ``dj_absurd`` facade driven from ``async def`` tests — same names, no ``await``.
+
+Parity, not new behavior: every test here has a sync counterpart elsewhere in this
+suite (``test_durable_clock.py``, ``test_events.py``, ``test_absurd_fixture.py``), and
+the point of the duplication is that only the ``async def`` differs. The loop is what
+matters, not the plugin that starts one, so nothing in ``django_absurd`` knows
+pytest-asyncio exists.
+"""
+
+import datetime as dt
+import typing as t
+
+import pytest
+
+from django_absurd.test import AbsurdTestRuntime
+from tests import atasks
+from tests.models import Payload
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
+
+FROZEN = dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)
+
+
+async def test_a_week_long_sleep_resumes_after_shifting_a_week(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    atasks.DURABLE_STEP_CALLS["n"] = 0
+
+    with dj_absurd.freeze_time(FROZEN) as frozen_time:
+        await atasks.asleep_for_once.aenqueue("k")
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=8))
+
+        assert dj_absurd.now == FROZEN + dt.timedelta(days=8)
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", 1)
+        ]
+
+
+async def test_an_emitted_event_resolves_an_await_event_waiter(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    await atasks.aawait_event_once.aenqueue("order.packed:async-test")
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+    dj_absurd.emit("order.packed:async-test", {"shipped": True})
+
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", {"shipped": True})
+    ]
+
+
+async def test_get_result_reports_a_completed_task(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = await atasks.aecho.aenqueue("round-trip")
+
+    dj_absurd.drain()
+
+    snapshot = dj_absurd.get_result(result.id)
+    assert snapshot.task_name == "tests.atasks.aecho"
+    assert snapshot.args == ["round-trip"]
+    assert snapshot.state == "completed"
+    assert snapshot.result == "round-trip"
+
+
+async def test_sync_queues_reprovisions_before_a_task_writes_a_row(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+
+    result = await atasks.acreate_payload.aenqueue({"async": True})
+    dj_absurd.drain()
+
+    pk = t.cast("int", dj_absurd.get_result(result.id).result)
+    assert (await Payload.objects.aget(pk=pk)).data == {"async": True}

--- a/tests/core/test_absurd_params.py
+++ b/tests/core/test_absurd_params.py
@@ -159,9 +159,11 @@ def test_enqueuing_inert_params_off_backend_warns_once(
         bound.enqueue("off-backend-ran")
         bound.enqueue("off-backend-ran-again")
     assert caplog.messages == [
-        "absurd_params ignored: tests.core.test_absurd_params."
-        "make_group_on_immediate_backend ran on task backend 'immediate', "
-        "which is not an Absurd backend"
+        (
+            "absurd_params ignored: tests.core.test_absurd_params."
+            "make_group_on_immediate_backend ran on task backend 'immediate', "
+            "which is not an Absurd backend"
+        )
     ]
     # The immediate backend still ran the task; only the params were inert.
     assert Group.objects.filter(name="off-backend-ran").exists()
@@ -176,8 +178,10 @@ def test_enqueuing_params_routed_off_backend_warns(
     with caplog.at_level(logging.WARNING, logger="django_absurd"):
         bound.using(backend="immediate").enqueue("routed-out")
     assert caplog.messages == [
-        "absurd_params ignored: tests.tasks.echo ran on task backend 'immediate', "
-        "which is not an Absurd backend"
+        (
+            "absurd_params ignored: tests.tasks.echo ran on task backend 'immediate', "
+            "which is not an Absurd backend"
+        )
     ]
 
 
@@ -197,7 +201,9 @@ def test_aenqueuing_inert_params_off_backend_warns(
     with caplog.at_level(logging.WARNING, logger="django_absurd"):
         asyncio.run(bound.aenqueue(3, 4))
     assert caplog.messages == [
-        "absurd_params ignored: tests.core.test_absurd_params."
-        "multiply_on_immediate_backend ran on task backend 'immediate', "
-        "which is not an Absurd backend"
+        (
+            "absurd_params ignored: tests.core.test_absurd_params."
+            "multiply_on_immediate_backend ran on task backend 'immediate', "
+            "which is not an Absurd backend"
+        )
     ]

--- a/tests/core/test_admin/test_checkpoint.py
+++ b/tests/core/test_admin/test_checkpoint.py
@@ -4,7 +4,6 @@ import uuid
 import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import AbstractBaseUser, User
-from django.core.management import call_command
 from django.db import connections
 from django.test import Client
 from django.urls import reverse, reverse_lazy
@@ -33,7 +32,6 @@ def insert_checkpoint(task_id: uuid.UUID, name: str, status: str = "committed") 
 
 
 def test_changelist(admin_user: AbstractBaseUser, client: Client) -> None:
-    call_command("absurd_sync_queues")
     insert_checkpoint(uuid.uuid4(), "cp1")
     client.force_login(t.cast("User", admin_user))
     response = client.get(CHANGELIST)
@@ -46,7 +44,6 @@ def test_changelist(admin_user: AbstractBaseUser, client: Client) -> None:
 
 
 def test_detail_with_nasty_name(admin_user: AbstractBaseUser, client: Client) -> None:
-    call_command("absurd_sync_queues")
     tid = uuid.uuid4()
     with connections["default"].cursor() as cur:
         cur.execute(

--- a/tests/core/test_admin/test_event.py
+++ b/tests/core/test_admin/test_event.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import User
-from django.core.management import call_command
 from django.db import connections
 from django.test import Client
 from django.urls import reverse, reverse_lazy
@@ -19,7 +18,6 @@ def change_url(pk: str) -> str:
 
 
 def test_changelist_and_detail(admin_user: User, client: Client) -> None:
-    call_command("absurd_sync_queues")
     with connections["default"].cursor() as cur:
         cur.execute(
             'INSERT INTO absurd."e_default" (event_name, payload) VALUES (%s, %s)',
@@ -42,7 +40,6 @@ def test_changelist_and_detail(admin_user: User, client: Client) -> None:
 
 
 def test_emit_event_writes_a_visible_row(admin_user: User, client: Client) -> None:
-    call_command("absurd_sync_queues")
     emit_event("order.shipped:demo", {"id": 1}, queue="default")
     client.force_login(admin_user)
     soup = parse_html(client.get(CHANGELIST))

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -35,7 +35,6 @@ def test_changelist_shows_dates_ordered_by_recent_activity(
     admin_user: User,
     client: Client,
 ) -> None:
-    call_command("absurd_sync_queues")
     older = tasks.add.enqueue(1, 1)
     call_command("absurd_worker", queue="default", burst=True)  # older run starts
     newer = tasks.add.enqueue(2, 2)
@@ -102,7 +101,6 @@ def test_changelist_and_detail_survive_indefinite_available_at(
     # psycopg cannot decode a literal infinity into a Python datetime, so an
     # un-guarded available_at column crashes both the changelist and the detail
     # page with a DataError before anything renders.
-    call_command("absurd_sync_queues")
     tasks.sawait_event_once.enqueue("admin-infinity-check")
     call_command("absurd_worker", queue="default", burst=True)  # suspends indefinitely
 

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -112,7 +112,6 @@ def test_changelist_search_narrows_by_task_name(
 def test_changelist_shows_dates_ordered_by_recent_activity(
     admin_user: User, client: Client
 ) -> None:
-    call_command("absurd_sync_queues")  # index the default queue
     older = tasks.add.enqueue(1, 1)
     newer = tasks.add.enqueue(2, 2)  # enqueued later → more recent activity
     client.force_login(admin_user)
@@ -140,7 +139,6 @@ def test_changelist_warns_about_unindexed_queue(
     # build the views over the declared queues, then create a queue directly
     # (config drift): it lands in the catalog but no view arm references it →
     # unindexed.
-    call_command("absurd_sync_queues")
     get_absurd_client().create_queue("drift")
     client.force_login(admin_user)
     resp = client.get(CHANGELIST)
@@ -225,7 +223,6 @@ def test_detail_groups_fields_and_inlines_runs(
 def test_detail_inlines_checkpoints_and_run_available_at(
     admin_user: User, client: Client
 ) -> None:
-    call_command("absurd_sync_queues")
     atasks.DURABLE_STEP_CALLS["n"] = 0
     atasks.asleep_for_once.enqueue("admin-k")
     call_command("absurd_worker", queue="default", burst=True)  # suspends
@@ -256,7 +253,6 @@ def test_detail_inlines_checkpoints_and_run_available_at(
 def test_detail_inlines_waits_for_a_suspended_await_event(
     admin_user: User, client: Client
 ) -> None:
-    call_command("absurd_sync_queues")
     tasks.sawait_event_once.enqueue("wait-admin-demo")
     call_command("absurd_worker", queue="default", burst=True)  # suspends
     client.force_login(admin_user)
@@ -309,14 +305,12 @@ def test_admin_labels_app_as_absurd(admin_user: User, client: Client) -> None:
 def test_changelist_degrades_when_view_dropped(
     admin_user: User, client: Client
 ) -> None:
-    call_command("absurd_sync_queues")
     with connections["default"].cursor() as cur:
         cur.execute("DROP VIEW IF EXISTS absurd.tasks_view")
     client.force_login(admin_user)
     resp = client.get(CHANGELIST)
     assert resp.status_code == 200
     assert result_rows(parse_html(resp)) == []
-    call_command("absurd_sync_queues")
 
 
 def test_partitioned_queue_appears_in_changelist(

--- a/tests/core/test_admin/test_wait.py
+++ b/tests/core/test_admin/test_wait.py
@@ -4,7 +4,6 @@ import uuid
 import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import AbstractBaseUser, User
-from django.core.management import call_command
 from django.db import connections
 from django.test import Client
 from django.urls import reverse, reverse_lazy
@@ -26,7 +25,6 @@ def change_url(pk: str) -> str:
 def test_changelist_and_composite_detail(
     admin_user: AbstractBaseUser, client: Client
 ) -> None:
-    call_command("absurd_sync_queues")
     rid, tid = uuid.uuid4(), uuid.uuid4()
     with connections["default"].cursor() as cur:
         cur.execute(

--- a/tests/core/test_admin/utils.py
+++ b/tests/core/test_admin/utils.py
@@ -35,7 +35,6 @@ def register_admin() -> None:
 
 
 def seed() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(2, 3)
     tasks.add.using(queue_name="other").enqueue(7, 8)
     tasks.boom.enqueue()
@@ -47,7 +46,6 @@ def seed_mixed() -> tuple[
     "TaskResult[t.Any, t.Any]", "TaskResult[t.Any, t.Any]", "TaskResult[t.Any, t.Any]"
 ]:
     """Three default-queue tasks in distinct terminal/queued states."""
-    call_command("absurd_sync_queues")
     completed = tasks.add.enqueue(2, 3)
     failed = absurd_params(max_attempts=1).bind(tasks.boom).enqueue()
     call_command("absurd_worker", queue="default", burst=True)

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -23,7 +23,6 @@ CHECKS_SPEC: EntitySpec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "check
 
 
 def seed_two_queues() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(2, 3)
     tasks.add.using(queue_name="other").enqueue(7, 8)
     call_command("absurd_worker", queue="default", burst=True)
@@ -31,7 +30,6 @@ def seed_two_queues() -> None:
 
 
 def test_zero_queue_view_is_empty() -> None:
-    call_command("absurd_sync_queues")  # tables exist but no tasks
     rebuild_admin_view(TASKS_SPEC, [], "default")
     tasks_model: t.Any = build_admin_model(TASKS_SPEC)
     assert tasks_model.objects.count() == 0

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -4,14 +4,14 @@ import typing as t
 
 import pytest
 from absurd_sdk import JsonValue
-from django.core.management import call_command
 from django.tasks import TaskResultStatus
 
 from django_absurd import absurd_params
 from django_absurd.backends import get_absurd_backends
+from django_absurd.test import AbsurdTestRuntime
 from tests import atasks, tasks
 from tests.models import Payload
-from tests.utils import get_task_result, run_absurd_worker
+from tests.utils import run_absurd_worker
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -20,85 +20,79 @@ pytestmark = pytest.mark.django_db(transaction=True)
     "value",
     [None, 0, False, "", [], {}, {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]}],
 )
-def test_async_return_value_round_trips(value: JsonValue) -> None:
-    call_command("absurd_sync_queues")
+def test_async_return_value_round_trips(
+    dj_absurd: AbsurdTestRuntime, value: JsonValue
+) -> None:
     r = atasks.aecho.enqueue(value)
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.state == "completed"
     assert snap.result == value
 
 
-def test_async_failure_recorded() -> None:
-    call_command("absurd_sync_queues")
+def test_async_failure_recorded(dj_absurd: AbsurdTestRuntime) -> None:
     r = absurd_params(max_attempts=1).bind(atasks.aboom).enqueue()
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.state == "failed"
 
 
-def test_async_takes_context_attempt_is_one() -> None:
-    call_command("absurd_sync_queues")
+def test_async_takes_context_attempt_is_one(dj_absurd: AbsurdTestRuntime) -> None:
     r = atasks.areport_attempt.enqueue()
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.result == 1
 
 
-def test_sync_orm_jsonfield_round_trips() -> None:
+def test_sync_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
     # ORM in a SYNC task (executor path) — matched pair with the async-ORM test below
-    call_command("absurd_sync_queues")
     r = tasks.create_payload.enqueue({"sync": True, "x": [9, 8]})
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"sync": True, "x": [9, 8]}
 
 
-def test_async_orm_jsonfield_round_trips() -> None:
+def test_async_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
     # ORM in an ASYNC task (loop path) — matched pair with the sync-ORM test above
-    call_command("absurd_sync_queues")
     r = atasks.acreate_payload.enqueue({"async": True, "y": {"z": None}})
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
 
 
-def test_async_task_queries_payload() -> None:
+def test_async_task_queries_payload(dj_absurd: AbsurdTestRuntime) -> None:
     # async QUERY path: a row created in the test, read back by an async task (aget)
-    call_command("absurd_sync_queues")
     obj = Payload.objects.create(data={"q": [1, {"x": None}], "u": "ünï"})
     r = atasks.aread_payload.enqueue(obj.pk)
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.state == "completed"
     assert snap.result == {"q": [1, {"x": None}], "u": "ünï"}
 
 
-def test_aenqueue_async_task_runs_end_to_end() -> None:
+def test_aenqueue_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     # exercise the aenqueue (produce) path for an async task, end-to-end
     # through the worker
-    call_command("absurd_sync_queues")
     r = asyncio.run(atasks.aecho.aenqueue("via-aenqueue"))
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.result == "via-aenqueue"
 
 
-def test_aenqueue_sync_task_runs_end_to_end() -> None:
+def test_aenqueue_sync_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     # aenqueue a SYNC task too — runs via the worker's executor path
-    call_command("absurd_sync_queues")
     r = asyncio.run(tasks.echo.aenqueue({"via": "aenqueue-sync"}))
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.result == {"via": "aenqueue-sync"}
 
@@ -106,7 +100,6 @@ def test_aenqueue_sync_task_runs_end_to_end() -> None:
 def test_full_async_workflow_aenqueue_to_aget_result() -> None:
     # The whole async pipeline in one flow: aenqueue (async produce) -> async task
     # on the loop doing async ORM (acreate) -> aget_result (async read of the result).
-    call_command("absurd_sync_queues")
     r = asyncio.run(atasks.acreate_payload.aenqueue({"full": "async", "n": [1, 2]}))
     run_absurd_worker()
     got = asyncio.run(get_absurd_backends()["default"].aget_result(r.id))
@@ -114,13 +107,12 @@ def test_full_async_workflow_aenqueue_to_aget_result() -> None:
     assert Payload.objects.filter(pk=got.return_value).exists()
 
 
-def test_sync_and_async_in_one_worker_run() -> None:
-    call_command("absurd_sync_queues")
+def test_sync_and_async_in_one_worker_run(dj_absurd: AbsurdTestRuntime) -> None:
     rs = tasks.echo.enqueue({"mixed": "sync"})
     ra = atasks.aecho.enqueue({"mixed": "async"})
     run_absurd_worker()
-    snap_s = get_task_result(rs.id)
-    snap_a = get_task_result(ra.id)
+    snap_s = dj_absurd.get_result(rs.id)
+    snap_a = dj_absurd.get_result(ra.id)
     assert snap_s is not None
     assert snap_a is not None
     assert snap_s.result == {"mixed": "sync"}
@@ -131,7 +123,6 @@ def test_worker_does_not_poison_jsonfield_reads() -> None:
     # The worker's loader is on its dedicated AsyncConnection; a Django
     # JSONField read on the shared connection after a worker run must still
     # decode (no SP6-style poison).
-    call_command("absurd_sync_queues")
     atasks.aecho.enqueue("x")
     run_absurd_worker()
     obj = Payload.objects.create(data={"k": "v", "n": 7})
@@ -139,7 +130,6 @@ def test_worker_does_not_poison_jsonfield_reads() -> None:
 
 
 def test_async_concurrency_is_not_serial() -> None:
-    call_command("absurd_sync_queues")
     for _ in range(4):
         atasks.asleeper.enqueue(0.5)
     start = time.monotonic()

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -26,7 +26,6 @@ def test_async_return_value_round_trips(
     r = atasks.aecho.enqueue(value)
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == value
 
@@ -35,7 +34,6 @@ def test_async_failure_recorded(dj_absurd: AbsurdTestRuntime) -> None:
     r = absurd_params(max_attempts=1).bind(atasks.aboom).enqueue()
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.state == "failed"
 
 
@@ -43,7 +41,6 @@ def test_async_takes_context_attempt_is_one(dj_absurd: AbsurdTestRuntime) -> Non
     r = atasks.areport_attempt.enqueue()
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.result == 1
 
 
@@ -52,7 +49,6 @@ def test_sync_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
     r = tasks.create_payload.enqueue({"sync": True, "x": [9, 8]})
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"sync": True, "x": [9, 8]}
 
@@ -62,7 +58,6 @@ def test_async_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
     r = atasks.acreate_payload.enqueue({"async": True, "y": {"z": None}})
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
 
@@ -73,7 +68,6 @@ def test_async_task_queries_payload(dj_absurd: AbsurdTestRuntime) -> None:
     r = atasks.aread_payload.enqueue(obj.pk)
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == {"q": [1, {"x": None}], "u": "ünï"}
 
@@ -84,7 +78,6 @@ def test_aenqueue_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> No
     r = asyncio.run(atasks.aecho.aenqueue("via-aenqueue"))
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.result == "via-aenqueue"
 
 
@@ -93,7 +86,6 @@ def test_aenqueue_sync_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> Non
     r = asyncio.run(tasks.echo.aenqueue({"via": "aenqueue-sync"}))
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.result == {"via": "aenqueue-sync"}
 
 
@@ -113,8 +105,6 @@ def test_sync_and_async_in_one_worker_run(dj_absurd: AbsurdTestRuntime) -> None:
     run_absurd_worker()
     snap_s = dj_absurd.get_result(rs.id)
     snap_a = dj_absurd.get_result(ra.id)
-    assert snap_s is not None
-    assert snap_a is not None
     assert snap_s.result == {"mixed": "sync"}
     assert snap_a.result == {"mixed": "async"}
 

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -12,12 +12,12 @@ from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.db import connection
 from django.utils import timezone
-from freezegun import freeze_time
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.cleanup import QueueCleanup, cleanup_queues
 from django_absurd.queues import get_absurd_client
 from django_absurd.scheduler import run_beat
+from django_absurd.test import AbsurdTestRuntime, FrozenTime
 from tests import tasks
 
 if t.TYPE_CHECKING:
@@ -33,6 +33,7 @@ pytestmark = [
 ]
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
+BEAT_EPOCH = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
 
 
 def sync_queue(
@@ -259,34 +260,38 @@ def test_flush_non_interactive_eof_keeps_queues(
 
 
 def run_beat_until(
+    frozen_time: FrozenTime,
     backend: "django_absurd.backends.AbsurdBackend",
     cutoff: dt.datetime,
 ) -> None:
-    with freeze_time("2026-01-01 00:00:00") as frozen:
+    def fake_wait(timeout: float) -> bool:
+        frozen_time.shift(dt.timedelta(seconds=timeout))
+        return timezone.now() >= cutoff
 
-        def fake_wait(timeout: float) -> bool:
-            frozen.tick(dt.timedelta(seconds=timeout))
-            return timezone.now() >= cutoff
-
-        run_beat(backend, wait=fake_wait)
+    run_beat(backend, wait=fake_wait)
 
 
 def test_beat_fires_cleanup_on_cadence(
     cleanup: "CleanupCallable",
+    dj_absurd: AbsurdTestRuntime,
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
-    tasks.add.enqueue(2, 3)
-    drain()  # completed → aged-terminal (cleanup_ttl="0 seconds")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    assert cleanup() == [
-        {"queue_name": "default", "tasks_deleted": 0, "events_deleted": 0}
-    ]
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        tasks.add.enqueue(2, 3)
+        drain()  # completed → aged-terminal (cleanup_ttl="0 seconds")
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        assert cleanup() == [
+            {"queue_name": "default", "tasks_deleted": 0, "events_deleted": 0}
+        ]
 
 
 def test_beat_isolates_failing_cleanup(
     caplog: pytest.LogCaptureFixture,
+    dj_absurd: AbsurdTestRuntime,
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
@@ -294,8 +299,13 @@ def test_beat_isolates_failing_cleanup(
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
-        with caplog.at_level(logging.ERROR, logger="django_absurd"):
-            run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
+        with (
+            dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time,
+            caplog.at_level(logging.ERROR, logger="django_absurd"),
+        ):
+            run_beat_until(
+                frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+            )
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert [r.getMessage() for r in errors] == ["django-absurd cleanup failed"]
     finally:
@@ -304,6 +314,7 @@ def test_beat_isolates_failing_cleanup(
 
 
 def test_beat_fires_cleanup_and_task_same_slot(
+    dj_absurd: AbsurdTestRuntime,
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     # A scheduled task and CLEANUP sharing a cron slot both fire in the one tick:
@@ -325,14 +336,17 @@ def test_beat_fires_cleanup_and_task_same_slot(
         }
     }
     call_command("absurd_sync_queues")
-    tasks.add.enqueue(2, 3)
-    drain()  # completed → aged-terminal, cleanup-eligible
     backend = get_absurd_backends()["default"]
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    # cleanup fired this tick: the aged task is already gone (nothing left to delete)
-    assert cleanup_queues() == [
-        {"queue_name": "default", "tasks_deleted": 0, "events_deleted": 0}
-    ]
-    # the scheduled task fired the same tick: run it and assert its side effect
-    drain()
-    assert Group.objects.filter(name="fired").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        tasks.add.enqueue(2, 3)
+        drain()  # completed → aged-terminal, cleanup-eligible
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        # cleanup fired this tick: the aged task is already gone, nothing left to delete
+        assert cleanup_queues() == [
+            {"queue_name": "default", "tasks_deleted": 0, "events_deleted": 0}
+        ]
+        # the scheduled task fired the same tick: run it and assert its side effect
+        drain()
+        assert Group.objects.filter(name="fired").exists()

--- a/tests/core/test_durable.py
+++ b/tests/core/test_durable.py
@@ -1,12 +1,12 @@
 import asyncio
+import datetime as dt
 import logging
-import time
 
 import pytest
-from django.core.management import call_command
 
 from django_absurd import absurd_params, aget_absurd_context, get_absurd_context
-from tests import atasks, tasks, utils
+from django_absurd.test import AbsurdTestRuntime
+from tests import atasks, tasks
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -38,136 +38,139 @@ def test_get_absurd_context_on_loop_raises() -> None:
         asyncio.run(call())
 
 
-def test_async_step_runs_and_returns_value() -> None:
-    call_command("absurd_sync_queues")
-    result = atasks.astep_echo.enqueue("hi")
-    utils.run_absurd_worker()
-    snap = utils.get_task_result(result.id)
-    assert snap is not None
-    assert snap.state == "completed"
-    assert snap.result == "hi"
+def test_async_step_runs_and_returns_value(dj_absurd: AbsurdTestRuntime) -> None:
+    atasks.astep_echo.enqueue("hi")
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", "hi")
+    ]
 
 
-def test_async_headers_readable_from_ctx() -> None:
-    call_command("absurd_sync_queues")
-    result = (
-        absurd_params(headers={"tenant": "acme"}).bind(atasks.aheaders_tenant).enqueue()
-    )
-    utils.run_absurd_worker()
-    snap = utils.get_task_result(result.id)
-    assert snap is not None
-    assert snap.result == "acme"
+def test_async_headers_readable_from_ctx(dj_absurd: AbsurdTestRuntime) -> None:
+    absurd_params(headers={"tenant": "acme"}).bind(atasks.aheaders_tenant).enqueue()
+    assert [run.result for run in dj_absurd.drain()] == ["acme"]
 
 
-def test_async_heartbeat_is_callable() -> None:
-    call_command("absurd_sync_queues")
-    result = atasks.aheartbeat_then_return.enqueue("ok")
-    utils.run_absurd_worker()
-    snap = utils.get_task_result(result.id)
-    assert snap is not None
-    assert snap.state == "completed"
-    assert snap.result == "ok"
+def test_async_heartbeat_is_callable(dj_absurd: AbsurdTestRuntime) -> None:
+    atasks.aheartbeat_then_return.enqueue("ok")
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", "ok")
+    ]
 
 
-def test_async_sleep_for_suspends_then_resumes_replaying_step() -> None:
-    call_command("absurd_sync_queues")
+def test_async_sleep_for_suspends_then_resumes_replaying_step(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
     atasks.DURABLE_STEP_CALLS["n"] = 0
-    result = atasks.asleep_for_once.enqueue("k")
 
-    utils.run_absurd_worker()  # drain 1: bump runs, then sleep -> suspend
-    suspended = utils.get_task_result(result.id)
-    assert suspended is not None
-    assert suspended.state == "sleeping"
+    with dj_absurd.freeze_time() as frozen_time:
+        result = atasks.asleep_for_once.enqueue("k")
 
-    time.sleep(2)  # past wake (Python-clock wake vs DB-clock claim; wide margin)
-    utils.run_absurd_worker()  # drain 2: body replays, bump cached, completes
-    done = utils.get_task_result(result.id)
+        # drain 1: bump runs, then sleep -> suspend
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+        suspended = dj_absurd.get_result(result.id)
+        assert suspended is not None
+        assert suspended.state == "sleeping"
+
+        frozen_time.shift(dt.timedelta(days=8))
+
+        # drain 2: body replays, bump cached, completes
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+    done = dj_absurd.get_result(result.id)
     assert done is not None
     assert done.state == "completed"
     assert done.result == 1
     assert atasks.DURABLE_STEP_CALLS["n"] == 1  # step body ran once across the replay
 
 
-def test_async_sleep_until_suspends_then_resumes() -> None:
-    call_command("absurd_sync_queues")
-    result = atasks.asleep_until_once.enqueue("k")
-    utils.run_absurd_worker()
-    suspended = utils.get_task_result(result.id)
-    assert suspended is not None
-    assert suspended.state == "sleeping"
-    time.sleep(2)
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
+def test_async_sleep_until_suspends_then_resumes(dj_absurd: AbsurdTestRuntime) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = atasks.asleep_until_once.enqueue("k")
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+        suspended = dj_absurd.get_result(result.id)
+        assert suspended is not None
+        assert suspended.state == "sleeping"
+
+        frozen_time.shift(dt.timedelta(days=8))
+
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+    done = dj_absurd.get_result(result.id)
     assert done is not None
     assert done.state == "completed"
     assert done.result == "woke"
 
 
-def test_sync_step_runs_and_returns_value() -> None:
-    call_command("absurd_sync_queues")
-    result = tasks.sstep_echo.enqueue("hi")
-    utils.run_absurd_worker()
-    snap = utils.get_task_result(result.id)
-    assert snap is not None
-    assert snap.result == "hi"
+def test_sync_step_runs_and_returns_value(dj_absurd: AbsurdTestRuntime) -> None:
+    tasks.sstep_echo.enqueue("hi")
+    assert [run.result for run in dj_absurd.drain()] == ["hi"]
 
 
-def test_sync_headers_heartbeat_and_run_step_forms() -> None:
-    call_command("absurd_sync_queues")
-    result = absurd_params(headers={"tenant": "acme"}).bind(tasks.scoverage).enqueue()
-    utils.run_absurd_worker()
-    snap = utils.get_task_result(result.id)
-    assert snap is not None
-    assert snap.result == {
-        "bare": "bare-val",
-        "derived": "derived-val",
-        "named": "named-val",
-        "tenant": "acme",
-    }
+def test_sync_headers_heartbeat_and_run_step_forms(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    absurd_params(headers={"tenant": "acme"}).bind(tasks.scoverage).enqueue()
+    assert [run.result for run in dj_absurd.drain()] == [
+        {
+            "bare": "bare-val",
+            "derived": "derived-val",
+            "named": "named-val",
+            "tenant": "acme",
+        }
+    ]
 
 
-def test_sync_sleep_for_suspends_then_resumes_replaying_step() -> None:
-    call_command("absurd_sync_queues")
+def test_sync_sleep_for_suspends_then_resumes_replaying_step(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
     tasks.SYNC_STEP_CALLS["n"] = 0
-    result = tasks.ssleep_for_once.enqueue("k")
 
-    utils.run_absurd_worker()
-    suspended = utils.get_task_result(result.id)
-    assert suspended is not None
-    assert suspended.state == "sleeping"
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.ssleep_for_once.enqueue("k")
 
-    time.sleep(2)
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+        suspended = dj_absurd.get_result(result.id)
+        assert suspended is not None
+        assert suspended.state == "sleeping"
+
+        frozen_time.shift(dt.timedelta(days=8))
+
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+    done = dj_absurd.get_result(result.id)
     assert done is not None
     assert done.state == "completed"
     assert done.result == 1
     assert tasks.SYNC_STEP_CALLS["n"] == 1
 
 
-def test_sync_sleep_until_suspends_then_resumes() -> None:
-    call_command("absurd_sync_queues")
-    result = tasks.ssleep_until_once.enqueue("k")
-    utils.run_absurd_worker()
-    suspended = utils.get_task_result(result.id)
-    assert suspended is not None
-    assert suspended.state == "sleeping"
-    time.sleep(2)
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
+def test_sync_sleep_until_suspends_then_resumes(dj_absurd: AbsurdTestRuntime) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.ssleep_until_once.enqueue("k")
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+        suspended = dj_absurd.get_result(result.id)
+        assert suspended is not None
+        assert suspended.state == "sleeping"
+
+        frozen_time.shift(dt.timedelta(days=8))
+
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+
+    done = dj_absurd.get_result(result.id)
     assert done is not None
     assert done.state == "completed"
     assert done.result == "woke"
 
 
 def test_suspend_logged_as_lifecycle_not_failure(
-    caplog: pytest.LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
 ) -> None:
-    call_command("absurd_sync_queues")
     atasks.DURABLE_STEP_CALLS["n"] = 0
     atasks.asleep_for_once.enqueue("k")
     with caplog.at_level(logging.INFO, logger="django_absurd"):
-        utils.run_absurd_worker()
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
     assert (
         "django-absurd task received SuspendTask: name=tests.atasks.asleep_for_once"
         in caplog.text

--- a/tests/core/test_durable.py
+++ b/tests/core/test_durable.py
@@ -63,43 +63,32 @@ def test_async_sleep_for_suspends_then_resumes_replaying_step(
     atasks.DURABLE_STEP_CALLS["n"] = 0
 
     with dj_absurd.freeze_time() as frozen_time:
-        result = atasks.asleep_for_once.enqueue("k")
+        atasks.asleep_for_once.enqueue("k")
 
         # drain 1: bump runs, then sleep -> suspend
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
-        suspended = dj_absurd.get_result(result.id)
-        assert suspended is not None
-        assert suspended.state == "sleeping"
 
         frozen_time.shift(dt.timedelta(days=8))
 
         # drain 2: body replays, bump cached, completes
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", 1)
+        ]
 
-    done = dj_absurd.get_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == 1
     assert atasks.DURABLE_STEP_CALLS["n"] == 1  # step body ran once across the replay
 
 
 def test_async_sleep_until_suspends_then_resumes(dj_absurd: AbsurdTestRuntime) -> None:
     with dj_absurd.freeze_time() as frozen_time:
-        result = atasks.asleep_until_once.enqueue("k")
+        atasks.asleep_until_once.enqueue("k")
 
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
-        suspended = dj_absurd.get_result(result.id)
-        assert suspended is not None
-        assert suspended.state == "sleeping"
 
         frozen_time.shift(dt.timedelta(days=8))
 
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
-
-    done = dj_absurd.get_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == "woke"
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", "woke")
+        ]
 
 
 def test_sync_step_runs_and_returns_value(dj_absurd: AbsurdTestRuntime) -> None:
@@ -127,41 +116,30 @@ def test_sync_sleep_for_suspends_then_resumes_replaying_step(
     tasks.SYNC_STEP_CALLS["n"] = 0
 
     with dj_absurd.freeze_time() as frozen_time:
-        result = tasks.ssleep_for_once.enqueue("k")
+        tasks.ssleep_for_once.enqueue("k")
 
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
-        suspended = dj_absurd.get_result(result.id)
-        assert suspended is not None
-        assert suspended.state == "sleeping"
 
         frozen_time.shift(dt.timedelta(days=8))
 
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", 1)
+        ]
 
-    done = dj_absurd.get_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == 1
     assert tasks.SYNC_STEP_CALLS["n"] == 1
 
 
 def test_sync_sleep_until_suspends_then_resumes(dj_absurd: AbsurdTestRuntime) -> None:
     with dj_absurd.freeze_time() as frozen_time:
-        result = tasks.ssleep_until_once.enqueue("k")
+        tasks.ssleep_until_once.enqueue("k")
 
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
-        suspended = dj_absurd.get_result(result.id)
-        assert suspended is not None
-        assert suspended.state == "sleeping"
 
         frozen_time.shift(dt.timedelta(days=8))
 
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
-
-    done = dj_absurd.get_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == "woke"
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", "woke")
+        ]
 
 
 def test_suspend_logged_as_lifecycle_not_failure(

--- a/tests/core/test_durable_clock.py
+++ b/tests/core/test_durable_clock.py
@@ -1,0 +1,378 @@
+import contextlib
+import datetime as dt
+import functools
+import importlib.abc
+import importlib.machinery
+import sys
+import typing as t
+import zoneinfo
+
+import psycopg
+import pytest
+import time_machine
+from django.core.exceptions import ImproperlyConfigured
+from django.db import connections
+
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+FROZEN = dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)
+
+NAIVE_INSTANT_MESSAGE = (
+    r"django-absurd: freeze_time\(\) and move_to\(\) need a timezone-aware datetime; a "
+    r"naive one is ambiguous and would desynchronise Postgres from Python\. Pass "
+    r"tzinfo=datetime\.UTC \(or any zone\)\."
+)
+
+
+def test_a_week_long_sleep_resumes_after_shifting_a_week(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.sleep_a_week.enqueue()
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=7))
+
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.result == "woke"
+
+
+def test_shifting_short_of_the_wake_leaves_the_task_sleeping(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with dj_absurd.freeze_time(FROZEN) as frozen_time:
+        result = tasks.sleep_a_week.enqueue()
+        dj_absurd.drain()
+
+        frozen_time.shift(dt.timedelta(days=6))
+
+        # Without this, a no-op shift() would pass the rest of the test.
+        assert dj_absurd.now == FROZEN + dt.timedelta(days=6)
+        assert dj_absurd.drain() == []
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.state == "sleeping"
+
+
+def test_a_chain_of_two_sleeps_needs_two_shifts(dj_absurd: AbsurdTestRuntime) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.sleep_twice.enqueue()
+        dj_absurd.drain()
+
+        frozen_time.shift(dt.timedelta(days=7))
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=3))
+        assert [run.state for run in dj_absurd.drain()] == ["completed"]
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.result == "woke-twice"
+
+
+def test_an_await_event_timeout_fires_after_shifting_past_it(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.sawait_event_timeout.enqueue(
+            "order.packed:never-arrives", timeout=tasks.WEEK_SECONDS
+        )
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(days=8))
+        dj_absurd.drain()
+
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.result == "timed-out"
+
+
+def test_a_retry_backoff_runs_the_next_attempt_after_shifting(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.fail_with_long_backoff.enqueue()
+        assert [run.attempt for run in dj_absurd.drain()] == [1]
+        mid_backoff = dj_absurd.get_result(result.id)
+        assert mid_backoff is not None
+        assert mid_backoff.state == "sleeping"
+        assert mid_backoff.failure is None
+
+        frozen_time.shift(dt.timedelta(hours=1, seconds=1))
+
+        assert [run.attempt for run in dj_absurd.drain()] == [2]
+
+
+def test_a_cancelled_task_produces_an_empty_drain(dj_absurd: AbsurdTestRuntime) -> None:
+    """Cancellation happens inside claim_task, before anything is claimed."""
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.cancellable_after_a_minute.enqueue()
+
+        frozen_time.shift(dt.timedelta(minutes=2))
+
+        assert dj_absurd.drain() == []
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.state == "cancelled"
+
+
+def test_an_expired_claim_is_swept_after_shifting_past_the_lease(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.add.enqueue(2, 3)
+        utils.claim_one_run("default", claim_timeout=3600)
+
+        frozen_time.shift(dt.timedelta(hours=2))
+        dj_absurd.drain()
+
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.state == "completed"
+        assert snapshot.attempts == 2
+
+
+def test_freeze_time_stamps_the_frozen_instant_on_enqueue(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    with dj_absurd.freeze_time(FROZEN):
+        result = tasks.add.enqueue(2, 3)
+
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.enqueued_at == FROZEN
+
+
+def test_now_is_real_outside_the_block_and_the_frozen_instant_inside(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    before = dj_absurd.now
+    assert before.utcoffset() == dt.timedelta(0)
+    assert abs(before - dt.datetime.now(dt.UTC)) < dt.timedelta(seconds=30)
+
+    with dj_absurd.freeze_time(FROZEN) as frozen_time:
+        assert dj_absurd.now == FROZEN
+
+        frozen_time.shift(dt.timedelta(days=2))
+        assert dj_absurd.now == FROZEN + dt.timedelta(days=2)
+
+        frozen_time.move_to(dt.datetime(2026, 3, 1, tzinfo=dt.UTC))
+        assert dj_absurd.now == dt.datetime(2026, 3, 1, tzinfo=dt.UTC)
+
+    assert abs(dj_absurd.now - dt.datetime.now(dt.UTC)) < dt.timedelta(seconds=30)
+
+
+def test_move_to_can_go_backward(dj_absurd: AbsurdTestRuntime) -> None:
+    """A backward move_to() reorders which clock moves first (Postgres, then Python)
+    so both still land in lockstep, exactly as a forward one does."""
+    with dj_absurd.freeze_time(FROZEN) as frozen_time:
+        frozen_time.shift(dt.timedelta(days=2))
+        assert dj_absurd.now == FROZEN + dt.timedelta(days=2)
+
+        frozen_time.move_to(FROZEN)
+        assert dj_absurd.now == FROZEN
+
+
+def test_leaving_the_block_releases_both_gucs_and_the_python_clock(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """Both halves, so a test can open several windows in sequence.
+
+    The database-level GUC is what a NEW worker session inherits and what outlives the
+    process; the session-level one is what Django's own already-open connection stamps
+    an ``enqueue()`` with; time-machine is Python's half.
+    """
+    real_before = dt.datetime.now(dt.UTC)
+
+    with dj_absurd.freeze_time(FROZEN):
+        assert utils.read_database_fake_now() == FROZEN.isoformat()
+        assert utils.read_session_fake_now() == FROZEN.isoformat()
+
+    assert utils.read_database_fake_now() is None
+    # A custom GUC that a session has SET reads back as empty once RESET, not as NULL.
+    assert utils.read_session_fake_now() == ""
+    assert abs(dt.datetime.now(dt.UTC) - real_before) < dt.timedelta(seconds=30)
+
+    later = dt.datetime(2027, 6, 1, tzinfo=dt.UTC)
+    with dj_absurd.freeze_time(later):
+        assert dj_absurd.now == later
+
+
+@pytest.mark.parametrize("mover", ["move_to", "shift"])
+def test_a_mover_used_after_the_block_exits_raises(
+    dj_absurd: AbsurdTestRuntime, mover: str
+) -> None:
+    """An escaped handle would otherwise re-freeze durable time silently, from real now,
+    and the fixture's crash net would tidy it away unnoticed."""
+    with dj_absurd.freeze_time(FROZEN) as frozen_time:
+        assert dj_absurd.now == FROZEN
+
+    move_after_exit: t.Callable[[], None] = (
+        functools.partial(frozen_time.move_to, FROZEN)
+        if mover == "move_to"
+        else functools.partial(frozen_time.shift, dt.timedelta(days=1))
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"django-absurd: this freeze_time\(\) block has already exited, so durable "
+            r"time is real again\. Open a new freeze_time\(\) window to move durable "
+            r"time again\."
+        ),
+    ):
+        move_after_exit()
+
+    assert utils.read_database_fake_now() is None  # nothing was re-frozen
+    assert abs(dj_absurd.now - dt.datetime.now(dt.UTC)) < dt.timedelta(seconds=30)
+
+
+def test_freeze_time_refuses_to_nest(dj_absurd: AbsurdTestRuntime) -> None:
+    """Two frozen instants cannot both be "now" — and an inner exit would restore real
+    time under the outer block rather than the instant it froze."""
+    with dj_absurd.freeze_time(FROZEN):
+        with (
+            contextlib.ExitStack() as stack,
+            pytest.raises(
+                RuntimeError,
+                match=(
+                    r"django-absurd: freeze_time\(\) is already active, and two frozen "
+                    r"instants cannot both be 'now'\. Move the open freeze with "
+                    r"move_to\(\)/shift\(\), or leave its with-block before opening "
+                    r"another\."
+                ),
+            ),
+        ):
+            stack.enter_context(dj_absurd.freeze_time(FROZEN + dt.timedelta(days=1)))
+
+        # The outer window survives a refused nest rather than being torn down by it.
+        assert dj_absurd.now == FROZEN
+
+
+def test_freeze_time_honors_a_non_utc_aware_zone(dj_absurd: AbsurdTestRuntime) -> None:
+    chicago = dt.datetime(
+        2026, 3, 8, 1, 30, tzinfo=zoneinfo.ZoneInfo("America/Chicago")
+    )
+    with dj_absurd.freeze_time(chicago) as frozen_time:
+        result = tasks.sleep_a_week.enqueue()
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(days=7))
+        dj_absurd.drain()
+
+        # The week crosses the US spring-forward gap, so the expectation is INSTANT
+        # arithmetic: shift() adds absolute elapsed time. `chicago + timedelta(days=7)`
+        # would be wall-clock arithmetic and lands an hour earlier.
+        assert dj_absurd.now == chicago.astimezone(dt.UTC) + dt.timedelta(days=7)
+        assert dj_absurd.now.utcoffset() == dt.timedelta(0)
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.enqueued_at == chicago
+        assert snapshot.state == "completed"
+
+
+def test_the_clock_is_correct_on_a_server_whose_timezone_is_not_utc(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """Regression: Django's adapter relabels timestamptz instead of converting it."""
+    dbname = connections["default"].settings_dict["NAME"]
+    params: dict[str, t.Any] = connections["default"].get_connection_params()
+    params.pop("cursor_factory", None)
+    params.pop("context", None)
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                psycopg.sql.SQL(
+                    "alter database {} set timezone = 'America/Chicago'"
+                ).format(psycopg.sql.Identifier(dbname))
+            )
+        with dj_absurd.freeze_time(FROZEN):
+            result = tasks.add.enqueue(2, 3)
+            dj_absurd.drain()
+
+            assert dj_absurd.now == FROZEN
+            assert dj_absurd.now.utcoffset() == dt.timedelta(0)
+            snapshot = dj_absurd.get_result(result.id)
+            assert snapshot is not None
+            assert snapshot.enqueued_at == FROZEN
+    finally:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                psycopg.sql.SQL("alter database {} reset timezone").format(
+                    psycopg.sql.Identifier(dbname)
+                )
+            )
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    "bad_instant",
+    [FROZEN.replace(tzinfo=None), "2026-01-01T12:00:00+00:00"],
+    ids=["naive-datetime", "string"],
+)
+@pytest.mark.parametrize("mover", ["freeze_time", "move_to"])
+def test_every_clock_entrypoint_needs_an_aware_datetime(
+    bad_instant: dt.datetime | str, dj_absurd: AbsurdTestRuntime, mover: str
+) -> None:
+    with contextlib.ExitStack() as stack:
+        # Entering IS the call for freeze_time, so both entrypoints reduce to one
+        # "hand it the instant" callable and the rule is asserted once per case.
+        def enter_freeze(instant: dt.datetime) -> None:
+            stack.enter_context(dj_absurd.freeze_time(instant))
+
+        move: t.Callable[[dt.datetime], None] = (
+            enter_freeze
+            if mover == "freeze_time"
+            else stack.enter_context(dj_absurd.freeze_time(FROZEN)).move_to
+        )
+
+        with pytest.raises(TypeError, match=NAIVE_INSTANT_MESSAGE):
+            move(bad_instant)  # type: ignore[arg-type]
+
+
+def test_freezing_without_time_machine_installed_raises(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """A real import condition, not a patched attribute: the module is uncached and a
+    finder ahead of every other one refuses to supply it.
+
+    The finder is installed around the single ``freeze_time()`` entry and removed again,
+    and the only import that entry makes is ``time_machine`` (everything else it touches
+    is already cached), so it can refuse unconditionally and name whatever it was asked
+    for. The module-level ``import time_machine`` is what makes the uncache-and-restore
+    exact rather than conditional.
+    """
+
+    class BlockTimeMachine(importlib.abc.MetaPathFinder):
+        def find_spec(
+            self,
+            fullname: str,
+            path: t.Sequence[str] | None = None,
+            target: object | None = None,
+        ) -> importlib.machinery.ModuleSpec | None:
+            msg = f"blocked for this test: {fullname}"
+            raise ImportError(msg)
+
+    blocker = BlockTimeMachine()
+    del sys.modules[time_machine.__name__]
+    sys.meta_path.insert(0, blocker)
+    try:
+        with (
+            pytest.raises(
+                ImproperlyConfigured,
+                match=(
+                    r"django-absurd: freezing durable time needs the time-machine "
+                    r"package\. Install it in your test environment: pip install "
+                    r"time-machine\."
+                ),
+            ),
+            contextlib.ExitStack() as stack,
+        ):
+            stack.enter_context(dj_absurd.freeze_time())
+    finally:
+        sys.meta_path.remove(blocker)
+        sys.modules[time_machine.__name__] = time_machine

--- a/tests/core/test_durable_clock.py
+++ b/tests/core/test_durable_clock.py
@@ -104,6 +104,35 @@ def test_a_retry_backoff_runs_the_next_attempt_after_shifting(
         assert [run.attempt for run in dj_absurd.drain()] == [2]
 
 
+def test_an_exponential_retry_backoff_doubles_the_delay_between_attempts(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """``tasks.retrying`` is ``kind="exponential", base_seconds=2`` (factor defaults
+    to 2): Absurd's ``fail_run`` computes each delay as
+    ``base_seconds * factor ** (attempt - 1)`` with no jitter term in the pinned SQL,
+    so exact rungs are deterministic — 2s after attempt 1, 4s after attempt 2.
+
+    Each rung is proven with two shifts: one short of the delay (still nothing due)
+    and one that lands past it (the next attempt fires) — proving 4s is actually
+    longer than 2s, not just the same fixed delay repeating.
+    """
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.retrying.enqueue()
+        assert [run.attempt for run in dj_absurd.drain()] == [1]
+
+        frozen_time.shift(dt.timedelta(seconds=1))
+        assert dj_absurd.drain() == []  # short of the 2s delay after attempt 1
+
+        frozen_time.shift(dt.timedelta(seconds=2))
+        assert [run.attempt for run in dj_absurd.drain()] == [2]
+
+        frozen_time.shift(dt.timedelta(seconds=2))
+        assert dj_absurd.drain() == []  # short of the 4s delay after attempt 2
+
+        frozen_time.shift(dt.timedelta(seconds=3))
+        assert [run.attempt for run in dj_absurd.drain()] == [3]
+
+
 def test_a_cancelled_task_produces_an_empty_drain(dj_absurd: AbsurdTestRuntime) -> None:
     """Cancellation happens inside claim_task, before anything is claimed."""
     with dj_absurd.freeze_time() as frozen_time:

--- a/tests/core/test_durable_clock.py
+++ b/tests/core/test_durable_clock.py
@@ -364,3 +364,47 @@ def test_freezing_without_time_machine_installed_raises(
     finally:
         sys.meta_path.remove(blocker)
         sys.modules[time_machine.__name__] = time_machine
+
+
+def test_freezing_a_past_instant_without_time_machine_installed_raises(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """The BACKWARD branch (``FROZEN`` is already in the past): ``_apply_clock_move``
+    would otherwise write the Postgres GUC before ``_move_python_clock`` ever ran,
+    leaking it once the missing dependency was discovered. ``require_time_machine()``
+    probes before either clock write, so this variant must show NEITHER clock moved —
+    not just that the same error is raised.
+    """
+
+    class BlockTimeMachine(importlib.abc.MetaPathFinder):
+        def find_spec(
+            self,
+            fullname: str,
+            path: t.Sequence[str] | None = None,
+            target: object | None = None,
+        ) -> importlib.machinery.ModuleSpec | None:
+            msg = f"blocked for this test: {fullname}"
+            raise ImportError(msg)
+
+    blocker = BlockTimeMachine()
+    del sys.modules[time_machine.__name__]
+    sys.meta_path.insert(0, blocker)
+    try:
+        with (
+            pytest.raises(
+                ImproperlyConfigured,
+                match=(
+                    r"django-absurd: freezing durable time needs the time-machine "
+                    r"package\. Install it in your test environment: pip install "
+                    r"time-machine\."
+                ),
+            ),
+            contextlib.ExitStack() as stack,
+        ):
+            stack.enter_context(dj_absurd.freeze_time(FROZEN))
+    finally:
+        sys.meta_path.remove(blocker)
+        sys.modules[time_machine.__name__] = time_machine
+
+    assert utils.read_database_fake_now() is None
+    assert abs(dj_absurd.now - dt.datetime.now(dt.UTC)) < dt.timedelta(seconds=30)

--- a/tests/core/test_durable_clock.py
+++ b/tests/core/test_durable_clock.py
@@ -31,15 +31,14 @@ def test_a_week_long_sleep_resumes_after_shifting_a_week(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:
     with dj_absurd.freeze_time() as frozen_time:
-        result = tasks.sleep_a_week.enqueue()
+        tasks.sleep_a_week.enqueue()
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
 
         frozen_time.shift(dt.timedelta(days=7))
 
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
-        snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
-        assert snapshot.result == "woke"
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", "woke")
+        ]
 
 
 def test_shifting_short_of_the_wake_leaves_the_task_sleeping(
@@ -61,34 +60,32 @@ def test_shifting_short_of_the_wake_leaves_the_task_sleeping(
 
 def test_a_chain_of_two_sleeps_needs_two_shifts(dj_absurd: AbsurdTestRuntime) -> None:
     with dj_absurd.freeze_time() as frozen_time:
-        result = tasks.sleep_twice.enqueue()
+        tasks.sleep_twice.enqueue()
         dj_absurd.drain()
 
         frozen_time.shift(dt.timedelta(days=7))
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
 
         frozen_time.shift(dt.timedelta(days=3))
-        assert [run.state for run in dj_absurd.drain()] == ["completed"]
-        snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
-        assert snapshot.result == "woke-twice"
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", "woke-twice")
+        ]
 
 
 def test_an_await_event_timeout_fires_after_shifting_past_it(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:
     with dj_absurd.freeze_time() as frozen_time:
-        result = tasks.sawait_event_timeout.enqueue(
+        tasks.sawait_event_timeout.enqueue(
             "order.packed:never-arrives", timeout=tasks.WEEK_SECONDS
         )
         assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
 
         frozen_time.shift(dt.timedelta(days=8))
-        dj_absurd.drain()
 
-        snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
-        assert snapshot.result == "timed-out"
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", "timed-out")
+        ]
 
 
 def test_a_retry_backoff_runs_the_next_attempt_after_shifting(
@@ -124,16 +121,14 @@ def test_an_expired_claim_is_swept_after_shifting_past_the_lease(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:
     with dj_absurd.freeze_time() as frozen_time:
-        result = tasks.add.enqueue(2, 3)
+        tasks.add.enqueue(2, 3)
         utils.claim_one_run("default", claim_timeout=3600)
 
         frozen_time.shift(dt.timedelta(hours=2))
-        dj_absurd.drain()
 
-        snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
-        assert snapshot.state == "completed"
-        assert snapshot.attempts == 2
+        assert [(run.attempt, run.state) for run in dj_absurd.drain()] == [
+            (2, "completed")
+        ]
 
 
 def test_freeze_time_stamps_the_frozen_instant_on_enqueue(
@@ -180,11 +175,8 @@ def test_move_to_can_go_backward(dj_absurd: AbsurdTestRuntime) -> None:
 def test_leaving_the_block_releases_both_gucs_and_the_python_clock(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:
-    """Both halves, so a test can open several windows in sequence.
-
-    The database-level GUC is what a NEW worker session inherits and what outlives the
-    process; the session-level one is what Django's own already-open connection stamps
-    an ``enqueue()`` with; time-machine is Python's half.
+    """Both halves, so a test can open several windows in sequence. The DB-level GUC,
+    session-level GUC, and Python-half distinction is documented on ``_write_fake_now``.
     """
     real_before = dt.datetime.now(dt.UTC)
 
@@ -338,13 +330,9 @@ def test_freezing_without_time_machine_installed_raises(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:
     """A real import condition, not a patched attribute: the module is uncached and a
-    finder ahead of every other one refuses to supply it.
-
-    The finder is installed around the single ``freeze_time()`` entry and removed again,
-    and the only import that entry makes is ``time_machine`` (everything else it touches
-    is already cached), so it can refuse unconditionally and name whatever it was asked
-    for. The module-level ``import time_machine`` is what makes the uncache-and-restore
-    exact rather than conditional.
+    finder ahead of every other one refuses to supply it. The only import the single
+    ``freeze_time()`` entry makes is ``time_machine``, so the finder can refuse
+    unconditionally and the uncache-and-restore stays exact.
     """
 
     class BlockTimeMachine(importlib.abc.MetaPathFinder):

--- a/tests/core/test_durable_clock.py
+++ b/tests/core/test_durable_clock.py
@@ -131,6 +131,33 @@ def test_an_expired_claim_is_swept_after_shifting_past_the_lease(
         ]
 
 
+def test_a_heartbeat_extends_the_claim_past_a_shift_that_would_otherwise_sweep_it(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """Companion to the test above, without a heartbeat: there a shift past the
+    ORIGINAL lease sweeps and re-arms the run (attempt 2). Here the same shift lands
+    short of the HEARTBEAT-extended lease, so the run is neither swept nor re-claimed
+    — ``drain()`` finds nothing to do and the task is still on its first attempt.
+
+    A manually claimed run stands in for one mid-execution (a real ``drain()`` always
+    resolves synchronously to a terminal or sleeping state before returning, so there
+    is no way to let a running task's own code straddle a clock shift);
+    ``heartbeat_one_run`` calls the exact ``absurd.extend_claim`` RPC
+    ``TaskContext.heartbeat()`` calls, against that same manually claimed run.
+    """
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.add.enqueue(2, 3)
+        run_id = utils.claim_one_run("default", claim_timeout=60)
+        utils.heartbeat_one_run(run_id, "default", seconds=3600)
+
+        frozen_time.shift(dt.timedelta(minutes=30))
+
+        assert dj_absurd.drain() == []
+        snapshot = dj_absurd.get_result(result.id)
+        assert snapshot is not None
+        assert snapshot.attempts == 1
+
+
 def test_freeze_time_stamps_the_frozen_instant_on_enqueue(
     dj_absurd: AbsurdTestRuntime,
 ) -> None:

--- a/tests/core/test_durable_clock.py
+++ b/tests/core/test_durable_clock.py
@@ -54,7 +54,6 @@ def test_shifting_short_of_the_wake_leaves_the_task_sleeping(
         assert dj_absurd.now == FROZEN + dt.timedelta(days=6)
         assert dj_absurd.drain() == []
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.state == "sleeping"
 
 
@@ -95,7 +94,6 @@ def test_a_retry_backoff_runs_the_next_attempt_after_shifting(
         result = tasks.fail_with_long_backoff.enqueue()
         assert [run.attempt for run in dj_absurd.drain()] == [1]
         mid_backoff = dj_absurd.get_result(result.id)
-        assert mid_backoff is not None
         assert mid_backoff.state == "sleeping"
         assert mid_backoff.failure is None
 
@@ -142,7 +140,6 @@ def test_a_cancelled_task_produces_an_empty_drain(dj_absurd: AbsurdTestRuntime) 
 
         assert dj_absurd.drain() == []
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.state == "cancelled"
 
 
@@ -183,7 +180,6 @@ def test_a_heartbeat_extends_the_claim_past_a_shift_that_would_otherwise_sweep_i
 
         assert dj_absurd.drain() == []
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.attempts == 1
 
 
@@ -194,7 +190,6 @@ def test_freeze_time_stamps_the_frozen_instant_on_enqueue(
         result = tasks.add.enqueue(2, 3)
 
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.enqueued_at == FROZEN
 
 
@@ -317,7 +312,6 @@ def test_freeze_time_honors_a_non_utc_aware_zone(dj_absurd: AbsurdTestRuntime) -
         assert dj_absurd.now == chicago.astimezone(dt.UTC) + dt.timedelta(days=7)
         assert dj_absurd.now.utcoffset() == dt.timedelta(0)
         snapshot = dj_absurd.get_result(result.id)
-        assert snapshot is not None
         assert snapshot.enqueued_at == chicago
         assert snapshot.state == "completed"
 
@@ -345,7 +339,6 @@ def test_the_clock_is_correct_on_a_server_whose_timezone_is_not_utc(
             assert dj_absurd.now == FROZEN
             assert dj_absurd.now.utcoffset() == dt.timedelta(0)
             snapshot = dj_absurd.get_result(result.id)
-            assert snapshot is not None
             assert snapshot.enqueued_at == FROZEN
     finally:
         with conn.cursor() as cursor:

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -12,6 +12,7 @@ from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd import absurd_params
 from django_absurd.connection import register_jsonb_loader
+from django_absurd.exceptions import QueueNotDeclaredError
 from django_absurd.queues import get_absurd_client
 from django_absurd.tasks import AbsurdTask
 from tests import tasks, utils
@@ -131,8 +132,13 @@ def test_enqueue_with_empty_queues_reports_undeclared(
             "OPTIONS": {"QUEUES": {}},
         }
     }
-    with pytest.raises(ImproperlyConfigured, match="not declared"):
+    with pytest.raises(QueueNotDeclaredError, match="not declared") as exc:
         tasks.add.enqueue(1, 2)
+    assert str(exc.value) == (
+        "Queue 'default' is not declared for backend 'default'. "
+        "Valid queues: (none). "
+        "Add it to the QUEUES list in your TASKS backend settings."
+    )
 
 
 def test_enqueue_auto_create_survives_outer_atomic() -> None:

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -132,7 +132,7 @@ def test_enqueue_with_empty_queues_reports_undeclared(
             "OPTIONS": {"QUEUES": {}},
         }
     }
-    with pytest.raises(QueueNotDeclaredError, match="not declared") as exc:
+    with pytest.raises(QueueNotDeclaredError) as exc:
         tasks.add.enqueue(1, 2)
     assert str(exc.value) == (
         "Queue 'default' is not declared for backend 'default'. "

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -35,7 +35,10 @@ def test_top_level_emit_event_no_backend_configured_raises(
     settings.TASKS = {"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}}
     with pytest.raises(BackendNotConfiguredError) as exc:
         emit_event("whatever")
-    assert str(exc.value) == "No Absurd backend configured."
+    assert str(exc.value) == (
+        "No Absurd backend configured. Add a django_absurd.backends.AbsurdBackend "
+        "entry to TASKS."
+    )
 
 
 def test_top_level_emit_event_unsynced_queue_raises(

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -20,7 +20,7 @@ pytestmark = [
 
 
 def test_top_level_emit_event_unknown_queue_raises() -> None:
-    with pytest.raises(QueueNotDeclaredError, match="ghost") as exc:
+    with pytest.raises(QueueNotDeclaredError) as exc:
         emit_event("whatever", queue="ghost")
     assert str(exc.value) == (
         "Queue 'ghost' is not declared for backend 'default'. "

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -1,33 +1,41 @@
+import psycopg.errors
 import pytest
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
+from django.db import connection
 from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd import emit_event
-from tests import atasks, tasks, utils
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+)
+from django_absurd.test import AbsurdTestRuntime
+from tests import atasks, tasks
 
-pytestmark = pytest.mark.django_db(transaction=True)
+pytestmark = [
+    pytest.mark.django_db(transaction=True),
+    pytest.mark.usefixtures("_isolate_queues"),
+]
 
 
 def test_top_level_emit_event_unknown_queue_raises() -> None:
-    with pytest.raises(
-        ImproperlyConfigured,
-        match=(
-            r"Queue 'ghost' is not declared in TASKS QUEUES\. Add it to the QUEUES "
-            r"list in your TASKS backend settings\."
-        ),
-    ):
+    with pytest.raises(QueueNotDeclaredError, match="ghost") as exc:
         emit_event("whatever", queue="ghost")
+    assert str(exc.value) == (
+        "Queue 'ghost' is not declared for backend 'default'. "
+        "Valid queues: default, other, reports. "
+        "Add it to the QUEUES list in your TASKS backend settings."
+    )
 
 
 def test_top_level_emit_event_no_backend_configured_raises(
     settings: SettingsWrapper,
 ) -> None:
     settings.TASKS = {"x": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}}
-    with pytest.raises(
-        ImproperlyConfigured, match=r"django-absurd: no Absurd backend configured\."
-    ):
+    with pytest.raises(BackendNotConfiguredError) as exc:
         emit_event("whatever")
+    assert str(exc.value) == "No Absurd backend configured."
 
 
 def test_top_level_emit_event_unsynced_queue_raises(
@@ -40,7 +48,7 @@ def test_top_level_emit_event_unsynced_queue_raises(
         }
     }
     with pytest.raises(
-        ImproperlyConfigured,
+        QueueNotProvisionedError,
         match=(
             r"Queue 'unsynced' is declared but its Absurd table is not provisioned\. "
             r"Run: manage\.py absurd_sync_queues"
@@ -49,109 +57,130 @@ def test_top_level_emit_event_unsynced_queue_raises(
         emit_event("whatever", queue="unsynced")
 
 
-def test_sync_await_event_suspends_then_top_level_emit_resumes() -> None:
+def test_emit_event_does_not_relabel_an_unrelated_missing_relation() -> None:
+    """Mirrors test_drain_queue_does_not_relabel_an_unrelated_missing_relation
+    (tests/core/test_worker.py): a missing relation that is NOT one of this queue's
+    own Absurd tables surfaces as itself, chained, rather than as the curated
+    unprovisioned-queue error.
+    """
     call_command("absurd_sync_queues")
-    result = tasks.sawait_event_once.enqueue("order.packed:sync-1")
+    try:
+        with connection.cursor() as cur:
+            cur.execute(
+                "create or replace function absurd.record_audit_probe() "
+                "returns trigger language plpgsql as $$ begin "
+                "insert into absurd.audit_probe (run_id) values (new.run_id); "
+                "return new; end; $$"
+            )
+            cur.execute(
+                "create trigger audit_probe_after_emit after insert "
+                "on absurd.e_default for each row "
+                "execute function absurd.record_audit_probe()"
+            )
 
-    utils.run_absurd_worker()  # drain 1: no event yet -> suspend
-    suspended = utils.get_task_result(result.id)
-    assert suspended is not None
-    assert suspended.state == "sleeping"
+        with pytest.raises(psycopg.errors.UndefinedTable) as undefined:
+            emit_event("order.packed:audit-probe", queue="default")
+
+        assert (
+            undefined.value.diag.message_primary
+            == 'relation "absurd.audit_probe" does not exist'
+        )
+    finally:
+        with connection.cursor() as cur:
+            cur.execute("drop function if exists absurd.record_audit_probe() cascade")
+
+
+def test_sync_await_event_suspends_then_top_level_emit_resumes(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    tasks.sawait_event_once.enqueue("order.packed:sync-1")
+
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
 
     emit_event("order.packed:sync-1", {"tracking": "abc"}, queue="default")
 
-    utils.run_absurd_worker()  # drain 2: resumes with the payload
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == {"tracking": "abc"}
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", {"tracking": "abc"})
+    ]
 
 
-def test_async_await_event_suspends_then_top_level_emit_resumes() -> None:
-    call_command("absurd_sync_queues")
-    result = atasks.aawait_event_once.enqueue("order.packed:async-1")
+def test_async_await_event_suspends_then_top_level_emit_resumes(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    atasks.aawait_event_once.enqueue("order.packed:async-1")
 
-    utils.run_absurd_worker()
-    suspended = utils.get_task_result(result.id)
-    assert suspended is not None
-    assert suspended.state == "sleeping"
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
 
     emit_event("order.packed:async-1", {"tracking": "abc"}, queue="default")
 
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == {"tracking": "abc"}
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", {"tracking": "abc"})
+    ]
 
 
-def test_emit_before_await_returns_immediately_no_suspend() -> None:
-    call_command("absurd_sync_queues")
+def test_emit_before_await_returns_immediately_no_suspend(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     emit_event("order.packed:before-1", {"tracking": "xyz"}, queue="default")
 
-    result = tasks.sawait_event_once.enqueue("order.packed:before-1")
-    utils.run_absurd_worker()  # single drain: event already there, no suspend
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == {"tracking": "xyz"}
+    tasks.sawait_event_once.enqueue("order.packed:before-1")
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", {"tracking": "xyz"})
+    ]
 
 
-def test_first_emit_per_name_wins() -> None:
-    call_command("absurd_sync_queues")
+def test_first_emit_per_name_wins(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     emit_event("order.packed:first-wins", {"tracking": "first"}, queue="default")
     emit_event("order.packed:first-wins", {"tracking": "second"}, queue="default")
 
-    result = tasks.sawait_event_once.enqueue("order.packed:first-wins")
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.result == {"tracking": "first"}
+    tasks.sawait_event_once.enqueue("order.packed:first-wins")
+    assert [run.result for run in dj_absurd.drain()] == [{"tracking": "first"}]
 
 
-def test_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
-    call_command("absurd_sync_queues")
+def test_in_task_emit_event_wakes_a_separately_enqueued_waiter(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     tasks.semit_event_once.enqueue("order.packed:in-task", {"tracking": "in-task"})
-    utils.run_absurd_worker()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
 
-    result = tasks.sawait_event_once.enqueue("order.packed:in-task")
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.result == {"tracking": "in-task"}
+    tasks.sawait_event_once.enqueue("order.packed:in-task")
+    assert [run.result for run in dj_absurd.drain()] == [{"tracking": "in-task"}]
 
 
-def test_async_in_task_emit_event_wakes_a_separately_enqueued_waiter() -> None:
-    call_command("absurd_sync_queues")
+def test_async_in_task_emit_event_wakes_a_separately_enqueued_waiter(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     atasks.aemit_event_once.enqueue("order.packed:in-task-async", {"tracking": "async"})
-    utils.run_absurd_worker()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
 
-    result = atasks.aawait_event_once.enqueue("order.packed:in-task-async")
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.result == {"tracking": "async"}
+    atasks.aawait_event_once.enqueue("order.packed:in-task-async")
+    assert [run.result for run in dj_absurd.drain()] == [{"tracking": "async"}]
 
 
-def test_uncaught_timeout_raises_absurd_sdk_timeout_error_and_is_catchable() -> None:
-    call_command("absurd_sync_queues")
-    result = tasks.sawait_event_timeout.enqueue("order.packed:never-arrives", timeout=0)
-    utils.run_absurd_worker()
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == "timed-out"
+def test_uncaught_timeout_raises_absurd_sdk_timeout_error_and_is_catchable(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    tasks.sawait_event_timeout.enqueue("order.packed:never-arrives", timeout=0)
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("sleeping", None),
+        ("completed", "timed-out"),
+    ]
 
 
-def test_event_already_present_returns_no_timeout_before_deadline() -> None:
-    call_command("absurd_sync_queues")
+def test_event_already_present_returns_no_timeout_before_deadline(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     emit_event("order.packed:before-timeout-1", {"tracking": "xyz"}, queue="default")
 
-    result = tasks.sawait_event_timeout.enqueue(
-        "order.packed:before-timeout-1", timeout=60
-    )
-    utils.run_absurd_worker()  # single drain: event already there, no suspend
-    done = utils.get_task_result(result.id)
-    assert done is not None
-    assert done.state == "completed"
-    assert done.result == "no-timeout"
+    tasks.sawait_event_timeout.enqueue("order.packed:before-timeout-1", timeout=60)
+    assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+        ("completed", "no-timeout")
+    ]

--- a/tests/core/test_orm_models.py
+++ b/tests/core/test_orm_models.py
@@ -65,7 +65,6 @@ def test_admin_uses_the_models_py_classes() -> None:
 
 
 def seed_two_queues() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(2, 3)
     tasks.add.using(queue_name="other").enqueue(7, 8)
     absurd_params(max_attempts=1).bind(tasks.boom).enqueue()

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -33,14 +33,12 @@ def view_oid(name: str) -> int | None:
 
 
 def test_rebuild_views_builds_all_five() -> None:
-    call_command("absurd_sync_queues")
     rebuild_views("default")
     for spec in ADMIN_ENTITY_SPECS:
         assert view_oid(spec.view_name) is not None
 
 
 def test_read_path_does_no_ddl() -> None:
-    call_command("absurd_sync_queues")
     rebuild_views("default")
     spec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     before = view_oid(spec.view_name)
@@ -90,7 +88,6 @@ def test_provision_skips_when_schema_absent(
 
 
 def test_sync_command_rebuilds_views_with_new_queue() -> None:
-    call_command("absurd_sync_queues")
     task_model: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
@@ -109,9 +106,7 @@ def test_worker_start_rebuilds_when_it_created_queue() -> None:
     task_model: t.Any = build_admin_model(
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
-    call_command("absurd_sync_queues")
     get_absurd_client().drop_queue("other")
-    call_command("absurd_sync_queues")
     call_command("absurd_worker", queue="other", burst=True)
     tasks.add.using(queue_name="other").enqueue(7, 8)
     call_command("absurd_worker", queue="other", burst=True)
@@ -119,7 +114,6 @@ def test_worker_start_rebuilds_when_it_created_queue() -> None:
 
 
 def test_dropped_queue_read_raises_typed_error() -> None:
-    call_command("absurd_sync_queues")
     rebuild_views("default")
     with connections["default"].cursor() as cur:
         cur.execute("DROP VIEW IF EXISTS absurd.tasks_view")
@@ -134,5 +128,5 @@ def test_dropped_queue_read_raises_typed_error() -> None:
         task_model.objects.exists()
     with pytest.raises(ViewNotProvisionedError):
         task_model.objects.aggregate(models.Count("natural_key"))
-    call_command("absurd_sync_queues")
+    call_command("absurd_sync_queues")  # rebuild the view this test dropped
     list(task_model.objects.all())

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import pathlib
 import typing as t
 
 import pytest
@@ -8,17 +9,32 @@ from django.db import connections
 from django.test import TransactionTestCase
 
 if t.TYPE_CHECKING:
-    import collections.abc
-
     import pytest_django.fixtures
 
 from django_absurd import absurd_params, pytest_plugin
 from django_absurd.flush import flush_absurd_state
 from django_absurd.models import Queue, Task
-from django_absurd.test import install_absurd_cleanup
+from django_absurd.test import AbsurdTestRuntime, install_absurd_cleanup
 from tests import tasks, utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
+
+# The leak-recovery tests below need a real session boundary — a session-scoped fixture
+# cannot be re-triggered inside the session that already ran it — so they drive a nested
+# pytest run through ``pytester``.
+pytest_plugins = ["pytester"]
+
+# Each inner run needs PYTHONPATH, so the inner interpreter can import
+# ``tests.core.settings``. Each inner run also needs an explicit settings module that
+# pins ``DATABASES["default"]["TEST"]["NAME"]`` to THIS run's own test database:
+# pytest-django takes its per-worker suffix from xdist's workerinput, which a serial
+# inner run has none of, so it would otherwise compute the unsuffixed name and touch a
+# database this test never planted a GUC on.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# A database that does not exist, for the inner run that has no Absurd backend: any
+# statement the plugin tried to issue there would fail to connect and error the session.
+ABSENT_DATABASE = "absurd_no_such_database"
 
 # django-stubs doesn't model TransactionTestCase's internal ``_post_teardown`` hook;
 # access it (and probe instances) through this alias to keep the mechanism assertions
@@ -27,7 +43,6 @@ TxnCase: t.Any = TransactionTestCase
 
 
 def test_flush_absurd_state_truncates_rows_by_default() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(1, 2)
     task_model: t.Any = Task
     assert task_model.objects.filter(queue="default").count() == 1
@@ -61,7 +76,6 @@ def test_flush_absurd_state_truncates_a_partitioned_queues_idempotency_table(
 
 
 def test_flush_absurd_state_drops_schema_when_requested() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(1, 2)
 
     flush_absurd_state(drop_schema=True)
@@ -87,8 +101,17 @@ def test_flush_absurd_state_is_a_noop_on_an_unmigrated_schema(
         connections["default"].close()
 
 
+def test_flush_absurd_state_resets_a_stranded_fake_now() -> None:
+    utils.set_database_fake_now("2036-01-01T00:00:00+00:00")
+    try:
+        flush_absurd_state()
+
+        assert utils.read_database_fake_now() is None
+    finally:
+        utils.reset_database_fake_now()
+
+
 def test_post_teardown_hook_truncates_absurd_state() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(1, 2)
     task_model: t.Any = Task
     assert task_model.objects.filter(queue="default").count() == 1
@@ -104,7 +127,6 @@ def test_post_teardown_hook_truncates_absurd_state() -> None:
 
 
 def test_post_teardown_hook_skips_undeclared_absurd_alias() -> None:
-    call_command("absurd_sync_queues")
     tasks.add.enqueue(1, 2)
 
     class NoDatabasesCase(TransactionTestCase):
@@ -161,19 +183,23 @@ def test_install_absurd_cleanup_wraps_a_fresh_post_teardown() -> None:
         TxnCase._post_teardown = installed
 
 
-def test_absurd_drain_queue_processes_an_enqueued_task(
-    absurd_drain_queue: "collections.abc.Callable[..., None]",
+def test_the_absurd_fixture_drains_an_enqueued_task(
+    dj_absurd: AbsurdTestRuntime,
 ) -> None:
-    call_command("absurd_sync_queues")
     result = tasks.add.enqueue(3, 4)
-    absurd_drain_queue()
-    snap = utils.get_task_result(result.id)
+    dj_absurd.drain()
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.state == "completed"
 
 
-def test_start_sweep_declares_only_request_so_the_guard_runs_first() -> None:
-    # Import-safety invariant: the session start-sweep must take ONLY ``request``.
+@pytest.mark.parametrize(
+    "fixture_name", ["_sweep_orphaned_pg_cron_jobs", "_sweep_stranded_fake_now"]
+)
+def test_start_sweeps_declare_only_request_so_the_guard_runs_first(
+    fixture_name: str,
+) -> None:
+    # Import-safety invariant: a session start-sweep must take ONLY ``request``.
     # Declaring ``django_db_setup``/``django_db_blocker`` as parameters would make
     # pytest resolve them BEFORE the body's ``settings.configured`` /
     # ``apps.is_installed`` guard, which in a non-Django or pytest-django-less project
@@ -181,8 +207,256 @@ def test_start_sweep_declares_only_request_so_the_guard_runs_first() -> None:
     # ``getfixturevalue`` only after the guard passes.
     # django-stubs/pytest type the fixture as FixtureFunctionDefinition, which doesn't
     # model the ``__wrapped__`` original-function handle; reach it through t.Any.
-    fixture: t.Any = pytest_plugin._sweep_orphaned_pg_cron_jobs
+    fixture: t.Any = getattr(pytest_plugin, fixture_name)
     assert list(inspect.signature(fixture.__wrapped__).parameters) == ["request"]
+
+
+def test_a_stranded_fake_now_is_swept_before_the_session_runs(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """A SIGKILLed run leaves the GUC behind; the next session must clear it."""
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    utils.set_database_fake_now("2036-01-01T00:00:00+00:00")
+    try:
+        real_name = connections["default"].settings_dict["NAME"]
+        pytester.makepyfile(
+            inner_settings=f"""
+            from tests.core.settings import *  # noqa: F403
+
+            DATABASES["default"]["TEST"]["NAME"] = {real_name!r}
+            """,
+            inner_test="""
+            import datetime as dt
+
+            import pytest
+
+            pytestmark = pytest.mark.django_db(transaction=True)
+
+
+            def test_clock_is_real(dj_absurd):
+                assert dj_absurd.now.year == dt.datetime.now(dt.UTC).year
+            """,
+        )
+
+        outcome = pytester.runpytest_subprocess("--reuse-db", "--ds=inner_settings")
+
+        outcome.assert_outcomes(passed=1)
+        assert utils.read_database_fake_now() is None
+    finally:
+        utils.reset_database_fake_now()
+
+
+def test_the_stranded_fake_now_sweep_skips_when_nothing_is_provisioned(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """A session with no ``django_db``-marked test anywhere provisions nothing for the
+    Absurd alias — ``NAME`` stays whatever the developer configured, never swapped to
+    a test database. Pointing that LIVE ``NAME`` at a database that does not exist
+    proves the sweep never issues its ``ALTER DATABASE``: were the skip to regress,
+    connecting to that nonexistent name would error the whole session before this
+    test's own body ever ran.
+    """
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    pytester.makepyfile(
+        inner_settings=f"""
+        from tests.core.settings import *  # noqa: F403
+
+        DATABASES["default"]["NAME"] = {ABSENT_DATABASE!r}
+        """,
+        inner_test="""
+        def test_no_db_backed_test_anywhere():
+            assert 1 + 1 == 2
+        """,
+    )
+
+    outcome = pytester.runpytest_subprocess("--ds=inner_settings")
+
+    outcome.assert_outcomes(passed=1)
+
+
+def test_the_orphaned_pg_cron_jobs_sweep_skips_when_nothing_is_provisioned(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """Mirrors the ``fake_now`` skip test above for ``_sweep_orphaned_pg_cron_jobs``'s
+    own unprovisioned-session guard.
+
+    That fixture only proceeds past its first guard when the pg_cron app is
+    INSTALLED, so the inner run needs ``tests.pg_cron.settings`` rather than this
+    suite's own — no new pytester harness, just tests/core's existing machinery
+    pointed at a different settings module (``tests/pg_cron`` has no pytester harness
+    of its own to mirror this into). A session with no ``django_db``-marked test
+    anywhere provisions nothing for the Absurd alias, so ``NAME`` stays whatever the
+    developer configured. Pointing that LIVE ``NAME`` at a database that does not
+    exist proves the sweep never issues its central-catalog ``DELETE``/unschedule:
+    were the skip to regress, connecting to that nonexistent name would error the
+    whole session before this test's own body ever ran.
+    """
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    pytester.makepyfile(
+        inner_settings=f"""
+        from tests.pg_cron.settings import *  # noqa: F403
+
+        DATABASES["default"]["NAME"] = {ABSENT_DATABASE!r}
+        """,
+        inner_test="""
+        def test_no_db_backed_test_anywhere():
+            assert 1 + 1 == 2
+        """,
+    )
+
+    outcome = pytester.runpytest_subprocess("--ds=inner_settings")
+
+    outcome.assert_outcomes(passed=1)
+
+
+def test_a_test_that_raises_inside_a_freeze_still_releases_the_clock(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """Proves recovery by SOME layer — the ``freeze_time`` block's own exit, the fixture
+    teardown behind it, or the flush reset. All three exist by now and all three fire
+    after the inner failing test; the sweep test above is the one that isolates the
+    sweep, since it runs before any inner test."""
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    real_name = connections["default"].settings_dict["NAME"]
+    pytester.makepyfile(
+        inner_settings=f"""
+        from tests.core.settings import *  # noqa: F403
+
+        DATABASES["default"]["TEST"]["NAME"] = {real_name!r}
+        """,
+        inner_test="""
+        import datetime as dt
+
+        import pytest
+
+        pytestmark = pytest.mark.django_db(transaction=True)
+
+
+        def test_shifts_then_fails(dj_absurd):
+            with dj_absurd.freeze_time() as frozen_time:
+                frozen_time.shift(dt.timedelta(days=7))
+                pytest.fail("deliberate")
+        """,
+    )
+    # The inner run plants a real-now+7d GUC on the database the OUTER session shares.
+    # Should every recovery layer regress at once, the reset below keeps the cost at one
+    # red test: a live fake_now over a real Python clock is the deadlock direction, and
+    # the next draining test in this session would hang unkillably instead of failing.
+    try:
+        outcome = pytester.runpytest_subprocess("--reuse-db", "--ds=inner_settings")
+
+        outcome.assert_outcomes(failed=1)
+        assert utils.read_database_fake_now() is None
+    finally:
+        utils.reset_database_fake_now()
+
+
+def test_freeze_time_refuses_a_test_with_no_db_marker(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """A test that never earned Django DB access must never reach ANY database through
+    ``freeze_time()``'s own raw connection — proven by pointing the LIVE ``NAME`` at a
+    database that does not exist. A second, marked test keeps ``django_db_setup`` and
+    the session sweep themselves working normally (their own aliases come from every
+    marked test in the whole session, not just this one), isolating the assertion to
+    the unmarked test's own guard: were it to regress, the raw connection would fail
+    trying to reach that nonexistent name, not raise this curated error.
+    """
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    real_name = connections["default"].settings_dict["NAME"]
+    pytester.makepyfile(
+        inner_settings=f"""
+        from tests.core.settings import *  # noqa: F403
+
+        DATABASES["default"]["NAME"] = {ABSENT_DATABASE!r}
+        DATABASES["default"]["TEST"]["NAME"] = {real_name!r}
+        """,
+        inner_test="""
+        import pytest
+
+
+        @pytest.mark.django_db(transaction=True)
+        def test_seed_the_alias():
+            pass
+
+
+        def test_no_marker(dj_absurd):
+            with pytest.raises(
+                RuntimeError,
+                match=(
+                    r"django-absurd: freeze_time\\(\\) needs real Django database "
+                    r"access to pin Postgres's clock on 'default', and this test "
+                    r"has none\\. Mark it "
+                    r"@pytest\\.mark\\.django_db\\(transaction=True\\)\\."
+                ),
+            ):
+                with dj_absurd.freeze_time():
+                    pass
+        """,
+    )
+
+    outcome = pytester.runpytest_subprocess("--reuse-db", "--ds=inner_settings")
+
+    outcome.assert_outcomes(passed=2)
+
+
+def test_the_start_sweep_no_ops_in_a_project_without_an_absurd_backend(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """The bail-out arm, for real: django-absurd installed, no Absurd backend.
+
+    The inner project points at a database that does not exist, so the promise — a
+    plugin that touches nothing when no Absurd backend is configured — is observable: a
+    clean session proves the sweep never resolved a database, let alone connected to
+    one. Past the guard it falls back to the ``default`` alias and tries, and failing to
+    connect errors every test in the session.
+    """
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    pytester.makepyfile(
+        inner_settings=f"""
+        from tests.core.settings import *  # noqa: F403
+
+        TASKS = {{"default": {{"BACKEND": "django.tasks.backends.dummy.DummyBackend"}}}}
+        DATABASES["default"]["NAME"] = {ABSENT_DATABASE!r}
+        """,
+        inner_test="""
+        from django_absurd.backends import get_absurd_backends
+
+
+        def test_no_absurd_backend_is_configured():
+            assert get_absurd_backends() == {}
+        """,
+    )
+
+    outcome = pytester.runpytest_subprocess("--reuse-db", "--ds=inner_settings")
+
+    outcome.assert_outcomes(passed=1)
+
+
+def test_a_pytest_run_with_no_django_settings_still_collects(
+    monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
+) -> None:
+    """The ``pytest11`` entry point loads on EVERY pytest run in any venv that has
+    django-absurd installed — Django project or not — and ``pytest_configure`` imports
+    ``django_absurd.test`` there. A module-level import in that module that reaches
+    ``django_absurd.models`` defines model classes against unconfigured settings, so the
+    run dies with ``INTERNALERROR: ImproperlyConfigured`` before collecting anything.
+
+    Only a subprocess with ``DJANGO_SETTINGS_MODULE`` removed can catch that: reloading
+    the plugin inside this already-configured session sees settings either way.
+    """
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    monkeypatch.delenv("DJANGO_SETTINGS_MODULE")
+    pytester.makepyfile(
+        inner_test="""
+        def test_django_is_never_configured():
+            assert 1 + 1 == 2
+        """
+    )
+
+    outcome = pytester.runpytest_subprocess()
+
+    outcome.assert_outcomes(passed=1)
 
 
 def test_plugin_module_imports_cleanly() -> None:
@@ -192,4 +466,4 @@ def test_plugin_module_imports_cleanly() -> None:
     # entry-point module imports cleanly and exposes its public surface.
     importlib.reload(pytest_plugin)
     assert callable(pytest_plugin.pytest_configure)
-    assert callable(pytest_plugin.absurd_drain_queue)
+    assert callable(pytest_plugin.dj_absurd)

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -321,6 +321,11 @@ def test_freeze_time_refuses_a_test_with_no_db_marker(
     ``freeze_time()``'s raw connection — proven by pointing the LIVE ``NAME`` at a
     database that does not exist. A second, marked test keeps ``django_db_setup``
     and the session sweep working, isolating the assert to the unmarked test's guard.
+
+    Both an ``async def`` unmarked test and a plain one, because the guard's
+    ``ensure_connection`` probe is the one that has to step off a running event loop to
+    run at all: the async case is what proves the hop still reaches the block instead of
+    quietly passing on a connection the test never had.
     """
     monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
     real_name = connections["default"].settings_dict["NAME"]
@@ -340,16 +345,23 @@ def test_freeze_time_refuses_a_test_with_no_db_marker(
             pass
 
 
+        NO_ACCESS = (
+            r"django-absurd: freeze_time\\(\\) needs real Django database "
+            r"access to pin Postgres's clock on 'default', and this test "
+            r"has none\\. Mark it "
+            r"@pytest\\.mark\\.django_db\\(transaction=True\\)\\."
+        )
+
+
         def test_no_marker(dj_absurd):
-            with pytest.raises(
-                RuntimeError,
-                match=(
-                    r"django-absurd: freeze_time\\(\\) needs real Django database "
-                    r"access to pin Postgres's clock on 'default', and this test "
-                    r"has none\\. Mark it "
-                    r"@pytest\\.mark\\.django_db\\(transaction=True\\)\\."
-                ),
-            ):
+            with pytest.raises(RuntimeError, match=NO_ACCESS):
+                with dj_absurd.freeze_time():
+                    pass
+
+
+        @pytest.mark.asyncio
+        async def test_no_marker_async(dj_absurd):
+            with pytest.raises(RuntimeError, match=NO_ACCESS):
                 with dj_absurd.freeze_time():
                     pass
         """,
@@ -357,7 +369,7 @@ def test_freeze_time_refuses_a_test_with_no_db_marker(
 
     outcome = pytester.runpytest_subprocess("--reuse-db", "--ds=inner_settings")
 
-    outcome.assert_outcomes(passed=2)
+    outcome.assert_outcomes(passed=3)
 
 
 def test_the_start_sweep_no_ops_in_a_project_without_an_absurd_backend(

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -1,5 +1,4 @@
 import importlib
-import inspect
 import pathlib
 import typing as t
 
@@ -14,7 +13,7 @@ if t.TYPE_CHECKING:
 from django_absurd import absurd_params, pytest_plugin
 from django_absurd.flush import flush_absurd_state
 from django_absurd.models import Queue, Task
-from django_absurd.test import AbsurdTestRuntime, install_absurd_cleanup
+from django_absurd.test import install_absurd_cleanup
 from tests import tasks, utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -183,34 +182,6 @@ def test_install_absurd_cleanup_wraps_a_fresh_post_teardown() -> None:
         TxnCase._post_teardown = installed
 
 
-def test_the_absurd_fixture_drains_an_enqueued_task(
-    dj_absurd: AbsurdTestRuntime,
-) -> None:
-    result = tasks.add.enqueue(3, 4)
-    dj_absurd.drain()
-    snap = dj_absurd.get_result(result.id)
-    assert snap is not None
-    assert snap.state == "completed"
-
-
-@pytest.mark.parametrize(
-    "fixture_name", ["_sweep_orphaned_pg_cron_jobs", "_sweep_stranded_fake_now"]
-)
-def test_start_sweeps_declare_only_request_so_the_guard_runs_first(
-    fixture_name: str,
-) -> None:
-    # Import-safety invariant: a session start-sweep must take ONLY ``request``.
-    # Declaring ``django_db_setup``/``django_db_blocker`` as parameters would make
-    # pytest resolve them BEFORE the body's ``settings.configured`` /
-    # ``apps.is_installed`` guard, which in a non-Django or pytest-django-less project
-    # skips or errors the whole session. The DB fixtures are pulled lazily via
-    # ``getfixturevalue`` only after the guard passes.
-    # django-stubs/pytest type the fixture as FixtureFunctionDefinition, which doesn't
-    # model the ``__wrapped__`` original-function handle; reach it through t.Any.
-    fixture: t.Any = getattr(pytest_plugin, fixture_name)
-    assert list(inspect.signature(fixture.__wrapped__).parameters) == ["request"]
-
-
 def test_a_stranded_fake_now_is_swept_before_the_session_runs(
     monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
 ) -> None:
@@ -277,19 +248,11 @@ def test_the_stranded_fake_now_sweep_skips_when_nothing_is_provisioned(
 def test_the_orphaned_pg_cron_jobs_sweep_skips_when_nothing_is_provisioned(
     monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
 ) -> None:
-    """Mirrors the ``fake_now`` skip test above for ``_sweep_orphaned_pg_cron_jobs``'s
-    own unprovisioned-session guard.
-
-    That fixture only proceeds past its first guard when the pg_cron app is
-    INSTALLED, so the inner run needs ``tests.pg_cron.settings`` rather than this
-    suite's own — no new pytester harness, just tests/core's existing machinery
-    pointed at a different settings module (``tests/pg_cron`` has no pytester harness
-    of its own to mirror this into). A session with no ``django_db``-marked test
-    anywhere provisions nothing for the Absurd alias, so ``NAME`` stays whatever the
-    developer configured. Pointing that LIVE ``NAME`` at a database that does not
-    exist proves the sweep never issues its central-catalog ``DELETE``/unschedule:
-    were the skip to regress, connecting to that nonexistent name would error the
-    whole session before this test's own body ever ran.
+    """Mirrors the ``fake_now`` skip test above, for ``_sweep_orphaned_pg_cron_jobs``'s
+    own unprovisioned-session guard. Needs ``tests.pg_cron.settings``: that fixture's
+    first guard requires the pg_cron app installed. Pointing the LIVE ``NAME`` at a
+    database that does not exist is the proof — a regressed skip would error the
+    whole session connecting to it.
     """
     monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
     pytester.makepyfile(
@@ -354,13 +317,10 @@ def test_a_test_that_raises_inside_a_freeze_still_releases_the_clock(
 def test_freeze_time_refuses_a_test_with_no_db_marker(
     monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
 ) -> None:
-    """A test that never earned Django DB access must never reach ANY database through
-    ``freeze_time()``'s own raw connection — proven by pointing the LIVE ``NAME`` at a
-    database that does not exist. A second, marked test keeps ``django_db_setup`` and
-    the session sweep themselves working normally (their own aliases come from every
-    marked test in the whole session, not just this one), isolating the assertion to
-    the unmarked test's own guard: were it to regress, the raw connection would fail
-    trying to reach that nonexistent name, not raise this curated error.
+    """A test with no Django DB access must never reach ANY database through
+    ``freeze_time()``'s raw connection — proven by pointing the LIVE ``NAME`` at a
+    database that does not exist. A second, marked test keeps ``django_db_setup``
+    and the session sweep working, isolating the assert to the unmarked test's guard.
     """
     monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
     real_name = connections["default"].settings_dict["NAME"]
@@ -403,13 +363,9 @@ def test_freeze_time_refuses_a_test_with_no_db_marker(
 def test_the_start_sweep_no_ops_in_a_project_without_an_absurd_backend(
     monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
 ) -> None:
-    """The bail-out arm, for real: django-absurd installed, no Absurd backend.
-
-    The inner project points at a database that does not exist, so the promise — a
-    plugin that touches nothing when no Absurd backend is configured — is observable: a
-    clean session proves the sweep never resolved a database, let alone connected to
-    one. Past the guard it falls back to the ``default`` alias and tries, and failing to
-    connect errors every test in the session.
+    """The bail-out arm: django-absurd installed, no Absurd backend. Points the
+    inner project's ``NAME`` at a database that does not exist, so a clean session
+    proves the sweep never resolved a database, let alone connected to one.
     """
     monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
     pytester.makepyfile(
@@ -436,14 +392,11 @@ def test_the_start_sweep_no_ops_in_a_project_without_an_absurd_backend(
 def test_a_pytest_run_with_no_django_settings_still_collects(
     monkeypatch: pytest.MonkeyPatch, pytester: pytest.Pytester
 ) -> None:
-    """The ``pytest11`` entry point loads on EVERY pytest run in any venv that has
-    django-absurd installed — Django project or not — and ``pytest_configure`` imports
-    ``django_absurd.test`` there. A module-level import in that module that reaches
-    ``django_absurd.models`` defines model classes against unconfigured settings, so the
-    run dies with ``INTERNALERROR: ImproperlyConfigured`` before collecting anything.
-
-    Only a subprocess with ``DJANGO_SETTINGS_MODULE`` removed can catch that: reloading
-    the plugin inside this already-configured session sees settings either way.
+    """``pytest11`` loads on EVERY pytest run in any venv with django-absurd
+    installed, Django project or not. A module-level import reaching
+    ``django_absurd.models`` would define models against unconfigured settings and
+    die with ``INTERNALERROR`` before collection — only a settings-less subprocess
+    catches that.
     """
     monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
     monkeypatch.delenv("DJANGO_SETTINGS_MODULE")

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -13,6 +13,7 @@ from django.tasks.exceptions import TaskResultDoesNotExist
 from django_absurd import absurd_params
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.queues import get_absurd_client
+from django_absurd.test import AbsurdTestRuntime
 from tests import tasks
 from tests.models import Payload
 
@@ -24,10 +25,6 @@ pytestmark = [
 
 def backend() -> AbsurdBackend:
     return get_absurd_backends()["default"]
-
-
-def run_absurd_worker(queue: str = "default") -> None:
-    call_command("absurd_worker", queue=queue, burst=True)
 
 
 def test_get_result_pending() -> None:
@@ -42,10 +39,10 @@ def test_get_result_pending() -> None:
     assert got.task.module_path == "tests.tasks.add"
 
 
-def test_get_result_successful() -> None:
-    call_command("absurd_sync_queues")
+def test_get_result_successful(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     r = tasks.add.enqueue(2, 3)
-    run_absurd_worker()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
     assert got.return_value == 5
@@ -54,28 +51,30 @@ def test_get_result_successful() -> None:
     assert got.worker_ids  # non-empty
 
 
-def test_get_result_suspended_on_indefinite_await_event() -> None:
-    call_command("absurd_sync_queues")
+def test_get_result_suspended_on_indefinite_await_event(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     r = tasks.sawait_event_once.enqueue("get-result-infinity-check")
-    run_absurd_worker()
+    assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.RUNNING
 
 
-def test_refresh_round_trip() -> None:
-    call_command("absurd_sync_queues")
+def test_refresh_round_trip(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     r = tasks.add.enqueue(2, 3)
     assert r.status == TaskResultStatus.READY  # prior to running
-    run_absurd_worker()
+    assert [run.state for run in dj_absurd.drain()] == ["completed"]
     r.refresh()
     assert r.status == TaskResultStatus.SUCCESSFUL  # type: ignore[comparison-overlap]
     assert r.return_value == 5
 
 
-def test_get_result_failed_has_errors() -> None:
-    call_command("absurd_sync_queues")
+def test_get_result_failed_has_errors(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     r = absurd_params(max_attempts=1).bind(tasks.boom).enqueue()
-    run_absurd_worker()
+    assert [run.state for run in dj_absurd.drain()] == ["failed"]
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.FAILED
     assert len(got.errors) == 1
@@ -195,29 +194,31 @@ def test_enqueue_does_not_poison_jsonfield_reads() -> None:
         {"nested": [1, 2, {"a": None, "b": "ünïçødé"}]},
     ],
 )
-def test_echo_return_value_round_trips(value: JsonValue) -> None:
-    call_command("absurd_sync_queues")
+def test_echo_return_value_round_trips(
+    dj_absurd: AbsurdTestRuntime, value: JsonValue
+) -> None:
+    dj_absurd.sync_queues()
     r = tasks.echo.enqueue(value)
-    run_absurd_worker()
+    assert [run.result for run in dj_absurd.drain()] == [value]
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
     assert got.return_value == value
 
 
-def test_echo_args_round_trip() -> None:
-    call_command("absurd_sync_queues")
+def test_echo_args_round_trip(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     nested = {"items": [1, None, False, "ünïçødé"], "sub": {"x": 0}}
     r = tasks.echo.enqueue(nested)
-    run_absurd_worker()
+    assert [run.result for run in dj_absurd.drain()] == [nested]
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
     assert got.return_value == nested
 
 
-def test_echo_kwargs_round_trip() -> None:
-    call_command("absurd_sync_queues")
+def test_echo_kwargs_round_trip(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     r = tasks.echo.using(queue_name="default").enqueue(value={"k": [True, None, 42]})
-    run_absurd_worker()
+    assert [run.result for run in dj_absurd.drain()] == [{"k": [True, None, 42]}]
     got = backend().get_result(r.id)
     assert got.status == TaskResultStatus.SUCCESSFUL
     assert got.return_value == {"k": [True, None, 42]}

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -8,11 +8,11 @@ import zoneinfo
 
 import pytest
 import pytest_django.fixtures
+import time_machine
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.utils import timezone
-from freezegun import freeze_time
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.scheduler import (
@@ -23,6 +23,7 @@ from django_absurd.scheduler import (
     run_beat,
     spawn_scheduled,
 )
+from django_absurd.test import AbsurdTestRuntime, FrozenTime
 from tests import tasks
 from tests.models import Payload
 from tests.utils import make_tasks_settings
@@ -31,6 +32,8 @@ pytestmark = [
     pytest.mark.django_db(transaction=True),
     pytest.mark.usefixtures("_isolate_queues"),
 ]
+
+BEAT_EPOCH = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
 
 
 def make_tasks_setting(
@@ -93,19 +96,21 @@ def test_settings_provider_no_schedule_key(
     assert get_settings_schedules(backend) == []
 
 
-@freeze_time("2026-01-01 01:59:00")
+@time_machine.travel(dt.datetime(2026, 1, 1, 1, 59, tzinfo=dt.UTC), tick=False)
 def test_get_next_datetime_same_day() -> None:
     expected = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
     assert get_next_datetime("0 2 * * *", timezone.now()) == expected
 
 
-@freeze_time("2026-01-01 02:00:00")
+@time_machine.travel(dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC), tick=False)
 def test_get_next_datetime_rolls_forward() -> None:
     expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
     assert get_next_datetime("0 2 * * *", timezone.now()) == expected
 
 
-@freeze_time("2026-01-01 12:00:00")  # 06:00 in Chicago (UTC-6)
+@time_machine.travel(
+    dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False
+)  # 06:00 in Chicago (UTC-6)
 def test_get_next_datetime_uses_django_timezone(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
@@ -117,7 +122,7 @@ def test_get_next_datetime_uses_django_timezone(
     assert result == expected
 
 
-@freeze_time("2026-01-01 12:00:00")
+@time_machine.travel(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False)
 def test_get_next_datetime_six_field_leading_seconds() -> None:
     # A 6-field cron uses a LEADING seconds column, so "*/30 * * * * *" means every
     # 30 seconds -> next fire at :30, not every second (which is what a trailing-seconds
@@ -126,14 +131,14 @@ def test_get_next_datetime_six_field_leading_seconds() -> None:
     assert get_next_datetime("*/30 * * * * *", timezone.now()) == expected
 
 
-@freeze_time("2026-01-01 12:00:00")
+@time_machine.travel(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False)
 def test_get_next_datetime_six_field_non_divisor_seconds() -> None:
     # Leading seconds holds for any step: "*/7 * * * * *" fires at :07, not :01.
     expected = dt.datetime(2026, 1, 1, 12, 0, 7, tzinfo=dt.UTC)
     assert get_next_datetime("*/7 * * * * *", timezone.now()) == expected
 
 
-@freeze_time("2026-01-01 12:00:00")
+@time_machine.travel(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False)
 def test_get_next_datetime_six_field_zero_seconds() -> None:
     # Leading seconds=0 with a minute step fires on the minute boundary, not every
     # second: "0 */5 * * * *" -> next at 12:05:00.
@@ -141,23 +146,26 @@ def test_get_next_datetime_six_field_zero_seconds() -> None:
     assert get_next_datetime("0 */5 * * * *", timezone.now()) == expected
 
 
-# run_beat_until and tests below it use run_beat's injected wait/now seam
-# because a real threading.Event.wait can't be fast-forwarded by freezegun;
-# the command path is not deterministic enough for exact multi-slot counts.
+# run_beat_until and tests below it use run_beat's injected wait/now seam because
+# time-machine never patches time.monotonic() — the clock threading.Event.wait relies
+# on — so freezing wall time can't fast-forward a real wait; the command path is not
+# deterministic enough for exact multi-slot counts. The caller opens the dj_absurd
+# freeze_time() window (so any prior enqueue/drain shares the same frozen instant) and
+# hands in the FrozenTime handle for this helper to shift.
 def run_beat_until(
+    frozen_time: FrozenTime,
     backend: AbsurdBackend,
     cutoff: dt.datetime,
 ) -> None:
-    with freeze_time("2026-01-01 00:00:00") as frozen:
+    def fake_wait(timeout: float) -> bool:
+        frozen_time.shift(dt.timedelta(seconds=timeout))
+        return timezone.now() >= cutoff
 
-        def fake_wait(timeout: float) -> bool:
-            frozen.tick(dt.timedelta(seconds=timeout))
-            return timezone.now() >= cutoff
-
-        run_beat(backend, wait=fake_wait)
+    run_beat(backend, wait=fake_wait)
 
 
 def test_beat_fires_each_due_slot(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.TASKS = make_tasks_setting(
@@ -171,13 +179,17 @@ def test_beat_fires_each_due_slot(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 2, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    expected_fires = 2  # slots 00:01 and 00:02
-    assert Payload.objects.count() == expected_fires
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 2, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        expected_fires = 2  # slots 00:01 and 00:02
+        assert Payload.objects.count() == expected_fires
 
 
 def test_beat_fires_multiple_schedules_due_same_slot(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     # Two distinct schedules sharing a cron slot both fire in the one tick pass.
@@ -197,9 +209,12 @@ def test_beat_fires_multiple_schedules_due_same_slot(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    assert set(Group.objects.values_list("name", flat=True)) == {"a", "b"}
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert set(Group.objects.values_list("name", flat=True)) == {"a", "b"}
 
 
 def test_beat_no_schedules_returns(
@@ -211,6 +226,7 @@ def test_beat_no_schedules_returns(
 
 
 def test_beat_isolates_failing_schedule(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.TASKS = make_tasks_setting(
@@ -225,13 +241,17 @@ def test_beat_isolates_failing_schedule(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    expected_good = 1  # "bad" raised in spawn (unimportable, logged); "good" still ran
-    assert Payload.objects.count() == expected_good
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        expected_good = 1  # "bad" raised in spawn (unimportable, logged); "good" ran
+        assert Payload.objects.count() == expected_good
 
 
 def test_beat_spawns_task_with_args(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.TASKS = make_tasks_setting(
@@ -245,12 +265,16 @@ def test_beat_spawns_task_with_args(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    assert Group.objects.filter(name="beat-args").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert Group.objects.filter(name="beat-args").exists()
 
 
 def test_beat_spawns_task_with_kwargs(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.TASKS = make_tasks_setting(
@@ -264,12 +288,16 @@ def test_beat_spawns_task_with_kwargs(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    assert Group.objects.filter(name="beat-kw").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert Group.objects.filter(name="beat-kw").exists()
 
 
 def test_beat_empty_queue_string_falls_back_to_task_queue(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     """queue: "" normalises to the task's own queue (parity with pg_cron's
@@ -286,12 +314,16 @@ def test_beat_empty_queue_string_falls_back_to_task_queue(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    assert Group.objects.filter(name="beat-empty-q").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert Group.objects.filter(name="beat-empty-q").exists()
 
 
 def test_beat_routes_task_to_queue(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.TASKS = make_tasks_setting(
@@ -306,14 +338,18 @@ def test_beat_routes_task_to_queue(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    assert not Group.objects.filter(name="beat-routed").exists()
-    call_command("absurd_worker", queue="other", burst=True)
-    assert Group.objects.filter(name="beat-routed").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert not Group.objects.filter(name="beat-routed").exists()
+        call_command("absurd_worker", queue="other", burst=True)
+        assert Group.objects.filter(name="beat-routed").exists()
 
 
 def test_beat_routes_task_to_queue_non_default_alias(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.TASKS = {
@@ -334,11 +370,14 @@ def test_beat_routes_task_to_queue_non_default_alias(
     }
     backend = get_absurd_backends()["second"]
     call_command("absurd_sync_queues")
-    run_beat_until(backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC))
-    call_command("absurd_worker", queue="default", burst=True)
-    assert not Group.objects.filter(name="beat-non-default").exists()
-    call_command("absurd_worker", queue="other", burst=True)
-    assert Group.objects.filter(name="beat-non-default").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert not Group.objects.filter(name="beat-non-default").exists()
+        call_command("absurd_worker", queue="other", burst=True)
+        assert Group.objects.filter(name="beat-non-default").exists()
 
 
 def test_derive_idempotency_key_stable_same_inputs() -> None:
@@ -618,7 +657,9 @@ def test_worker_with_beat_runs_scheduled_task(
     watcher.start()
     # tick=True near a boundary: next "*/1" slot is ~1s away in real time, so beat fires
     # almost immediately; the live worker (fast poll) drains it.
-    with freeze_time("2026-01-01 00:00:59", tick=True):
+    with time_machine.travel(
+        dt.datetime(2026, 1, 1, 0, 0, 59, tzinfo=dt.UTC), tick=True
+    ):
         call_command("absurd_worker", queue="default", beat=True, poll_interval=0.05)
     watcher.join(timeout=5)
 
@@ -651,6 +692,7 @@ def test_beat_already_stopped_on_entry_skips_loop(
 
 
 def test_beat_skips_not_yet_due_schedule(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     # Covers scheduler.py 99->98: if due <= current False branch.
@@ -672,15 +714,17 @@ def test_beat_skips_not_yet_due_schedule(
     )
     backend = get_absurd_backends()["default"]
     call_command("absurd_sync_queues")
-    # Cutoff at 00:01:30 → "due" slot 00:01 fires, "later" slot 02:00 does not.
-    run_beat_until(
-        backend,
-        dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC),
-    )
-    call_command("absurd_worker", queue="default", burst=True)
-    assert Payload.objects.count() == 1
-    assert Payload.objects.filter(data="due").exists()
-    assert not Payload.objects.filter(data="later").exists()
+    with dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time:
+        # Cutoff at 00:01:30 → "due" slot 00:01 fires, "later" slot 02:00 does not.
+        run_beat_until(
+            frozen_time,
+            backend,
+            dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC),
+        )
+        call_command("absurd_worker", queue="default", burst=True)
+        assert Payload.objects.count() == 1
+        assert Payload.objects.filter(data="due").exists()
+        assert not Payload.objects.filter(data="later").exists()
 
 
 def test_plain_worker_runs_blocking_worker(

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -539,6 +539,17 @@ def test_absurd_beat_rejects_alias_flag(
         call_command("absurd_beat", "--alias", "default")
 
 
+def test_absurd_beat_no_backend_errors(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    with pytest.raises(CommandError) as exc:
+        call_command("absurd_beat")
+    assert str(exc.value) == "No Absurd backend configured."
+
+
 def test_worker_beat_rejects_burst(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -589,7 +589,10 @@ def test_absurd_beat_no_backend_errors(
     }
     with pytest.raises(CommandError) as exc:
         call_command("absurd_beat")
-    assert str(exc.value) == "No Absurd backend configured."
+    assert str(exc.value) == (
+        "No Absurd backend configured. Add a django_absurd.backends.AbsurdBackend "
+        "entry to TASKS."
+    )
 
 
 def test_worker_beat_rejects_burst(

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -96,54 +96,57 @@ def test_settings_provider_no_schedule_key(
     assert get_settings_schedules(backend) == []
 
 
-@time_machine.travel(dt.datetime(2026, 1, 1, 1, 59, tzinfo=dt.UTC), tick=False)
-def test_get_next_datetime_same_day() -> None:
-    expected = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
-    assert get_next_datetime("0 2 * * *", timezone.now()) == expected
+def test_get_next_datetime_same_day(dj_absurd: AbsurdTestRuntime) -> None:
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 1, 59, tzinfo=dt.UTC)):
+        expected = dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)
+        assert get_next_datetime("0 2 * * *", timezone.now()) == expected
 
 
-@time_machine.travel(dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC), tick=False)
-def test_get_next_datetime_rolls_forward() -> None:
-    expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
-    assert get_next_datetime("0 2 * * *", timezone.now()) == expected
+def test_get_next_datetime_rolls_forward(dj_absurd: AbsurdTestRuntime) -> None:
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 2, 0, tzinfo=dt.UTC)):
+        expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=dt.UTC)
+        assert get_next_datetime("0 2 * * *", timezone.now()) == expected
 
 
-@time_machine.travel(
-    dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False
-)  # 06:00 in Chicago (UTC-6)
 def test_get_next_datetime_uses_django_timezone(
-    settings: pytest_django.fixtures.SettingsWrapper,
+    dj_absurd: AbsurdTestRuntime, settings: pytest_django.fixtures.SettingsWrapper
 ) -> None:
-    # cron interpreted in Django TIME_ZONE: 02:00 Chicago already passed -> tomorrow
-    settings.TIME_ZONE = "America/Chicago"
-    chicago = zoneinfo.ZoneInfo("America/Chicago")
-    expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=chicago)
-    result = get_next_datetime("0 2 * * *", timezone.now())
-    assert result == expected
+    # 06:00 in Chicago (UTC-6)
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)):
+        # cron interpreted in Django TIME_ZONE: 02:00 Chicago already passed -> tomorrow
+        settings.TIME_ZONE = "America/Chicago"
+        chicago = zoneinfo.ZoneInfo("America/Chicago")
+        expected = dt.datetime(2026, 1, 2, 2, 0, tzinfo=chicago)
+        result = get_next_datetime("0 2 * * *", timezone.now())
+        assert result == expected
 
 
-@time_machine.travel(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False)
-def test_get_next_datetime_six_field_leading_seconds() -> None:
+def test_get_next_datetime_six_field_leading_seconds(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
     # A 6-field cron uses a LEADING seconds column, so "*/30 * * * * *" means every
     # 30 seconds -> next fire at :30, not every second (which is what a trailing-seconds
     # reading of the same string produces).
-    expected = dt.datetime(2026, 1, 1, 12, 0, 30, tzinfo=dt.UTC)
-    assert get_next_datetime("*/30 * * * * *", timezone.now()) == expected
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)):
+        expected = dt.datetime(2026, 1, 1, 12, 0, 30, tzinfo=dt.UTC)
+        assert get_next_datetime("*/30 * * * * *", timezone.now()) == expected
 
 
-@time_machine.travel(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False)
-def test_get_next_datetime_six_field_non_divisor_seconds() -> None:
+def test_get_next_datetime_six_field_non_divisor_seconds(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
     # Leading seconds holds for any step: "*/7 * * * * *" fires at :07, not :01.
-    expected = dt.datetime(2026, 1, 1, 12, 0, 7, tzinfo=dt.UTC)
-    assert get_next_datetime("*/7 * * * * *", timezone.now()) == expected
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)):
+        expected = dt.datetime(2026, 1, 1, 12, 0, 7, tzinfo=dt.UTC)
+        assert get_next_datetime("*/7 * * * * *", timezone.now()) == expected
 
 
-@time_machine.travel(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC), tick=False)
-def test_get_next_datetime_six_field_zero_seconds() -> None:
+def test_get_next_datetime_six_field_zero_seconds(dj_absurd: AbsurdTestRuntime) -> None:
     # Leading seconds=0 with a minute step fires on the minute boundary, not every
     # second: "0 */5 * * * *" -> next at 12:05:00.
-    expected = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.UTC)
-    assert get_next_datetime("0 */5 * * * *", timezone.now()) == expected
+    with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)):
+        expected = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.UTC)
+        assert get_next_datetime("0 */5 * * * *", timezone.now()) == expected
 
 
 # run_beat_until and tests below it use run_beat's injected wait/now seam because

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -96,7 +96,6 @@ def test_end_to_end_executes_and_records_result(dj_absurd: AbsurdTestRuntime) ->
     run_absurd_worker()
     assert Group.objects.filter(name="alpha").exists()
     snap = dj_absurd.get_result(result.id)
-    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == "alpha"
 
@@ -106,7 +105,6 @@ def test_failing_task_records_failure(dj_absurd: AbsurdTestRuntime) -> None:
     result = tasks.boom.enqueue()
     run_absurd_worker()
     snap = dj_absurd.get_result(result.id)
-    assert snap is not None
     assert snap.state == "failed"
 
 
@@ -117,7 +115,6 @@ def test_takes_context_attempt_is_one_on_first_run(
     result = tasks.report_attempt.enqueue()
     run_absurd_worker()
     snap = dj_absurd.get_result(result.id)
-    assert snap is not None
     assert snap.result == 1
 
 
@@ -128,7 +125,6 @@ def test_takes_context_task_result_carries_real_args(
     result = tasks.report_args.enqueue("x", "y")
     run_absurd_worker()
     snap = dj_absurd.get_result(result.id)
-    assert snap is not None
     assert snap.result == ["x", "y"]
 
 
@@ -155,7 +151,6 @@ def test_unregistered_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> N
     )
     run_absurd_worker()
     snap = dj_absurd.get_result(spawn["task_id"])
-    assert snap is not None
     assert snap.state != "failed"
 
 
@@ -167,7 +162,6 @@ def test_task_outside_tasks_py_runs(dj_absurd: AbsurdTestRuntime) -> None:
     run_absurd_worker()
     assert Group.objects.filter(name="from-jobs").exists()
     snap = dj_absurd.get_result(result.id)
-    assert snap is not None
     assert snap.result == "from-jobs"
 
 
@@ -262,7 +256,6 @@ def test_command_burst_runs_task_end_to_end(dj_absurd: AbsurdTestRuntime) -> Non
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="via-command").exists()
     snap = dj_absurd.get_result(result.id)
-    assert snap is not None
     assert snap.state == "completed"
 
 
@@ -418,7 +411,6 @@ def test_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     r = atasks.aecho.enqueue("hi-async")
     run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
-    assert snap is not None
     assert snap.state == "completed"
     assert snap.result == "hi-async"
 
@@ -546,5 +538,4 @@ def test_non_task_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> None:
     )
     run_absurd_worker()
     snap = dj_absurd.get_result(spawn["task_id"])
-    assert snap is not None
     assert snap.state != "failed"

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime as dt
 import logging
 
+import psycopg.errors
 import pytest
 from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured
@@ -11,17 +12,23 @@ from django.db import connection
 from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
+from django_absurd.exceptions import (
+    DjangoAbsurdError,
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+)
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
+from django_absurd.test import AbsurdTestRuntime
 from django_absurd.worker import (
     WorkerOptions,
     aworker_client,
+    drain_queue,
     run_blocking_worker,
-    run_burst_worker,
 )
 from tests import atasks, tasks
 from tests.jobs import record_from_jobs
-from tests.utils import get_task_result, run_absurd_worker
+from tests.utils import run_absurd_worker
 
 pytestmark = [
     pytest.mark.django_db(transaction=True),
@@ -83,40 +90,44 @@ def test_worker_client_absent_schema_errors() -> None:
         call_command("migrate", verbosity=0)  # restore absurd schema
 
 
-def test_end_to_end_executes_and_records_result() -> None:
-    call_command("absurd_sync_queues")
+def test_end_to_end_executes_and_records_result(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     result = tasks.make_group.enqueue("alpha")
     run_absurd_worker()
     assert Group.objects.filter(name="alpha").exists()
-    snap = get_task_result(result.id)
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.state == "completed"
     assert snap.result == "alpha"
 
 
-def test_failing_task_records_failure() -> None:
-    call_command("absurd_sync_queues")
+def test_failing_task_records_failure(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     result = tasks.boom.enqueue()
     run_absurd_worker()
-    snap = get_task_result(result.id)
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.state == "failed"
 
 
-def test_takes_context_attempt_is_one_on_first_run() -> None:
-    call_command("absurd_sync_queues")
+def test_takes_context_attempt_is_one_on_first_run(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     result = tasks.report_attempt.enqueue()
     run_absurd_worker()
-    snap = get_task_result(result.id)
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.result == 1
 
 
-def test_takes_context_task_result_carries_real_args() -> None:
-    call_command("absurd_sync_queues")
+def test_takes_context_task_result_carries_real_args(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
     result = tasks.report_args.enqueue("x", "y")
     run_absurd_worker()
-    snap = get_task_result(result.id)
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.result == ["x", "y"]
 
@@ -137,25 +148,25 @@ def test_handler_logs_task_outcome(caplog: pytest.LogCaptureFixture) -> None:
     assert "completed" in caplog.text
 
 
-def test_unregistered_name_defers_not_crashes() -> None:
-    call_command("absurd_sync_queues")
+def test_unregistered_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     spawn = get_absurd_client("default").spawn(
         "not.a.real.task", {"args": [], "kwargs": {}}, queue="default"
     )
     run_absurd_worker()
-    snap = get_task_result(spawn["task_id"])
+    snap = dj_absurd.get_result(spawn["task_id"])
     assert snap is not None
     assert snap.state != "failed"
 
 
-def test_task_outside_tasks_py_runs() -> None:
+def test_task_outside_tasks_py_runs(dj_absurd: AbsurdTestRuntime) -> None:
     # record_from_jobs is in tests/jobs.py, NOT tests/tasks.py — the old scan would
     # never find it (it would defer forever). Lazy resolution runs it by module_path.
-    call_command("absurd_sync_queues")
+    dj_absurd.sync_queues()
     result = record_from_jobs.enqueue("from-jobs")
     run_absurd_worker()
     assert Group.objects.filter(name="from-jobs").exists()
-    snap = get_task_result(result.id)
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.result == "from-jobs"
 
@@ -245,12 +256,12 @@ def test_command_parses_all_flags_with_defaults() -> None:
     assert opts["worker_id"] is None
 
 
-def test_command_burst_runs_task_end_to_end() -> None:
-    call_command("absurd_sync_queues")
+def test_command_burst_runs_task_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     result = tasks.make_group.enqueue("via-command")
     call_command("absurd_worker", queue="default", burst=True)
     assert Group.objects.filter(name="via-command").exists()
-    snap = get_task_result(result.id)
+    snap = dj_absurd.get_result(result.id)
     assert snap is not None
     assert snap.state == "completed"
 
@@ -381,9 +392,8 @@ def test_worker_command_schema_absent_errors_migrate() -> None:
 
 
 def test_worker_non_burst_command_schema_absent_errors_migrate() -> None:
-    # Non-burst path's own provision_backend/ImproperlyConfigured translation
-    # (run_burst_worker has an independent copy, covered by the burst test above) --
-    # errors before ever reaching the blocking worker loop.
+    # The provision_backend/ImproperlyConfigured translation errors before ever
+    # reaching the blocking worker loop.
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
@@ -403,11 +413,11 @@ def test_start_worker_drains_concurrently() -> None:
     assert Group.objects.filter(name__startswith="g").count() == 5
 
 
-def test_async_task_runs_end_to_end() -> None:
-    call_command("absurd_sync_queues")
+def test_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
+    dj_absurd.sync_queues()
     r = atasks.aecho.enqueue("hi-async")
     run_absurd_worker()
-    snap = get_task_result(r.id)
+    snap = dj_absurd.get_result(r.id)
     assert snap is not None
     assert snap.state == "completed"
     assert snap.result == "hi-async"
@@ -439,50 +449,102 @@ def test_blocking_worker_drains_then_stops() -> None:
     assert Group.objects.filter(name__startswith="blk-").count() == 3
 
 
-def test_run_burst_worker_processes_a_task_and_returns_sync_result() -> None:
-
-    call_command("absurd_sync_queues")
-    result = tasks.make_group.enqueue("via-function")
-    sync_result = run_burst_worker("default")
-    assert Group.objects.filter(name="via-function").exists()
-    snap = get_task_result(result.id)
-    assert snap is not None
-    assert snap.state == "completed"
-    assert sync_result.created == []
-    assert sync_result.reconciled == []
-
-
 @pytest.mark.parametrize(
-    "run_burst",
-    ["command", "function"],
+    ("entrypoint", "expected_error"),
+    [("command", CommandError), ("function", QueueNotDeclaredError)],
 )
-def test_undeclared_queue_is_rejected(run_burst: str) -> None:
-
+def test_undeclared_queue_is_rejected(
+    entrypoint: str, expected_error: type[Exception]
+) -> None:
+    # Same rule, two enforcing entrypoints, two vocabularies: the management command
+    # raises CommandError, drain_queue raises the package's own QueueNotDeclaredError.
     def invoke() -> None:
-        if run_burst == "command":
+        if entrypoint == "command":
             call_command("absurd_worker", queue="nope", burst=True)
         else:
-            run_burst_worker("nope")
+            drain_queue("nope")
 
-    with pytest.raises(CommandError) as exc:
+    with pytest.raises(expected_error) as exc:
         invoke()
     message = str(exc.value)
     expected = (
         "Queue 'nope' is not declared for backend 'default'. "
-        "Valid queues: default, other, reports"
+        "Valid queues: default, other, reports. "
+        "Add it to the QUEUES list in your TASKS backend settings."
     )
     assert message == expected
 
 
-def test_non_task_name_defers_not_crashes() -> None:
+def test_undeclared_queue_error_is_also_a_django_absurd_error() -> None:
+    # QueueNotDeclaredError is a DjangoAbsurdError: the base catches it too, pinning
+    # the base's purpose (a caller can catch the package's typed errors generically).
+    with pytest.raises(DjangoAbsurdError):
+        drain_queue("nope")
+
+
+def test_drain_queue_on_an_unprovisioned_queue_errors_sync_queues() -> None:
+    # Declared but never provisioned (no absurd_sync_queues, and _isolate_queues
+    # dropped every queue's tables): drain_queue does not provision, so the missing
+    # table surfaces as the curated error naming the command that fixes it. No
+    # enqueue() here — that one auto-creates the queue it writes to.
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        drain_queue("default")
+
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+
+
+def test_drain_queue_does_not_relabel_an_unrelated_missing_relation() -> None:
+    """A missing relation that is NOT one of this queue's own Absurd tables surfaces as
+    itself. Relabeling it "run absurd_sync_queues" would send the reader to the wrong
+    door, and dropping the cause would hide which relation is actually missing.
+
+    Driven the way it happens in production: an audit trigger on a queue table whose
+    target relation is gone. A plpgsql body carries no dependency on the tables it
+    names, so nothing blocks the drop and the failure lands when the trigger next fires
+    — from inside the claim, i.e. exactly where the curated error used to swallow it.
+    """
+    call_command("absurd_sync_queues")
+    tasks.add.enqueue(2, 3)
+    try:
+        with connection.cursor() as cur:
+            cur.execute(
+                "create or replace function absurd.record_audit_probe() "
+                "returns trigger language plpgsql as $$ begin "
+                "insert into absurd.audit_probe (run_id) values (new.run_id); "
+                "return new; end; $$"
+            )
+            cur.execute(
+                "create trigger audit_probe_after_claim after update "
+                "on absurd.r_default for each row "
+                "execute function absurd.record_audit_probe()"
+            )
+
+        with pytest.raises(psycopg.errors.UndefinedTable) as undefined:
+            drain_queue("default")
+
+        assert (
+            undefined.value.diag.message_primary
+            == 'relation "absurd.audit_probe" does not exist'
+        )
+    finally:
+        # cascade takes the trigger with it; `if exists` keeps the cleanup honest even
+        # if the trigger DDL above is what failed.
+        with connection.cursor() as cur:
+            cur.execute("drop function if exists absurd.record_audit_probe() cascade")
+
+
+def test_non_task_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> None:
     # A name that IMPORTS but is not a Task (asleep is the asyncio.sleep alias
     # in atasks) -> LazyTaskRegistry resolves it, sees it's not a Task, defers
     # (state not failed).
-    call_command("absurd_sync_queues")
+    dj_absurd.sync_queues()
     spawn = get_absurd_client("default").spawn(
         "tests.atasks.asleep", {"args": [], "kwargs": {}}, queue="default"
     )
     run_absurd_worker()
-    snap = get_task_result(spawn["task_id"])
+    snap = dj_absurd.get_result(spawn["task_id"])
     assert snap is not None
     assert snap.state != "failed"

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -212,7 +212,13 @@ def test_worker_no_backend_errors(settings: SettingsWrapper) -> None:
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }
-    with pytest.raises(CommandError, match="No Absurd backend configured\\."):
+    with pytest.raises(
+        CommandError,
+        match=(
+            r"No Absurd backend configured\. Add a "
+            r"django_absurd\.backends\.AbsurdBackend entry to TASKS\."
+        ),
+    ):
         call_command("absurd_worker", burst=True)
 
 

--- a/tests/multidb/pytest.toml
+++ b/tests/multidb/pytest.toml
@@ -3,6 +3,10 @@ DJANGO_SETTINGS_MODULE = "tests.multidb.settings"
 addopts = [
   "--allow-hosts=db,localhost,127.0.0.1",
   "--confcutdir=..",
+  "--cov",
+  "--cov-append",
+  "--cov-report=term",
+  "--cov-report=xml",
   "--disable-socket",
   "--junitxml=junit-multidb.xml",
   "--reuse-db",

--- a/tests/multidb/pytest.toml
+++ b/tests/multidb/pytest.toml
@@ -10,3 +10,5 @@ addopts = [
 ]
 pythonpath = ["../.."]
 testpaths = ["."]
+# See tests/core/pytest.toml: nothing here waits on a clock (whole suite runs in <1s).
+timeout = "10"

--- a/tests/multidb/test_check.py
+++ b/tests/multidb/test_check.py
@@ -1,27 +1,10 @@
-import typing as t
-
 import pytest
 from django.core.management import call_command
-from django.core.management.base import SystemCheckError
 from pytest_django.fixtures import SettingsWrapper
 
 pytestmark = pytest.mark.django_db(databases=["default", "absurd"])
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
-
-
-def run_absurd_check(
-    capsys: pytest.CaptureFixture[str],
-    *args: t.Any,
-    **kwargs: t.Any,
-) -> str:
-    try:
-        call_command("check", "django_absurd", *args, **kwargs)
-    except SystemCheckError as exc:
-        cap = capsys.readouterr()
-        return cap.out + cap.err + str(exc)
-    cap = capsys.readouterr()
-    return cap.out + cap.err
 
 
 def test_storage_mode_drift_detected_on_non_default_alias(
@@ -46,7 +29,9 @@ def test_storage_mode_drift_detected_on_non_default_alias(
             },
         }
     }
-    out = run_absurd_check(capsys, databases=["absurd"])
+    call_command("check", "django_absurd", databases=["absurd"])
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
     assert "absurd.W002" in out
     assert (
         "django-absurd: a queue's declared storage_mode differs from the database"

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -80,5 +80,4 @@ def test_roundtrip_drains_on_the_non_default_alias(
     result = sum_numbers.enqueue(1, 2)
     assert [run.result for run in dj_absurd.drain()] == [3]
     snapshot = dj_absurd.get_result(result.id)
-    assert snapshot is not None
     assert snapshot.result == 3

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -3,12 +3,14 @@ import typing as t
 import pytest
 from django.core.management import call_command
 from django.db import connections
+from django.tasks import task
 
 if t.TYPE_CHECKING:
     import pytest_django.fixtures
 
 from django_absurd.models import Queue
 from django_absurd.routers import AbsurdRouter
+from django_absurd.test import AbsurdTestRuntime
 
 pytestmark = [
     pytest.mark.django_db(databases=["default", "absurd"]),
@@ -16,6 +18,11 @@ pytestmark = [
 ]
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
+
+
+@task
+def sum_numbers(a: int, b: int) -> int:
+    return a + b
 
 
 def absurd_schema_present(alias: str) -> bool:
@@ -61,3 +68,17 @@ def test_sync_command_honors_alias(
     }
     call_command("absurd_sync_queues")
     assert Queue.objects.get(queue_name="routed").queue_name == "routed"
+
+
+@pytest.mark.django_db(databases=["absurd", "default"], transaction=True)
+def test_roundtrip_drains_on_the_non_default_alias(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # the fixture resolves the Absurd alias itself (resolve_absurd_database), so a
+    # drain/get_result here must land on "absurd", never the router's "default"
+    assert dj_absurd.alias == "absurd"
+    result = sum_numbers.enqueue(1, 2)
+    assert [run.result for run in dj_absurd.drain()] == [3]
+    snapshot = dj_absurd.get_result(result.id)
+    assert snapshot is not None
+    assert snapshot.result == 3

--- a/tests/pg_cron/pytest.toml
+++ b/tests/pg_cron/pytest.toml
@@ -14,3 +14,8 @@ addopts = [
 ]
 pythonpath = ["../.."]
 testpaths = ["."]
+# test_isolation_regression.py::test_producing_schedule_never_fires_into_this_test_db
+# legitimately takes 14-17s waiting for the real pg_cron launcher to complete a cycle,
+# and that time is variable, so 40s is roughly 2.4x the observed maximum -- loose
+# enough not to flake, tight enough to catch a genuine hang.
+timeout = "40"

--- a/tests/pg_cron/test_absurd_sync_crons_command.py
+++ b/tests/pg_cron/test_absurd_sync_crons_command.py
@@ -51,7 +51,10 @@ def test_sync_crons_command_no_backend_errors(
     }
     with pytest.raises(CommandError) as excinfo:
         call_command("absurd_sync_crons")
-    assert str(excinfo.value) == "No Absurd backend configured."
+    assert str(excinfo.value) == (
+        "No Absurd backend configured. Add a django_absurd.backends.AbsurdBackend "
+        "entry to TASKS."
+    )
 
 
 def test_sync_crons_command_creates_cron_jobs(

--- a/tests/pg_cron/test_absurd_sync_crons_command.py
+++ b/tests/pg_cron/test_absurd_sync_crons_command.py
@@ -43,6 +43,17 @@ def test_sync_crons_command_malformed_schedule_raises_commanderror(
         call_command("absurd_sync_crons")
 
 
+def test_sync_crons_command_no_backend_errors(
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_sync_crons")
+    assert str(excinfo.value) == "No Absurd backend configured."
+
+
 def test_sync_crons_command_creates_cron_jobs(
     capsys: pytest.CaptureFixture[str],
     settings: pytest_django.fixtures.SettingsWrapper,

--- a/tests/pg_cron/test_pg_cron_e2e.py
+++ b/tests/pg_cron/test_pg_cron_e2e.py
@@ -9,6 +9,7 @@ from django.db import connection
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.reconcile import sync_crons
+from django_absurd.test import AbsurdTestRuntime
 from tests.models import Payload
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -33,6 +34,7 @@ TASKS_PG_CRON = {
 
 
 def test_e2e_sync_fire_worker_assert_payload(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     """Sync schedule into pg_cron, fire wrapper directly, drain queue, assert row."""
@@ -47,7 +49,7 @@ def test_e2e_sync_fire_worker_assert_payload(
             ["s", "e"],
         )
 
-    call_command("absurd_worker", queue="default", burst=True)
+    dj_absurd.drain()
 
     payload = Payload.objects.filter(data="e2e").first()
     assert payload is not None, "Payload row with data='e2e' was not created"

--- a/tests/pg_cron/test_run_scheduled_fn.py
+++ b/tests/pg_cron/test_run_scheduled_fn.py
@@ -1,10 +1,10 @@
 import json
 
 import pytest
-from django.core.management import call_command
 from django.db import connection
 
 from django_absurd.pg_cron.models import ScheduledTask
+from django_absurd.test import AbsurdTestRuntime
 from tests import tasks
 from tests.models import Payload
 
@@ -27,7 +27,7 @@ def fire_wrapper(source: str, name: str) -> None:
         )
 
 
-def test_fires_task_from_row() -> None:
+def test_fires_task_from_row(dj_absurd: AbsurdTestRuntime) -> None:
     ScheduledTask.objects.create(
         source="s",
         name="p",
@@ -38,7 +38,7 @@ def test_fires_task_from_row() -> None:
         cron="* * * * *",
     )
     fire_wrapper("s", "p")
-    call_command("absurd_worker", queue="default", burst=True)
+    dj_absurd.drain()
     assert Payload.objects.count() == 1
 
 
@@ -46,7 +46,7 @@ def test_missing_row_is_noop() -> None:
     fire_wrapper("s", "nope")  # no exception
 
 
-def test_disabled_row_is_noop() -> None:
+def test_disabled_row_is_noop(dj_absurd: AbsurdTestRuntime) -> None:
     ScheduledTask.objects.create(
         source="s",
         name="off",
@@ -58,7 +58,7 @@ def test_disabled_row_is_noop() -> None:
         enabled=False,
     )
     fire_wrapper("s", "off")
-    call_command("absurd_worker", queue="default", burst=True)
+    dj_absurd.drain()
     assert Payload.objects.count() == 0
 
 

--- a/tests/pg_cron/test_run_scheduled_fn.py
+++ b/tests/pg_cron/test_run_scheduled_fn.py
@@ -28,7 +28,6 @@ def fire_wrapper(source: str, name: str) -> None:
 
 
 def test_fires_task_from_row() -> None:
-    call_command("absurd_sync_queues")
     ScheduledTask.objects.create(
         source="s",
         name="p",
@@ -64,7 +63,6 @@ def test_disabled_row_is_noop() -> None:
 
 
 def test_wrapper_rebuilds_retry_strategy_from_columns() -> None:
-    call_command("absurd_sync_queues")
     ScheduledTask.objects.create(
         source="s",
         name="retry_opts",
@@ -88,7 +86,6 @@ def test_wrapper_rebuilds_retry_strategy_from_columns() -> None:
 
 
 def test_wrapper_rebuilds_cancellation_from_columns() -> None:
-    call_command("absurd_sync_queues")
     ScheduledTask.objects.create(
         source="s",
         name="cancel_opts",
@@ -116,7 +113,6 @@ def test_wrapper_reassembles_options_from_columns() -> None:
     max_attempts isn't observable via worker side effects so we inspect the
     spawned task row directly via the absurd.tasks_view (params is a jsonb blob).
     """
-    call_command("absurd_sync_queues")
     ScheduledTask.objects.create(
         source="s",
         name="opts",

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -80,8 +80,8 @@ def on_reports() -> str:
 @task
 @absurd_params(retry_strategy=RetryStrategy(kind="exponential", base_seconds=2))
 def retrying() -> t.Never:
-    msg = "path-resolved for its decorator; never run"
-    raise NotImplementedError(msg)
+    msg = "boom"
+    raise ValueError(msg)
 
 
 @task

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -10,6 +10,8 @@ from django_absurd import absurd_params, get_absurd_context
 from tests.models import Payload
 
 SYNC_STEP_CALLS: dict[str, int] = {"n": 0}
+RETRY_CALLS: dict[str, int] = {"n": 0}
+WEEK_SECONDS = 7 * 24 * 3600
 
 
 @task
@@ -135,13 +137,13 @@ def ssleep_for_once(key: str) -> int:
         return SYNC_STEP_CALLS["n"]
 
     n = context.step("bump", bump)
-    context.sleep_for("nap", 1.5)
+    context.sleep_for("nap", WEEK_SECONDS)
     return n
 
 
 @task
 def ssleep_until_once(key: str) -> str:
-    get_absurd_context().sleep_until("nap", time.time() + 1.5)
+    get_absurd_context().sleep_until("nap", time.time() + WEEK_SECONDS)
     return "woke"
 
 
@@ -162,3 +164,52 @@ def sawait_event_timeout(name: str, timeout: int) -> str:
     except absurd_sdk.TimeoutError:
         return "timed-out"
     return "no-timeout"
+
+
+@task
+def spawn_child_then_return(value: int) -> str:
+    run_child.enqueue(value)
+    return "spawned"
+
+
+@task
+def run_child(value: int) -> int:
+    return value * 2
+
+
+@task
+def sleep_a_week() -> str:
+    get_absurd_context().sleep_for("nap", WEEK_SECONDS)
+    return "woke"
+
+
+@task
+def sleep_twice() -> str:
+    context = get_absurd_context()
+    context.sleep_for("first", WEEK_SECONDS)
+    context.sleep_for("second", 3 * 24 * 3600)
+    return "woke-twice"
+
+
+@task
+@absurd_params(retry_strategy=RetryStrategy(kind="fixed", base_seconds=3600))
+def fail_with_long_backoff() -> t.Never:
+    msg = "boom"
+    raise ValueError(msg)
+
+
+@task
+@absurd_params(cancellation=CancellationPolicy(max_delay=60))
+def cancellable_after_a_minute() -> t.Never:
+    msg = "cancelled before it ever ran"
+    raise NotImplementedError(msg)
+
+
+@task
+@absurd_params(retry_strategy=RetryStrategy(kind="fixed", base_seconds=0))
+def fail_twice_then_succeed() -> str:
+    RETRY_CALLS["n"] += 1
+    if RETRY_CALLS["n"] < 3:
+        msg = f"attempt {RETRY_CALLS['n']} fails"
+        raise ValueError(msg)
+    return "third-time-lucky"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import typing as t
+import uuid
 
 import psycopg
 import psycopg.sql
@@ -62,8 +63,8 @@ def run_absurd_worker(queue: str = "default", concurrency: int = 1) -> None:
     call_command("absurd_worker", queue=queue, burst=True, concurrency=concurrency)
 
 
-def claim_one_run(queue: str = "default", *, claim_timeout: int) -> None:
-    """Take a lease on one run without executing it.
+def claim_one_run(queue: str = "default", *, claim_timeout: int) -> uuid.UUID:
+    """Take a lease on one run without executing it, returning its run_id.
 
     Leaves the run ``running`` with a ``claim_expires_at`` ``claim_timeout`` seconds
     out, so advancing durable time past that lease lets the ``$ClaimTimeout`` sweep
@@ -72,7 +73,31 @@ def claim_one_run(queue: str = "default", *, claim_timeout: int) -> None:
     params = connections["default"].get_connection_params()
     conn = psycopg.connect(**params, autocommit=True)
     try:
-        Absurd(conn, queue_name=queue).claim_tasks(claim_timeout=claim_timeout)
+        claimed = Absurd(conn, queue_name=queue).claim_tasks(
+            claim_timeout=claim_timeout
+        )
+        return uuid.UUID(str(claimed[0]["run_id"]))
+    finally:
+        conn.close()
+
+
+def heartbeat_one_run(
+    run_id: uuid.UUID, queue: str = "default", *, seconds: int
+) -> None:
+    """Extend a claimed run's lease by ``seconds`` from now, via the same
+    ``absurd.extend_claim`` RPC ``TaskContext.heartbeat()`` calls.
+
+    A run claimed manually by ``claim_one_run`` (rather than actually executing) has
+    no live ``TaskContext`` to heartbeat through, so this calls the SQL function
+    directly on a fresh connection instead.
+    """
+    params = connections["default"].get_connection_params()
+    conn = psycopg.connect(**params, autocommit=True)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "select absurd.extend_claim(%s, %s, %s)", (queue, run_id, seconds)
+            )
     finally:
         conn.close()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,12 +113,9 @@ def read_database_fake_now() -> str | None:
 
 
 def read_session_fake_now() -> str:
-    """Return ``absurd.fake_now`` as DJANGO's own open session sees it.
-
-    The session-level twin of ``read_database_fake_now``: a database-level default only
-    reaches NEW sessions, so this is what an ``enqueue()`` on Django's already-open
-    connection stamps a task with. A custom GUC a session has SET reads back as an empty
-    string once RESET, never as NULL.
+    """``absurd.fake_now`` as Django's own open session sees it — the session-level
+    twin of ``read_database_fake_now``, what an ``enqueue()`` stamps a task with. Reads
+    back as an empty string once RESET, never as NULL.
     """
     with connections["default"].cursor() as cursor:
         cursor.execute("select current_setting('absurd.fake_now', true)")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,12 @@
 import typing as t
-import uuid
 
 import psycopg
-from absurd_sdk import Absurd, CreateQueueOptions, TaskResultSnapshot
+import psycopg.sql
+from absurd_sdk import Absurd, CreateQueueOptions
 from django.core.management import call_command
 from django.db import connections
 
-from django_absurd.connection import register_jsonb_loader
+from django_absurd.test import open_test_connection
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -62,17 +62,73 @@ def run_absurd_worker(queue: str = "default", concurrency: int = 1) -> None:
     call_command("absurd_worker", queue=queue, burst=True, concurrency=concurrency)
 
 
-def get_task_result(
-    task_id: str | uuid.UUID, queue: str = "default"
-) -> TaskResultSnapshot | None:
-    # task_id is either a TaskResult.id ("queue:uuid" string) or a raw SpawnResult
-    # ["task_id"] — the latter is typed str by absurd_sdk's stub, but psycopg
-    # deserializes the uuid column to a real uuid.UUID at runtime.
-    raw_task_id = str(task_id).rsplit(":", 1)[-1]
+def claim_one_run(queue: str = "default", *, claim_timeout: int) -> None:
+    """Take a lease on one run without executing it.
+
+    Leaves the run ``running`` with a ``claim_expires_at`` ``claim_timeout`` seconds
+    out, so advancing durable time past that lease lets the ``$ClaimTimeout`` sweep
+    inside the next ``claim_task`` expire and re-arm it.
+    """
     params = connections["default"].get_connection_params()
     conn = psycopg.connect(**params, autocommit=True)
     try:
-        register_jsonb_loader(conn)
-        return Absurd(conn).fetch_task_result(raw_task_id, queue)
+        Absurd(conn, queue_name=queue).claim_tasks(claim_timeout=claim_timeout)
     finally:
         conn.close()
+
+
+def set_database_fake_now(value: str) -> None:
+    """Plant a database-level ``absurd.fake_now``, as a killed frozen test would leave.
+
+    ``ALTER DATABASE`` rejects bind parameters, hence the composed literal. The database
+    name comes from the settings dict at runtime so an xdist worker plants it on its own
+    test database.
+    """
+    statement = psycopg.sql.SQL(
+        "alter database {name} set absurd.fake_now = {value}"
+    ).format(
+        name=psycopg.sql.Identifier(connections["default"].settings_dict["NAME"]),
+        value=psycopg.sql.Literal(value),
+    )
+    with open_test_connection("default") as cursor:
+        cursor.execute(statement)
+
+
+def read_database_fake_now() -> str | None:
+    """Return the database-level ``absurd.fake_now``, or ``None`` when it is unset.
+
+    Read from the catalog rather than from a session, so it reports what a NEW
+    connection would inherit — the thing that outlives a killed run.
+    """
+    with open_test_connection("default") as cursor:
+        cursor.execute(
+            "select split_part(cfg, '=', 2) from pg_db_role_setting s "
+            "join pg_database d on d.oid = s.setdatabase "
+            "cross join unnest(s.setconfig) as cfg "
+            "where d.datname = %s and cfg like 'absurd.fake_now=%%'",
+            [connections["default"].settings_dict["NAME"]],
+        )
+        row = cursor.fetchone()
+    return None if row is None else str(row[0])
+
+
+def read_session_fake_now() -> str:
+    """Return ``absurd.fake_now`` as DJANGO's own open session sees it.
+
+    The session-level twin of ``read_database_fake_now``: a database-level default only
+    reaches NEW sessions, so this is what an ``enqueue()`` on Django's already-open
+    connection stamps a task with. A custom GUC a session has SET reads back as an empty
+    string once RESET, never as NULL.
+    """
+    with connections["default"].cursor() as cursor:
+        cursor.execute("select current_setting('absurd.fake_now', true)")
+        return str(cursor.fetchone()[0])
+
+
+def reset_database_fake_now() -> None:
+    """Clear the database-level ``absurd.fake_now`` — cleanup half of planting one."""
+    statement = psycopg.sql.SQL("alter database {name} reset absurd.fake_now").format(
+        name=psycopg.sql.Identifier(connections["default"].settings_dict["NAME"])
+    )
+    with open_test_connection("default") as cursor:
+        cursor.execute(statement)

--- a/uv.lock
+++ b/uv.lock
@@ -254,6 +254,7 @@ dev = [
     { name = "mypy" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-socket" },
@@ -284,6 +285,7 @@ dev = [
     { name = "mypy", specifier = "==2.3.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-django", specifier = "==4.12.0" },
     { name = "pytest-socket", specifier = "==0.8.0" },
@@ -712,6 +714,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -258,8 +258,10 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-socket" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "time-machine" },
     { name = "types-croniter" },
     { name = "zensical" },
 ]
@@ -287,8 +289,10 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-django", specifier = "==4.12.0" },
     { name = "pytest-socket", specifier = "==0.8.0" },
+    { name = "pytest-timeout", specifier = "==2.4.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.16.0" },
+    { name = "time-machine", specifier = "==3.2.0" },
     { name = "types-croniter", specifier = "==6.2.4.20260711" },
     { name = "zensical", specifier = "==0.0.51" },
 ]
@@ -763,6 +767,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -906,6 +922,69 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "time-machine"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/fc/37b02f6094dbb1f851145330460532176ed2f1dc70511a35828166c41e52/time_machine-3.2.0.tar.gz", hash = "sha256:a4ddd1cea17b8950e462d1805a42b20c81eb9aafc8f66b392dd5ce997e037d79", size = 14804, upload-time = "2025-12-17T23:33:02.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/8b/080c8eedcd67921a52ba5bd0e075362062509ab63c86fc1a0442fad241a6/time_machine-3.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc4bee5b0214d7dc4ebc91f4a4c600f1a598e9b5606ac751f42cb6f6740b1dbb", size = 19255, upload-time = "2025-12-17T23:31:58.057Z" },
+    { url = "https://files.pythonhosted.org/packages/66/17/0e5291e9eb705bf8a5a1305f826e979af307bbeb79def4ddbf4b3f9a81e0/time_machine-3.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ca036304b4460ae2fdc1b52dd8b1fa7cf1464daa427fc49567413c09aa839c1", size = 15360, upload-time = "2025-12-17T23:31:59.048Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e8/9ab87b71d2e2b62463b9b058b7ae7ac09fb57f8fcd88729dec169d304340/time_machine-3.2.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5442735b41d7a2abc2f04579b4ca6047ed4698a8338a4fec92c7c9423e7938cb", size = 33029, upload-time = "2025-12-17T23:32:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/26/b5ca19da6f25ea905b3e10a0ea95d697c1aeba0404803a43c68f1af253e6/time_machine-3.2.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:97da3e971e505cb637079fb07ab0bcd36e33279f8ecac888ff131f45ef1e4d8d", size = 34579, upload-time = "2025-12-17T23:32:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ca/6ac7ad5f10ea18cc1d9de49716ba38c32132c7b64532430d92ef240c116b/time_machine-3.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3cdda6dee4966e38aeb487309bb414c6cb23a81fc500291c77a8fcd3098832e7", size = 35961, upload-time = "2025-12-17T23:32:02.521Z" },
+    { url = "https://files.pythonhosted.org/packages/33/67/390dd958bed395ab32d79a9fe61fe111825c0dd4ded54dbba7e867f171e6/time_machine-3.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:33d9efd302a6998bcc8baa4d84f259f8a4081105bd3d7f7af7f1d0abd3b1c8aa", size = 34668, upload-time = "2025-12-17T23:32:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/da/57/c88fff034a4e9538b3ae7c68c9cfb283670b14d17522c5a8bc17d29f9a4b/time_machine-3.2.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3a0b0a33971f14145853c9bd95a6ab0353cf7e0019fa2a7aa1ae9fddfe8eab50", size = 32891, upload-time = "2025-12-17T23:32:04.656Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/70/ebbb76022dba0fec8f9156540fc647e4beae1680c787c01b1b6200e56d70/time_machine-3.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2d0be9e5f22c38082d247a2cdcd8a936504e9db60b7b3606855fb39f299e9548", size = 34080, upload-time = "2025-12-17T23:32:06.146Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/2ca9e7af3df540dc1c79e3de588adeddb7dcc2107829248e6969c4f14167/time_machine-3.2.0-cp312-cp312-win32.whl", hash = "sha256:3f74623648b936fdce5f911caf386c0a0b579456410975de8c0dfeaaffece1d8", size = 17371, upload-time = "2025-12-17T23:32:07.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ce/21d23efc9c2151939af1b7ee4e60d86d661b74ef32b8eaa148f6fe8c899c/time_machine-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:34e26a41d994b5e4b205136a90e9578470386749cc9a2ecf51ca18f83ce25e23", size = 18132, upload-time = "2025-12-17T23:32:08.447Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/34/c2b70be483accf6db9e5d6c3139bce3c38fe51f898ccf64e8d3fe14fbf4d/time_machine-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:0615d3d82c418d6293f271c348945c5091a71f37e37173653d5c26d0e74b13a8", size = 16930, upload-time = "2025-12-17T23:32:09.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cd/43ad5efc88298af3c59b66769cea7f055567a85071579ed40536188530c1/time_machine-3.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c421a8eb85a4418a7675a41bf8660224318c46cc62e4751c8f1ceca752059090", size = 19318, upload-time = "2025-12-17T23:32:10.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f6/084010ef7f4a3f38b5a4900923d7c85b29e797655c4f6ee4ce54d903cca8/time_machine-3.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f4e758f7727d0058c4950c66b58200c187072122d6f7a98b610530a4233ea7b", size = 15390, upload-time = "2025-12-17T23:32:11.625Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/1cabb74134f492270dc6860cb7865859bf40ecf828be65972827646e91ad/time_machine-3.2.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:154bd3f75c81f70218b2585cc12b60762fb2665c507eec5ec5037d8756d9b4e0", size = 33115, upload-time = "2025-12-17T23:32:13.219Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/78c5d7dfa366924eb4dbfcc3fc917c39a4280ca234b12819cc1f16c03d88/time_machine-3.2.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50cfe5ebea422c896ad8d278af9648412b7533b8ea6adeeee698a3fd9b1d3b7", size = 34705, upload-time = "2025-12-17T23:32:14.29Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/d5e877c24541f674c6869ff6e9c56833369796010190252e92c9d7ae5f0f/time_machine-3.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636576501724bd6a9124e69d86e5aef263479e89ef739c5db361469f0463a0a1", size = 36104, upload-time = "2025-12-17T23:32:15.354Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1c/d4bae72f388f67efc9609f89b012e434bb19d9549c7a7b47d6c7d9e5c55d/time_machine-3.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:40e6f40c57197fcf7ec32d2c563f4df0a82c42cdcc3cab27f688e98f6060df10", size = 34765, upload-time = "2025-12-17T23:32:16.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c3/ac378cf301d527d8dfad2f0db6bad0dfb1ab73212eaa56d6b96ee5d9d20b/time_machine-3.2.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a1bcf0b846bbfc19a79bc19e3fa04d8c7b1e8101c1b70340ffdb689cd801ea53", size = 33010, upload-time = "2025-12-17T23:32:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/06/35/7ce897319accda7a6970b288a9a8c52d25227342a7508505a2b3d235b649/time_machine-3.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ae55a56c179f4fe7a62575ad5148b6ed82f6c7e5cf2f9a9ec65f2f5b067db5f5", size = 34185, upload-time = "2025-12-17T23:32:18.566Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/28/f922022269749cb02eee2b62919671153c4088994fa955a6b0e50327ff81/time_machine-3.2.0-cp313-cp313-win32.whl", hash = "sha256:a66fe55a107e46916007a391d4030479df8864ec6ad6f6a6528221befc5c886e", size = 17397, upload-time = "2025-12-17T23:32:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/fd87cde397f4a7bea493152f0aca8fd569ec709cad9e0f2ca7011eb8c7f7/time_machine-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:30c9ce57165df913e4f74e285a8ab829ff9b7aa3e5ec0973f88f642b9a7b3d15", size = 18139, upload-time = "2025-12-17T23:32:20.991Z" },
+    { url = "https://files.pythonhosted.org/packages/75/81/b8ce58233addc5d7d54d2fabc49dcbc02d79e3f079d150aa1bec3d5275ef/time_machine-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:89cad7e179e9bdcc84dcf09efe52af232c4cc7a01b3de868356bbd59d95bd9b8", size = 16964, upload-time = "2025-12-17T23:32:22.075Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e7/487f0ba5fe6c58186a5e1af2a118dfa2c160fedb37ef53a7e972d410408e/time_machine-3.2.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:59d71545e62525a4b85b6de9ab5c02ee3c61110fd7f636139914a2335dcbfc9c", size = 20000, upload-time = "2025-12-17T23:32:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/17/eb2c0054c8d44dd42df84ccd434539249a9c7d0b8eb53f799be2102500ab/time_machine-3.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:999672c621c35362bc28e03ca0c7df21500195540773c25993421fd8d6cc5003", size = 15657, upload-time = "2025-12-17T23:32:24.125Z" },
+    { url = "https://files.pythonhosted.org/packages/43/21/93443b5d1dd850f8bb9442e90d817a9033dcce6bfbdd3aabbb9786251c80/time_machine-3.2.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5faf7397f0580c7b9d67288522c8d7863e85f0cffadc0f1fccdb2c3dfce5783e", size = 39216, upload-time = "2025-12-17T23:32:25.542Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/9e/18544cf8acc72bb1dc03762231c82ecc259733f4bb6770a7bbe5cd138603/time_machine-3.2.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3dd886ec49f1fa5a00e844f5947e5c0f98ce574750c24b7424c6f77fc1c3e87", size = 40764, upload-time = "2025-12-17T23:32:26.643Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f7/9fe9ce2795636a3a7467307af6bdf38bb613ddb701a8a5cd50ec713beb5e/time_machine-3.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0ecd96bc7bbe450acaaabe569d84e81688f1be8ad58d1470e42371d145fb53", size = 43526, upload-time = "2025-12-17T23:32:27.693Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/a93e975ba9dec22e87ec92d18c28e67d36bd536f9119ffa439b2892b0c9c/time_machine-3.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:158220e946c1c4fb8265773a0282c88c35a7e3bb5d78e3561214e3b3231166f3", size = 41727, upload-time = "2025-12-17T23:32:28.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fb/e3633e5a6bbed1c76bb2e9810dabc2f8467532ffcd29b9aed404b473061a/time_machine-3.2.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c1aee29bc54356f248d5d7dfdd131e12ca825e850a08c0ebdb022266d073013", size = 38952, upload-time = "2025-12-17T23:32:30.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3d/02e9fb2526b3d6b1b45bc8e4d912d95d1cd699d1a3f6df985817d37a0600/time_machine-3.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8ed2224f09d25b1c2fc98683613aca12f90f682a427eabb68fc824d27014e4a", size = 39829, upload-time = "2025-12-17T23:32:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c8/c14265212436da8e0814c45463987b3f57de3eca4de023cc2eabb0c62ef3/time_machine-3.2.0-cp313-cp313t-win32.whl", hash = "sha256:3498719f8dab51da76d29a20c1b5e52ee7db083dddf3056af7fa69c1b94e1fe6", size = 17852, upload-time = "2025-12-17T23:32:32.079Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/bc/8acb13cf6149f47508097b158a9a8bec9ec4530a70cb406124e8023581f5/time_machine-3.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e0d90bee170b219e1d15e6a58164aa808f5170090e4f090bd0670303e34181b1", size = 18918, upload-time = "2025-12-17T23:32:33.106Z" },
+    { url = "https://files.pythonhosted.org/packages/24/87/c443ee508c2708fd2514ccce9052f5e48888783ce690506919629ebc8eb0/time_machine-3.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:051de220fdb6e20d648111bbad423d9506fdbb2e44d4429cef3dc0382abf1fc2", size = 17261, upload-time = "2025-12-17T23:32:34.446Z" },
+    { url = "https://files.pythonhosted.org/packages/61/70/b4b980d126ed155c78d1879c50d60c8dcbd47bd11cb14ee7be50e0dfc07f/time_machine-3.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1398980c017fe5744d66f419e0115ee48a53b00b146d738e1416c225eb610b82", size = 19303, upload-time = "2025-12-17T23:32:35.796Z" },
+    { url = "https://files.pythonhosted.org/packages/73/73/eaa33603c69a68fe2b6f54f9dd75481693d62f1d29676531002be06e2d1c/time_machine-3.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4f8f4e35f4191ef70c2ab8ff490761ee9051b891afce2bf86dde3918eb7b537b", size = 15431, upload-time = "2025-12-17T23:32:37.244Z" },
+    { url = "https://files.pythonhosted.org/packages/76/10/b81e138e86cc7bab40cdb59d294b341e172201f4a6c84bb0ec080407977a/time_machine-3.2.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6db498686ecf6163c5aa8cf0bcd57bbe0f4081184f247edf3ee49a2612b584f9", size = 33206, upload-time = "2025-12-17T23:32:38.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/72/4deab446b579e8bd5dca91de98595c5d6bd6a17ce162abf5c5f2ce40d3d8/time_machine-3.2.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:027c1807efb74d0cd58ad16524dec94212fbe900115d70b0123399883657ac0f", size = 34792, upload-time = "2025-12-17T23:32:40.223Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/39/439c6b587ddee76d533fe972289d0646e0a5520e14dc83d0a30aeb5565f7/time_machine-3.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92432610c05676edd5e6946a073c6f0c926923123ce7caee1018dc10782c713d", size = 36187, upload-time = "2025-12-17T23:32:41.705Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/db/2da4368db15180989bab83746a857bde05ad16e78f326801c142bb747a06/time_machine-3.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c25586b62480eb77ef3d953fba273209478e1ef49654592cd6a52a68dfe56a67", size = 34855, upload-time = "2025-12-17T23:32:42.817Z" },
+    { url = "https://files.pythonhosted.org/packages/88/84/120a431fee50bc4c241425bee4d3a4910df4923b7ab5f7dff1bf0c772f08/time_machine-3.2.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6bf3a2fa738d15e0b95d14469a0b8ea42635467408d8b490e263d5d45c9a177f", size = 33222, upload-time = "2025-12-17T23:32:43.94Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/89cfda82bb8c57ff91bb9a26751aa234d6d90e9b4d5ab0ad9dce0f9f0329/time_machine-3.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ce76b82276d7ad2a66cdc85dad4df19d1422b69183170a34e8fbc4c3f35502f7", size = 34270, upload-time = "2025-12-17T23:32:45.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/aa/235357da4f69a51a8d35fcbfcfa77cdc7dc24f62ae54025006570bda7e2d/time_machine-3.2.0-cp314-cp314-win32.whl", hash = "sha256:14d6778273c543441863dff712cd1d7803dee946b18de35921eb8df10714539d", size = 17544, upload-time = "2025-12-17T23:32:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/51/6c8405a7276be79693b792cff22ce41067ec05db26a7d02f2d5b06324434/time_machine-3.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbf821da96dbc80d349fa9e7c36e670b41d68a878d28c8850057992fed430eef", size = 18423, upload-time = "2025-12-17T23:32:47.468Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/03/a3cf419e20c35fc203c6e4fed48b5b667c1a2b4da456d9971e605f73ecef/time_machine-3.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:71c75d71f8e68abc8b669bca26ed2ddd558430a6c171e32b8620288565f18c0e", size = 17050, upload-time = "2025-12-17T23:32:48.91Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a1/142de946dc4393f910bf4564b5c3ba819906e1f49b06c9cb557519c849e4/time_machine-3.2.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e374779021446fc2b5c29d80457ec9a3b1a5df043dc2aae07d7c1415d52323c", size = 19991, upload-time = "2025-12-17T23:32:49.933Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/62/7f17def6289901f94726921811a16b9adce46e666362c75d45730c60274f/time_machine-3.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:122310a6af9c36e9a636da32830e591e7923e8a07bdd0a43276c3a36c6821c90", size = 15707, upload-time = "2025-12-17T23:32:50.969Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/d3/3502fb9bd3acb159c18844b26c43220201a0d4a622c0c853785d07699a92/time_machine-3.2.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba3eeb0f018cc362dd8128befa3426696a2e16dd223c3fb695fde184892d4d8c", size = 39207, upload-time = "2025-12-17T23:32:52.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/be/8b27f4aa296fda14a5a2ad7f588ddd450603c33415ab3f8e85b2f1a44678/time_machine-3.2.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:77d38ba664b381a7793f8786efc13b5004f0d5f672dae814430445b8202a67a6", size = 40764, upload-time = "2025-12-17T23:32:53.167Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cd/fe4c4e5c8ab6d48fab3624c32be9116fb120173a35fe67e482e5cf68b3d2/time_machine-3.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f09abeb8f03f044d72712207e0489a62098ad3ad16dac38927fcf80baca4d6a7", size = 43508, upload-time = "2025-12-17T23:32:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/28/5a3ba2fce85b97655a425d6bb20a441550acd2b304c96b2c19d3839f721a/time_machine-3.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6b28367ce4f73987a55e230e1d30a57a3af85da8eb1a140074eb6e8c7e6ef19f", size = 41712, upload-time = "2025-12-17T23:32:55.781Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/e38084be7fdabb4835db68a3a47e58c34182d79fc35df1ecbe0db2c5359f/time_machine-3.2.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:903c7751c904581da9f7861c3015bed7cdc40047321291d3694a3cdc783bbca3", size = 38939, upload-time = "2025-12-17T23:32:56.867Z" },
+    { url = "https://files.pythonhosted.org/packages/40/d0/ad3feb0a392ef4e0c08bc32024950373ddc0669002cbdcbb9f3bf0c2d114/time_machine-3.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:528217cad85ede5f85c8bc78b0341868d3c3cfefc6ecb5b622e1cacb6c73247b", size = 39837, upload-time = "2025-12-17T23:32:58.283Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/9e/5f4b2ea63b267bd78f3245e76f5528836611b5f2d30b5e7300a722fe4428/time_machine-3.2.0-cp314-cp314t-win32.whl", hash = "sha256:75724762ffd517e7e80aaec1fad1ff5a7414bd84e2b3ee7a0bacfeb67c14926e", size = 18091, upload-time = "2025-12-17T23:32:59.403Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6f/456b1f4d2700ae02b19eba830f870596a4b89b74bac3b6c80666f1b108c5/time_machine-3.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2526abbd053c5bca898d1b3e7898eec34626b12206718d8c7ce88fd12c1c9c5c", size = 19208, upload-time = "2025-12-17T23:33:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/22/8063101427ecd3d2652aada4d21d0876b07a3dc789125bca2ee858fec3ed/time_machine-3.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7f2fb6784b414edbe2c0b558bfaab0c251955ba27edd62946cce4a01675a992c", size = 17359, upload-time = "2025-12-17T23:33:01.54Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,6 @@ dev = [
     { name = "build" },
     { name = "django-coverage-plugin" },
     { name = "django-stubs" },
-    { name = "freezegun" },
     { name = "hatch-vcs" },
     { name = "hatchling" },
     { name = "mypy" },
@@ -280,7 +279,6 @@ dev = [
     { name = "build", specifier = "==1.5.0" },
     { name = "django-coverage-plugin", specifier = "==3.2.2" },
     { name = "django-stubs", specifier = "==6.0.7" },
-    { name = "freezegun", specifier = "==1.5.5" },
     { name = "hatch-vcs", specifier = "==0.5.0" },
     { name = "hatchling", specifier = "==1.31.0" },
     { name = "mypy", specifier = "==2.3.0" },
@@ -345,18 +343,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
-]
-
-[[package]]
-name = "freezegun"
-version = "1.5.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Durable primitives (sleep, `await_event`, retry backoff) had no deterministic test — the
old recipe slept ~1.5s in the task and `time.sleep(2)` in the test, and couldn't express a
seven-day sleep at all. The `dj_absurd` fixture freezes Postgres and Python together and
exposes `freeze_time`/`drain`/`emit`/`get_result`/`now`/`sync_queues`. Works unchanged from
an `async def` test.

Also drops freezegun (it patches `time.monotonic`, asyncio's loop clock) and adopts ruff
0.16.0 in the pre-commit gate — main bumped the dev dep but left the hook rev behind.

Closes #108
Closes #127