### PR TITLE
feat: send Django's task signals from AbsurdBackend

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -216,6 +216,11 @@ accepted by Absurd's own [task definition](https://earendil-works.github.io/absu
 time. Backend capabilities: result retrieval, async tasks, and deferred (run-later)
 enqueue are supported; priority is not.
 
+`max_attempts=None` is accepted (and typed) at both sites, and means **retry forever** —
+Absurd stores a NULL ceiling and retries while it is NULL. Omitting `max_attempts` is
+not the same thing: the backend fills in its own `OPTIONS["DEFAULT_MAX_ATTEMPTS"]` (5)
+on every enqueue, so only an explicit `None` reaches the unbounded behaviour.
+
 **An idempotency key is scoped to its queue, not to your task.** A key reserves itself
 against one queue, with no task name and no arguments in the comparison. Whichever
 enqueue arrives first owns the key; every later enqueue is swallowed and handed the
@@ -685,6 +690,9 @@ send_report.get_result(result.id)              # fetch by id (sync)
 await send_report.aget_result(result.id)       # async variant
 ```
 
+Every id has the same `"<queue>:<uuid>"` shape — including `context.task_result.id`
+inside a `takes_context` task, so that can be handed straight back to `get_result`.
+
 ## Exceptions
 
 django-absurd raises its own exception types for conditions specific to this package,
@@ -945,6 +953,17 @@ run (also needs `OPTIONS["SYNC_SCHEDULES_ON_TEST_DB"] = True` —
 test — it doesn't care how it got there, only what's present.
 
 ## Deployment notes
+
+### Django Task lifecycle logging
+
+Django's own `django.tasks` logger reports each task's lifecycle on this backend —
+`DEBUG` on enqueue, `INFO` on start and on success, `ERROR` with a traceback when a
+task's last attempt raises — because `AbsurdBackend` emits Django's task signals.
+
+Django's logs are not a complete record. Postgres is: a retried attempt's failure logs
+nothing, and neither does an ending Absurd decides on its own.
+[Queue state](#querying-queue-state-orm) and the [stored result](#retrieving-results)
+are the record.
 
 - **Database privileges.** `migrate` runs `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`
   and `CREATE SCHEMA IF NOT EXISTS absurd`, so the migrating role needs rights to create

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -12,9 +12,11 @@ from django.tasks import TaskResult, TaskResultStatus, task_backends
 from django.tasks.backends.base import BaseTaskBackend
 from django.tasks.base import TaskError
 from django.tasks.exceptions import TaskResultDoesNotExist
+from django.tasks.signals import task_enqueued
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
+from django_absurd import dispatch
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
 from django_absurd.deferred import DEFER_NAME_SUFFIX
@@ -203,7 +205,7 @@ class AbsurdBackend(BaseTaskBackend):
                     queue=task.queue_name,
                     **merged,
                 )
-        return TaskResult(
+        result: TaskResult[t.Any, t.Any] = TaskResult(
             task=task,
             id=f"{task.queue_name}:{spawn_result['task_id']}",
             status=TaskResultStatus.READY,
@@ -217,6 +219,8 @@ class AbsurdBackend(BaseTaskBackend):
             errors=[],
             worker_ids=[],
         )
+        dispatch.send_task_signal(task_enqueued, type(self), result)
+        return result
 
     def get_result(self, result_id: str) -> "TaskResult[t.Any, t.Any]":
         queue, task_id = decode_result_id(result_id)
@@ -331,8 +335,11 @@ def build_task_result(
     except ImportError as exc:
         msg = f"task '{task_name}' is no longer importable"
         raise ImproperlyConfigured(msg) from exc
-    if task_obj.queue_name != queue:
-        task_obj = task_obj.using(queue_name=queue)
+    # Rebinding re-runs Task.__post_init__, which validates the queue against the
+    # DEFINITION's backend alias — one this read need not have configured. So the alias
+    # moves with the queue.
+    if (task_obj.queue_name, task_obj.backend) != (queue, backend.alias):
+        task_obj = task_obj.using(queue_name=queue, backend=backend.alias)
     status = map_state_to_status(state)
     if is_deferred_wrapper and state == "sleeping":
         # No Django status means "the deferral is retrying", and READY is the honest

--- a/django_absurd/dispatch.py
+++ b/django_absurd/dispatch.py
@@ -1,0 +1,44 @@
+"""The one place every django-absurd signal send goes through.
+
+Routing sends through here means a receiver's exception can never reach the task: the
+send is wrapped in its own try/except, logged, and swallowed.
+"""
+
+import logging
+import typing as t
+
+from django.dispatch import Signal
+from django.tasks.signals import task_enqueued, task_finished, task_started
+
+if t.TYPE_CHECKING:
+    from django.tasks import TaskResult
+
+logger = logging.getLogger("django_absurd")
+
+# A Signal's repr carries nothing identifying, and a caught exception's traceback holds
+# no frame above the raise, so neither says WHICH send a receiver broke.
+SIGNAL_NAMES: dict[Signal, str] = {
+    task_enqueued: "task_enqueued",
+    task_finished: "task_finished",
+    task_started: "task_started",
+}
+
+
+def send_task_signal(
+    signal: Signal, sender: type, task_result: "TaskResult[t.Any, t.Any]"
+) -> None:
+    """Send ``signal`` for ``task_result``, logging (not raising) a receiver failure.
+
+    Catches ``Exception``, never ``BaseException``: ``asyncio.CancelledError`` at
+    shutdown must still propagate.
+    """
+    try:
+        signal.send(sender, task_result=task_result)
+    except Exception:
+        # A missing name degrades to the generic word: a KeyError raised here would
+        # escape the containment and reach the task.
+        logger.exception(
+            "django-absurd %s receiver failed for task result id=%s",
+            SIGNAL_NAMES.get(signal, "signal"),
+            task_result.id,
+        )

--- a/django_absurd/params.py
+++ b/django_absurd/params.py
@@ -91,7 +91,7 @@ class PerCallParams(ParamsBase):
 @t.overload
 def absurd_params(
     *,
-    max_attempts: int = ...,
+    max_attempts: int | None = ...,
     retry_strategy: RetryStrategy = ...,
     cancellation: CancellationPolicy = ...,
 ) -> AbsurdParams: ...
@@ -100,7 +100,7 @@ def absurd_params(
 @t.overload
 def absurd_params(
     *,
-    max_attempts: int = ...,
+    max_attempts: int | None = ...,
     retry_strategy: RetryStrategy = ...,
     cancellation: CancellationPolicy = ...,
     headers: JsonObject = ...,
@@ -110,7 +110,7 @@ def absurd_params(
 
 def absurd_params(
     *,
-    max_attempts: int | NotSet = NOT_SET,
+    max_attempts: int | NotSet | None = NOT_SET,
     retry_strategy: RetryStrategy | NotSet = NOT_SET,
     cancellation: CancellationPolicy | NotSet = NOT_SET,
     headers: JsonObject | NotSet = NOT_SET,

--- a/django_absurd/tasks.py
+++ b/django_absurd/tasks.py
@@ -23,7 +23,7 @@ class SpawnKwargs(t.TypedDict, total=False):
     accept — mirrors their signatures field-for-field so ``**merged`` calls into them
     type-check per field instead of collapsing to a union."""
 
-    max_attempts: int
+    max_attempts: int | None
     # Two known gaps we deliberately do not guard. An unrecognised ``kind`` is
     # validated NOWHERE: absurd.fail_run does coalesce(v_retry_strategy->>'kind',
     # 'none') and falls through to v_delay_seconds := 0, so a typo retries with no

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -9,6 +9,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from traceback import format_exception
 
 import psycopg
 import psycopg.errors
@@ -25,10 +26,13 @@ from asgiref.sync import sync_to_async
 from django.core.exceptions import ImproperlyConfigured
 from django.db import close_old_connections, connections
 from django.tasks import Task, TaskContext, TaskResult, TaskResultStatus
+from django.tasks.base import TaskError
+from django.tasks.signals import task_finished, task_started
 from django.utils import timezone
+from django.utils.json import normalize_json
 from django.utils.module_loading import import_string
 
-from django_absurd import admin_views
+from django_absurd import admin_views, dispatch
 from django_absurd.backends import AbsurdBackend, RunModel, TaskParams
 from django_absurd.connection import register_jsonb_loader, validate_backend
 from django_absurd.context import WORKER_LOOP
@@ -85,9 +89,10 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
     entry mixes str/None/Callable fields, so the inner ``Any`` is a genuine boundary.
     """
 
-    def __init__(self, queue: str) -> None:
+    def __init__(self, queue: str, backend: AbsurdBackend) -> None:
         super().__init__()
         self.queue = queue
+        self.backend = backend
 
     @t.overload
     def get(self, name: str, default: None = None, /) -> dict[str, t.Any] | None: ...
@@ -121,7 +126,7 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
                 "queue": self.queue,
                 "default_max_attempts": None,
                 "default_cancellation": None,
-                "handler": build_handler(task),
+                "handler": build_handler(task, backend=self.backend, queue=self.queue),
             }
         return super().get(name, default)
 
@@ -212,7 +217,7 @@ async def aworker_client(
     try:
         register_jsonb_loader(conn)
         client = AsyncAbsurd(conn, queue_name=queue)
-        client._registry = LazyTaskRegistry(queue)  # noqa: SLF001 -- SDK has no public fallback-resolver hook; install lazy import_string resolution
+        client._registry = LazyTaskRegistry(queue, backend)  # noqa: SLF001 -- SDK has no public fallback-resolver hook; install lazy import_string resolution
         try:
             # Probes for the schema-absent guard; raises if Absurd is not migrated.
             await client.list_queues()
@@ -308,32 +313,49 @@ async def fetch_run_outcome(
     return run.state, run.result, run.failure_reason
 
 
-def build_task_context(
+def build_running_task_result(
     task: "Task[t.Any, t.Any]",
     ctx: AsyncTaskContext,
     args: t.Sequence[t.Any],
     kwargs: dict[str, t.Any],
-) -> "TaskContext[t.Any, t.Any]":
+    *,
+    backend: AbsurdBackend,
+    queue: str,
+) -> "TaskResult[t.Any, t.Any]":
+    # ClaimedTask carries no queue, and the re-imported task holds its
+    # definition-time one, so only the worker's own queue is authoritative here. The
+    # alias moves with it: rebinding re-runs Django's Task.__post_init__, which
+    # validates the queue against whatever backend the DEFINITION named — an alias a
+    # beat-scheduled task need not even have configured — and the TaskResult below
+    # reports this worker's alias anyway.
+    if (task.queue_name, task.backend) != (queue, backend.alias):
+        task = task.using(queue_name=queue, backend=backend.alias)
     attempt = read_sdk_attempt(ctx)
+    # One instant for both fields, as Django's own backend does: this handler entry IS
+    # the attempt, so "when it started" and "when it was last attempted" cannot differ.
+    started_at = timezone.now()
     task_result: TaskResult[t.Any, t.Any] = TaskResult(
         task=task,
-        id=ctx.task_id,
+        id=f"{queue}:{ctx.task_id}",
         status=TaskResultStatus.RUNNING,
         enqueued_at=None,
-        started_at=timezone.now(),
+        started_at=started_at,
         finished_at=None,
-        last_attempted_at=None,
+        last_attempted_at=started_at,
         args=list(args),
         kwargs=dict(kwargs),
-        backend=task.backend,
+        backend=backend.alias,
         errors=[],
         worker_ids=["absurd"] * attempt,
     )
-    return TaskContext(task_result=task_result)
+    return task_result
 
 
 def build_handler(
     task: "Task[t.Any, t.Any]",
+    *,
+    backend: AbsurdBackend,
+    queue: str,
 ) -> t.Callable[[TaskParams, AsyncTaskContext], t.Awaitable[JsonValue]]:
     async def handler(params: TaskParams, ctx: AsyncTaskContext) -> JsonValue:
         WORKER_LOOP.set(asyncio.get_running_loop())
@@ -347,9 +369,13 @@ def build_handler(
             ctx.task_id,
             attempt,
         )
+        task_result = build_running_task_result(
+            task, ctx, args, kwargs, backend=backend, queue=queue
+        )
+        dispatch.send_task_signal(task_started, type(backend), task_result)
         try:
             if task.takes_context:
-                ctx_ = build_task_context(task, ctx, args, kwargs)
+                ctx_: TaskContext[t.Any, t.Any] = TaskContext(task_result=task_result)
             if inspect.iscoroutinefunction(task.func):
                 if task.takes_context:
                     result = t.cast("JsonValue", await task.func(ctx_, *args, **kwargs))
@@ -368,6 +394,9 @@ def build_handler(
 
                 result = await asyncio.to_thread(call_sync)
         except (SuspendTask, CancelledTask, FailedTask) as exc:
+            # Absurd decided this run's fate itself, so no task_finished is sent: these
+            # are not endings Django's task signals describe. The arm exists to keep
+            # them out of the ``except Exception`` arm below, which WOULD report one.
             logger.info(
                 "django-absurd task received %s: name=%s task_id=%s attempt=%d",
                 type(exc).__name__,
@@ -376,7 +405,7 @@ def build_handler(
                 attempt,
             )
             raise
-        except Exception:
+        except Exception as exc:
             duration = time.monotonic() - start
             logger.exception(
                 "django-absurd task failed: name=%s task_id=%s attempt=%d "
@@ -386,6 +415,7 @@ def build_handler(
                 attempt,
                 duration,
             )
+            send_finished_if_terminal(ctx, attempt, exc, task_result, backend=backend)
             raise
         else:
             duration = time.monotonic() - start
@@ -397,14 +427,75 @@ def build_handler(
                 attempt,
                 duration,
             )
+            object.__setattr__(task_result, "status", TaskResultStatus.SUCCESSFUL)
+            object.__setattr__(task_result, "finished_at", timezone.now())
+            # normalize_json, as Django's own backend applies to a raw return value
+            # before storing it — otherwise a receiver sees the tuple a task returned
+            # while ``get_result().return_value`` reads back the list Postgres holds.
+            # The value handed BACK to the SDK stays raw; only the payload normalizes.
+            object.__setattr__(task_result, "_return_value", normalize_json(result))
+            dispatch.send_task_signal(task_finished, type(backend), task_result)
             return result
 
     return handler
 
 
+def send_finished_if_terminal(
+    ctx: AsyncTaskContext,
+    attempt: int,
+    exc: Exception,
+    task_result: "TaskResult[t.Any, t.Any]",
+    *,
+    backend: AbsurdBackend,
+) -> None:
+    """Send ``task_finished`` for a failed run, but only once it is provably terminal.
+
+    A failed non-final attempt is READY again, not FAILED — Absurd itself will retry
+    it, so sending here would be a false completion signal.
+
+    Sent from inside the handler's ``except`` arm, so ``sys.exc_info()`` already holds
+    ``exc`` — the traceback Django's ``log_task_finished`` attaches to its ERROR line is
+    the task's own, matching the ``TaskError`` payload with nothing to arrange.
+    """
+    if not is_terminal_attempt(attempt, read_sdk_max_attempts(ctx)):
+        return
+    mark_task_result_failed(task_result, exc)
+    dispatch.send_task_signal(task_finished, type(backend), task_result)
+
+
+def is_terminal_attempt(attempt: int, max_attempts: int | None) -> bool:
+    """Whether this attempt is the last one Absurd will make.
+
+    ``fail_run`` retries when ``v_max_attempts is null or v_next_attempt <=
+    v_max_attempts``, so a NULL ``max_attempts`` means retry forever: no attempt is
+    ever terminal, and ``task_finished`` must stay unsent.
+    """
+    return max_attempts is not None and attempt >= max_attempts
+
+
+def mark_task_result_failed(
+    task_result: "TaskResult[t.Any, t.Any]", exc: Exception
+) -> None:
+    """Mutate ``task_result`` into its terminal FAILED shape, exactly as
+    ``ImmediateBackend._execute_task`` does for its own failure branch."""
+    object.__setattr__(task_result, "status", TaskResultStatus.FAILED)
+    object.__setattr__(task_result, "finished_at", timezone.now())
+    task_result.errors.append(
+        TaskError(
+            exception_class_path=f"{type(exc).__module__}.{type(exc).__qualname__}",
+            traceback="".join(format_exception(exc)),
+        )
+    )
+
+
 def read_sdk_attempt(ctx: AsyncTaskContext) -> int:
     attempt: int = ctx._task["attempt"]  # noqa: SLF001 -- SDK TaskContext has no public attempt property
     return attempt
+
+
+def read_sdk_max_attempts(ctx: AsyncTaskContext) -> int | None:
+    max_attempts: int | None = ctx._task["max_attempts"]  # noqa: SLF001 -- SDK TaskContext has no public max_attempts property
+    return max_attempts
 
 
 async def run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions) -> None:

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -1,0 +1,124 @@
+# Upstream asks
+
+Gaps in [Absurd](https://github.com/earendil-works/absurd) — SDK or schema — that
+django-absurd currently compensates for. One section per **askable change**: what we
+would want, why, and which workaround it retires. Grouped that way on purpose, so a
+section can be filed as-is rather than re-derived from a list of symptoms.
+
+**Nothing here is filed yet.** When upstream ships one, delete the section rather than
+marking it done, and remove the workaround it names.
+
+Three of these are marked in code by the `noqa: SLF001` comments in
+`django_absurd/worker.py` — each names the private attribute it reaches and why.
+
+## Accept a future availability on `spawn`
+
+`spawn` can only make a task immediately available; the schema's `spawn_task` takes no
+availability argument.
+
+Needed for `run_after`. Today a deferred enqueue spawns a **wrapper** task that sleeps
+until due and then enqueues the caller's task (`django_absurd/deferred.py`). The obvious
+alternative — claim the caller's own task and sleep inside it — starts both cancellation
+clocks before any of the work exists, which is the design we built and abandoned (see
+[WHY.md](WHY.md), "deferred enqueue").
+
+So this ask and the next are entangled: fix the clocks and an injected sleep becomes
+viable; fix `spawn` and no sleep is needed at all.
+
+Retires: the wrapper name, its handler, and the derived idempotency key that keeps the
+wrapper from deduping against itself.
+
+## Exclude deliberate suspension from the cancellation clocks
+
+Both cancellation policies treat "suspended on purpose" and "waiting to be picked up" as
+the same thing. Durable sleep is a first-class Absurd feature the policy has no concept
+of.
+
+- `max_duration` is measured from `first_started_at` and keeps accruing across
+  `ctx.sleep_for` / `await_event`. A workflow that deliberately waits a day cannot also
+  be given a one-hour execution budget.
+- `max_delay` cancels a task that has not started within its window, and the check stops
+  applying once a run is claimed. A task claimed promptly and then suspended
+  indefinitely is never cancelled by delay.
+
+One ask, two symptoms: the clocks should measure work, not waiting.
+
+Retires: nothing. No workaround exists — we document the trap. It is also what makes the
+ask above expensive.
+
+## Surface a run's terminal outcome to the worker
+
+**Concretely: a third entry in `AbsurdHooks`,** `after_run_outcome(ctx, outcome)`, fired
+once the run's completion / failure / cancellation is persisted. That TypedDict already
+exists and its own docstring names "tracing, **logging**, and context propagation" as
+its purpose — this is an increment to a documented extension point, not a new concept.
+
+Its two current hooks both stop short. `before_spawn` runs at enqueue;
+`wrap_task_execution` wraps the handler call, so it is still inside the window _before_
+the outcome is written. Verified against upstream `main`, not just our pinned wheel:
+there is no `after_task` / `on_complete` / `after_run`, and no hook receives the result
+or the exception outside the wrapped handler.
+
+Meanwhile `_execute_task` catches `SuspendTask` / `CancelledTask` / `FailedTask` and
+swallows the result of its own `fail_run` call, so nothing reports what the run became.
+
+Two consequences:
+
+- When attempts remain but `max_duration` is exceeded, `fail_run` cancels the task
+  instead of retrying it, and we never learn the task went terminal.
+- There is no post-persist seam at all on the blocking-worker path, which is the SDK's
+  own claim → execute → gather loop.
+
+Needed wherever a worker must know how a run actually ended. Burst draining reads the
+outcome back from the database for exactly this reason (`fetch_run_outcome`), and any
+observer of an Absurd-side ending — a cancellation, an expired claim, a `max_duration`
+sweep — has no seam to learn of it from.
+
+## Public API to execute one claimed run and return its outcome
+
+`work_batch` runs its own claim loop. Burst draining needs "execute exactly these
+claims, then stop", so `execute_claimed_run` calls `client._execute_task`. And because
+no public accessor keys by `run_id` — only by `task_id`, which collapses a retry's
+several runs into one answer — the outcome comes from a second read through the
+per-queue dynamic model.
+
+Ask: a public `execute(claimed) -> outcome`. It retires both workarounds at once; a read
+accessor keyed by `run_id` would retire half.
+
+Retires: the `_execute_task` reach, `fetch_run_outcome`, and the `sync_to_async` hop
+that read forces — along with the once-per-run `close_old_connections` it needs so a
+Django session on asgiref's thread-sensitive executor cannot outlive the worker and
+block `DROP DATABASE`.
+
+## Call an optional resolver before deferring an unknown task
+
+A framework integration cannot enumerate its tasks. Django has no task registry — tasks
+are decorated functions, discoverable only by importing the module that defines them —
+so eager registration means Celery-style `tasks.py` autodiscovery, which misses every
+task defined anywhere else. What is needed is resolution by dotted path, on demand.
+
+Ask: at the existing `if not registration:` branch in `_execute_task`, call an optional
+resolver callable before falling through to the unknown-task defer. Registration stays
+exactly as it is for everyone who can enumerate.
+
+django-absurd resolves by replacing `_registry` with `LazyTaskRegistry`, a `dict`
+subclass overriding `.get`, so any importable `Task` resolves on first claim. That works
+because all three registry reads (SDK lines 1252, 1728, 2233) go through `.get`. If one
+ever becomes `_registry[name]` or `name in _registry`, the override stops firing and the
+SDK defers the run with jitter instead — **silently**, no exception, no log, task never
+executes. Cheap workaround, bad failure mode.
+
+Retires: `LazyTaskRegistry`.
+
+## Expose `attempt`, `run_id` and `enqueue_at` on the task context
+
+`ClaimedTask` carries `attempt` and `run_id`; `TaskContext` exposes neither, so
+`read_sdk_attempt` reaches into `ctx._task`. Every attempt-aware behaviour depends on it
+— retry-terminal predicates, `TaskResult.worker_ids`, `TaskContext.attempt`.
+
+Nothing exposes the task's enqueue time either, so a `TaskResult` a worker builds
+carries `enqueued_at=None` — correct at enqueue, unknown at execution.
+
+Ask: public properties for all three.
+
+Retires: `read_sdk_attempt`, and the `enqueued_at=None` compromise.

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -114,6 +114,79 @@ enqueueing a second task. While the wrapper waits, the caller's id reports "read
 truthful answer to "has my task started", and the framework has no status meaning "the
 deferral is retrying."
 
+### Lifecycle signals: sent for the framework's logging, not offered as a hook
+
+The framework logs a task's lifecycle by receiving its own three task signals, so a
+backend that sends none logs nothing. Sending them is therefore part of the backend
+contract, and not sending them was a plain defect rather than a missing feature. That —
+wiring Absurd tasks into the framework's built-in logging — is the whole reason they are
+sent. They are deliberately not promoted as an extension point: the stored result and
+the queue-state models answer the same questions without sitting inside a live run, so
+the docs point there instead.
+
+The package registers no receiver of its own either. An unfiltered receiver fires for
+every configured backend, so listening would mean reporting tasks that never touched the
+engine.
+
+**The sends must not be able to damage a task, and are contained in one place.**
+Uncontained, an exception from any receiver — including the framework's own — escapes
+into the engine's error handling, which reads it as the _task_ failing, so one buggy
+receiver would consume every attempt of every task until the queue was uniformly failed.
+Each seam has a worse variant: a raiser on the success send re-executes an
+already-succeeded body, one on the failure send persists the receiver's error as the
+task's failure reason, and one on the enqueue seam leaves a deferred wrapper's
+checkpoint uncommitted and duplicates the very enqueue it woke to make. One helper, so
+there is one rule and one branch.
+
+**Worker-side sends happen inline, on the loop.** The framework's built-in receivers
+only log, and nothing that only logs needs a database — so the sends stay where the
+handler already is. A receiver that does reach for the ORM meets the framework's
+async-safety guard and is contained and logged like any other broken receiver, which is
+the honest outcome once the signals are not an extension point. Two costs come with
+being inline and are accepted rather than mitigated: the sends sit inside the claim
+lease, because the run's completion is not persisted until the handler returns, and a
+receiver runs on the same loop as the task's own durable operations.
+
+**Only provable terminality is announced, and a start is per episode.** The framework's
+four result statuses have no member for "retrying", "cancelled" or "sleeping", so a
+failed non-final attempt has nowhere honest to go but "ready" — reporting a finish per
+attempt would make the framework log an error and a traceback for a task that later
+succeeds. Symmetrically, a suspended task re-enters its handler from the top on every
+wake, and the information freely available cannot distinguish a replay of this run from
+a retry of a task that had already completed a step — so a start is reported per
+episode, and the docs say so rather than pretending otherwise.
+
+**Endings the engine decides on its own are outside what these signals describe.** They
+report the lifecycle the framework knows: enqueued, started, and finished on success or
+on a failure the task's own code raised. The engine ends tasks on several paths of its
+own — a delay or duration budget expiring before or between claims, an expired claim,
+cancelling a task nothing has claimed — none of which reaches a handler or reports an
+outcome back, and two more (a cancel, or a run failed elsewhere) which a handler DOES
+observe, as an error out of the run's next durable write.
+
+Reporting those last two was tried and dropped, and that is what makes the rule one rule
+instead of two plus a list of exceptions. A handler sees them only when the deciding
+event happens to land while a worker is mid-run; the same cancel arriving a moment
+earlier is one of the unreported paths. Announcing a finish that depends on that race is
+worse than not announcing one, and it cost two exported exception types to dress the
+engine's internal classes up as ours for a payload field only a receiver reads.
+Predicting the unreported paths instead would mean replicating the engine's retry and
+duration arithmetic in Python, duplicating pinned-SQL policy, and still would not turn
+an engine decision into a framework lifecycle event. The handler's arm for those three
+exceptions therefore only logs and re-raises — but it must exist, because they are
+ordinary exception subclasses and the generic failure arm below would otherwise report
+them as the task failing. The stored result and the queue-state models are the record of
+what happened.
+
+**The worker is authoritative for a run's queue and backend, never the task object.** A
+re-imported task carries its _definition's_ queue and alias, so a task defined on one
+backend and enqueued onto Absurd would otherwise be reported under one backend at
+enqueue and another at execution, and its result id would name the wrong queue and fail
+to resolve. Both the worker and the result read therefore force queue and alias together
+— separately is not an option, because the framework's routing call re-validates the
+queue against whichever backend the definition named, an alias the project need not have
+configured at all.
+
 ## Durable execution: steps & sleep
 
 Absurd's durable primitives — checkpointed steps and durable sleep (a task suspends and

--- a/docs/plans/2026-08-02-task-signals.md
+++ b/docs/plans/2026-08-02-task-signals.md
@@ -1,0 +1,1110 @@
+# Task Signals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `AbsurdBackend` sends Django's `task_enqueued` / `task_started` /
+`task_finished`, so Django's own `django.tasks` logging works for Absurd tasks.
+
+**Architecture:** Two seams. `backends.enqueue` sends `task_enqueued` after a successful
+spawn. `worker.build_handler` sends `task_started` per handler entry, and
+`task_finished` on a success or on a terminal failure the task's own code raised —
+inline, where the handler already is. Endings Absurd decides on its own send nothing.
+Every send goes through one contained helper in a new `django_absurd/dispatch.py`, so a
+receiver can never fail a task. The signals are not an extension point: users are not
+invited to build on them.
+
+**Tech Stack:** Django 6.0 Tasks API, absurd-sdk, psycopg3, pytest + pytest-django +
+pytest-asyncio, the project's `dj_absurd` fixture.
+
+**Spec:**
+[`docs/specs/2026-08-01-task-signals-design.md`](../specs/2026-08-01-task-signals-design.md).
+Read it before Task 1 — it carries the reasoning this plan only executes.
+
+## Global Constraints
+
+- Floor Django 6.0 / Python 3.12. psycopg3 backend only.
+- `import typing as t` — never `from typing import X`. Absolute imports only.
+- Functions contain a verb. No leading-underscore module constants or helpers. Helpers
+  go BELOW the public function that uses them.
+- Own exception types under `DjangoAbsurdError` in `django_absurd/exceptions.py`; the
+  exception owns its message; constructor takes the data.
+- Re-raise inside `except` always chains `from exc`. Never `from None`.
+- No ruff ignores or `noqa` beyond the one **pre-authorized in Task 5**. No
+  `unittest.mock.patch`. No comments narrating prior state.
+- Log past tense, after the action.
+- 100% statement + branch coverage on lines this patch adds.
+- Tests: pytest, function-based only. Read [`tests/CLAUDE.md`](../../tests/CLAUDE.md)
+  first.
+  - Autouse `_enable_db` gives DB access. Add `@pytest.mark.django_db(transaction=True)`
+    to any test that drains, crosses a thread, or calls `dj_absurd.get_result` —
+    `guard_against_open_transaction` raises otherwise.
+  - Type the fixture: `dj_absurd: AbsurdTestRuntime`, from `django_absurd.test`. Never
+    `t.Any` — the real type is what catches the two-result-types mistake below
+    statically.
+  - Fixture parameters are alphabetized: `(caplog, dj_absurd)`.
+  - Anything that executes freezes time through `dj_absurd`, never `time.sleep`.
+
+**The two result types — the single most likely mistake in this plan:**
+
+| Call                                      | Returns             | Has                                                                |
+| ----------------------------------------- | ------------------- | ------------------------------------------------------------------ |
+| `task_backends["default"].get_result(id)` | Django `TaskResult` | `.status`, `.return_value`, `.errors`, `.attempts`                 |
+| `dj_absurd.get_result(id)`                | `TaskSnapshot`      | `.queue`, `.task_id`, `.state`, `.result`, `.failure`, `.attempts` |
+
+`TaskSnapshot` has **no** `.id`, `.status`, `.return_value` or `.errors`. Use the
+backend for Django semantics, the fixture for Absurd state.
+`test_run_after.py:37,46-48,71-72` uses both side by side.
+
+- Gates: `uv run pytest tests/core/<file> -v` while iterating, then
+  `uvx --with tox-uv tox -e dev` and `uv run pre-commit run --all-files` before each
+  task's final commit. Never invoke ruff or mypy directly.
+- Compose services up first: `docker compose up -d db db_pg_cron`.
+
+---
+
+### Task 1: Contained dispatch + the enqueue seam
+
+**Files:**
+
+- Create: `django_absurd/dispatch.py`
+- Create: `tests/core/test_signals_enqueue.py`
+- Modify: `django_absurd/backends.py` (`enqueue`, at the `TaskResult` construction,
+  `backends.py:206-219`)
+- Modify: `tests/utils.py`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `django_absurd.dispatch.send_task_signal(signal: Signal, sender: type, task_result: TaskResult[t.Any, t.Any]) -> None`
+    — sends, catching `Exception` (never `BaseException`), logging failures. Tasks 3-6
+    use it.
+  - `tests.utils.connect_receiver(signal, receiver, *, sender)` — `contextmanager`.
+  - `tests.utils.RecordingReceiver` — thread-safe collector; `.results` returns a copy.
+
+- [ ] **Step 1: Add the test-support helpers**
+
+Append to `tests/utils.py`, merging imports into its existing block:
+
+```python
+class RecordingReceiver:
+    """Collects TaskResults from a signal.
+
+    Thread-safe because the enqueue seam sends on whatever thread called it, so a sync
+    task body enqueueing at concurrency>1 reaches it from several pool threads at once
+    and a bare list would race. A class rather than a closure so a test can hold one
+    object and read it after the block.
+    """
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.received: list[TaskResult[t.Any, t.Any]] = []
+
+    def __call__(
+        self, sender: type, task_result: "TaskResult[t.Any, t.Any]", **kwargs: t.Any
+    ) -> None:
+        with self.lock:
+            self.received.append(task_result)
+
+    @property
+    def results(self) -> list["TaskResult[t.Any, t.Any]"]:
+        with self.lock:
+            return list(self.received)
+
+
+@contextlib.contextmanager
+def connect_receiver(
+    signal: Signal, receiver: t.Any, *, sender: type
+) -> t.Iterator[None]:
+    """Connect for the duration of the block, always disconnecting.
+
+    connect() sits inside the try so a failure anywhere after it still disconnects; a
+    receiver leaked here fires for every later test in the same process. weak=False
+    because Signal.connect otherwise holds a weak reference and a receiver the caller
+    does not keep alive can be collected mid-test, silently never firing.
+    """
+    try:
+        signal.connect(receiver, sender=sender, weak=False)
+        yield
+    finally:
+        signal.disconnect(receiver, sender=sender)
+```
+
+Needs `contextlib`, `threading`, `django.dispatch.Signal`, `django.tasks.TaskResult` in
+the module's imports.
+
+- [ ] **Step 2: Write the failing tests**
+
+`tests/core/test_signals_enqueue.py`, complete and copy-pasteable:
+
+```python
+import asyncio
+import datetime as dt
+import logging
+import typing as t
+
+import pytest
+from django.tasks import TaskResultStatus
+from django.tasks.signals import task_enqueued, task_finished, task_started
+from django.utils import timezone
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import models, tasks, utils
+
+
+def test_enqueue_sends_task_enqueued() -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        result = tasks.add.enqueue(1, 2)
+
+    assert [r.id for r in receiver.results] == [result.id]
+    assert receiver.results[0].status == TaskResultStatus.READY
+    assert receiver.results[0].task.module_path == tasks.add.module_path
+
+
+@pytest.mark.django_db(transaction=True)
+def test_enqueued_payload_id_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        tasks.add.enqueue(1, 2)
+
+    sent_id = receiver.results[0].id
+    snapshot = dj_absurd.get_result(sent_id)
+    assert f"{snapshot.queue}:{snapshot.task_id}" == sent_id
+
+
+@pytest.mark.django_db(transaction=True)
+def test_aenqueue_sends_one_task_enqueued() -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        result = asyncio.run(tasks.add.aenqueue(1, 2))
+
+    assert [r.id for r in receiver.results] == [result.id]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_an_aenqueue_receiver_can_write_to_the_database() -> None:
+    """Django hops aenqueue off the loop itself via
+    sync_to_async(thread_sensitive=True), so this is the one seam where a receiver can
+    reach the ORM. Asserted rather than assumed.
+    """
+
+    def write_a_row(sender: type, task_result: t.Any, **kwargs: t.Any) -> None:
+        models.Payload.objects.create(data={"id": task_result.id})
+
+    with utils.connect_receiver(task_enqueued, write_a_row, sender=AbsurdBackend):
+        asyncio.run(tasks.add.aenqueue(1, 2))
+
+    assert models.Payload.objects.count() == 1
+
+
+def test_enqueue_survives_a_receiver_that_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def explode(sender: type, task_result: t.Any, **kwargs: t.Any) -> None:
+        raise RuntimeError("receiver is broken")
+
+    with utils.connect_receiver(task_enqueued, explode, sender=AbsurdBackend):
+        with caplog.at_level(logging.ERROR, logger="django_absurd"):
+            result = tasks.add.enqueue(1, 2)
+
+    assert result.status == TaskResultStatus.READY
+    errors = [r for r in caplog.records if r.name == "django_absurd"]
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None
+
+
+def test_django_logs_the_enqueue(caplog: pytest.LogCaptureFixture) -> None:
+    # tests/settings.py sets no LOGGING, so Django's default puts "django" at INFO and
+    # this DEBUG record is dropped at the logger before any handler sees it.
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    result = tasks.add.enqueue(1, 2)
+
+    records = [r for r in caplog.records if r.name == "django.tasks"]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert result.id in records[0].getMessage()
+    assert tasks.add.module_path in records[0].getMessage()
+
+
+def test_absurd_sender_filter_ignores_another_backend() -> None:
+    receiver = utils.RecordingReceiver()
+    on_immediate = tasks.add.using(backend="immediate")
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        on_immediate.enqueue(1, 2)
+
+    assert receiver.results == []
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_deferred_enqueue_sends_two_signals(dj_absurd: AbsurdTestRuntime) -> None:
+    enqueued = utils.RecordingReceiver()
+    started = utils.RecordingReceiver()
+    finished = utils.RecordingReceiver()
+    with utils.connect_receiver(task_enqueued, enqueued, sender=AbsurdBackend):
+        with utils.connect_receiver(task_started, started, sender=AbsurdBackend):
+            with utils.connect_receiver(task_finished, finished, sender=AbsurdBackend):
+                with dj_absurd.freeze_time() as frozen_time:
+                    due = timezone.now() + dt.timedelta(hours=1)
+                    wrapper = tasks.add.using(run_after=due).enqueue(1, 2)
+                    assert [r.id for r in enqueued.results] == [wrapper.id]
+
+                    frozen_time.shift(dt.timedelta(hours=2))
+                    dj_absurd.drain()
+
+    sent = enqueued.results
+    assert len(sent) == 2
+    assert sent[0].task.run_after is not None
+    assert sent[1].task.run_after is None
+    assert sent[0].id != sent[1].id
+    # The wrapper's id is a permanent orphan: the wrapper handler sends nothing, so only
+    # the real task's id ever starts or finishes. A refactor breaks this silently.
+    # Both assertions are vacuous until Task 3 sends task_started; Task 3 adds the
+    # positive half that makes them load-bearing.
+    assert wrapper.id not in [r.id for r in started.results]
+    assert wrapper.id not in [r.id for r in finished.results]
+```
+
+`run_after` must be a **datetime**: `validate_task` calls `timezone.is_aware()` on it,
+so a `timedelta` raises `AttributeError` at `.using()` time. Precedent:
+`test_run_after.py:116-117`.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_signals_enqueue.py -v` Expected: every test FAILS on
+empty `receiver.results` or zero `django.tasks` records, EXCEPT
+`test_absurd_sender_filter_ignores_another_backend`, which asserts emptiness and passes
+at RED — it is a guard against over-sending later, not a RED target.
+
+- [ ] **Step 4: Write `django_absurd/dispatch.py`**
+
+Minimal, in prose:
+
+- Module docstring: the one place every signal send goes through, so a receiver's
+  exception can never reach the task.
+- `logger = logging.getLogger("django_absurd")` — the flat name the package uses today;
+  the hierarchy rename belongs to a later unit of #25.
+- `send_task_signal(signal, sender, task_result)`:
+  `signal.send(sender, task_result=...)` inside `try`; `except Exception:` →
+  `logger.exception(...)` naming the task result id. `Exception`, not `BaseException` —
+  `asyncio.CancelledError` at shutdown must propagate.
+- One function. Every seam — enqueue and both worker sends — calls it directly.
+
+- [ ] **Step 5: Send from `enqueue`**
+
+Bind the constructed `TaskResult` to a name instead of returning it inline, call
+`dispatch.send_task_signal(task_enqueued, type(self), result)`, then return it. Import
+`from django_absurd import dispatch` and the signal from `django.tasks.signals`.
+Placement: after the spawn succeeded, before the return — never before the spawn.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_signals_enqueue.py -v` Expected: PASS, all nine. The
+deferred test passes with no extra production change — the wrapper's inner enqueue
+already goes through this seam.
+
+- [ ] **Step 7: Full gates, then commit**
+
+```bash
+docker compose up -d db db_pg_cron
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/dispatch.py django_absurd/backends.py tests/utils.py tests/core/test_signals_enqueue.py
+git commit -m "feat: send task_enqueued from AbsurdBackend.enqueue"
+```
+
+---
+
+### Task 2: Trust the worker's backend and queue, not the task
+
+**Files:**
+
+- Modify: `django_absurd/worker.py` (`LazyTaskRegistry`, `build_handler`,
+  `build_task_context`, the registry construction at `worker.py:215`)
+- Create: `tests/core/test_signals_worker_result.py`
+- Modify: `tests/tasks.py` (one fixture task)
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1.
+- Produces: `build_handler(task, *, backend: AbsurdBackend, queue: str)`,
+  `build_task_context(task, ctx, args, kwargs, *, backend, queue)`,
+  `LazyTaskRegistry(queue, backend)`. Tasks 3-6 send with `sender=type(backend)`.
+
+No signals in this task. Deliverable: the worker-side `TaskResult` is correct, which
+every later payload depends on.
+
+- [ ] **Step 1: Add the fixture task**
+
+In `tests/tasks.py`, matching the file's existing style (`JsonValue` is already imported
+there, and `scoverage` shows the return idiom):
+
+```python
+@task(takes_context=True)
+def report_context(context: "TaskContext[t.Any, t.Any]") -> dict[str, JsonValue]:
+    return {
+        "id": context.task_result.id,
+        "backend": context.task_result.backend,
+        "attempts": context.task_result.attempts,
+    }
+```
+
+`dict[str, JsonValue]`, not `dict[str, str]` — `attempts` is an `int`, and mypy strict
+runs on tests.
+
+- [ ] **Step 2: Write the failing tests**
+
+`tests/core/test_signals_worker_result.py`:
+
+```python
+import pytest
+
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_worker_result_id_is_queue_prefixed(dj_absurd: AbsurdTestRuntime) -> None:
+    result = tasks.report_context.enqueue()
+    dj_absurd.drain()
+
+    payload = dj_absurd.get_result(result.id).result
+    assert payload["id"] == result.id
+    assert payload["id"].startswith("default:")
+
+
+def test_worker_result_id_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
+    result = tasks.report_context.enqueue()
+    dj_absurd.drain()
+
+    payload = dj_absurd.get_result(result.id).result
+    snapshot = dj_absurd.get_result(payload["id"])
+    assert f"{snapshot.queue}:{snapshot.task_id}" == result.id
+
+
+def test_worker_result_names_the_absurd_backend(dj_absurd: AbsurdTestRuntime) -> None:
+    result = tasks.report_context.enqueue()
+    dj_absurd.drain()
+
+    assert dj_absurd.get_result(result.id).result["backend"] == "default"
+```
+
+`dj_absurd.get_result(...).result` — the snapshot's payload field. Not `.return_value`,
+which `TaskSnapshot` does not have. Read `tests/core/test_worker.py:111-129` for the
+`takes_context` drain idiom.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_signals_worker_result.py -v` Expected: FAIL, and not
+for the obvious reason — today the id is a `uuid.UUID`, so the SDK's `json.dumps` of the
+return payload raises `TypeError`, the task burns its attempts, and `.result` is `None`.
+The failure surfaces as `TypeError: 'NoneType' object is not subscriptable`. That IS the
+RED; do not go hunting for a different cause.
+
+- [ ] **Step 4: Plumb the backend and queue through**
+
+- `LazyTaskRegistry.__init__` takes the resolved `AbsurdBackend` alongside `queue`,
+  stores both, passes both to `build_handler`.
+- `aworker_client` already has `backend` — pass it at the construction on
+  `worker.py:215`.
+- `build_handler(task, *, backend, queue)` forwards both to `build_task_context`.
+- `build_task_context` builds `id=f"{queue}:{ctx.task_id}"` — the f-string also coerces
+  the `uuid.UUID` — and sets `backend=backend.alias`. Rebind with
+  `.using(queue_name=queue)` when `task.queue_name` disagrees, as
+  `backends.build_task_result` already does (`backends.py:334-335`).
+- Comment the queue source: `ClaimedTask` carries no queue and the re-imported task
+  holds its definition-time one, so only the worker knows the truth.
+
+Leave the `TaskResult` conditional on `task.takes_context` for now — Task 3 makes it
+unconditional with the first send.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run:
+`uv run pytest tests/core/test_signals_worker_result.py tests/core/test_worker.py -v`
+Expected: PASS, including the pre-existing `takes_context` tests.
+
+Coverage note: the `.using(queue_name=queue)` rebind's True arm is NOT reachable in this
+task — only `takes_context` tasks build the result here, and none is drained off-queue.
+It becomes covered in Task 3, when the build goes unconditional and `test_worker.py`'s
+off-queue routing test drains through it. Do not chase it now.
+
+- [ ] **Step 6: Commit**
+
+```bash
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/worker.py tests/tasks.py tests/core/test_signals_worker_result.py
+git commit -m "fix: build the worker-side TaskResult id from the worker's own queue"
+```
+
+---
+
+### Task 3: task_started
+
+**Files:**
+
+- Modify: `django_absurd/dispatch.py`
+- Modify: `django_absurd/worker.py` (`build_handler`)
+- Create: `tests/core/test_signals_started.py`
+
+**Interfaces:**
+
+- Consumes: `dispatch.send_task_signal` (Task 1);
+  `build_handler(task, *, backend, queue)` (Task 2).
+- Produces: nothing new. The worker calls the same contained helper the enqueue seam
+  does.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import datetime as dt
+import logging
+import typing as t
+
+import pytest
+from django.tasks import TaskResultStatus
+from django.tasks.signals import task_started
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_started_fires_once_per_successful_run(dj_absurd: AbsurdTestRuntime) -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_started, receiver, sender=AbsurdBackend):
+        with dj_absurd.freeze_time():
+            result = tasks.add.enqueue(1, 2)
+            dj_absurd.drain()
+
+    assert [r.id for r in receiver.results] == [result.id]
+    assert receiver.results[0].status == TaskResultStatus.RUNNING
+    assert receiver.results[0].attempts == 1
+    assert receiver.results[0].started_at is not None
+    assert receiver.results[0].enqueued_at is None
+
+
+def test_started_fires_per_handler_entry_across_a_sleep(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_started, receiver, sender=AbsurdBackend):
+        with dj_absurd.freeze_time() as frozen_time:
+            result = tasks.sleep_a_week.enqueue()
+            dj_absurd.drain()          # entry 1: suspends on the durable sleep
+            assert len(receiver.results) == 1
+
+            frozen_time.shift(dt.timedelta(days=8))
+            dj_absurd.drain()          # entry 2: replays and finishes
+
+    assert len(receiver.results) == 2
+    # One attempt, two entries: the run is rescheduled, never re-created.
+    assert [r.attempts for r in receiver.results] == [1, 1]
+    assert dj_absurd.get_result(result.id).state == "completed"
+
+
+def test_a_raising_receiver_does_not_fail_the_task(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    """Uncontained, this exception escapes the handler and the SDK reads it as the TASK
+    failing — an audit receiver would burn every attempt of every task.
+    """
+
+    def explode(sender: type, task_result: t.Any, **kwargs: t.Any) -> None:
+        raise RuntimeError("receiver is broken")
+
+    with utils.connect_receiver(task_started, explode, sender=AbsurdBackend):
+        with caplog.at_level(logging.ERROR, logger="django_absurd"):
+            with dj_absurd.freeze_time():
+                result = tasks.add.enqueue(1, 2)
+                dj_absurd.drain()
+
+    assert dj_absurd.get_result(result.id).state == "completed"
+    contained = [
+        r
+        for r in caplog.records
+        if r.name == "django_absurd" and r.levelno >= logging.ERROR
+    ]
+    assert len(contained) == 1
+```
+
+`tasks.sleep_a_week` (`tests/tasks.py:180-183`) already exists.
+`test_durable.py:113-129` shows the drain-shift-drain sequence.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_signals_started.py -v` Expected: FAIL — nothing is
+sent, so the recording tests see empty lists. The raising-receiver test PASSES at this
+stage (the receiver never fires, so the task trivially completes and nothing is logged)
+— it is a guard, not a RED target.
+
+- [ ] **Step 3: Send from the handler**
+
+In `build_handler`: build the `TaskResult` unconditionally (currently only under
+`if task.takes_context`), reuse it for `TaskContext`, and call
+`dispatch.send_task_signal(task_started, type(backend), task_result)` in the coroutine
+before the body runs.
+
+- [ ] **Step 4: Name the signal in the containment log**
+
+Carried over from Task 1's review as a Minor, actionable here because this task already
+edits `dispatch.py`. The contained-failure log names the task id but not which signal
+failed, and from this task on three signals share the helper. Django `Signal` objects
+are anonymous — their repr carries nothing — so the traceback is otherwise the only
+clue.
+
+Add a module-level mapping from the three `django.tasks.signals` objects to their names
+and use it in the `logger.exception` message. Call sites stay unchanged. Then extend
+Task 1's `test_enqueue_survives_a_receiver_that_raises` and this task's
+`test_a_raising_receiver_does_not_fail_the_task` to assert `"task_enqueued"` and
+`"task_started"` respectively appear in the record's message.
+
+While here, rewrite the deferred test's comment so it describes the code as it now is
+rather than as it will be — Task 1 left it half future-tense on purpose.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run:
+`uv run pytest tests/core/test_signals_started.py tests/core/test_worker.py tests/core/test_async_worker.py -v`
+Expected: PASS. The existing worker tests are included deliberately — this is the step
+where the unconditional `TaskResult` and the first sends could disturb them.
+
+- [ ] **Step 6: Make the deferred orphan assertions load-bearing**
+
+`tests/core/test_signals_enqueue.py::test_a_deferred_enqueue_sends_two_signals` (Task 1)
+asserts the wrapper's id is absent from `started` and `finished`. Those were vacuous
+while nothing sent `task_started`. Now add the positive half at the end of that test, so
+the absence means something:
+
+```python
+    assert sent[1].id in [r.id for r in started.results]
+```
+
+Run: `uv run pytest tests/core/test_signals_enqueue.py -v` Expected: PASS — the inner
+task starts under its own id, the wrapper's never does.
+
+- [ ] **Step 7: Commit**
+
+```bash
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/dispatch.py django_absurd/worker.py tests/core/test_signals_started.py tests/core/test_signals_enqueue.py
+git commit -m "feat: send task_started from the worker"
+```
+
+---
+
+### Task 4: task_finished on success
+
+**Files:**
+
+- Modify: `django_absurd/worker.py` (`build_handler`'s `else` arm)
+- Create: `tests/core/test_signals_finished_success.py`
+
+**Interfaces:**
+
+- Consumes: `dispatch.send_task_signal(signal, sender, task_result)` (Task 1) and
+  `worker.build_running_task_result`, which is what Task 3 named the function this plan
+  earlier called `build_task_context`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import datetime as dt
+import logging
+
+import pytest
+from django.tasks import TaskResultStatus, task_backends
+from django.tasks.signals import task_finished
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_finished_reports_success_and_the_return_value(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_finished, receiver, sender=AbsurdBackend):
+        with dj_absurd.freeze_time():
+            result = tasks.add.enqueue(1, 2)
+            dj_absurd.drain()
+
+    assert [r.id for r in receiver.results] == [result.id]
+    sent = receiver.results[0]
+    assert sent.status == TaskResultStatus.SUCCESSFUL
+    assert sent.finished_at is not None
+    # An unset _return_value reads as None here — silently wrong rather than raising.
+    assert sent.return_value == 3
+    assert task_backends["default"].get_result(result.id).return_value == 3
+
+
+def test_django_logs_the_whole_successful_lifecycle(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    with dj_absurd.freeze_time():
+        tasks.add.enqueue(1, 2)
+        dj_absurd.drain()
+
+    records = [
+        (r.levelno, r.getMessage()) for r in caplog.records if r.name == "django.tasks"
+    ]
+    assert [level for level, _ in records] == [
+        logging.DEBUG,
+        logging.INFO,
+        logging.INFO,
+    ]
+    assert "state=RUNNING" in records[1][1]
+    assert "state=SUCCESSFUL" in records[2][1]
+
+
+def test_django_logs_a_sleeping_task_as_two_running_lines(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    with dj_absurd.freeze_time() as frozen_time:
+        tasks.sleep_a_week.enqueue()
+        dj_absurd.drain()
+        frozen_time.shift(dt.timedelta(days=8))
+        dj_absurd.drain()
+
+    messages = [r.getMessage() for r in caplog.records if r.name == "django.tasks"]
+    assert len([m for m in messages if "state=RUNNING" in m]) == 2
+    assert len([m for m in messages if "state=SUCCESSFUL" in m]) == 1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_signals_finished_success.py -v` Expected: FAIL —
+`receiver.results == []`, and the log assertions see one DEBUG + one INFO (started, from
+Task 3) with no SUCCESSFUL line.
+
+- [ ] **Step 3: Send on the success path**
+
+In `build_handler`'s `else` arm, mutate the frozen `TaskResult` with
+`object.__setattr__` for **all three** of `status` (`SUCCESSFUL`), `finished_at` (now)
+and `_return_value` — it is a `frozen=True, slots=True` dataclass, and this is how
+Django's own backend mutates it (`immediate.py:71-73`). Then call
+`dispatch.send_task_signal(task_finished, ...)` before returning.
+
+`_return_value` must be set: `TaskResult.return_value` returns it and it defaults to
+`None`, so omitting it hands a receiver a wrong value rather than an error.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_signals_finished_success.py -v` Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/worker.py tests/core/test_signals_finished_success.py
+git commit -m "feat: send task_finished when a run succeeds"
+```
+
+---
+
+### Task 5: task_finished on failure — terminal only
+
+**Files:**
+
+- Modify: `django_absurd/params.py` (widen `max_attempts` to `int | None`)
+- Modify: `django_absurd/worker.py` (`build_handler`'s `except Exception` arm)
+- Create: `tests/core/test_signals_finished_failure.py`
+- Modify: `tests/core/test_absurd_params.py` (one params-level assertion)
+
+**Interfaces:**
+
+- Consumes: `dispatch.send_task_signal` (Task 1) and `worker.build_running_task_result`
+  (Task 3's name for what this plan earlier called `build_task_context`).
+- Produces: `read_sdk_max_attempts(ctx) -> int | None` in `worker.py`, beside
+  `read_sdk_attempt`.
+
+The send goes inside the handler's `except` arm, so `sys.exc_info()` already holds the
+task's exception and Django's `log_task_finished` (`signals.py:52-53`) attaches the
+right traceback with nothing arranged.
+
+**Pre-authorized:** `read_sdk_max_attempts` reads `ctx._task["max_attempts"]` and
+carries `# noqa: SLF001` with the same justification wording as `read_sdk_attempt`
+(`worker.py:406`) — same private attribute, same reason, already ledgered in
+[`docs/UPSTREAM.md`](../UPSTREAM.md). This is the ONLY new ignore this plan authorizes.
+Do not add any other.
+
+- [ ] **Step 1: Widen `absurd_params(max_attempts=...)` to accept None**
+
+`params.py:91-108` types it `int` in both overloads and the implementation, but SQL NULL
+is a real Absurd feature — it means retry forever, which the terminal predicate below
+depends on. Change all three signatures to `int | None = ...`. The runtime already
+passes None through (only the `NOT_SET` sentinel is filtered, `params.py:137-138`), so
+no logic changes.
+
+Add to `tests/core/test_absurd_params.py`, following its existing style:
+
+```python
+def test_max_attempts_accepts_none_for_unbounded_retries() -> None:
+    task_with_unbounded_attempts = params_module.absurd_params(max_attempts=None).bind(
+        tasks.add
+    )
+
+    assert task_with_unbounded_attempts.absurd_params == {"max_attempts": None}
+```
+
+Check the file's actual import alias for `params` and its assertion idiom before writing
+this.
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+import logging
+
+import pytest
+from absurd_sdk import RetryStrategy
+from django.tasks import TaskResultStatus, task_backends
+from django.tasks.signals import task_finished, task_started
+
+from django_absurd import params as params_module
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_a_non_final_failed_attempt_sends_nothing(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    finished = utils.RecordingReceiver()
+    started = utils.RecordingReceiver()
+    two_attempts = params_module.absurd_params(max_attempts=2).bind(tasks.boom)
+    with utils.connect_receiver(task_started, started, sender=AbsurdBackend):
+        with utils.connect_receiver(task_finished, finished, sender=AbsurdBackend):
+            with dj_absurd.freeze_time():
+                two_attempts.enqueue()
+                # Default retry strategy is kind 'none' -> delay 0, so both attempts are
+                # claimable inside one drain; no clock movement needed.
+                dj_absurd.drain()
+
+    assert len(started.results) == 2
+    assert len(finished.results) == 1
+    assert finished.results[0].status == TaskResultStatus.FAILED
+    assert len(finished.results[0].errors) == 1
+
+
+def test_unbounded_attempts_never_report_terminal(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    finished = utils.RecordingReceiver()
+    # A backoff is mandatory here: with max_attempts=None and the default delay-0
+    # strategy, the burst drain re-claims the failing task forever and the test hangs
+    # until pytest-timeout kills it.
+    unbounded = params_module.absurd_params(
+        max_attempts=None,
+        retry_strategy=RetryStrategy(kind="fixed", base_seconds=3600),
+    ).bind(tasks.boom)
+    with utils.connect_receiver(task_finished, finished, sender=AbsurdBackend):
+        with dj_absurd.freeze_time():
+            unbounded.enqueue()
+            dj_absurd.drain()
+
+    assert finished.results == []
+
+
+def test_django_logs_error_only_on_the_terminal_attempt(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    two_attempts = params_module.absurd_params(max_attempts=2).bind(tasks.boom)
+    with dj_absurd.freeze_time():
+        two_attempts.enqueue()
+        dj_absurd.drain()
+
+    django_records = [r for r in caplog.records if r.name == "django.tasks"]
+    errors = [r for r in django_records if r.levelno >= logging.WARNING]
+    assert len(errors) == 1
+    assert errors[0].levelno == logging.ERROR
+    assert "state=FAILED" in errors[0].getMessage()
+    assert errors[0].exc_info is not None
+    # The line names the task's OWN exception: the send happens inside the handler's
+    # except arm, so sys.exc_info() is what the task raised.
+    assert errors[0].exc_info[0] is ValueError
+
+
+def test_the_persisted_traceback_holds_only_the_tasks_own_failure(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """The SDK formats the live exception's __traceback__ into failure_reason, so
+    anything django-absurd runs while REPORTING that failure must stay off it.
+    """
+    one_attempt = params_module.absurd_params(max_attempts=1).bind(tasks.boom)
+    with dj_absurd.freeze_time():
+        result = one_attempt.enqueue()
+        dj_absurd.drain()
+
+    failure = dj_absurd.get_result(result.id).failure
+    assert failure is not None
+    assert "send_finished_if_terminal" not in failure["traceback"]
+    assert "send_task_signal" not in failure["traceback"]
+    # Ends at the task's own exception, so nothing was appended after the handler saw
+    # it.
+    assert failure["traceback"].strip().endswith("ValueError: boom")
+    assert task_backends["default"].get_result(result.id).errors[0].traceback
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/core/test_signals_finished_failure.py -v` Expected: the first
+three FAIL (no `task_finished` at all, no ERROR record);
+`test_unbounded_attempts_never_report_terminal` PASSES as a guard, and so does the
+traceback test — it is a guard on what the reporting path must never touch.
+
+- [ ] **Step 4: Implement the predicate and the failure send**
+
+In `build_handler`'s `except Exception` arm, before the existing `raise`:
+
+- Add `read_sdk_max_attempts(ctx)` beside `read_sdk_attempt` (helpers below their
+  caller), with the pre-authorized `noqa: SLF001`.
+- Terminal is `max_attempts is not None and attempt >= max_attempts`. Comment the NULL
+  case with the SQL it mirrors: `fail_run` retries when
+  `v_max_attempts is null or v_next_attempt <= v_max_attempts`, so NULL is
+  retry-forever.
+- Terminal: `object.__setattr__` for `status` (`FAILED`) and `finished_at`, append one
+  `TaskError` built from the live exception exactly as `ImmediateBackend` does —
+  `exception_class_path` from `type(exc).__module__` + `__qualname__`, `traceback` from
+  `format_exception(exc)`. Then call `dispatch.send_task_signal(task_finished, ...)`.
+- Non-terminal: send nothing. A failed non-final attempt is READY, not FAILED.
+- Leave the existing `raise` untouched — the SDK must receive the original exception,
+  and nothing on the reporting path may touch its `__traceback__`: the SDK's
+  `_serialize_error` formats that into the stored `failure_reason`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `uv run pytest tests/core/test_signals_finished_failure.py -v` Expected: PASS, all
+five.
+
+- [ ] **Step 6: Commit**
+
+```bash
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/params.py django_absurd/worker.py tests/core/test_signals_finished_failure.py tests/core/test_absurd_params.py
+git commit -m "feat: send task_finished on a terminal failure, with its traceback"
+```
+
+---
+
+### Task 6: Absurd's own control-flow states
+
+**Files:**
+
+- Modify: `django_absurd/worker.py` (the
+  `except (SuspendTask, CancelledTask, FailedTask)` arm)
+- Modify: `tests/core/test_signals_finished_success.py`
+
+**Interfaces:**
+
+- Consumes: `dispatch.send_task_signal` (Task 1).
+- Produces: nothing.
+
+- [ ] **Step 0: Three carried-over findings from earlier reviews**
+
+These were deferred only because `worker.py` was held by another task. Each is small and
+each has a test consequence, so do them first and let the same gates cover them.
+
+1. **`last_attempted_at` contradicts the design.** The spec's payload table promises
+   `started_at`/`last_attempted_at` = now on `task_started`, but
+   `build_running_task_result` sets `last_attempted_at=None`. Django's own backend sets
+   it to the attempt's start (`immediate.py`, alongside `started_at`). Fix the CODE, not
+   the spec — set it to the same instant as `started_at` — and extend an existing
+   `task_started` assertion in `tests/core/test_signals_started.py` to pin it.
+2. **`_return_value` is not normalized.** Django applies `normalize_json` to the raw
+   return value before storing it; we hand the raw object to the receiver. So a task
+   returning a tuple gives the finish receiver a tuple while `get_result().return_value`
+   yields a list. Apply the same normalization Django does, and assert it with a task
+   whose return value changes shape under normalization (a tuple is the obvious case;
+   add a small fixture task locally if `tests/tasks.py` has none).
+3. **Rot-prone citation.** `tests/utils.py` cites `immediate.py:71-73` by line number,
+   which will drift with any Django release. Cite the file and the behaviour instead.
+
+- [ ] **Step 1: Send nothing from the control-flow arm**
+
+`SuspendTask`, `CancelledTask` and `FailedTask` all send nothing, so
+`except (SuspendTask, CancelledTask, FailedTask) as exc` keeps its `logger.info` on the
+`django_absurd` logger and its bare `raise`, and gains no send.
+
+The arm is still load-bearing and must not be deleted: all three are `Exception`
+subclasses, so without it they fall into `except Exception`, which builds a `FAILED`
+payload and sends `task_finished` — reporting an ending Absurd decided as the task
+failing.
+
+**The rule, stated once:** Django's task signals report the lifecycle Django knows —
+enqueued, started, and finished on success or on a failure the task's own code raised.
+Endings Absurd decides on its own are outside what Django's task signals describe.
+
+Why AB001/AB002 are not reported despite being the two Absurd endings a handler CAN
+observe: `task_finished` already sends nothing for the `max_delay` pre-claim sweep,
+claim expiry, an admin cancel of an unclaimed task, `max_duration` inside `fail_run`, a
+queue mismatch and an unknown-task defer failure. Reporting the mid-run cancel too would
+mean a cancelled task gets a Django `FAILED` line only when the cancel happened to land
+while a worker was mid-run — logging that depends on a race, and one rule replaced by
+two plus six exceptions.
+
+- [ ] **Step 2: Pin the suspended-run behaviour**
+
+One test, beside the other sleeping-task assertions: a task that suspends on a durable
+sleep sends no `task_finished`. That is what pins `SuspendTask` not reaching the
+`except Exception` arm.
+
+`CancelledTask`/`FailedTask` get no test. They send nothing, and the arm that swallows
+them is the same one the sleep test covers; reaching them specifically would need a task
+that sabotages its own run (cancelling itself through a fresh SDK client, or
+`absurd.fail_run` on `ctx._task["run_id"]` by raw SQL) in order to assert an absence.
+
+- [ ] **Step 3: Whole suite plus coverage, then commit**
+
+```bash
+uv run pytest tests/core --cov=django_absurd --cov-branch -q
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/worker.py tests/core/test_signals_finished_success.py
+git commit -m "feat: leave Absurd-decided endings out of Django's task signals"
+```
+
+`worker.py` should be fully covered — the control-flow arm has no branches of its own
+and the sleep test enters it.
+
+---
+
+### Task 7: The read path's twin of the rebind bug
+
+Found by Task 3's review, not by the original plan. Task 3 fixed a queue-only
+`.using(queue_name=...)` rebind in the worker: `Task.using` is a bare
+`dataclasses.replace` and `__post_init__` re-validates against the **definition's**
+backend alias, so rebinding queue-only raises `InvalidTaskBackend` when that alias is
+not configured. `backends.build_task_result` has the identical rebind and was left alone
+— deliberately, since it is a different seam with no covering test.
+
+It is not theoretical. A beat-routed task under a second alias now executes fine, but
+`get_result()` on it imports the task, sees `task_obj.queue_name != queue`, rebinds
+queue-only, and raises — an uncurated crash on a pure read. That also hollows out Task
+2's promise that the worker-side id round-trips through `get_result()`.
+
+**Files:**
+
+- Modify: `django_absurd/backends.py` (`build_task_result`, the rebind near
+  `backends.py:338`)
+- Modify: `tests/core/test_signals_worker_result.py` (or the multi-alias test module
+  that already configures a second backend — find it first and follow its setup)
+
+- [ ] **Step 1: Write the failing test**
+
+Drive it through the real path, not by calling `build_task_result` directly: enqueue a
+task whose definition alias differs from the alias the run is routed through, drain it,
+then call `get_result()` via the routed backend. Look at how
+`tests/core/test_scheduler.py`'s `test_beat_routes_task_to_queue_non_default_alias` sets
+up its aliases and reuse that shape — that is the test Task 3's regression surfaced
+through.
+
+Assert `get_result()` returns a `TaskResult` whose `.status` is `SUCCESSFUL` — today it
+raises `InvalidTaskBackend` instead.
+
+- [ ] **Step 2: Run to verify failure**
+
+Expected: `InvalidTaskBackend`, naming the unconfigured definition alias. If you instead
+see a passing test, you have not reproduced the condition — the definition alias must be
+one the settings do NOT configure.
+
+- [ ] **Step 3: Fix it the same way Task 3 did**
+
+Move the alias with the queue, mirroring `worker.py:328-329`: compare
+`(task_obj.queue_name, task_obj.backend)` against `(queue, backend.alias)` as a tuple
+and pass both to `.using()`. Same reasoning as the worker: a result read through a given
+backend belongs to that backend, so forcing the alias cannot mislabel a legitimately
+foreign task.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run the new test plus `tests/core/test_results.py`, `tests/core/test_run_after.py` and
+`tests/core/test_scheduler.py` — every existing consumer of `build_task_result`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+git add django_absurd/backends.py tests/core/
+git commit -m "fix: keep the backend alias with the queue when rebinding a result's task"
+```
+
+---
+
+### Task 8: Documentation
+
+**Files:**
+
+- Modify: `django_absurd/AGENTS.md`
+- Modify: `docs/web/` (the page covering enqueueing and results — locate it first)
+- Modify: `README.md` if it lists backend capabilities
+
+- [ ] **Step 1: Invoke the docs skill**
+
+Run the `sync-docs` skill. This change touches user-facing behaviour, so it owns the
+docs sweep rather than hand-editing one file.
+
+- [ ] **Step 2: Cover exactly these points**
+
+Each is a promise a user can otherwise get wrong:
+
+- The three signals are sent so Django's own `django.tasks` logging works. They are not
+  offered as an extension point, and the docs carry no receiver-authoring material and
+  no example receiver.
+- A worker-side receiver runs on the worker's event loop, where Django's ORM refuses to
+  run at all, and inside the run's claim lease — a slow receiver ages the claim toward
+  `claim_timeout`.
+- A receiver's exception is logged and contained, never fatal to the task.
+- `task_started` fires per execution episode, so a task with a durable sleep sends
+  several for one attempt. **Do not build counters or gauges on it.**
+- The payload may be mutated after a receiver returns, as Django's own backends do it.
+  Receivers must snapshot what they need and rely on neither send-time state nor object
+  identity across signals: `task_enqueued` carries a different object, and each handler
+  entry of a sleeping task builds a fresh one, so identity holds only started→finished
+  within one entry.
+- `task_finished` reports a success or a failure the task's own code raised, once it is
+  terminal. An ending Absurd decided itself is outside what these signals describe, with
+  the list of those endings.
+- A deferred (`run_after`) enqueue sends two `task_enqueued`; the discriminator is
+  `task_result.task.run_after`, and the wrapper's id never receives a start or finish.
+- pg_cron-scheduled tasks send no `task_enqueued`; beat schedules do.
+- A rollback after enqueue leaves a `task_enqueued` already sent.
+- `absurd_params(max_attempts=None)` is now typed as well as supported: it means retry
+  forever, and therefore no `task_finished`.
+- Release note: `TaskContext.task_result.id` changes shape from a bare uuid to
+  `"queue:uuid"` — the form that round-trips through `get_result()`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+uv run pre-commit run --all-files
+git add -A
+git commit -m "docs: document the task signals AbsurdBackend now sends"
+```
+
+---
+
+## Finishing
+
+Do NOT push or open a PR. Local review flow: `revdiff` against `origin/main` after
+`git fetch`, then an adversarial review with the best available model. Merging is the
+maintainer's call.

--- a/docs/specs/2026-08-01-task-signals-design.md
+++ b/docs/specs/2026-08-01-task-signals-design.md
@@ -1,0 +1,482 @@
+# Send Django's task signals from AbsurdBackend
+
+Unit 1 of [#25](https://github.com/lincolnloop/django-absurd/issues/25). Stays under #25
+— no separate issue.
+
+## Problem
+
+`django/tasks/__init__.py:4` does `from . import checks, signals`, so the three logging
+receivers in `django/tasks/signals.py` connect eagerly in any project with `TASKS`
+configured. `ImmediateBackend` sends all three (`immediate.py:29,37,69,73`);
+`DummyBackend` sends `task_enqueued` only (`dummy.py:24`) — it never executes.
+`AbsurdBackend` sends **none**.
+
+Consequences: Django logs no task lifecycle at all against our backend, and a user's
+`@receiver(task_finished)` silently never fires. Contract defect, independent of the
+styled-logger work #25 is really about.
+
+Non-goals here: Absurd's own vocabulary (steps, sleeps, events, beat), logger hierarchy
+rename, pretty formatter, support gate. Later units.
+
+## Never register a receiver
+
+django-absurd **sends** signals, never listens. An unfiltered receiver fires for every
+backend, so we would report tasks that never touched Absurd. If one is ever needed:
+`sender=AbsurdBackend` (senders are the backend _class_, per Django's `type(self)`).
+
+## Seam 1 — enqueue
+
+`backends.py:enqueue`. Build the `TaskResult` before returning; send
+`task_enqueued.send(type(self), task_result=result)`. Sent after a successful spawn,
+never before.
+
+`await task.aenqueue()` reaches the identical code through
+`sync_to_async(self.enqueue, thread_sensitive=True)` (`base.py:89-93`), which we do not
+override — `AbsurdTask.aenqueue` only adds the inert-params warning (`tasks.py:68-72`).
+So one send covers both entry points; no async twin, unusually for this project.
+
+Neither path lands a receiver on a thread with a running loop — but because Django
+already hopped it, not because the code is inherently sync. From an async caller the
+receiver runs on asgiref's shared thread-sensitive thread, which is Django's choice, not
+ours. So this is the one seam where a receiver can reach the ORM at all; it is asserted
+in tests rather than left to this paragraph, and it implies nothing about the worker
+sends.
+
+## Seam 2 — worker
+
+`worker.py:build_handler`. Single dispatch point for sync and async tasks — async
+awaited directly, sync via `asyncio.to_thread` — and every SDK dispatch path
+(`work_batch`, `start_worker`, our `execute_claimed_run`) funnels through
+`_registry.get` into it. So async parity is structural, not duplicated. The worker-side
+`TaskResult`, today built only when `task.takes_context` (`build_task_context`,
+`worker.py:311`), becomes unconditional; `TaskContext` wraps the same object.
+
+**The worker's own backend and queue are plumbed into `build_handler`; the re-imported
+task is not trusted for either.** `LazyTaskRegistry.get` re-imports the decorator-time
+task (`worker.py:114`), so `task.backend` and `task.queue_name` are its _definition_
+values. A task defined on a non-Absurd backend and enqueued via `.using(backend=...)` —
+a path `backends.py:127-134` explicitly supports — would otherwise send `task_enqueued`
+with sender `AbsurdBackend` and then started/finished with sender `ImmediateBackend` and
+`backend="default"`: a `sender=AbsurdBackend` receiver sees an enqueue with no start or
+finish, and an Immediate-filtered receiver gets ghost events for tasks it never ran.
+
+So the resolved backend (already in hand at `arun_worker`, `worker.py:168`) and the
+worker's queue (`LazyTaskRegistry.queue` / `registration["queue"]`, `worker.py:88-126`)
+reach `build_handler`. Sender is `type(backend)`, so a subclass of `AbsurdBackend` is
+its own sender; `TaskResult.backend` is that backend's alias; and the task object is
+rebound with `.using(queue_name=..., backend=...)` when either disagrees. The alias
+travels with the queue because `Task.using` is a bare `dataclasses.replace` and
+`__post_init__` re-validates against whichever alias the task's DEFINITION named —
+rebinding the queue alone raises `InvalidTaskBackend` when that alias is unconfigured.
+`build_task_result` carries the same tuple rebind, for the same reason, on the read
+path.
+
+No DB reads for our own fields. Every one comes from the claim, our own timings, the
+live exception.
+
+| Event                             | Status       | Fields                                                                                        |
+| --------------------------------- | ------------ | --------------------------------------------------------------------------------------------- |
+| `task_started`, per handler entry | `RUNNING`    | `started_at`/`last_attempted_at` = now, `worker_ids=["absurd"] * attempt`, `enqueued_at=None` |
+| success                           | `SUCCESSFUL` | `finished_at`, `_return_value` set                                                            |
+| terminal failure                  | `FAILED`     | `finished_at`, one `TaskError` from the live exception                                        |
+| non-terminal failure              | —            | **no signal**                                                                                 |
+| `SuspendTask`                     | —            | **no signal** — the run is sleeping, not finished                                             |
+| `CancelledTask` (AB001)           | —            | **no signal** — an ending Absurd decided, not one the task raised                             |
+| `FailedTask` (AB002)              | —            | **no signal** — same                                                                          |
+
+`_return_value` must be set on success, but not because omitting it raises:
+`TaskResult.return_value` returns `_return_value`, which defaults to `None`
+(`base.py:196, 202-215`). Omit it and a receiver silently reads `None` in place of the
+real value — a wrong answer, not an error. It is normalized with `normalize_json`, as
+Django's own backend does, so the payload agrees with what `get_result()` later reports;
+the raw value still goes back to the SDK.
+
+### Why not the SDK's hooks
+
+`AbsurdHooks` exists for "tracing, logging, and context propagation"
+(`absurd_sdk:224-229`), so `wrap_task_execution` is the obvious candidate. It buys
+nothing here: it wraps the handler call on the same loop thread, still before the
+outcome is persisted, and `build_handler` is our own code rather than a private reach,
+so there is no access to legitimise. It would also cost two things — the direct `Task`
+object (the hook sees only `task_name`) and a name-suffix filter, because the hook fires
+for the `:run_after` wrapper too, which must not send started/finished.
+
+Both hooks stay relevant elsewhere: `before_spawn` is where a correlation id would ride
+into task headers, and the missing third hook is what
+[the upstream ask](../UPSTREAM.md#surface-a-runs-terminal-outcome-to-the-worker) asks
+for by name.
+
+## Where receivers run
+
+`Signal.send` calls every receiver inline on the calling thread. The worker-side sends
+are inline too, in the handler's own coroutine on the worker's event loop.
+
+**Users are not invited to build on these signals.** They are sent so Django's own
+`django.tasks` logging works, and Django's three built-in receivers only log — they
+never touch the ORM, so nothing on this path needs a database. A receiver of the user's
+own that does reach for the ORM meets Django's `async_unsafe` guard, which raises
+`SynchronousOnlyOperation` on a thread with a running loop; containment logs that as a
+broken receiver. An `async def` receiver fails the same way: Django wraps it in
+`async_to_sync`, which refuses to run on a thread that already has a loop.
+
+**Receiver exceptions are contained,** through a single `send_task_signal(...)` helper
+that every send goes through — worker sends and the enqueue seam alike. It catches
+`Exception` (never `BaseException`: `asyncio.CancelledError` at shutdown must propagate)
+and logs `logger.exception(...)` on the `django_absurd` logger. One helper, not three
+inlined `except` arms, so there is one branch to cover and one raiser test to write.
+
+Containment matters more than it looks:
+
+- Without it a receiver's exception escapes the handler and the SDK's `except Exception`
+  reads it as the _task_ failing (`absurd_sdk:2304`) — an ordinary audit receiver
+  consumes attempts until every task is FAILED.
+- A raiser during the success send would re-execute an already-succeeded body.
+- A raiser inside the terminal-failure `except` would have `fail_run` persist the
+  _receiver's_ error as `failure_reason`.
+- On the enqueue seam, `enqueue_deferred_target` calls `backend.enqueue` _inside a
+  checkpointed step_ (`deferred.py:63-97`). An uncontained raiser after the inner spawn
+  commits leaves the checkpoint uncommitted, so the wrapper retries and enqueues the
+  real task again — up to `max_attempts` duplicates from one buggy logging receiver.
+
+So "a receiver can never damage the task" is literally true, on every seam.
+
+**Cost, accepted:** receivers run inside the claim lease, because the run's completion
+is not persisted until our handler returns. A slow receiver ages the claim toward
+`claim_timeout`. That belongs to the user's receiver, not to us — document it, do not
+mitigate it.
+
+## The traceback on Django's ERROR line
+
+Django's `log_task_finished` calls `sys.exc_info()` to attach the traceback
+(`signals.py:52-53`). Sending inline, from inside the handler's `except` arm, means
+Python has already populated it: the ordinary terminal-failure send needs nothing
+arranged, and Django's ERROR line carries the task's own exception, matching the
+`TaskError` on the payload.
+
+The failure arm is the only send with an exception in play; `task_started` and the
+success send have none.
+
+## Absurd's own control-flow states send nothing
+
+`SuspendTask`, `CancelledTask` and `FailedTask` are Absurd's internal control-flow
+signals, raised from a run's next durable write rather than from the task's code. None
+of them sends `task_finished`.
+
+`SuspendTask` is uncontroversial — the run is sleeping, not finished, and it re-enters
+the handler later.
+
+The other two were tried and dropped. Reporting them meant a cancelled task produced a
+Django `FAILED` line **only when the cancel happened to land while a worker was
+mid-run** — the same cancel arriving a moment earlier, before the claim, is one of the
+endings below that reports nothing. Logging that depends on a race is worse than logging
+that does not happen, and the two-plus-a-list-of-exceptions shape collapses to one rule
+without them:
+
+**Django's task signals report the lifecycle Django knows — enqueued, started, and
+finished on success or on a failure the task's own code raised. Endings Absurd decides
+on its own are outside what Django's task signals describe.**
+
+The handler's `except (SuspendTask, CancelledTask, FailedTask)` arm therefore only logs
+on the `django_absurd` logger and re-raises. It cannot be deleted: those three are
+`Exception` subclasses, so without the arm they fall into `except Exception`, which
+reports an Absurd-decided ending as the task failing.
+
+## Terminal predicate
+
+`max_attempts is not None and attempt >= max_attempts`, both off `ctx._task`
+(`ClaimedTask`, `absurd_sdk/__init__.py:158,161`).
+
+Mirrors the pinned SQL exactly. `fail_run` retries when
+`v_max_attempts is null or v_next_attempt <= v_max_attempts` (schema line 1188, with
+`v_next_attempt := v_attempt + 1`), and `max_attempts integer` is nullable with no
+default (line 154) — **NULL means retry forever**. So None ⇒ never terminal is the DB's
+rule, not a guess.
+
+Our `enqueue` sets it via `merged.setdefault` (`backends.py:137`) on every path, with
+two exceptions that both land on the None branch safely:
+`absurd_params(max_attempts=None)` survives the sentinel filter (`params.py:137-138`)
+and spawns SQL NULL, and pg_cron-spawned rows never pass through `enqueue` at all.
+
+## What task_finished promises
+
+**It fires where the task's own code ended the run and the handler can prove that ending
+is terminal.** Not a completeness guarantee — Django's wording implies one, and we do
+not honour it. Absurd ends tasks on its own account, on paths that never reach a handler
+and where the SDK reports no outcome (`_execute_task` swallows it,
+`absurd_sdk:2302-2313`).
+
+That is the boundary, not a gap: these signals report the lifecycle Django knows —
+enqueued, started, and finished on success or on a failure the task's own code raised.
+Endings Absurd decides on its own are outside what Django's task signals describe. The
+list below is worth keeping because a reader will otherwise infer a promise from
+Django's docs that this backend does not make.
+
+Terminal without any `task_finished`:
+
+- **`max_delay` cancellation** — `claim_task`'s pre-claim sweep cancels a task that has
+  not started in its window. Under worker backlog: `task_enqueued`, then terminal, with
+  no `task_started` either. Most likely of these in production.
+- **`max_duration` while sleeping** — same pre-claim sweep. `task_started` ×N, then
+  silence.
+- **A concurrent cancel** during a non-terminal failure — `fail_run` raises AB001, the
+  SDK swallows it, and the task is cancelled.
+- **`max_duration` inside `fail_run`** — attempts remain but the budget is spent, so it
+  cancels instead of retrying (its `v_task_cancel` branch, inside the retry arm at
+  schema line 1188).
+- **Claim expiry** — `claim_task` itself calls `fail_run` with `$ClaimTimeout` on an
+  expired lease, consuming an attempt with no handler involved; enough of those exhaust
+  `max_attempts` while the worker is dead.
+- **`cancel_task` on an unclaimed task** (admin or user) — never claimed again.
+- **A cancel or an elsewhere-failed run that DOES reach a handler** — AB001/AB002 out of
+  the next durable write. Observable, unlike the rest, and still unreported: the same
+  cancel landing a moment earlier is the unclaimed-task case above, so reporting only
+  the mid-run one would make the log depend on a race.
+- **Queue mismatch** and **unknown-task defer failure** — the SDK fails the run without
+  entering the handler (`absurd_sdk:2263-2273`, `2249-2259`).
+
+Replicating Absurd's retry-delay and duration arithmetic in Python to predict these
+would duplicate pinned-SQL policy, and predicting them still would not make them Django
+lifecycle events. The stored result and the queue-state models are the record of what
+happened.
+
+**Pre-persist window.** Even where we do send, SUCCESSFUL is announced before
+`_complete_task_run_async` writes it (`absurd_sdk:2299`). A concurrent cancel or claim
+expiry can make that write fail (AB001/AB002, swallowed), after receivers were told the
+task succeeded — `get_result()` then reports FAILED.
+
+Shutdown widens that window by however long receivers take. A hard cancel landing on a
+send raises `CancelledError`, which containment deliberately does not swallow — but it
+replaces the task's own exception before the handler's bare `raise`, so the SDK never
+runs `_fail_task_run_async` and the attempt resurfaces later as a `$ClaimTimeout` rather
+than the real error. Documented, not fixed.
+
+## task_started per entry, not per attempt
+
+A durable sleep or `await_event` reschedules the SAME `run_id` (`absurd.schedule_run`
+updates the row in place; no insert, no attempt change), so the handler re-enters from
+the top on every wake. One attempt, N entries. No suspension path creates a run or bumps
+`attempt` — only `fail_run`'s retry arm and `retry_task` do.
+
+Fire on every entry:
+
+- Suppressing requires "did this run already execute", and the free signal cannot answer
+  it. `ctx._checkpoint_cache` is preloaded by the SDK before the handler runs
+  (`absurd_sdk:663-668`) but drops `owner_run_id` (line 662), and
+  `get_task_checkpoint_states` selects by `task_id` filtered to owner-run attempt ≤
+  current (schema 1574-1624). So `bool(cache)` cannot separate replay-of-this-run from
+  attempt-2-of-a-task-that-completed-a-step — it would silently suppress `task_started`
+  for every retry of a multi-step task.
+- Absurd's model agrees: each wake is a fresh claim, possibly by a different worker.
+  `worker_ids` is a list for exactly that reason.
+
+**What this costs, stated plainly rather than waved off.** The N payloads for one
+attempt are identical — same id, same `attempts`, same synthetic `worker_ids` — so there
+is no per-entry key. A stateless receiver cannot tell replay from redelivery; a
+running-gauge (inc on started, dec on finished) drifts by N−1 per sleeping task,
+permanently; a plain counter over-counts with no way to correct. Entries can also arrive
+from different processes, so process-local memory does not help either. So **counters
+and gauges cannot be built on `task_started` from this backend.** A `run_id` on the
+payload is what would fix it — part of the same upstream ask as above.
+
+Replay _legibility_ is not Django's job — `step.replayed` / `sleep.resumed` belong to
+the vocabulary unit.
+
+## Retry: one task_finished, terminal only
+
+Django documents no retry behaviour for the signals; `TaskResult` settles it. `READY` =
+"just enqueued, **or is ready to be executed again**" (`base.py:33`, verbatim). A
+non-final failed attempt is READY, not FAILED — sending FAILED per attempt makes
+Django's own receiver log ERROR + traceback for a task that later succeeds.
+
+The scarcity forces it. `TaskResultStatus` (`base.py:32-40`) has exactly four members —
+`READY`, `RUNNING`, `FAILED`, `SUCCESSFUL`. No `CANCELLED`, no `RETRYING`, no
+`SLEEPING`. So a failed non-final attempt has nowhere to go but `READY`, and Absurd's
+six states collapse into those four, as `STATE_TO_STATUS` (`backends.py:242-249`)
+already does: `sleeping` → `RUNNING`, `cancelled` → `FAILED`.
+
+## Result id
+
+Worker-side `TaskResult.id` becomes `f"{queue}:{task_id}"`, the same shape `enqueue`
+returns (`backends.py:208`). Two defects fixed at once: `build_task_context` uses bare
+`ctx.task_id`, which `decode_result_id` rejects (`rsplit(":", 1)` yields one part →
+`TaskResultDoesNotExist`), and that value is a `uuid.UUID` at runtime, not the `str` the
+field is annotated as (psycopg decodes the uuid columns — see the `DrainedRun`
+docstring, `worker.py:64-66`). The f-string coerces it.
+
+**`queue` comes from the worker, not from the task.** `ClaimedTask` has no queue field
+(`absurd_sdk:152-164`), and the re-imported task carries its definition-time
+`queue_name` — so `f"{task.queue_name}:{...}"` would label a task defined on `default`
+but drained from `other` as `default:<uuid>`, and `get_result()` on that id would look
+in the wrong queue's tables and raise `TaskResultDoesNotExist`. Exactly the defect this
+section claims to fix, one `.using(queue_name=...)` away. The source is the plumbed
+queue from Seam 2.
+
+No internal consumer breaks: nothing reads `ctx.task_result.id`, and
+`dj_absurd.get_result` already accepts both forms (`test.py:283-291`). But a
+`takes_context` task that persisted that id sees stored ids change shape, so it needs a
+release-note line, not just a spec paragraph.
+
+## Deferred tasks
+
+`build_deferred_handler` sends nothing: the `:run_after` wrapper sleeping until due is
+not the caller's task starting. Its inner enqueue at wake goes through
+`backend.enqueue`, so a deferred task yields **two** `task_enqueued` — the wrapper's id,
+then the real task's. Both are genuine enqueues; neither is suppressed.
+
+What holds, and matters because the payloads are otherwise nearly identical (both carry
+the real `task` and the real `args`, only the id differs):
+
+- The discriminator is `task_result.task.run_after` — set on the first, `None` on the
+  second (`deferred.py:90-95` re-imports the target fresh).
+- The first id is a permanent orphan: it never receives a `task_started` or
+  `task_finished`, because the wrapper sends nothing. It does still round-trip through
+  `get_result()`, which follows the wrapper's `completed_payload` to the real task
+  (`backends.py:228-231`).
+- A third `task_enqueued` is possible in the crash window between the inner spawn
+  committing and its checkpoint committing, unless the caller supplied an
+  `idempotency_key`.
+
+## Known gaps
+
+- **`task_enqueued` can fire for a task that never exists.** Enqueue runs on Django's
+  connection inside the caller's transaction, and a rollback discards the spawn — but
+  the signal has already been sent. Not moved to `on_commit`: that would desync our
+  timing from every other Django backend. Documented instead.
+- **pg_cron-scheduled tasks send no `task_enqueued`.** Their spawn is raw SQL run by
+  pg_cron (`public.django_absurd_run_scheduled` → `absurd.spawn_task`), never touching
+  `backend.enqueue`, so receivers see a `task_started` with no enqueue before it. Beat
+  schedules DO go through the seam (`scheduler.py:76`).
+- **`enqueued_at=None` at the worker.** The `t_` row does record `enqueue_at` (NOT NULL,
+  schema line 156) and `get_result` reads it (`backends.py:310`) — it is the _claim
+  payload_ that omits it, and our own no-DB-reads rule that makes it unreachable here.
+  Ask:
+  [expose `enqueue_at` on the task context](../UPSTREAM.md#expose-attempt-run_id-and-enqueue_at-on-the-task-context).
+- **`worker_ids` synthetic.** `["absurd"] * attempt` keeps `attempts` and
+  `TaskContext.attempt` truthful; the real `claimed_by` strings stay reachable via
+  `get_result()`.
+- **`errors` never accumulates** — Django documents a list across every execution; we
+  send one, from this attempt. Matches existing `build_task_result`
+  (`backends.py:343-351`). Pre-existing, out of scope.
+
+## Tests — `tests/core`
+
+Conventions: autouse `_enable_db`, so only add `django_db(transaction=True)` where a
+test commits or crosses threads; anything that executes freezes time through
+`dj_absurd`; no monkeypatching.
+
+Connecting receivers needs a helper, not ten hand-rolled `try/finally`s — a
+`contextmanager` in `tests/utils.py`, per the plain-function-over-fixture convention. No
+test in this repo connects a `django.dispatch` signal today, so there is no precedent to
+copy, and two edges must be encoded in it:
+
+- **Connect inside the `try`** — an error between connect and `try` leaks a receiver
+  into every later test in the same process.
+- **Receivers must be named functions the caller keeps alive.** `Signal.connect`
+  defaults to weak references, so an inline `lambda` can be garbage-collected mid-test
+  and silently never fire — a test that passes for the wrong reason.
+
+Collecting receivers must be thread-safe: the enqueue seam sends on whatever thread
+called it, and a sync task body enqueueing at `concurrency>1` reaches it from several
+pool threads at once, so appending to a bare list races.
+
+### Signal level
+
+- enqueue sends one `task_enqueued`, status `READY`, carrying the id `enqueue` returned
+- `await task.aenqueue()` sends exactly one `task_enqueued`, same payload shape — the
+  async entry point is covered by the sync seam, asserted rather than assumed
+- drain sends `enqueued` → `started` → `finished`, `SUCCESSFUL`, return value readable
+- worker-side payload id is `f"default:{uuid}"` and round-trips through
+  `dj_absurd.get_result` — otherwise the id fix ships asserted only on the enqueue side
+- sleeping task: `started` ×2, `finished` ×1, `attempts == 1`. Needs **two** drains:
+  `enqueue()` → `drain()` (entry 1, suspends) → `frozen_time.shift(8 days)` → `drain()`
+  (entry 2, finishes). The count is exactly 2 because drain 1's claim loop re-claims,
+  finds `available_at` a week out under the frozen clock, and breaks
+  (`worker.py:248-254`). Pattern: `test_durable.py:113-129`.
+- `max_attempts=2`, always fails: `started` ×2, `finished` ×1 `FAILED`, one `TaskError`
+  — in **one** drain, no clock movement. The default retry strategy is kind `'none'` →
+  delay 0, so a failed non-final attempt is immediately claimable and the burst loop
+  takes it. Precedent: `test_absurd_fixture.py:334-346` burns all five default attempts
+  in one drain.
+- `absurd_params(max_attempts=None)` + a failing task: **no** `task_finished` ever,
+  across attempts — the NULL-means-retry-forever promise, which nothing else pins (the
+  backend default is 5, `backends.py:117`, so only the explicit `None` reaches it)
+- a receiver that raises on a worker send: the task still succeeds, one ERROR on
+  `django_absurd` — the containment rule. One test suffices only because containment is
+  a single `send_task_signal()` helper; inlined at three sites it would need three.
+- a receiver that raises on the **enqueue** send: `enqueue()` still returns its
+  `TaskResult`, one ERROR logged — the seam that would otherwise duplicate deferred
+  enqueues
+- deferred enqueue sends **two** `task_enqueued`: `run_after` set on the first and
+  `None` on the second, and the wrapper's id never receives a `started` or `finished`.
+  No new branch, but "the wrapper sends nothing" is exactly what a later refactor breaks
+  silently.
+- sender is the backend class, and a receiver registered `sender=AbsurdBackend` does not
+  fire for an `ImmediateBackend` enqueue in the same test — `tests/settings.py:66`
+  already carries the `"immediate"` alias, and `absurd.E004` counts only Absurd backends
+  (`checks.py:392-398`)
+
+### caplog on the `django.tasks` logger
+
+No receiver of ours involved; these fail today because nothing is logged.
+
+- enqueue → one DEBUG, `"Task id=%s path=%s enqueued backend=%s"`, filled with the
+  prefixed id, the task's `module_path`, our alias. Needs
+  `caplog.set_level(logging.DEBUG, logger="django.tasks")`: `tests/settings.py` sets no
+  `LOGGING`, so Django's default puts `"django"` at INFO and the record is dropped at
+  the logger before any handler.
+- successful drain → DEBUG, then INFO `state=RUNNING`, then INFO `state=SUCCESSFUL`, in
+  that order
+- non-terminal failed attempt → INFO `state=RUNNING`, and **no `django.tasks` record at
+  or above WARNING**. Scope by logger name: `worker.py:379-389` already emits
+  `logger.exception` on the `django_absurd` logger for every failed attempt, so an
+  unscoped assertion is false.
+- terminal failed attempt → one ERROR, `state=FAILED`, `record.exc_info` populated and
+  naming the task's own exception class, since the send sits inside the handler's
+  `except` arm
+- sleeping task → two INFO `state=RUNNING` and one `state=SUCCESSFUL`, the per-entry
+  rule as a console shows it
+- every assertion scoped by logger name, so nothing downstream can silently start
+  styling `django.tasks`
+
+### Absurd's control-flow arm
+
+One test: a task that suspends on a durable sleep sends no `task_finished`. It pins that
+`SuspendTask` does not reach the `except Exception` arm, which would report the
+suspension as the task failing.
+
+`CancelledTask`/`FailedTask` get no test, and need none — they send nothing, and the arm
+that swallows them is the same one the sleep test already covers. Reaching them
+specifically would need a task that sabotages its own run (cancelling itself through a
+fresh SDK client, or `absurd.fail_run` on `ctx._task["run_id"]` by raw SQL) to assert an
+absence, which is not worth a fixture.
+
+## Docs
+
+The shipped documentation is deliberately thin: ~8 lines under `## Deployment notes` in
+`django_absurd/AGENTS.md` and ~13 in `docs/web/how-it-works.md`, both titled "Django
+Task lifecycle logging". Between them they say only what an operator needs — Django's
+`django.tasks` logger reports task lifecycle on this backend because the backend emits
+Django's task signals; the log is NOT a complete record (no line marks a retried
+attempt's failure, and an ending Absurd decides on its own produces none at all); and
+queue state plus the stored result are the record.
+
+No receiver-authoring material and no example receiver, because users are not invited to
+build on these signals. The constraints below are the reason that is the right advice.
+They live HERE rather than in the shipped docs, since writing them up for users would
+amount to a guide for the thing we are declining to offer:
+
+- A receiver's exception is contained and logged, so nothing a user connects can fail a
+  task.
+- A worker-side receiver runs on the worker's event loop, where Django's ORM refuses to
+  run at all, and inside the run's claim lease.
+- `task_started` arrives once per execution episode, not once per attempt — so counters
+  and gauges built on it are wrong by construction.
+- `task_finished` never arrives for an ending Absurd decided itself.
+- The payload may be mutated after a receiver returns, as Django's own backends mutate
+  theirs. Nothing may rely on the payload still holding its send-time state, nor on
+  object identity across signals: `task_enqueued` carries a different object (often
+  built in another process), and each handler entry of a task that sleeps builds a fresh
+  one — identity holds only from `task_started` to `task_finished` within one entry.
+
+The `TaskResult.id` shape change is release-note material. There is no CHANGELOG in this
+repo, so it rides the commit body under `BREAKING:` for the release drafter to surface.

--- a/docs/web/how-it-works.md
+++ b/docs/web/how-it-works.md
@@ -58,6 +58,19 @@ One worker runs both sync and `async def` [tasks](tasks.md) (async on an event l
 sync in a thread pool). On start it does a full sync — provisioning every declared queue
 and rebuilding the admin views — then polls for work.
 
+## Django Task lifecycle logging
+
+Django logs a task's lifecycle on the `django.tasks` logger — `DEBUG` when it's
+enqueued, `INFO` at `state=RUNNING` and `state=SUCCESSFUL`, `ERROR` with a traceback at
+`state=FAILED`. `AbsurdBackend` emits the signals Django's logging listens for, so those
+lines appear for Absurd tasks too.
+
+Django's logs are not a complete record. Postgres is: a retried attempt's failure logs
+nothing, and neither does an ending Absurd decided itself — a
+[`max_delay`/`max_duration` cancellation](tasks.md#retries-spawn-options), an expired
+claim, or a cancellation. The [stored result](tasks.md#read-the-result) and the
+queue-state models below are the record.
+
 ## Admin & ORM introspection
 
 When `django.contrib.admin` is installed, django-absurd registers **read-only** admin

--- a/docs/web/tasks.md
+++ b/docs/web/tasks.md
@@ -108,13 +108,19 @@ are silently inert and you get one `WARNING` naming the task and the backend it 
 Precedence for `max_attempts`: per-invocation → decorator default →
 [`OPTIONS["DEFAULT_MAX_ATTEMPTS"]`](configuration.md#backend-options) (5).
 
+`max_attempts=None` is accepted at both sites and means **retry forever** — Absurd
+stores a NULL ceiling and keeps retrying while it is NULL. Such a task is never
+terminal, so Django's task logger never records a final line for it. Leaving
+`max_attempts` out is not the same thing: the backend fills in its own default on every
+enqueue, so only an explicit `None` is unbounded.
+
 The fields (types come from `absurd_sdk`); the "Where" column is enforced by
 `absurd_params`'s own overload pair, not just convention — passing `headers` or
 `idempotency_key` to the decorator form is a static and a runtime error:
 
 | Field             | Where              | What it does                                                                             |
 | ----------------- | ------------------ | ---------------------------------------------------------------------------------------- |
-| `max_attempts`    | default + per-call | Retry ceiling for the task.                                                              |
+| `max_attempts`    | default + per-call | Retry ceiling for the task; `None` means retry forever.                                  |
 | `retry_strategy`  | default + per-call | Backoff: `kind` (`fixed`/`exponential`/`none`), `base_seconds`, `factor`, `max_seconds`. |
 | `cancellation`    | default + per-call | `max_duration`, `max_delay` (seconds).                                                   |
 | `headers`         | per-call only      | Arbitrary JSON metadata carried with the task.                                           |
@@ -171,6 +177,10 @@ result.status         # READY | RUNNING | SUCCESSFUL | FAILED
 result.return_value   # available once SUCCESSFUL
 result.errors         # populated when FAILED
 ```
+
+The id `enqueue` returned is the `"<queue>:<uuid>"` form, and it is the same id
+`context.task_result.id` reports inside a `takes_context` task — so either can be handed
+straight back to `get_result`.
 
 A task may run **more than once** (at-least-once delivery), so keep handlers idempotent
 — use `idempotency_key` (above) where it helps. See

--- a/tests/core/test_absurd_params.py
+++ b/tests/core/test_absurd_params.py
@@ -57,6 +57,12 @@ def test_unset_fields_never_enter_the_params() -> None:
     assert bound.absurd_params == {"max_attempts": 3}
 
 
+def test_max_attempts_accepts_none_for_unbounded_retries() -> None:
+    bound = absurd_params(max_attempts=None).bind(tasks.add)
+    assert isinstance(bound, AbsurdTask)
+    assert bound.absurd_params == {"max_attempts": None}
+
+
 def test_bound_task_aenqueues() -> None:
     call_command("absurd_sync_queues")
     asyncio.run(absurd_params(max_attempts=3).bind(tasks.add).aenqueue(1, 2))

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -12,6 +12,7 @@ import time_machine
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.tasks import TaskResultStatus
 from django.utils import timezone
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
@@ -381,6 +382,30 @@ def test_beat_routes_task_to_queue_non_default_alias(
         assert not Group.objects.filter(name="beat-non-default").exists()
         call_command("absurd_worker", queue="other", burst=True)
         assert Group.objects.filter(name="beat-non-default").exists()
+
+
+def test_get_result_rebinds_queue_and_backend_together(
+    dj_absurd: AbsurdTestRuntime,
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    # tasks.make_group's own decorator names the "default" alias, and these settings
+    # deliberately omit it: only "second" is configured, so a queue-only rebind of the
+    # re-imported definition raises InvalidTaskBackend on the read path, exactly as it
+    # does on the worker path (build_running_task_result).
+    settings.TASKS = {
+        "second": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"QUEUES": {"default": {}, "other": {}}},
+        }
+    }
+    backend = get_absurd_backends()["second"]
+    call_command("absurd_sync_queues")
+    r = tasks.make_group.using(queue_name="other", backend="second").enqueue(
+        "get-result-second-alias"
+    )
+    dj_absurd.drain(queue="other")
+    got = backend.get_result(r.id)
+    assert got.status == TaskResultStatus.SUCCESSFUL
 
 
 def test_derive_idempotency_key_stable_same_inputs() -> None:

--- a/tests/core/test_signals_enqueue.py
+++ b/tests/core/test_signals_enqueue.py
@@ -1,0 +1,106 @@
+import asyncio
+import datetime as dt
+import logging
+import typing as t
+
+import pytest
+from django.tasks import TaskResultStatus
+from django.tasks.signals import task_enqueued, task_finished, task_started
+from django.utils import timezone
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+
+def test_enqueue_sends_task_enqueued(caplog: pytest.LogCaptureFixture) -> None:
+    receiver = utils.RecordingReceiver()
+    # tests/settings.py sets no LOGGING, so Django's default puts "django" at INFO and
+    # the DEBUG record this asserts on is dropped at the logger before any handler sees
+    # it.
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        result = tasks.add.enqueue(1, 2)
+
+    assert [r.id for r in receiver.results] == [result.id]
+    assert receiver.results[0].status == TaskResultStatus.READY
+    assert receiver.results[0].task.module_path == tasks.add.module_path
+
+    records = [r for r in caplog.records if r.name == "django.tasks"]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert records[0].getMessage() == (
+        f"Task id={result.id} path={tasks.add.module_path} enqueued "
+        f"backend={result.backend}"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_aenqueue_sends_one_task_enqueued() -> None:
+    receiver = utils.RecordingReceiver()
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        result = asyncio.run(tasks.add.aenqueue(1, 2))
+
+    assert [r.id for r in receiver.results] == [result.id]
+
+
+def test_enqueue_survives_a_receiver_that_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def explode(sender: type, task_result: t.Any, **kwargs: t.Any) -> None:
+        msg = "receiver is broken"
+        raise RuntimeError(msg)
+
+    with (
+        utils.connect_receiver(task_enqueued, explode, sender=AbsurdBackend),
+        caplog.at_level(logging.ERROR, logger="django_absurd"),
+    ):
+        result = tasks.add.enqueue(1, 2)
+
+    assert result.status == TaskResultStatus.READY
+    errors = [r for r in caplog.records if r.name == "django_absurd"]
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None
+    assert errors[0].getMessage() == (
+        f"django-absurd task_enqueued receiver failed for task result id={result.id}"
+    )
+
+
+def test_absurd_sender_filter_ignores_another_backend() -> None:
+    receiver = utils.RecordingReceiver()
+    on_immediate = tasks.add.using(backend="immediate")
+    with utils.connect_receiver(task_enqueued, receiver, sender=AbsurdBackend):
+        on_immediate.enqueue(1, 2)
+
+    assert receiver.results == []
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_deferred_enqueue_sends_two_signals(dj_absurd: AbsurdTestRuntime) -> None:
+    enqueued = utils.RecordingReceiver()
+    started = utils.RecordingReceiver()
+    finished = utils.RecordingReceiver()
+    with (
+        utils.connect_receiver(task_enqueued, enqueued, sender=AbsurdBackend),
+        utils.connect_receiver(task_started, started, sender=AbsurdBackend),
+        utils.connect_receiver(task_finished, finished, sender=AbsurdBackend),
+        dj_absurd.freeze_time() as frozen_time,
+    ):
+        due = timezone.now() + dt.timedelta(hours=1)
+        wrapper = tasks.add.using(run_after=due).enqueue(1, 2)
+        assert [r.id for r in enqueued.results] == [wrapper.id]
+
+        frozen_time.shift(dt.timedelta(hours=2))
+        dj_absurd.drain()
+
+    sent = enqueued.results
+    assert len(sent) == 2
+    assert sent[0].task.run_after is not None
+    assert sent[1].task.run_after is None
+    assert sent[0].id != sent[1].id
+    # The wrapper's id is a permanent orphan: the wrapper handler sends nothing, so only
+    # the real task's id ever starts or finishes. A refactor breaks this silently. The
+    # positive assertion is what keeps the absence a claim rather than a tautology.
+    assert wrapper.id not in [r.id for r in started.results]
+    assert wrapper.id not in [r.id for r in finished.results]
+    assert sent[1].id in [r.id for r in started.results]

--- a/tests/core/test_signals_finished_failure.py
+++ b/tests/core/test_signals_finished_failure.py
@@ -1,0 +1,94 @@
+import logging
+
+import pytest
+from absurd_sdk import RetryStrategy
+from django.tasks import TaskResultStatus, task_backends
+from django.tasks.signals import task_finished, task_started
+
+from django_absurd import params as params_module
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_only_the_terminal_attempt_reports_a_failure(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    finished = utils.RecordingReceiver()
+    started = utils.RecordingReceiver()
+    two_attempts = params_module.absurd_params(max_attempts=2).bind(tasks.boom)
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    with (
+        utils.connect_receiver(task_started, started, sender=AbsurdBackend),
+        utils.connect_receiver(task_finished, finished, sender=AbsurdBackend),
+        dj_absurd.freeze_time(),
+    ):
+        two_attempts.enqueue()
+        # Default retry strategy is kind 'none' -> delay 0, so both attempts are
+        # claimable inside one drain; no clock movement needed.
+        dj_absurd.drain()
+
+    assert len(started.results) == 2
+    assert len(finished.results) == 1
+    assert finished.results[0].status == TaskResultStatus.FAILED
+    assert len(finished.results[0].errors) == 1
+
+    errors = [
+        r
+        for r in caplog.records
+        if r.name == "django.tasks" and r.levelno >= logging.WARNING
+    ]
+    assert len(errors) == 1
+    assert errors[0].levelno == logging.ERROR
+    failed = finished.results[0]
+    assert errors[0].getMessage() == (
+        f"Task id={failed.id} path={tasks.boom.module_path} state=FAILED"
+    )
+    assert errors[0].exc_info is not None
+    # The line names the task's OWN exception: the send happens inside the handler's
+    # except arm, so sys.exc_info() is what the task raised.
+    assert errors[0].exc_info[0] is ValueError
+
+
+def test_unbounded_attempts_never_report_terminal(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    finished = utils.RecordingReceiver()
+    # A backoff is mandatory here: with max_attempts=None and the default delay-0
+    # strategy, the burst drain re-claims the failing task forever and the test hangs
+    # until pytest-timeout kills it.
+    unbounded = params_module.absurd_params(
+        max_attempts=None,
+        retry_strategy=RetryStrategy(kind="fixed", base_seconds=3600),
+    ).bind(tasks.boom)
+    with (
+        utils.connect_receiver(task_finished, finished, sender=AbsurdBackend),
+        dj_absurd.freeze_time(),
+    ):
+        unbounded.enqueue()
+        dj_absurd.drain()
+
+    assert finished.results == []
+
+
+def test_the_persisted_traceback_holds_only_the_tasks_own_failure(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    """The SDK formats the live exception's __traceback__ into failure_reason, so
+    anything django-absurd runs while REPORTING that failure must stay off it.
+    """
+    one_attempt = params_module.absurd_params(max_attempts=1).bind(tasks.boom)
+    with dj_absurd.freeze_time():
+        result = one_attempt.enqueue()
+        dj_absurd.drain()
+
+    failure = dj_absurd.get_result(result.id).failure
+    assert failure is not None
+    assert "send_finished_if_terminal" not in failure["traceback"]
+    assert "send_task_signal" not in failure["traceback"]
+    # Ends at the task's own exception, so nothing was appended after the handler saw
+    # it.
+    assert failure["traceback"].strip().endswith("ValueError: boom")
+    assert task_backends["default"].get_result(result.id).errors[0].traceback

--- a/tests/core/test_signals_finished_success.py
+++ b/tests/core/test_signals_finished_success.py
@@ -1,0 +1,80 @@
+import logging
+
+import pytest
+from django.tasks import TaskResultStatus, task, task_backends
+from django.tasks.signals import task_finished
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@task
+def return_a_tuple() -> tuple[int, int]:
+    return (1, 2)
+
+
+def test_finished_reports_success_and_the_return_value(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    receiver = utils.RecordingReceiver()
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    with (
+        utils.connect_receiver(task_finished, receiver, sender=AbsurdBackend),
+        dj_absurd.freeze_time(),
+    ):
+        result = tasks.add.enqueue(1, 2)
+        dj_absurd.drain()
+
+    assert [r.id for r in receiver.results] == [result.id]
+    sent = receiver.results[0]
+    assert sent.status == TaskResultStatus.SUCCESSFUL
+    assert sent.finished_at is not None
+    # An unset _return_value reads as None here — silently wrong rather than raising.
+    assert sent.return_value == 3
+    assert task_backends["default"].get_result(result.id).return_value == 3
+
+    records = [r for r in caplog.records if r.name == "django.tasks"]
+    assert [r.levelno for r in records] == [logging.DEBUG, logging.INFO, logging.INFO]
+    assert [r.getMessage() for r in records] == [
+        (
+            f"Task id={result.id} path={tasks.add.module_path} enqueued "
+            f"backend={result.backend}"
+        ),
+        f"Task id={result.id} path={tasks.add.module_path} state=RUNNING",
+        f"Task id={result.id} path={tasks.add.module_path} state=SUCCESSFUL",
+    ]
+
+
+def test_finished_normalizes_the_return_value(dj_absurd: AbsurdTestRuntime) -> None:
+    """A raw tuple would reach the receiver as a tuple while the store reads back a
+    list — the same value in two shapes depending on where you read it.
+    """
+    receiver = utils.RecordingReceiver()
+    with (
+        utils.connect_receiver(task_finished, receiver, sender=AbsurdBackend),
+        dj_absurd.freeze_time(),
+    ):
+        result = return_a_tuple.enqueue()
+        dj_absurd.drain()
+
+    assert receiver.results[0].return_value == [1, 2]
+    assert task_backends["default"].get_result(result.id).return_value == [1, 2]
+
+
+def test_a_suspended_run_reports_nothing(dj_absurd: AbsurdTestRuntime) -> None:
+    """A durable sleep is not an ending, so the handler's ``SuspendTask`` arm sends
+    nothing. Were it to fall through to the ``except Exception`` arm instead, the
+    suspension would be reported as the task failing.
+    """
+    receiver = utils.RecordingReceiver()
+    with (
+        utils.connect_receiver(task_finished, receiver, sender=AbsurdBackend),
+        dj_absurd.freeze_time(),
+    ):
+        tasks.sleep_a_week.enqueue()
+        dj_absurd.drain()
+
+    assert receiver.results == []

--- a/tests/core/test_signals_started.py
+++ b/tests/core/test_signals_started.py
@@ -1,0 +1,95 @@
+import datetime as dt
+import logging
+import typing as t
+
+import pytest
+from django.tasks import TaskResultStatus
+from django.tasks.signals import task_started
+
+from django_absurd.backends import AbsurdBackend
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks, utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_started_fires_once_per_successful_run(dj_absurd: AbsurdTestRuntime) -> None:
+    receiver = utils.RecordingReceiver()
+    with (
+        utils.connect_receiver(task_started, receiver, sender=AbsurdBackend),
+        dj_absurd.freeze_time(),
+    ):
+        result = tasks.add.enqueue(1, 2)
+        dj_absurd.drain()
+
+    assert [r.id for r in receiver.results] == [result.id]
+    # Through statuses, not results[0].status: one TaskResult is mutated across the
+    # lifecycle, so by now that object reports the task's final status instead.
+    assert receiver.statuses == [TaskResultStatus.RUNNING]
+    assert receiver.results[0].attempts == 1
+    assert receiver.results[0].started_at is not None
+    # One handler entry IS one attempt, so the two instants are the same one.
+    assert receiver.results[0].last_attempted_at == receiver.results[0].started_at
+    assert receiver.results[0].enqueued_at is None
+
+
+def test_started_fires_per_handler_entry_across_a_sleep(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    receiver = utils.RecordingReceiver()
+    caplog.set_level(logging.DEBUG, logger="django.tasks")
+    with (
+        utils.connect_receiver(task_started, receiver, sender=AbsurdBackend),
+        dj_absurd.freeze_time() as frozen_time,
+    ):
+        result = tasks.sleep_a_week.enqueue()
+        dj_absurd.drain()  # entry 1: suspends on the durable sleep
+        assert len(receiver.results) == 1
+
+        frozen_time.shift(dt.timedelta(days=8))
+        dj_absurd.drain()  # entry 2: replays and finishes
+
+    assert len(receiver.results) == 2
+    # One attempt, two entries: the run is rescheduled, never re-created.
+    assert [r.attempts for r in receiver.results] == [1, 1]
+    assert dj_absurd.get_result(result.id).state == "completed"
+
+    path = tasks.sleep_a_week.module_path
+    messages = [r.getMessage() for r in caplog.records if r.name == "django.tasks"]
+    assert messages == [
+        f"Task id={result.id} path={path} enqueued backend={result.backend}",
+        f"Task id={result.id} path={path} state=RUNNING",
+        f"Task id={result.id} path={path} state=RUNNING",
+        f"Task id={result.id} path={path} state=SUCCESSFUL",
+    ]
+
+
+def test_a_raising_receiver_does_not_fail_the_task(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    """Uncontained, this exception escapes the handler and the SDK reads it as the TASK
+    failing — an audit receiver would burn every attempt of every task.
+    """
+
+    def explode(sender: type, task_result: t.Any, **kwargs: t.Any) -> None:
+        msg = "receiver is broken"
+        raise RuntimeError(msg)
+
+    with (
+        utils.connect_receiver(task_started, explode, sender=AbsurdBackend),
+        caplog.at_level(logging.ERROR, logger="django_absurd"),
+        dj_absurd.freeze_time(),
+    ):
+        result = tasks.add.enqueue(1, 2)
+        dj_absurd.drain()
+
+    assert dj_absurd.get_result(result.id).state == "completed"
+    contained = [
+        r
+        for r in caplog.records
+        if r.name == "django_absurd" and r.levelno >= logging.ERROR
+    ]
+    assert len(contained) == 1
+    assert contained[0].getMessage() == (
+        f"django-absurd task_started receiver failed for task result id={result.id}"
+    )

--- a/tests/core/test_signals_worker_result.py
+++ b/tests/core/test_signals_worker_result.py
@@ -1,0 +1,21 @@
+import pytest
+
+from django_absurd.test import AbsurdTestRuntime
+from tests import tasks
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_the_worker_result_id_round_trips_and_names_the_backend(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    result = tasks.report_context.enqueue()
+    dj_absurd.drain()
+
+    payload = dj_absurd.get_result(result.id).result
+    assert payload is not None
+    assert payload["id"] == result.id
+    assert payload["id"].startswith("default:")
+    assert payload["backend"] == "default"
+    snapshot = dj_absurd.get_result(payload["id"])
+    assert f"{snapshot.queue}:{snapshot.task_id}" == result.id

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -43,6 +43,15 @@ def report_args(
     return context.task_result.args
 
 
+@task(takes_context=True)
+def report_context(context: "TaskContext[t.Any, t.Any]") -> dict[str, JsonValue]:
+    return {
+        "id": context.task_result.id,
+        "backend": context.task_result.backend,
+        "attempts": context.task_result.attempts,
+    }
+
+
 @task(queue_name="other")
 def routed() -> str:
     Group.objects.create(name="routed")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+import contextlib
+import threading
 import typing as t
 import uuid
 
@@ -6,11 +8,14 @@ import psycopg.sql
 from absurd_sdk import Absurd, CreateQueueOptions
 from django.core.management import call_command
 from django.db import connections
+from django.dispatch import Signal
 
 from django_absurd.test import open_test_connection
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from django.tasks import TaskResult, TaskResultStatus
 
 ABSURD_BACKEND = "django_absurd.backends.AbsurdBackend"
 
@@ -70,8 +75,7 @@ def claim_one_run(queue: str = "default", *, claim_timeout: int) -> uuid.UUID:
     out, so advancing durable time past that lease lets the ``$ClaimTimeout`` sweep
     inside the next ``claim_task`` expire and re-arm it.
     """
-    params = connections["default"].get_connection_params()
-    conn = psycopg.connect(**params, autocommit=True)
+    conn = psycopg.connect(**get_absurd_connection_params(), autocommit=True)
     try:
         claimed = Absurd(conn, queue_name=queue).claim_tasks(
             claim_timeout=claim_timeout
@@ -91,8 +95,7 @@ def heartbeat_one_run(
     no live ``TaskContext`` to heartbeat through, so this calls the SQL function
     directly on a fresh connection instead.
     """
-    params = connections["default"].get_connection_params()
-    conn = psycopg.connect(**params, autocommit=True)
+    conn = psycopg.connect(**get_absurd_connection_params(), autocommit=True)
     try:
         with conn.cursor() as cursor:
             cursor.execute(
@@ -100,6 +103,17 @@ def heartbeat_one_run(
             )
     finally:
         conn.close()
+
+
+def get_absurd_connection_params() -> dict[str, t.Any]:
+    """Django's own connection params for the Absurd database, for a raw psycopg client.
+
+    Anything reaching Absurd outside Django's connection — a manual claim, a heartbeat
+    on a claimed run — needs the database THIS session provisioned, and only Django
+    knows which that is (pytest-django swaps ``NAME`` per run, per xdist worker).
+    """
+    params: dict[str, t.Any] = connections["default"].get_connection_params()
+    return params
 
 
 def set_database_fake_now(value: str) -> None:
@@ -154,3 +168,61 @@ def reset_database_fake_now() -> None:
     )
     with open_test_connection("default") as cursor:
         cursor.execute(statement)
+
+
+class RecordingReceiver:
+    """Collects TaskResults from a signal.
+
+    Thread-safe because the enqueue seam sends on whatever thread called it, so a sync
+    task body enqueueing at concurrency>1 reaches it from several pool threads at once
+    and a bare list would race. A class rather than a closure so a test can hold one
+    object and read it after the block.
+
+    ``statuses`` exists because one ``TaskResult`` is MUTATED through a task's whole
+    lifecycle and handed to every signal. That is Django's own semantics, not ours
+    (``ImmediateBackend._execute_task`` mutates one result in place from READY through
+    to its final status), so
+    ``results[0].status`` read after the block is the task's FINAL status, not the
+    status when that signal fired. Assert transient state through ``statuses``, which
+    snapshots it at receive time.
+    """
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.received: list[TaskResult[t.Any, t.Any]] = []
+        self.seen_statuses: list[TaskResultStatus] = []
+
+    def __call__(
+        self, sender: type, task_result: "TaskResult[t.Any, t.Any]", **kwargs: t.Any
+    ) -> None:
+        with self.lock:
+            self.received.append(task_result)
+            self.seen_statuses.append(task_result.status)
+
+    @property
+    def results(self) -> list["TaskResult[t.Any, t.Any]"]:
+        with self.lock:
+            return list(self.received)
+
+    @property
+    def statuses(self) -> list["TaskResultStatus"]:
+        with self.lock:
+            return list(self.seen_statuses)
+
+
+@contextlib.contextmanager
+def connect_receiver(
+    signal: Signal, receiver: t.Any, *, sender: type
+) -> t.Iterator[None]:
+    """Connect for the duration of the block, always disconnecting.
+
+    connect() sits inside the try so a failure anywhere after it still disconnects; a
+    receiver leaked here fires for every later test in the same process. weak=False
+    because Signal.connect otherwise holds a weak reference and a receiver the caller
+    does not keep alive can be collected mid-test, silently never firing.
+    """
+    try:
+        signal.connect(receiver, sender=sender, weak=False)
+        yield
+    finally:
+        signal.disconnect(receiver, sender=sender)


### PR DESCRIPTION
AbsurdBackend sent none of Django’s three task signals, so Django’s own `django.tasks` logging reported nothing for this backend and a user’s `@receiver(task_finished)` never fired.

Emits all three through one contained helper: a receiver’s exception is logged and swallowed, because uncontained the SDK reads it as the *task* failing and burns its attempts. `task_started` fires per execution episode; `task_finished` only where the handler can prove terminality. Endings Absurd decides itself are outside what these signals describe — Django’s logs are not a complete record, Postgres is.

Not an extension point, so the docs stay thin (~8 lines under Deployment notes).

Also fixes, independent of the signals: wrong sender/queue on the worker-side `TaskResult`; `InvalidTaskBackend` when rebinding a result’s queue without its backend alias (fatal in the handler for a beat-routed task, and in `get_result()`); unset `last_attempted_at`; missing `normalize_json` on the success payload; untyped `absurd_params(max_attempts=None)`.

Unit 1 of #25.

**BREAKING:** `TaskContext.task_result.id` changes from a bare uuid to `"<queue>:<uuid>"` — the form `enqueue` already returned and the only form `get_result()` accepts.