### PR TITLE
feat: support run_after by deferring on a durable sleep

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -216,6 +216,21 @@ accepted by Absurd's own [task definition](https://earendil-works.github.io/absu
 time. Backend capabilities: result retrieval, async tasks, and deferred (run-later)
 enqueue are supported; priority is not.
 
+**An idempotency key is scoped to its queue, not to your task.** A key reserves itself
+against one queue, with no task name and no arguments in the comparison. Whichever
+enqueue arrives first owns the key; every later enqueue is swallowed and handed the
+FIRST task's id — even a different task, even with different arguments, so
+`absurd_params(idempotency_key="nightly").bind(purge_cache).enqueue()` after the same
+key was used for `send_report` returns `send_report`'s id and never runs `purge_cache`.
+Namespace the key so it identifies the work (`f"send_report:{report_id}:{date}"`), as
+the beat scheduler does for its own spawns (see
+[Scheduling recurring tasks](#scheduling-recurring-tasks)). Two further properties:
+different queues never collide (the same key on `default` and on `reports` reserves
+independently and both run), and a key is held for as long as its task row exists —
+freed only once the task is terminal and cleanup deletes it, `cleanup_ttl` (default 30
+days) after it finished, with a pending/running/sleeping task holding its key
+indefinitely. A key is therefore not a time window; it is "once until the row is swept."
+
 **Deferred enqueue.** `task.using(run_after=<aware datetime>).enqueue(...)` defers one
 enqueue. Absurd's spawn has no `available_at`, so a deferred enqueue spawns a second row
 named `<your task's dotted path>:run_after` that waits, then enqueues yours with the

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -213,8 +213,16 @@ convention. Field types come from `absurd_sdk` (`RetryStrategy`, `CancellationPo
 accepted by Absurd's own [task definition](https://earendil-works.github.io/absurd/)
 (`default_max_attempts`, `default_cancellation`), but not field-for-field: Absurd's
 `register_task` takes no `retry_strategy`, so that field is ours alone, applied at spawn
-time. Backend capabilities: result retrieval and async tasks are supported; deferred
-(run-later) enqueue and priority are not.
+time. Backend capabilities: result retrieval, async tasks, and deferred (run-later)
+enqueue are supported; priority is not.
+
+**Deferred enqueue.** `task.using(run_after=<aware datetime>).enqueue(...)` defers one
+enqueue. Absurd's spawn has no `available_at`, so a deferred enqueue spawns a second row
+named `<your task's dotted path>:run_after` that waits, then enqueues yours with the
+options you passed — both rows show up in the admin, filterable by that name. The id
+`enqueue` returned keeps working throughout: `READY` while the wrapper waits, then your
+task's own status and return value once it runs; a struggling wrapper leaves that id
+`READY` with no visible errors until it runs out of attempts, then `FAILED`.
 
 ## Workers
 

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -3,7 +3,7 @@ import typing as t
 import uuid
 
 import psycopg.errors
-from absurd_sdk import CreateQueueOptions, JsonValue
+from absurd_sdk import CreateQueueOptions, JsonObject, JsonValue
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
@@ -17,8 +17,9 @@ from django.utils.module_loading import import_string
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
+from django_absurd.deferred import DEFER_NAME_SUFFIX
 from django_absurd.exceptions import QueueNotDeclaredError
-from django_absurd.tasks import AbsurdTask, build_merged_spawn_options
+from django_absurd.tasks import AbsurdTask, SpawnKwargs, build_merged_spawn_options
 
 if t.TYPE_CHECKING:
     from django.tasks.base import Task
@@ -66,6 +67,7 @@ class TaskModel(t.Protocol):
     attempts: int
     completed_payload: JsonValue
     cancelled_at: dt.datetime | None
+    headers: JsonObject
     last_attempt_run: uuid.UUID | None
 
 
@@ -103,7 +105,7 @@ class AbsurdBackend(BaseTaskBackend):
     task_class = AbsurdTask
     supports_get_result = True
     supports_async_task = True
-    supports_defer = False
+    supports_defer = True
     supports_priority = False
 
     def __init__(self, alias: str, params: dict[str, t.Any]) -> None:
@@ -133,13 +135,43 @@ class AbsurdBackend(BaseTaskBackend):
         )
         merged = build_merged_spawn_options(params, None)
         merged.setdefault("max_attempts", self.default_max_attempts)
+        # Absurd's spawn takes no available_at, so a deferred enqueue spawns a WRAPPER
+        # row that sleeps until due and then enqueues the caller's task. The caller's
+        # task is therefore never claimed before its work exists, which is what both of
+        # Absurd's cancellation rules measure from. The caller's own options ride in the
+        # wrapper's params and are replayed on the inner enqueue; the wrapper gets only
+        # its own max_attempts.
+        if task.run_after is not None:
+            spawn_name = f"{task.module_path}{DEFER_NAME_SUFFIX}"
+            spawn_params: dict[str, t.Any] = {
+                "args": [],
+                "kwargs": {
+                    "args": list(args),
+                    "kwargs": dict(kwargs),
+                    "queue": task.queue_name,
+                    "options": dict(merged),
+                    "due": normalize_to_utc(task.run_after).isoformat(),
+                },
+            }
+            wrapper_options: SpawnKwargs = {"max_attempts": self.default_max_attempts}
+            # The caller's key stays on the inner enqueue, so the wrapper takes a
+            # derived one: verbatim, it would reserve the key against its own row and
+            # the enqueue it wakes to make would dedupe against itself.
+            if "idempotency_key" in merged:
+                wrapper_options["idempotency_key"] = (
+                    f"{merged['idempotency_key']}{DEFER_NAME_SUFFIX}"
+                )
+            merged = wrapper_options
+        else:
+            spawn_name = task.module_path
+            spawn_params = {"args": list(args), "kwargs": dict(kwargs)}
         try:
             # Savepoint so a misconfig DB error (below) rolls back only the spawn,
             # leaving an enclosing transaction.atomic() block usable.
             with transaction.atomic(using=self.database, savepoint=True):
                 spawn_result = client.spawn(
-                    task.module_path,
-                    {"args": list(args), "kwargs": dict(kwargs)},
+                    spawn_name,
+                    spawn_params,
                     queue=task.queue_name,
                     **merged,
                 )
@@ -166,8 +198,8 @@ class AbsurdBackend(BaseTaskBackend):
                 raise ImproperlyConfigured(msg) from exc
             with transaction.atomic(using=self.database, savepoint=True):
                 spawn_result = client.spawn(
-                    task.module_path,
-                    {"args": list(args), "kwargs": dict(kwargs)},
+                    spawn_name,
+                    spawn_params,
                     queue=task.queue_name,
                     **merged,
                 )
@@ -193,6 +225,10 @@ class AbsurdBackend(BaseTaskBackend):
         task, run, worker_ids = fetch_task_and_run(
             self.database, queue, task_id, result_id
         )
+        if task.task_name.endswith(DEFER_NAME_SUFFIX) and task.state == "completed":
+            # Its payload is the id of the task it enqueued, so the caller's id keeps
+            # describing their own task for the rest of its life.
+            return self.get_result(str(task.completed_payload))
         return build_task_result(self, result_id, task, run, worker_ids)
 
 
@@ -280,6 +316,16 @@ def build_task_result(
     completed_at = run.completed_at if run else None
     failed_at = run.failed_at if run else None
     failure_reason = run.failure_reason if run else None
+    is_deferred_wrapper = task_name.endswith(DEFER_NAME_SUFFIX)
+    if is_deferred_wrapper:
+        # The caller's id names the wrapper, but their TaskResult must describe THEIR
+        # task: its path is the name's suffix and its call is in the wrapper's kwargs.
+        task_name = task_name.removesuffix(DEFER_NAME_SUFFIX)
+        spec = params["kwargs"]
+        params = {"args": list(spec["args"]), "kwargs": dict(spec["kwargs"])}
+        # Claimed at t=0 only so it could sleep — nothing of the caller's has started.
+        first_started_at = None
+        run_started = None
     try:
         task_obj = import_string(task_name)
     except ImportError as exc:
@@ -288,6 +334,12 @@ def build_task_result(
     if task_obj.queue_name != queue:
         task_obj = task_obj.using(queue_name=queue)
     status = map_state_to_status(state)
+    if is_deferred_wrapper and state == "sleeping":
+        # No Django status means "the deferral is retrying", and READY is the honest
+        # answer to whether the caller's task has started — so a wrapper waiting for its
+        # due time and one in retry backoff both read READY. A launch that keeps failing
+        # ends FAILED once out of attempts, carrying its error.
+        status = TaskResultStatus.READY
     errors: list[TaskError] = []
     if state == "failed" and failure_reason:
         errors = [
@@ -316,6 +368,19 @@ def build_task_result(
     if state == "completed":
         object.__setattr__(result, "_return_value", completed_payload)
     return result
+
+
+def normalize_to_utc(moment: dt.datetime) -> dt.datetime:
+    """Aware UTC, whatever awareness the caller had.
+
+    Django only rejects a naive ``run_after`` when ``USE_TZ`` is true, so under
+    ``USE_TZ=False`` a naive one reaches here — and would reach the SDK, whose clock is
+    aware, raising a ``TypeError`` per attempt until the task ran out of them. A naive
+    value means local time, per Django's own convention.
+    """
+    if timezone.is_naive(moment):
+        moment = timezone.make_aware(moment)
+    return moment.astimezone(dt.UTC)
 
 
 def get_declared_queues(backend: "AbsurdBackend") -> dict[str, CreateQueueOptions]:

--- a/django_absurd/deferred.py
+++ b/django_absurd/deferred.py
@@ -1,0 +1,97 @@
+"""Deferred enqueue: the wrapper's name, and the handler that runs it.
+
+A deferred enqueue spawns a wrapper row rather than the caller's task, so the caller's
+task is never claimed before its work exists. ``backends`` spawns that row and
+``worker`` dispatches it, so the name they agree on lives here — importable by both
+without a cycle.
+
+There is deliberately no ``@task``: decorating one resolves ``task_backends["default"]``
+and validates its queue at decoration time, so a project whose ``QUEUES`` omits
+``"default"`` would raise ``InvalidTask`` on import — at dispatch, where it takes the
+worker down. ``worker.LazyTaskRegistry`` builds the handler instead.
+"""
+
+import asyncio
+import datetime as dt
+import logging
+import typing as t
+
+from absurd_sdk import AsyncTaskContext, JsonValue
+from django.db import close_old_connections
+from django.utils.module_loading import import_string
+
+from django_absurd import params as params_module
+
+if t.TYPE_CHECKING:
+    # backends imports DEFER_NAME_SUFFIX from here, so this one stays type-only.
+    from django_absurd.backends import TaskParams
+
+logger = logging.getLogger("django_absurd")
+
+# A deferred enqueue spawns `<target dotted path>:run_after` rather than the caller's
+# task. Leading with the target sorts the row beside it in the admin and names the kwarg
+# that caused it.
+#
+# The colon is load-bearing: it cannot appear in a dotted path, so this can never
+# collide with a real task name. A bare `.run_after` would — a user's own task called
+# `run_after` would be read as a deferral of the module containing it.
+DEFER_NAME_SUFFIX = ":run_after"
+
+
+def build_deferred_handler(
+    target: str,
+) -> t.Callable[["TaskParams", AsyncTaskContext], t.Awaitable[JsonValue]]:
+    """Handle one deferred run: sleep until due, then enqueue ``target``.
+
+    The enqueue is a checkpointed step, so a retry of this run replays the stored id
+    rather than enqueueing a second time. Enqueuing is synchronous Django work, so it
+    goes to a thread — the same hop ``worker.build_handler`` makes for a sync task.
+    """
+
+    async def handler(params: "TaskParams", ctx: AsyncTaskContext) -> JsonValue:
+        spec = params["kwargs"]
+        logger.info(
+            "django-absurd deferred task waiting: target=%s due=%s task_id=%s",
+            target,
+            spec["due"],
+            ctx.task_id,
+        )
+        await ctx.sleep_until(
+            "wait-until-due", dt.datetime.fromisoformat(str(spec["due"]))
+        )
+
+        async def enqueue_the_target() -> JsonValue:
+            return await asyncio.to_thread(
+                enqueue_deferred_target,
+                target,
+                list(spec["args"]),
+                dict(spec["kwargs"]),
+                str(spec["queue"]),
+                dict(spec["options"]),
+            )
+
+        # Named for what it enqueued: the Checkpoints changelist shows no task name,
+        # and checkpoint_name is searchable, so the target belongs in it.
+        return await ctx.step(f"enqueue:{target}", enqueue_the_target)
+
+    return handler
+
+
+def enqueue_deferred_target(
+    target: str,
+    args: list[t.Any],
+    kwargs: dict[str, t.Any],
+    queue: str,
+    options: dict[str, t.Any],
+) -> str:
+    """Enqueue the caller's task, returning its ``TaskResult.id``."""
+    close_old_connections()
+    try:
+        target_task = import_string(target)
+        if target_task.queue_name != queue:
+            target_task = target_task.using(queue_name=queue)
+        if options:
+            target_task = params_module.absurd_params(**options).bind(target_task)
+        return str(target_task.enqueue(*args, **kwargs).id)
+    finally:
+        close_old_connections()

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -32,6 +32,7 @@ from django_absurd import admin_views
 from django_absurd.backends import AbsurdBackend, RunModel, TaskParams
 from django_absurd.connection import register_jsonb_loader, validate_backend
 from django_absurd.context import WORKER_LOOP
+from django_absurd.deferred import DEFER_NAME_SUFFIX, build_deferred_handler
 from django_absurd.exceptions import QueueNotDeclaredError, QueueNotProvisionedError
 from django_absurd.management.base import resolve_backend
 from django_absurd.queues import names_a_queue_table
@@ -98,6 +99,17 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
         self, name: str, default: dict[str, t.Any] | D | None = None
     ) -> dict[str, t.Any] | D | None:
         if name not in self:
+            if name.endswith(DEFER_NAME_SUFFIX):
+                self[name] = {
+                    "name": name,
+                    "queue": self.queue,
+                    "default_max_attempts": None,
+                    "default_cancellation": None,
+                    "handler": build_deferred_handler(
+                        name.removesuffix(DEFER_NAME_SUFFIX)
+                    ),
+                }
+                return super().get(name, default)
             try:
                 task = import_string(name)
             except ImportError:

--- a/docs/plans/2026-07-31-run-after-wrapper-task.md
+++ b/docs/plans/2026-07-31-run-after-wrapper-task.md
@@ -1,0 +1,794 @@
+# `run_after` via a wrapper task — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Defer a task by enqueueing a separate wrapper run that sleeps and then
+enqueues the real task, so Absurd's `cancellation` rules measure the caller's task
+rather than the wait.
+
+**Architecture:** Absurd's `spawn` takes no `available_at`. This branch currently claims
+the caller's task at t=0 and sleeps inside it, which sets `first_started_at` before any
+work exists and breaks both cancellation rules. Replacement: `enqueue` spawns a row
+named `django_absurd:defer:<target path>`, which **is not a Django `@task`** —
+`LazyTaskRegistry` recognises the prefix and builds a handler for it. The handler sleeps
+until due, then enqueues the target with the caller's options as a checkpointed step.
+`get_result` on the caller's id reports `READY` while waiting and follows the wrapper's
+completion payload afterwards.
+
+**Tech Stack:** Django 6.0 Tasks, `absurd_sdk`, psycopg 3, pytest + the `dj_absurd`
+fixture.
+
+## Why there is no `@task` — read this before touching Task 1
+
+Two measured facts killed the obvious design. **Do not reintroduce a module-level
+`@task`.**
+
+1. A module-level `@task` reads `settings.TASKS`, raising
+   `ImproperlyConfigured: Requested setting TASKS` on import. `django_absurd.test` must
+   import with no settings at all.
+2. Worse: `@task` resolves `task_backends["default"]` and validates its queue at
+   **decoration** time. Measured with
+   `TASKS = {"default": {"BACKEND": ABSURD, "QUEUES": ["reports"]}}`:
+
+   ```
+   InvalidTask: Queue 'default' is not valid for backend.
+   ```
+
+   So any project whose `QUEUES` omits `"default"`, or whose `TASKS` alias isn't
+   `"default"`, would crash — at dispatch, inside `LazyTaskRegistry.get`, where the
+   `except ImportError` does **not** catch `InvalidTask`, taking the worker down. A
+   `@task`'s `queue_name` is fixed at decoration and is unrelated to the `queue` we pass
+   to `spawn`, so spawning onto the right queue does not help.
+
+Hence: a synthetic `task_name`, resolved by our own registry. It also gives per-target
+filtering in the admin's Tasks changelist, which is the point of the name carrying the
+target.
+
+## Global Constraints
+
+- Floor: Django 6.0 / Python 3.12. `uv run pre-commit run --all-files` owns ruff and
+  mypy — never invoke either directly.
+- **`django_absurd.test` must import with NO Django settings configured.** Verify with
+  the import oracle after every task.
+- **Never add a ruff `noqa`/ignore or a coverage pragma.** If you think one is
+  unavoidable, stop and report rather than adding it.
+- `import typing as t`, `import datetime as dt`, absolute imports only. Functions
+  contain a verb. Helpers BELOW their callers. No leading-underscore module-level names.
+- Re-raise inside `except` with `from exc`. Exceptions own their messages, under
+  `DjangoAbsurdError`.
+- Tests: function-based; assert COMPLETE error messages; alphabetize parametrize values
+  and each test's own fixture parameters; reach fixture tasks module-qualified
+  (`tasks.add`); never unit-test an internal helper; don't wrap two lines in a helper.
+- Durable tests freeze through `dj_absurd.freeze_time()`, never `time.sleep`.
+- 100% coverage on lines this plan adds or changes.
+- Never `commit --amend`; every change is a new commit. No AI attribution in messages.
+
+## Verified interfaces (measured — do not re-derive)
+
+- `absurd_sdk.Absurd.spawn(task_name, params, max_attempts, retry_strategy, headers, queue, cancellation, idempotency_key)`
+  — **no `available_at`, no `task_id`.**
+- `AsyncTaskContext`:
+  `await_event, await_task_result, begin_step, complete_step, emit_event, headers, heartbeat, sleep_for, sleep_until, step`.
+  **No `spawn`.**
+- **An enqueue performed inside a task body runs in the SAME drain.** Proven live:
+  `[(run_deferred, completed, "default:<uuid>"), (tests.tasks.add, completed, 3)]`.
+  Every test below relies on it, and `tests/core/test_absurd_fixture.py`'s
+  `spawn_child_then_return` already pins the same-drain behaviour.
+- **A task's return value lands in `completed_payload` as the plain value** — the
+  wrapper's returned id string arrives as a string, so the redirect can use it directly.
+- `absurd_params(**merged_dict).bind(task)` round-trips the caller's options — verified:
+  `max_attempts=9` and `headers={"trace": "abc"}` came back exactly.
+- `LazyTaskRegistry.get` (`worker.py`) is the single dispatch-resolution hook; its entry
+  shape is
+  `{"name", "queue", "default_max_attempts", "default_cancellation", "handler"}`.
+
+## Decisions already taken (do not relitigate)
+
+- Synthetic, per-target name: `django_absurd:defer:<target dotted path>`.
+- The wrapper spawns onto the **target's** queue, or a worker consuming only that queue
+  would never run it.
+- Caller options pass through the wrapper's params; the wrapper itself gets none of
+  them.
+- The inner enqueue is a checkpointed step — effectively-once across wrapper retries.
+- Status: `READY` while the wrapper sleeps (**always**, including retry backoff — Django
+  has no status for "the deferral is retrying", and READY is the truthful answer to "has
+  the caller's task started"), the inner task's result once the wrapper completes, the
+  wrapper's own `FAILED` if the deferral exhausts attempts. While READY, pass any
+  wrapper failure through to `errors` so a struggling launch is visible without
+  misreporting status.
+- **Accepted and to be documented, not fixed:** a wrapper swept by `cleanup_ttl` after
+  wake makes the caller's id raise `TaskResultDoesNotExist` though the real task lives;
+  and two deferred enqueues sharing one `idempotency_key` create two wrapper rows,
+  deduping at wake rather than at enqueue.
+
+## File structure
+
+| File                                           | Responsibility                                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `django_absurd/worker.py`                      | `DEFER_NAME_PREFIX`, the registry branch that recognises it, and `build_deferred_handler`. Deletes `sleep_until_run_after`, `DEFER_STEP_NAME`, the `RUN_AFTER_HEADER` import, and the injected sleep in `handler`. Dispatch machinery belongs here beside `build_handler`; no new module, so nothing new lands on any import path. |
+| `django_absurd/backends.py`                    | Spawn the wrapper when `run_after` is set; redirect `get_result`. Deletes `RUN_AFTER_HEADER`, `waits_for_its_run_after`, `warn_if_cancellation_misreads_the_wait` and its dedupe set. Keeps `normalize_to_utc`.                                                                                                                    |
+| `tests/core/test_run_after.py`                 | Rewritten. Every existing test's disposition is listed in Task 3.                                                                                                                                                                                                                                                                  |
+| `docs/web/tasks.md`, `django_absurd/AGENTS.md` | Drop the cancellation caveat; document the wrapper row and the two accepted consequences.                                                                                                                                                                                                                                          |
+
+---
+
+### Task 1: Dispatch a synthetic deferred name
+
+**Files:**
+
+- Modify: `django_absurd/worker.py`
+- Test: `tests/core/test_run_after.py`
+
+**Interfaces:**
+
+- Produces: `DEFER_NAME_PREFIX = "django_absurd:defer:"`, and a registry entry for any
+  `task_name` starting with it whose handler sleeps then enqueues the target. Wrapper
+  params are
+  `{"args": [], "kwargs": {"args": list, "kwargs": dict, "queue": str, "options": dict, "due": str}}`
+  — the target path comes from the **name**, not the params.
+
+- [ ] **Step 1: Write the failing test**
+
+Spawn a wrapper row directly through the SDK client — the enqueue side does not exist
+until Task 2, and this is the dispatch contract, driven the way a worker drives it:
+
+```python
+def test_a_deferred_name_sleeps_then_enqueues_its_target(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        due = (dj_absurd.now + dt.timedelta(hours=1)).isoformat()
+        get_absurd_client().spawn(
+            "django_absurd:defer:tests.tasks.add",
+            {
+                "args": [],
+                "kwargs": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                    "queue": "default",
+                    "options": {},
+                    "due": due,
+                },
+            },
+            queue="default",
+        )
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        ran = [(run.task_name, run.state) for run in dj_absurd.drain()]
+        assert ("django_absurd:defer:tests.tasks.add", "completed") in ran
+        assert ("tests.tasks.add", "completed") in ran
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+`uv run pytest tests/core/test_run_after.py::test_a_deferred_name_sleeps_then_enqueues_its_target -v --no-cov`
+Expected: FAIL — the drain returns `[]`, because `LazyTaskRegistry.get` cannot
+`import_string` that name and returns `default`, so the run is never dispatched.
+
+- [ ] **Step 3: Teach the registry the prefix**
+
+In `worker.py`, add the constant beside `logger`:
+
+```python
+# A deferred enqueue spawns a row under this prefix rather than the caller's task, so the
+# caller's task is never claimed before its work exists. Not a Django @task: decorating one
+# reads settings.TASKS and validates a queue at import, which breaks any project whose
+# QUEUES omits "default". The suffix is the target's dotted path, which makes deferred work
+# filterable by target in the admin.
+DEFER_NAME_PREFIX = "django_absurd:defer:"
+```
+
+In `LazyTaskRegistry.get`, branch before the `import_string` attempt:
+
+```python
+        if name not in self:
+            if name.startswith(DEFER_NAME_PREFIX):
+                self[name] = {
+                    "name": name,
+                    "queue": self.queue,
+                    "default_max_attempts": None,
+                    "default_cancellation": None,
+                    "handler": build_deferred_handler(
+                        name.removeprefix(DEFER_NAME_PREFIX)
+                    ),
+                }
+                return super().get(name, default)
+            try:
+                task = import_string(name)
+```
+
+Add the handler builder BELOW `build_handler`:
+
+```python
+def build_deferred_handler(
+    target: str,
+) -> t.Callable[[TaskParams, AsyncTaskContext], t.Awaitable[JsonValue]]:
+    """Handle one deferred run: sleep until due, then enqueue ``target``.
+
+    The enqueue is a checkpointed step, so a retry of this run replays the stored id
+    rather than enqueueing a second time. Enqueuing is synchronous Django work, so it
+    goes to a thread — the same hop ``handler`` makes for a sync task.
+    """
+
+    async def handler(params: TaskParams, ctx: AsyncTaskContext) -> JsonValue:
+        spec = params["kwargs"]
+        logger.info(
+            "django-absurd deferred task waiting: target=%s due=%s task_id=%s",
+            target,
+            spec["due"],
+            ctx.task_id,
+        )
+        await ctx.sleep_until(
+            "django_absurd:defer", dt.datetime.fromisoformat(str(spec["due"]))
+        )
+
+        async def enqueue_the_target() -> JsonValue:
+            return await asyncio.to_thread(
+                enqueue_deferred_target,
+                target,
+                list(spec["args"]),
+                dict(spec["kwargs"]),
+                str(spec["queue"]),
+                dict(spec["options"]),
+            )
+
+        return await ctx.step("django_absurd:enqueue", enqueue_the_target)
+
+    return handler
+
+
+def enqueue_deferred_target(
+    target: str,
+    args: list[t.Any],
+    kwargs: dict[str, t.Any],
+    queue: str,
+    options: dict[str, t.Any],
+) -> str:
+    """Enqueue the caller's task, returning its ``TaskResult.id``."""
+    close_old_connections()
+    try:
+        target_task = import_string(target)
+        if target_task.queue_name != queue:
+            target_task = target_task.using(queue_name=queue)
+        if options:
+            target_task = params_module.absurd_params(**options).bind(target_task)
+        return str(target_task.enqueue(*args, **kwargs).id)
+    finally:
+        close_old_connections()
+```
+
+`worker.py` already imports `close_old_connections`. Import the params module at the top
+— `from django_absurd import params as params_module` — no lazy import and no `noqa`:
+`worker.py` is not on the settings-free path (`django_absurd.test` imports it inside
+`drain()`), so a top-level import is safe and cheaper.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run:
+`uv run pytest tests/core/test_run_after.py::test_a_deferred_name_sleeps_then_enqueues_its_target -v --no-cov`
+Expected: PASS, with both rows in the second drain.
+
+- [ ] **Step 5: Import oracle**
+
+From a scratch directory OUTSIDE the repo, one plain non-Django test file:
+`env -u DJANGO_SETTINGS_MODULE <repo>/.venv/bin/python -m pytest test_plain.py -p no:cacheprovider -q`
+Expected: `1 passed`, not INTERNALERROR.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add django_absurd/worker.py tests/core/test_run_after.py
+git commit -m "feat: dispatch a deferred run through a synthetic task name"
+```
+
+---
+
+### Task 2: Spawn the wrapper on a deferred enqueue
+
+**Files:**
+
+- Modify: `django_absurd/backends.py`, `django_absurd/worker.py`
+- Test: `tests/core/test_run_after.py`
+
+**Interfaces:**
+
+- Consumes: `DEFER_NAME_PREFIX` and the params shape from Task 1.
+- Produces: `enqueue` returns a `TaskResult` whose id names the **wrapper** row.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_a_deferred_enqueue_spawns_a_wrapper_named_for_its_target(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    register_jsonb_loader(connections["default"].connection)
+    with dj_absurd.freeze_time():
+        tasks.add.using(run_after=dj_absurd.now + dt.timedelta(hours=1)).enqueue(1, 2)
+
+    claimed = get_absurd_client().claim_tasks(batch_size=1)
+    assert claimed[0]["task_name"] == "django_absurd:defer:tests.tasks.add"
+
+
+def test_a_deferred_task_keeps_the_callers_per_call_options(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # bind() options are per-invocation, so they must survive the hop to the inner spawn.
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        absurd_params(max_attempts=9, headers={"trace": "abc"}).bind(tasks.add).using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        dj_absurd.drain()
+
+    # The inner task ran inside that second drain, so read its ROW — nothing is claimable.
+    with connections["default"].cursor() as cursor:
+        cursor.execute(
+            "select max_attempts, headers from absurd.t_default "
+            "where task_name = 'tests.tasks.add'"
+        )
+        assert cursor.fetchone() == (9, {"trace": "abc"})
+
+
+def test_a_deferred_task_runs_on_the_callers_queue(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # Both rows must land on the target's queue, or a worker consuming only that queue
+    # never runs the wrapper.
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.on_reports.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue()
+        assert [run.queue for run in dj_absurd.drain("reports")] == ["reports"]
+        frozen_time.shift(dt.timedelta(hours=1))
+        assert {run.queue for run in dj_absurd.drain("reports")} == {"reports"}
+
+
+def test_a_deferred_task_routed_off_its_own_queue_lands_where_it_was_sent(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # tasks.add's own queue is "default"; routing it to "other" is what makes the wrapper
+    # re-route the inner enqueue. A target that already declares the queue it is sent to
+    # (tasks.on_reports above) leaves that branch untaken, so this is the case that
+    # covers `if target_task.queue_name != queue` in enqueue_deferred_target.
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.add.using(
+            queue_name="other", run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        assert [run.queue for run in dj_absurd.drain("other")] == ["other"]
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        ran = dj_absurd.drain("other")
+        assert [run.queue for run in ran] == ["other", "other"]
+        assert ("tests.tasks.add", 3) in [(run.task_name, run.result) for run in ran]
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run:
+`uv run pytest tests/core/test_run_after.py -k "spawns_a_wrapper or per_call_options or callers_queue" -v --no-cov`
+Expected: FAIL — the first sees `task_name == "tests.tasks.add"`.
+
+Check `tests/tasks.py` for a `reports`-queue task before writing the third test; if
+`tasks.on_reports` is not the right name, use whichever exists and say so in your
+report.
+
+- [ ] **Step 3: Spawn the wrapper**
+
+In `enqueue`, replace the whole `if task.run_after is not None:` block (the
+`RUN_AFTER_HEADER` write and the `warn_if_cancellation_misreads_the_wait` call) with a
+branch choosing what to spawn. The caller's options ride in the wrapper's params; the
+wrapper gets only its own `max_attempts`:
+
+```python
+        if task.run_after is not None:
+            spawn_name = f"{DEFER_NAME_PREFIX}{task.module_path}"
+            spawn_params = {
+                "args": [],
+                "kwargs": {
+                    "args": list(args),
+                    "kwargs": dict(kwargs),
+                    "queue": task.queue_name,
+                    "options": dict(merged),
+                    "due": normalize_to_utc(task.run_after).isoformat(),
+                },
+            }
+            merged = {"max_attempts": self.default_max_attempts}
+        else:
+            spawn_name = task.module_path
+            spawn_params = {"args": list(args), "kwargs": dict(kwargs)}
+```
+
+Both `client.spawn(...)` call sites then pass `spawn_name` and `spawn_params` in place
+of `task.module_path` and the inline params dict. **The queue is unchanged** — the
+existing `queue=task.queue_name` argument already sends the wrapper to the caller's
+queue, so nothing here hardcodes `"default"`.
+
+`backends.py` cannot import `worker.py` — `worker` imports `backends`, so that closes a
+cycle. Do **not** duplicate the literal. Move it to a leaf module both import, created
+in Task 1:
+
+```python
+# django_absurd/deferred.py
+"""Where a deferred enqueue's name comes from.
+
+A constant and nothing else, so both ``backends`` (which spawns the row) and ``worker``
+(which dispatches it) can import it without a cycle and without touching settings.
+
+There is deliberately no ``@task`` here: decorating one resolves
+``task_backends["default"]`` and validates its queue at decoration time, so a project
+whose ``QUEUES`` omits ``"default"`` would raise ``InvalidTask`` on import — at dispatch,
+where it takes the worker down. The handler is built by ``worker.LazyTaskRegistry``
+instead.
+"""
+
+DEFER_NAME_PREFIX = "django_absurd:defer:"
+```
+
+Delete from `backends.py`: `RUN_AFTER_HEADER`, `warn_if_cancellation_misreads_the_wait`,
+`WARNED_DEFERRED_CANCELLATION_PATHS`, and the `logging` import plus `logger` if nothing
+else uses them. Keep `normalize_to_utc`.
+
+Delete from `worker.py`: `sleep_until_run_after`, its call inside `handler`,
+`DEFER_STEP_NAME`, and the `RUN_AFTER_HEADER` import.
+
+**Careful with `DEFER_STEP_NAME`.** Task 1's `build_deferred_handler` passes its sleep
+step name as a literal precisely so this deletion is safe. Delete the constant; do
+**not** rewrite the handler's literal to reference it, and do not mistake the handler's
+own `sleep_until` call for the one being removed — they are different code paths that
+happen to share a step name.
+
+- [ ] **Step 4: Run the three tests to verify they pass**
+
+Run:
+`uv run pytest tests/core/test_run_after.py -k "spawns_a_wrapper or per_call_options or callers_queue" -v --no-cov`
+Expected: PASS. Other tests in the file still fail — Task 3 owns them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/backends.py django_absurd/worker.py tests/core/test_run_after.py
+git commit -m "feat: spawn a deferred wrapper instead of sleeping inside the caller's task"
+```
+
+---
+
+### Task 3: `get_result` follows the wrapper, and the old tests are settled
+
+**Files:**
+
+- Modify: `django_absurd/backends.py`
+- Test: `tests/core/test_run_after.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_a_waiting_deferred_task_reads_as_ready_with_no_start_times(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time():
+        result = tasks.add.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+
+        waiting = backend.get_result(result.id)
+        assert waiting.status is TaskResultStatus.READY
+        assert waiting.started_at is None
+        assert waiting.last_attempted_at is None
+        assert waiting.args == [1, 2]          # the caller's args, not the wrapper's
+
+
+def test_a_woken_deferred_task_reports_the_targets_own_result(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.add.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        dj_absurd.drain()
+
+        done = backend.get_result(result.id)
+        assert done.status is TaskResultStatus.SUCCESSFUL
+        assert done.return_value == 3
+
+
+def test_a_deferral_that_cannot_launch_reports_failed(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # A wrapper naming a target that does not import can never launch it. Once it is out
+    # of attempts the caller sees FAILED — the deferral failed, and nothing of theirs ran.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        get_absurd_client().spawn(
+            "django_absurd:defer:tests.tasks.does_not_exist",
+            {
+                "args": [],
+                "kwargs": {
+                    "args": [],
+                    "kwargs": {},
+                    "queue": "default",
+                    "options": {},
+                    "due": (dj_absurd.now + dt.timedelta(hours=1)).isoformat(),
+                },
+            },
+            queue="default",
+            max_attempts=1,
+        )
+        drained = dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        drained = dj_absurd.drain()
+
+        result_id = f"default:{drained[0].task_id}"
+        assert backend.get_result(result_id).status is TaskResultStatus.FAILED
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run:
+`uv run pytest tests/core/test_run_after.py -k "reads_as_ready or targets_own_result or cannot_launch or prefixes_agree" -v --no-cov`
+Expected: the woken test reports the wrapper's own return value (an id string) rather
+than `3`.
+
+- [ ] **Step 3: Add the redirect**
+
+In `get_result`, branch on a completed wrapper before building a result:
+
+```python
+        task, run, worker_ids = fetch_task_and_run(
+            self.database, queue, task_id, result_id
+        )
+        if task.task_name.startswith(DEFER_NAME_PREFIX) and task.state == "completed":
+            # Its payload is the id of the task it enqueued, so the caller's id keeps
+            # describing their own task for the rest of its life.
+            return self.get_result(str(task.completed_payload))
+        return build_task_result(self, result_id, task, run, worker_ids)
+```
+
+In `build_task_result`, insert immediately after the block of local assignments and
+**before** the `try: task_obj = import_string(task_name)` below it — `task_name` is
+rebound, so order matters:
+
+```python
+    is_deferred_wrapper = task_name.startswith(DEFER_NAME_PREFIX)
+    if is_deferred_wrapper:
+        # The caller's id names the wrapper, but their TaskResult must describe THEIR
+        # task: its path is the name's suffix and its call is in the wrapper's kwargs.
+        task_name = task_name.removeprefix(DEFER_NAME_PREFIX)
+        spec = params["kwargs"]
+        params = {"args": list(spec["args"]), "kwargs": dict(spec["kwargs"])}
+        # Claimed at t=0 only so it could sleep — nothing of the caller's has started.
+        first_started_at = None
+        run_started = None
+```
+
+and on the existing `status` line:
+
+```python
+    status = map_state_to_status(state)
+    if is_deferred_wrapper and state == "sleeping":
+        # No Django status means "the deferral is retrying", and READY is the honest
+        # answer to whether the caller's task has started. A failing launch stays visible
+        # through `errors` below, and ends FAILED once out of attempts.
+        status = TaskResultStatus.READY
+```
+
+**Do not widen the `errors` block** — the earlier draft said to, and its premise is
+false. `absurd.fail_run` inserts the retry run with `failure_reason` NULL and repoints
+`last_attempt_run` at it, so a wrapper in backoff has no failure to surface (measured:
+`sleeping / attempts=2 / READY / errors=[]` with and without the change). A struggling
+launch is therefore invisible to `get_result` until attempts run out and it reports
+FAILED; it is visible on the wrapper's own admin row throughout.
+
+Delete `waits_for_its_run_after` — the prefix check replaces it, which removes the
+aware-clock comparison and its `USE_TZ` handling.
+
+- [ ] **Step 4: Settle every existing test in the file**
+
+The file has eleven tests. Disposition for each — do not leave any as-is without
+checking:
+
+| Test                                                           | Action                                                                                                                                                                                 |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test_run_after_is_accepted_now_that_defer_is_supported`       | keep, unchanged                                                                                                                                                                        |
+| `test_run_after_rides_a_namespaced_spawn_header`               | **delete** — the header no longer exists; Task 2's wrapper-name test replaces it                                                                                                       |
+| `test_run_after_merges_with_a_caller_s_own_headers`            | **delete** — we never touch the caller's headers now; Task 2's per-call-options test covers what it protected                                                                          |
+| `test_a_run_after_already_past_runs_on_the_first_drain`        | **rewrite** — the drain now returns wrapper + target, so assert both, and read state through the backend                                                                               |
+| `test_a_deferred_task_sleeps_until_run_after_then_runs_once`   | **rewrite** — second drain returns two runs, and `.attempts` would read the wrapper's                                                                                                  |
+| `test_a_deferred_task_runs_its_own_steps_exactly_once`         | **rewrite** — second drain returns wrapper `completed` + target `sleeping`. Still worth keeping: it proves the caller's own steps are untouched now that nothing is injected into them |
+| `test_a_waiting_deferred_task_reports_no_start_times`          | **delete** — folded into Step 1's `reads_as_ready_with_no_start_times`                                                                                                                 |
+| `test_a_deferred_task_survives_a_project_that_disables_use_tz` | **rewrite** — still load-bearing (the wrapper's `sleep_until` needs an aware instant, and `normalize_to_utc` is what supplies it), but its drain assertion breaks                      |
+| `test_deferring_a_task_that_sets_cancellation_warns_once`      | **delete** — the warning is gone, because the bug it warned about is gone                                                                                                              |
+| `test_a_deferred_task_reads_as_ready_while_it_waits`           | **delete** — replaced by Step 1's version                                                                                                                                              |
+| `test_a_woken_deferred_task_no_longer_reads_as_ready`          | **delete** — replaced by Step 1's `targets_own_result`, which asserts more                                                                                                             |
+
+- [ ] **Step 4b: Fix two tautological queue assertions Task 2 flagged**
+
+`RunSnapshot.queue` is the queue passed to `drain()`, not a per-run column
+(`test.py:363` — `queue=queue`). So
+`assert [run.queue for run in drain("reports")] == ["reports"]` cannot fail, and both
+queue tests from Task 2 assert it. The real evidence is already there: a drain of one
+queue only claims rows from that queue, so finding the rows there _is_ the proof.
+Replace the `run.queue` assertions with task names:
+
+```python
+    # in test_a_deferred_task_runs_on_the_callers_queue
+        assert [run.task_name for run in dj_absurd.drain("reports")] == [
+            "django_absurd:defer:tests.tasks.on_reports"
+        ]
+        frozen_time.shift(dt.timedelta(hours=1))
+        assert sorted(run.task_name for run in dj_absurd.drain("reports")) == [
+            "django_absurd:defer:tests.tasks.on_reports",
+            "tests.tasks.on_reports",
+        ]
+
+    # in test_a_deferred_task_routed_off_its_own_queue_lands_where_it_was_sent
+        # drop the `[run.queue for run in ran] == ["other", "other"]` line; the
+        # ("tests.tasks.add", 3) membership assertion below it is the load-bearing one
+```
+
+- [ ] **Step 5: Prove both cancellation bugs are fixed**
+
+These two are why the plan exists. Both fail on the old mechanism.
+
+```python
+def test_a_deferred_tasks_max_duration_measures_its_body_not_its_wait(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = absurd_params(cancellation={"max_duration": 60}).bind(tasks.add).using(
+            run_after=dj_absurd.now + dt.timedelta(hours=2)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=2))
+        dj_absurd.drain()
+
+        assert backend.get_result(result.id).return_value == 3
+
+
+def test_a_deferred_tasks_max_delay_measures_from_its_due_time(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # max_delay is "cancel if not started within N of enqueue". It must count from when
+    # the task was really enqueued — at wake — not from the caller's deferred enqueue.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = absurd_params(cancellation={"max_delay": 300}).bind(tasks.add).using(
+            run_after=dj_absurd.now + dt.timedelta(hours=2)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=2))
+        dj_absurd.drain()
+
+        assert backend.get_result(result.id).return_value == 3
+```
+
+Run both. If the second passes trivially (because the inner task runs immediately at
+wake and never has a chance to be late), say so in your report rather than dressing it
+up — a test that cannot fail is worth knowing about.
+
+- [ ] **Step 6: Decide the fixture's own read path**
+
+`dj_absurd.get_result` (`django_absurd/test.py`) is a **separate** read path from the
+backend's and is NOT redirected by anything above. A deferred id read through it reports
+the raw wrapper row: `task_name` with the prefix, `args`/`kwargs` from the wrapper's
+params, `result` the inner id string.
+
+Leave it un-redirected — a test facade reporting the row that exists is defensible, and
+the fixture is for inspecting real state. But **add a test pinning that behaviour** so
+it is a decision rather than an accident, and a sentence to `docs/web/testing.md`'s
+`get_result` section. If you think it should redirect instead, stop and report rather
+than deciding alone.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add django_absurd/backends.py django_absurd/test.py tests/core/test_run_after.py docs/web/testing.md
+git commit -m "feat: report a deferred task's real result through its wrapper"
+```
+
+---
+
+### Task 4: Docs, then every gate
+
+**Files:**
+
+- Modify: `docs/web/tasks.md`, `django_absurd/AGENTS.md`
+
+- [ ] **Step 1: Delete the cancellation caveat from both**
+
+`tasks.md`'s admonition ("`run_after` and `cancellation` measure the wait differently")
+and `AGENTS.md`'s "Don't combine `run_after` with `cancellation`" describe a limitation
+that no longer exists.
+
+- [ ] **Step 2: Document what a reader will now see**
+
+In `tasks.md`'s "Run it later", replace the claimed-at-enqueue paragraph with: a
+deferred enqueue creates a second row named `django_absurd:defer:<your task path>` that
+waits and then enqueues theirs, both visible in the admin and filterable by that name;
+the id `enqueue` returned keeps working throughout — `READY` while waiting, then their
+task's own status and return value. Plus the two accepted consequences, one sentence
+each:
+
+- a very short `cleanup_ttl` can sweep the wrapper after it wakes, in which case the id
+  raises `TaskResultDoesNotExist` even though the task ran;
+- two deferred enqueues sharing one `idempotency_key` produce two wrapper rows and
+  dedupe when they wake, rather than at enqueue.
+
+Mirror into `AGENTS.md`, keeping it terse — that file is a user guide, not an internals
+tour.
+
+- [ ] **Step 3: Build the docs site**
+
+Run: `uvx zensical build` Expected: `No issues found`. The site slugifies
+`## Retries & spawn options` to `#retries-spawn-options` (single hyphen), not GitHub's
+double.
+
+- [ ] **Step 4: Run every gate**
+
+```bash
+uv run pytest tests/core -q --no-cov -n4 --timeout=120
+uv run pytest tests/pg_cron -q --no-cov -n4 --timeout=120   # 258
+uv run pytest tests/multidb -q --no-cov                     # 7
+uv run pre-commit run --all-files
+uvx --with tox-uv tox -e dev
+uv run pytest tests/core -q --no-cov --create-db --timeout=120
+```
+
+`tests/core` is 451 before this plan; six deletions and the new tests move it, so report
+the actual number rather than checking it against a prediction. Then the import oracle
+again, the GUC-leak check on both ports
+(`select datname, setconfig from pg_db_role_setting s join pg_database d on d.oid = s.setdatabase;`
+→ 0 rows), and `uv run coverage report --include='django_absurd/*' --show-missing` to
+confirm 100% on changed lines.
+
+- [ ] **Step 5: Rewrite the PR body**
+
+PR #135 describes the mechanism this plan replaces — header, injected sleep, and the
+cancellation limitation presented as an accepted trade. It is now actively misleading.
+Rewrite it around the wrapper, and say why the design is what it is: `spawn` has no
+`available_at`, a library-shipped `@task` cannot exist, and the cancellation defects
+came from claiming the caller's task early.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/web/tasks.md django_absurd/AGENTS.md
+git commit -m "docs: describe deferred enqueue as a wrapper row"
+```
+
+---
+
+## Notes for the implementer
+
+- **A hang means Postgres is ahead of Python.** SIGKILL, then
+  `PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d postgres -c 'alter database "absurd_test_core_gw0" reset "absurd.fake_now";'`
+  (adjust `_gwN`, or drop the suffix for the serial database).
+- Both compose services must be up: `docker compose up -d db db_pg_cron` from the repo
+  root. They do not survive a restart; a refused connection means a stopped container.
+- `run_deferred.using(run_after=...)` — a caller deferring the wrapper itself —
+  terminates after one extra hop, and `get_result` then walks two levels. No guard is
+  planned. If you find it loops or misreports, report it.
+- If any test here cannot be made to pass **as specified**, stop and report rather than
+  adjusting the assertion until it goes green. Two of this plan's predecessors were
+  wrong about what a drain returns, and the tests are what caught it.

--- a/docs/web/tasks.md
+++ b/docs/web/tasks.md
@@ -118,7 +118,35 @@ The fields (types come from `absurd_sdk`); the "Where" column is enforced by
 | `retry_strategy`  | default + per-call | Backoff: `kind` (`fixed`/`exponential`/`none`), `base_seconds`, `factor`, `max_seconds`. |
 | `cancellation`    | default + per-call | `max_duration`, `max_delay` (seconds).                                                   |
 | `headers`         | per-call only      | Arbitrary JSON metadata carried with the task.                                           |
-| `idempotency_key` | per-call only      | Dedupe — a repeat enqueue with the same key is a no-op.                                  |
+| `idempotency_key` | per-call only      | Dedupe within a queue — see the warning below.                                           |
+
+!!! warning "An idempotency key is scoped to its queue, not to your task"
+
+    A key reserves itself against **one queue**, with no task name and no arguments in
+    the comparison. Whichever enqueue gets there first owns the key; every later
+    enqueue is swallowed and handed the **first** task's id — even a different task,
+    even with different arguments:
+
+    ```python
+    absurd_params(idempotency_key="nightly").bind(send_report).enqueue(42)
+    absurd_params(idempotency_key="nightly").bind(purge_cache).enqueue()
+    # -> same id, and purge_cache never runs
+    ```
+
+    Namespace the key yourself so it identifies the work: include the task and the
+    thing it acts on, e.g. `f"send_report:{report_id}:{date}"`. The
+    [beat scheduler](cron-jobs.md) does this for its own spawns — its keys are a
+    `cron:`-prefixed hash of the schedule name, cron expression, and slot.
+
+    Two more properties worth knowing:
+
+    - **Different queues never collide.** The same key on `default` and on `reports`
+      reserves independently, and both tasks run.
+    - **A key is held for as long as its task row exists** — freed only once the task
+      is terminal and [cleanup](cleanup.md) deletes it, `cleanup_ttl` (default 30
+      days) after it finished. A task still pending, running, or sleeping holds its
+      key indefinitely. So a key is not a "once per hour" window; it is "once until
+      the row is swept."
 
 The decorator's `max_attempts` and `cancellation` fields mirror the defaults accepted by
 Absurd's own [task definition](https://earendil-works.github.io/absurd/)

--- a/docs/web/tasks.md
+++ b/docs/web/tasks.md
@@ -31,6 +31,25 @@ result = send_report.enqueue(42)   # returns a TaskResult; a worker runs it
 Enqueuing rides the surrounding database transaction — a task spawned inside `atomic()`
 is dropped if the block rolls back.
 
+### Run it later
+
+Django's
+[`run_after`](https://docs.djangoproject.com/en/6.0/ref/tasks/#django.tasks.Task.run_after)
+defers a single enqueue to a moment of your choosing:
+
+```python
+send_report.using(run_after=timezone.now() + dt.timedelta(hours=1)).enqueue(42)
+```
+
+It takes a timezone-aware `datetime`. A deferred enqueue creates a second row named
+`<your task's dotted path>:run_after` that waits, then enqueues yours with the options
+you passed — both rows are visible in the admin, and the name makes deferred work
+filterable by target. The id `enqueue` returned keeps working throughout: it reads
+`READY` while the wrapper waits, then your task's own status and return value once it
+runs. If the wrapper's own launch struggles, that id stays `READY` with no visible
+errors until it runs out of attempts, then reports `FAILED`. For a repeating schedule
+rather than a one-off, use [Scheduling](cron-jobs.md).
+
 ## Retries & spawn options
 
 Absurd's spawn options (retries, retry backoff, idempotency, …) attach through one

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -208,6 +208,14 @@ A task-level view cannot express an in-flight [retry](tasks.md#retries-spawn-opt
 right after that run executes, so a retry sequence reads attempt-by-attempt instead of
 collapsing to one ambiguous final read.
 
+**A deferred task's id names its wrapper here.** A [`run_after`](tasks.md#run-it-later)
+enqueue creates a `<your task path>:run_after` row that waits and then enqueues yours,
+and this method reports the row the id names: a prefixed `task_name`, the wrapper's own
+`args`/`kwargs`, and your task's id as `result`. That is deliberate — the fixture is for
+inspecting the state that really exists. Django's own
+[`my_task.get_result(result.id)`](tasks.md#read-the-result) follows the wrapper through
+to your task instead, so use that when you want your task's status and return value.
+
 ### `now`
 
 Virtual now, timezone-aware, as Postgres itself reports it — read through the fixture's

--- a/examples/web/app.py
+++ b/examples/web/app.py
@@ -5,16 +5,18 @@ browse the read-only queue tables in the admin (auto-registered by django-absurd
 
 Also demonstrates Steps (checkpoints) + Events: an order-fulfillment
 workflow that checkpoints each step and suspends on await_event until a
-"mark packed" button emits the matching event.
+"mark packed" button emits the matching event; and run_after, which defers an
+enqueue until a chosen moment.
 
     docker compose up
-    http://localhost:8000/         enqueue add(a, b) or the order workflow
+    http://localhost:8000/         enqueue add(a, b), defer one, or the order workflow
     http://localhost:8000/admin/  Tasks / Runs / Checkpoints / Waits / … (admin / admin)
 
 psycopg (v3) backend required — DATABASES is overridden (nanodjango defaults to sqlite).
 """
 
 import dataclasses
+import datetime as dt
 import html
 import logging
 import os
@@ -29,6 +31,7 @@ from django.shortcuts import redirect
 from django.tasks import TaskResultStatus, default_task_backend, task
 from django.tasks.exceptions import TaskResultDoesNotExist
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 from nanodjango import Django
 
@@ -103,6 +106,12 @@ class AddForm(forms.Form):
     b = forms.CharField(label="B")
 
 
+class LaterForm(forms.Form):
+    a = forms.CharField(label="A")
+    b = forms.CharField(label="B")
+    seconds = forms.IntegerField(label="Run in (seconds)", initial=10, min_value=1)
+
+
 class WorkflowForm(forms.Form):
     order = forms.CharField(label="Order", initial="order-42")
 
@@ -125,10 +134,47 @@ def index(request: HttpRequest) -> HttpResponse | str:
           <button type="submit">Add</button>
         </form>
         <p>
+          <a href="/later/">Run one later</a>
+          — the same task, deferred with <code>run_after</code>.
+        </p>
+        <p>
           <a href="/workflow/">Try the order-fulfillment workflow</a>
           — checkpointed steps with a wait between them.
         </p>
         <p><a href="/admin/">Browse the queues in the admin</a> (admin / admin)</p>
+    """
+
+
+@app.route("/later/")
+def later_view(request: HttpRequest) -> HttpResponse | str:
+    """Defer the SAME add task with run_after — nothing about the task changes.
+
+    The result page reports READY for the whole wait, then the task's own value.
+    Meanwhile the admin gains a second row, `app.add:run_after`, which
+    is what waits; it enqueues `add` when the time comes.
+    """
+    if request.method == "POST":
+        form = LaterForm(request.POST)
+        if form.is_valid():
+            seconds = form.cleaned_data.pop("seconds")
+            due = timezone.now() + dt.timedelta(seconds=seconds)
+            result = add.using(run_after=due).enqueue(**form.cleaned_data)
+            return redirect(f"/tasks/{result.id}/")
+    else:
+        form = LaterForm()
+    return f"""
+        <h1>Run a task later</h1>
+        <p>
+          Enqueues <code>add(a, b)</code> with
+          <code>run_after=now + seconds</code>. Watch the result page sit at
+          <strong>READY</strong> until it comes due — nothing has run yet.
+        </p>
+        <form method="post">
+          <input type="hidden" name="csrfmiddlewaretoken" value="{get_token(request)}">
+          {form.as_p()}
+          <button type="submit">Schedule it</button>
+        </form>
+        <p><a href="/">Back</a></p>
     """
 
 

--- a/examples/web/pyproject.toml
+++ b/examples/web/pyproject.toml
@@ -3,6 +3,8 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest-django",
+  # Freezing durable time is opt-in: django-absurd never bundles it.
+  "time-machine",
 ]
 
 [project]

--- a/examples/web/tests/test_views.py
+++ b/examples/web/tests/test_views.py
@@ -3,6 +3,7 @@ the Django test client, asserting observable responses. The `add` task and the
 `fulfill_order` workflow are exercised end-to-end via the `dj_absurd` fixture's
 `drain()`."""
 
+import datetime as dt
 import uuid
 
 import pytest
@@ -121,3 +122,37 @@ def test_pack_view_rejects_an_off_site_next(client: Client) -> None:
     resp = client.get("/workflow/order-x/pack/?next=https://evil.example/steal")
     assert resp.status_code == 302
     assert resp.headers["Location"] == "/"
+
+
+def test_later_get_renders_the_defer_form(client: Client) -> None:
+    body = client.get("/later/").content.decode()
+    assert "Run a task later" in body
+    assert 'name="seconds"' in body
+
+
+def test_later_post_invalid_rerenders_the_form(client: Client) -> None:
+    resp = client.post("/later/", {"a": "1", "seconds": "10"})  # missing b
+    assert resp.status_code == 200
+    assert "This field is required." in resp.content.decode()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_deferred_add_reads_ready_until_it_comes_due(
+    client: Client, dj_absurd: AbsurdTestRuntime
+) -> None:
+    with dj_absurd.freeze_time() as frozen_time:
+        resp = client.post("/later/", {"a": "2", "b": "3", "seconds": "10"})
+        detail_url = resp.headers["Location"]
+
+        # The wrapper is claimed and sleeps; nothing of add() has run.
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+        assert (
+            "Status: <strong>READY</strong>" in client.get(detail_url).content.decode()
+        )
+
+        frozen_time.shift(dt.timedelta(seconds=10))
+        dj_absurd.drain()
+
+        body = client.get(detail_url).content.decode()
+        assert "Status: <strong>SUCCESSFUL</strong>" in body
+        assert "Result: <strong>5.0</strong>" in body

--- a/tests/core/test_run_after.py
+++ b/tests/core/test_run_after.py
@@ -1,0 +1,440 @@
+import datetime as dt
+
+import pytest
+from django.db import connections
+from django.tasks import TaskResultStatus, task_backends
+from django.utils import timezone
+from pytest_django.fixtures import SettingsWrapper
+
+from django_absurd import absurd_params
+from django_absurd.connection import register_jsonb_loader
+from django_absurd.queues import get_absurd_client
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks
+
+pytestmark = [
+    pytest.mark.django_db(transaction=True),
+    pytest.mark.usefixtures("_isolate_queues"),
+]
+
+
+def test_run_after_is_accepted_now_that_defer_is_supported(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    run_after = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
+
+    result = tasks.add.using(run_after=run_after).enqueue(1, 2)
+
+    assert result.status is TaskResultStatus.READY
+
+
+def test_a_run_after_already_past_runs_on_the_first_drain(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # A wrapper already due never suspends, so both rows run in the one drain.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time():
+        run_after = dj_absurd.now - dt.timedelta(hours=1)
+        result = tasks.add.using(run_after=run_after).enqueue(1, 2)
+
+        assert [(run.task_name, run.state) for run in dj_absurd.drain()] == [
+            ("tests.tasks.add:run_after", "completed"),
+            ("tests.tasks.add", "completed"),
+        ]
+        done = backend.get_result(result.id)
+        assert done.status is TaskResultStatus.SUCCESSFUL
+        assert done.return_value == 3
+
+
+def test_a_deferred_task_sleeps_until_run_after_then_runs_once(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.add.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        assert [(run.task_name, run.state) for run in dj_absurd.drain()] == [
+            ("tests.tasks.add:run_after", "completed"),
+            ("tests.tasks.add", "completed"),
+        ]
+        assert backend.get_result(result.id).return_value == 3
+        # The caller's id names the wrapper, whose attempts are its own, so count the
+        # target's through the id the wrapper recorded.
+        inner_id = str(dj_absurd.get_result(result.id).result)
+        assert dj_absurd.get_result(inner_id).attempts == 1
+
+
+def test_a_deferred_task_runs_its_own_steps_exactly_once(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # Nothing is injected into the caller's task any more: its step and its sleep are
+    # the only checkpoints in its own namespace, and the wrapper's sleep belongs to a
+    # different task entirely. A replayed "bump" would mean the two had merged.
+    dj_absurd.sync_queues()
+    tasks.SYNC_STEP_CALLS["n"] = 0
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.ssleep_for_once.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue("k")
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]  # the wrapper
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        assert [(run.task_name, run.state) for run in dj_absurd.drain()] == [
+            ("tests.tasks.ssleep_for_once:run_after", "completed"),
+            ("tests.tasks.ssleep_for_once", "sleeping"),  # its own nap
+        ]
+
+        frozen_time.shift(dt.timedelta(days=8))
+        assert [(run.state, run.result) for run in dj_absurd.drain()] == [
+            ("completed", 1)
+        ]
+
+    assert tasks.SYNC_STEP_CALLS["n"] == 1
+
+
+def test_a_deferred_task_survives_a_project_that_disables_use_tz(
+    dj_absurd: AbsurdTestRuntime, settings: SettingsWrapper
+) -> None:
+    # Django only rejects a naive run_after when USE_TZ is on, and timezone.now() is
+    # itself naive when it is off — so normalize_to_utc is what keeps the instant the
+    # wrapper's sleep_until receives aware, or a deferred task dies far from its cause.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    settings.USE_TZ = False
+    with dj_absurd.freeze_time() as frozen_time:
+        # timezone.now() is naive under USE_TZ=False — the shape a real project's
+        # own code hands to run_after.
+        run_after = timezone.now() + dt.timedelta(hours=1)
+        result = tasks.add.using(run_after=run_after).enqueue(1, 2)
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+        assert backend.get_result(result.id).status is TaskResultStatus.READY
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        assert [(run.task_name, run.state) for run in dj_absurd.drain()] == [
+            ("tests.tasks.add:run_after", "completed"),
+            ("tests.tasks.add", "completed"),
+        ]
+        assert backend.get_result(result.id).return_value == 3
+
+
+def test_a_waiting_deferred_task_reads_as_ready_with_no_start_times(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time():
+        result = tasks.add.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+
+        waiting = backend.get_result(result.id)
+        assert waiting.status is TaskResultStatus.READY
+        assert waiting.started_at is None
+        assert waiting.last_attempted_at is None
+        assert waiting.args == [1, 2]  # the caller's args, not the wrapper's
+
+
+def test_a_woken_deferred_task_reports_the_targets_own_result(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.add.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        dj_absurd.drain()
+
+        done = backend.get_result(result.id)
+        assert done.status is TaskResultStatus.SUCCESSFUL
+        assert done.return_value == 3
+
+
+def test_a_deferral_that_cannot_launch_reports_failed(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # A wrapper told to launch its target onto a queue the backend never declared can
+    # never launch it. Once it is out of attempts the caller sees FAILED, carrying the
+    # launch's own error — the deferral failed, and nothing of theirs ran.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        get_absurd_client().spawn(
+            "tests.tasks.add:run_after",
+            {
+                "args": [],
+                "kwargs": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                    "queue": "undeclared",
+                    "options": {},
+                    "due": (dj_absurd.now + dt.timedelta(hours=1)).isoformat(),
+                },
+            },
+            queue="default",
+            max_attempts=1,
+        )
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        drained = dj_absurd.drain()
+
+        failed = backend.get_result(f"default:{drained[0].task_id}")
+        assert failed.status is TaskResultStatus.FAILED
+        assert [error.exception_class_path for error in failed.errors] == [
+            "InvalidTask"
+        ]
+
+
+def test_a_deferral_retrying_its_launch_still_reads_as_ready(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # Django has no status for "the deferral is retrying", and READY is the truthful
+    # answer to whether the caller's task has started — so a wrapper in retry backoff
+    # reads READY too, not the RUNNING that "sleeping" maps to for everything else.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        get_absurd_client().spawn(
+            "tests.tasks.add:run_after",
+            {
+                "args": [],
+                "kwargs": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                    "queue": "undeclared",
+                    "options": {},
+                    "due": (dj_absurd.now + dt.timedelta(hours=1)).isoformat(),
+                },
+            },
+            queue="default",
+            max_attempts=3,
+            retry_strategy={"kind": "fixed", "base_seconds": 7200},
+        )
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        drained = dj_absurd.drain()
+
+        result_id = f"default:{drained[0].task_id}"
+        assert dj_absurd.get_result(result_id).state == "sleeping"
+        assert backend.get_result(result_id).status is TaskResultStatus.READY
+
+
+def test_a_deferred_tasks_max_duration_measures_its_body_not_its_wait(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = (
+            absurd_params(cancellation={"max_duration": 60})
+            .bind(tasks.add)
+            .using(run_after=dj_absurd.now + dt.timedelta(hours=2))
+            .enqueue(1, 2)
+        )
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=2))
+        dj_absurd.drain()
+
+        assert backend.get_result(result.id).return_value == 3
+
+
+def test_a_deferred_tasks_max_delay_measures_from_its_due_time(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # max_delay is "cancel if not started within N of enqueue". It must count from when
+    # the task was really enqueued — at wake — not from the caller's deferred enqueue.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        result = (
+            absurd_params(cancellation={"max_delay": 300})
+            .bind(tasks.add)
+            .using(run_after=dj_absurd.now + dt.timedelta(hours=2))
+            .enqueue(1, 2)
+        )
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=2))
+        dj_absurd.drain()
+
+        assert backend.get_result(result.id).return_value == 3
+
+
+def test_the_fixtures_own_read_path_reports_the_wrapper_row(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # dj_absurd.get_result is a separate read path from the backend's and deliberately
+    # is NOT redirected: the fixture exists to inspect the state that really exists, so
+    # a deferred id reports the wrapper row it names — prefixed name, the wrapper's own
+    # params, and the inner task's id as its result.
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        result = tasks.add.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        dj_absurd.drain()
+
+        wrapper = dj_absurd.get_result(result.id)
+        assert wrapper.task_name == "tests.tasks.add:run_after"
+        assert wrapper.args == []
+        assert wrapper.kwargs["args"] == [1, 2]
+        assert dj_absurd.get_result(str(wrapper.result)).task_name == "tests.tasks.add"
+
+
+def test_a_deferred_enqueue_spawns_a_wrapper_named_for_its_target(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    register_jsonb_loader(connections["default"].connection)
+    with dj_absurd.freeze_time():
+        tasks.add.using(run_after=dj_absurd.now + dt.timedelta(hours=1)).enqueue(1, 2)
+
+    claimed = get_absurd_client().claim_tasks(batch_size=1)
+    assert claimed[0]["task_name"] == "tests.tasks.add:run_after"
+
+
+def test_a_deferred_task_keeps_the_callers_per_call_options(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # bind() options are per-invocation, so they must survive the hop to the inner
+    # spawn.
+    dj_absurd.sync_queues()
+    register_jsonb_loader(connections["default"].connection)
+    with dj_absurd.freeze_time() as frozen_time:
+        absurd_params(max_attempts=9, headers={"trace": "abc"}).bind(tasks.add).using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(hours=1))
+        dj_absurd.drain()
+
+    # The inner task ran inside that second drain, so read its ROW — nothing is
+    # claimable.
+    with connections["default"].cursor() as cursor:
+        cursor.execute(
+            "select max_attempts, headers from absurd.t_default "
+            "where task_name = 'tests.tasks.add'"
+        )
+        assert cursor.fetchone() == (9, {"trace": "abc"})
+
+
+def test_a_deferred_task_runs_on_the_callers_queue(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # Both rows must land on the target's queue, or a worker consuming only that queue
+    # never runs the wrapper. A drain of one queue claims only that queue's rows, so
+    # finding the rows in this drain IS the proof of where they live — RunSnapshot.queue
+    # is the argument passed to drain(), so asserting on it cannot fail.
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.on_reports.using(
+            run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue()
+        assert [run.task_name for run in dj_absurd.drain("reports")] == [
+            "tests.tasks.on_reports:run_after"
+        ]
+        frozen_time.shift(dt.timedelta(hours=1))
+        # Claim order, which here is execution order: the wrapper wakes and enqueues,
+        # then the task it enqueued runs in the same drain.
+        assert [run.task_name for run in dj_absurd.drain("reports")] == [
+            "tests.tasks.on_reports:run_after",
+            "tests.tasks.on_reports",
+        ]
+
+
+def test_a_deferred_task_routed_off_its_own_queue_lands_where_it_was_sent(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # tasks.add's own queue is "default"; routing it to "other" is what makes the
+    # wrapper re-route the inner enqueue. A target that already declares the queue it
+    # is sent to (tasks.on_reports above) leaves that branch untaken, so this is the
+    # case that covers `if target_task.queue_name != queue` in enqueue_deferred_target.
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.add.using(
+            queue_name="other", run_after=dj_absurd.now + dt.timedelta(hours=1)
+        ).enqueue(1, 2)
+        assert [run.task_name for run in dj_absurd.drain("other")] == [
+            "tests.tasks.add:run_after"
+        ]
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        ran = dj_absurd.drain("other")
+        assert ("tests.tasks.add", 3) in [(run.task_name, run.result) for run in ran]
+
+
+def test_a_deferred_name_sleeps_then_enqueues_its_target(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    with dj_absurd.freeze_time() as frozen_time:
+        due = (dj_absurd.now + dt.timedelta(hours=1)).isoformat()
+        get_absurd_client().spawn(
+            "tests.tasks.add:run_after",
+            {
+                "args": [],
+                "kwargs": {
+                    "args": [1, 2],
+                    "kwargs": {},
+                    "queue": "default",
+                    "options": {},
+                    "due": due,
+                },
+            },
+            queue="default",
+        )
+
+        assert [run.state for run in dj_absurd.drain()] == ["sleeping"]
+
+        frozen_time.shift(dt.timedelta(hours=1))
+        ran = [(run.task_name, run.state) for run in dj_absurd.drain()]
+        assert ("tests.tasks.add:run_after", "completed") in ran
+        assert ("tests.tasks.add", "completed") in ran
+
+
+def test_deferred_enqueues_sharing_an_idempotency_key_collapse_to_one_wrapper(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # The caller's key rides to the inner enqueue, so the wrapper carries a derived one
+    # — without it the herd spawns a wrapper each and dedupes only on waking; with the
+    # caller's key verbatim the wrapper would collide with the target it goes on to
+    # enqueue.
+    dj_absurd.sync_queues()
+    backend = task_backends["default"]
+    with dj_absurd.freeze_time() as frozen_time:
+        due = dj_absurd.now + dt.timedelta(hours=1)
+        bound = absurd_params(idempotency_key="nightly").bind(
+            tasks.add.using(run_after=due)
+        )
+
+        first = bound.enqueue(1, 2)
+        second = bound.enqueue(1, 2)
+
+        assert first.id == second.id
+        assert [run.task_name for run in dj_absurd.drain()] == [
+            "tests.tasks.add:run_after"
+        ]
+
+        frozen_time.move_to(due + dt.timedelta(minutes=1))
+
+        assert [run.task_name for run in dj_absurd.drain()] == [
+            "tests.tasks.add:run_after",
+            "tests.tasks.add",
+        ]
+        done = backend.get_result(first.id)
+        assert done.status is TaskResultStatus.SUCCESSFUL
+        assert done.return_value == 3


### PR DESCRIPTION
Django's `run_after` defers one enqueue. Absurd's `spawn` has no `available_at`, so there is
no scheduled spawn to map it onto — a deferred task has to be made to wait some other way.

`enqueue` spawns a second row named `<your task's dotted path>:run_after`, which waits until
the due time and then enqueues yours with the options you set. The id `enqueue` returns keeps
working throughout: `READY` while waiting, then your task's own status and return value.
`supports_defer` flips to `True`.

## Why a wrapper rather than sleeping inside the task

The first attempt on this branch made the caller's task sleep. That claims it at t=0, which
sets `first_started_at` before any work exists — and both of Absurd's `cancellation` rules
pivot on that column. `max_duration` counted the wait and could cancel a task before its body
ran; `max_delay` could never fire at all. Measured, not theorised: `max_duration=60` with
`run_after=+2h` was cancelled five minutes in.

A wrapper removes the cause. `cancellation` rides through to the inner spawn, so
`max_duration` measures execution and `max_delay` measures from the due time. The caller's task
is untouched — no injected step sharing its checkpoint namespace, no header written into
theirs.

## Why it is not a `@task`

A library cannot ship one. `@task` resolves `task_backends["default"]` and validates its queue
at decoration time, so with `QUEUES=["reports"]` importing it raises `InvalidTask: Queue
'default' is not valid for backend.` — at dispatch, where `LazyTaskRegistry`'s `except
ImportError` does not catch it and the worker goes down. It also reads settings at import,
which `django_absurd.test` cannot afford. So the name is synthetic and our own registry builds
the handler; the target rides in the name, which makes deferred work filterable per task in
the admin.

## Idempotency

The wrapper spawns with a derived key, `<your key>:run_after`, so deferred enqueues sharing an
`idempotency_key` collapse to one wrapper at enqueue and every caller gets the same id back —
identical to a non-deferred enqueue. The key has to be derived rather than reused: wrapper and
target share one per-queue uniqueness scope, so a verbatim key would reserve itself against the
wrapper row and the enqueue it later makes would dedupe against itself, leaving the target
unrun.

That scope is `(queue, key)` alone — no task name, no arguments — which was undocumented and
surprising enough to earn a warning in `docs/web/tasks.md` and `AGENTS.md`.

## Known consequence

A deferral whose launch keeps erroring reads `READY` until its attempts run out, then `FAILED`.
Django has no status meaning "retrying", and the wrapper's own admin row shows it throughout.

Both cancellation rules have a test that fails on the old mechanism. `spawn(available_at=...)`
upstream would retire the wrapper entirely.

Closes #116
