### PR TITLE
docs: stop naming a pg_cron cleanup job that does not exist

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -636,16 +636,26 @@ TASKS = {
 ```
 
 This works under **either** scheduler: beat runs cleanup in-process on the declared
-cadence; pg_cron schedules Absurd's own native cleanup job (`absurd_cleanup_all`, the
-same identity `absurdctl cron` uses — compatible, not a parallel job). When
-`django_absurd.pg_cron` is installed, django-absurd is authoritative over that job: it
-schedules it from `OPTIONS["CLEANUP"]` and removes it otherwise — including at migrate
-teardown / scheduler-flip even when `CLEANUP` was never set — so a job created via
-`absurdctl cron` is reclaimed and removed. Drive cleanup one way only —
-`OPTIONS["CLEANUP"]` **or** `absurdctl cron`, not both. `manage.py check` reports
-`absurd.E010` for a malformed `CLEANUP` (the beat cron grammar is checked then too;
-pg_cron's is validated by the database at sync). Retention knobs (`cleanup_ttl`,
-`cleanup_limit`) remain per-queue policy — set them in `OPTIONS["QUEUES"]`.
+cadence; pg_cron calls Absurd's own native cleanup function (`absurd.cleanup_all_queues`
+— a SQL function in Absurd's schema, not something the Python SDK exposes) from a job on
+django-absurd's own database-namespaced lane, `_dj:<absurd database>:c:cleanup_all`.
+
+Absurd's built-in maintenance scheduler is a separate mechanism: `absurd.enable_cron`,
+which `absurdctl cron --enable <queue>` drives, creates **per-queue** jobs
+(`absurd_cleanup_<suffix>`, `absurd_partitions_<suffix>`, `absurd_detach_plan_<suffix>`)
+and needs `cron.schedule` in the Absurd database itself — which a central
+`cron.database_name` topology never provides. django-absurd does not use it.
+
+So django-absurd is authoritative over **its own** job only: it schedules that from
+`OPTIONS["CLEANUP"]` and removes it otherwise, including at migrate teardown or a
+scheduler flip even when `CLEANUP` was never set. It never sees or removes an
+`absurd_cleanup_<suffix>` job created by `absurdctl cron` — those names sit outside the
+namespace django-absurd manages, so they survive every teardown and would fire alongside
+it. **Drive cleanup one way only** — `OPTIONS["CLEANUP"]` **or** `absurdctl cron`, never
+both. `manage.py check` reports `absurd.E010` for a malformed `CLEANUP` (the beat cron
+grammar is checked then too; pg_cron's is validated by the database at sync). Retention
+knobs (`cleanup_ttl`, `cleanup_limit`) remain per-queue policy — set them in
+`OPTIONS["QUEUES"]`.
 
 **Reset (destructive):** `manage.py absurd_flush` **deletes all task history** — it
 removes every queue (its per-queue tables and registry entry) along with all tasks,

--- a/django_absurd/pg_cron/reconcile.py
+++ b/django_absurd/pg_cron/reconcile.py
@@ -17,15 +17,17 @@ from django_absurd.queues import resolve_absurd_database
 from django_absurd.scheduler import get_cleanup_schedule, get_settings_schedules
 from django_absurd.tasks import build_merged_spawn_options
 
-# Absurd's global queue-cleanup job. It rides the catalog seam like every other
+# The OPTIONS["CLEANUP"] job. It rides the catalog seam like every other
 # schedule, on its own db-namespaced lane (source="c" → jobname
-# _dj:<app db>:c:cleanup_all), so it's scoped to the app database and swept by the same
-# per-database flush. This deliberately breaks the old shared ``absurd_cleanup_all``
-# identity with
-# absurd.enable_cron / `absurdctl cron` — under central topology those same-DB functions
-# can't run in the app DB anyway. Drive cleanup ONE way — OPTIONS["CLEANUP"] OR
-# `absurdctl cron`, not both (deferred: multi-manager cleanup-job arbitration is out of
-# scope here).
+# _dj:<app db>:c:cleanup_all), so it's scoped to the app database and swept by
+# the same per-database flush.
+#
+# Deliberately NOT absurd.enable_cron / `absurdctl cron --enable <queue>`, which
+# schedule per-queue jobs (absurd_cleanup_<suffix>, absurd_partitions_<suffix>,
+# absurd_detach_plan_<suffix>) and need cron.schedule in the app database — which
+# the central cron.database_name topology never gives it. Nothing here can see or
+# unschedule those names, so drive cleanup ONE way — OPTIONS["CLEANUP"] OR
+# `absurdctl cron`, not both (deferred: multi-manager arbitration is out of scope).
 CLEANUP_SOURCE = "c"
 CLEANUP_NAME = "cleanup_all"
 CLEANUP_COMMAND = "select * from absurd.cleanup_all_queues(null::text);"

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -343,12 +343,22 @@ overwrite a name already captured, only fill in one it hasn't seen yet.
 Retention — deleting aged task history — is enforced by a plain function
 (`cleanup_queues()`) plus an on-demand command (`absurd_cleanup`), and wired to a
 cadence via `OPTIONS["CLEANUP"] = {"schedule": "<cron>"}`. No user code required: the
-library drives cleanup in-process under beat, and schedules Absurd's own native cleanup
-job (`absurd_cleanup_all`, the same identity `absurdctl cron` uses — not a parallel job)
-under pg_cron — the same declarative config works for both schedulers. When
-`OPTIONS["CLEANUP"]` is set, django-absurd is authoritative over that job (schedules and
-unschedules it), so cleanup is driven one way only — via `OPTIONS["CLEANUP"]` or
-`absurdctl cron`, not both (multi-manager arbitration deferred).
+library drives cleanup in-process under beat, and under pg_cron schedules a job calling
+Absurd's own native cleanup function — the same declarative config works for both
+schedulers.
+
+That job rides the ordinary schedule seam, on its own source lane namespaced by the app
+database, rather than reusing the identity Absurd's built-in maintenance scheduler would
+have used. Two reasons, and only the second is about tidiness. Absurd's own maintenance
+scheduling needs `cron.schedule` in the Absurd database itself, which the cross-database
+topology above never provides — so that path is unavailable here, not merely declined.
+And riding the normal lane means the same per-database scoping, teardown, and flush that
+every other schedule gets, instead of a second bespoke reconcile path.
+
+The cost is that the two mechanisms are now invisible to each other: a maintenance job
+created by Absurd's own tooling is outside the namespace this package manages, so
+nothing here can see or remove it and both would fire. Hence cleanup must be driven one
+way only (multi-manager arbitration deferred) — a warning, not an implementation detail.
 
 The first iteration shipped the retention logic and asked each project to wrap it in its
 own `@task` and register that task in `SCHEDULE`. That was a reasonable first step, but

--- a/docs/web/cleanup.md
+++ b/docs/web/cleanup.md
@@ -59,13 +59,21 @@ TASKS = {
 This works under **either** scheduler:
 
 - **beat** — runs cleanup in-process on the declared cadence.
-- **pg_cron** — schedules Absurd's own native cleanup job (`absurd_cleanup_all`, the
-  same identity `absurdctl cron` uses) alongside your other cron jobs (see
+- **pg_cron** — calls Absurd's own native cleanup function (`absurd.cleanup_all_queues`)
+  from a job on django-absurd's own database-namespaced lane,
+  `_dj:<absurd database>:c:cleanup_all`, alongside your other cron jobs (see
   [Cron Jobs](cron-jobs.md)). When `django_absurd.pg_cron` is installed, django-absurd
-  is authoritative over this job: it schedules it from `OPTIONS["CLEANUP"]` and removes
-  it otherwise — including at migrate teardown / scheduler-flip even when `CLEANUP` was
-  never set — so a job created via `absurdctl cron` is reclaimed and removed. Drive
-  cleanup one way only — `OPTIONS["CLEANUP"]` **or** `absurdctl cron`, not both.
+  is authoritative over **that** job: it schedules it from `OPTIONS["CLEANUP"]` and
+  removes it otherwise — including at migrate teardown / scheduler-flip even when
+  `CLEANUP` was never set.
+
+!!! warning "Drive cleanup one way only"
+
+    `OPTIONS["CLEANUP"]` **or** `absurdctl cron` — never both. Absurd's own maintenance
+    scheduler (`absurd.enable_cron`, which `absurdctl cron --enable <queue>` drives) is a
+    separate mechanism creating **per-queue** jobs, and django-absurd neither uses nor
+    manages it. It cannot see or remove those jobs, so they survive every teardown and
+    would fire alongside its own.
 
 `manage.py check` reports `absurd.E010` for a malformed `CLEANUP` (not a
 `{"schedule": …}` map, or unknown keys); the cron grammar is checked at `check` time for
@@ -98,12 +106,12 @@ python manage.py absurd_flush --noinput  # drops without prompting
 
     Any existing scheduled jobs (pg_cron schedule jobs and beat schedules) survive the
     flush and will **error on each fire** until the queues exist again — re-provision
-    promptly. Exception: the `absurd_cleanup_all` job (set via `OPTIONS["CLEANUP"]`)
-    also survives and runs harmlessly — it finds no eligible rows until queues are
-    re-provisioned.
+    promptly. Exception: the cleanup job from `OPTIONS["CLEANUP"]`
+    (`_dj:<absurd database>:c:cleanup_all`) also survives and runs harmlessly — it finds
+    no eligible rows until queues are re-provisioned.
 
     `absurd_flush` (via per-queue `drop_queue` → `disable_cron`) also removes that
     queue's per-queue Absurd maintenance cron jobs (`absurd_partitions_<md5>` /
     `absurd_cleanup_<md5>` / `absurd_detach_plan_<md5>`) if any were created via
-    `absurdctl cron --enable <queue>`; the global `absurd_cleanup_all` job is
-    unaffected (it survives).
+    `absurdctl cron --enable <queue>`; the `OPTIONS["CLEANUP"]` job is not per-queue and
+    is unaffected (it survives).


### PR DESCRIPTION
`absurd_cleanup_all` appears nowhere — not in `absurd_sdk`, the pinned schema SQL, or the `absurdctl` wheel. Our job is `_dj:<absurd db>:c:cleanup_all`; `absurd.enable_cron` makes per-queue `absurd_cleanup_<suffix>` jobs we never touch.

That also made "a job created via `absurdctl cron` is reclaimed and removed" false — every unschedule goes through `build_jobname`, so those jobs survive teardown and fire alongside ours. Now a warning.

`reconcile.py` is comment-only.