### PR TITLE
feat!: one worker mode, with working concurrency

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -257,14 +257,17 @@ A single worker runs **both** sync and async tasks: `async def` tasks run on an 
 loop (true concurrency for I/O-bound work), sync `def` tasks run in a thread pool. On
 start it runs a full sync — reconciling **every** declared queue (creating missing ones,
 applying declared policy changes) and rebuilding the admin views so they reflect the
-whole catalog, not just the served queue — and reports to stdout.
+whole catalog, not just the served queue — and reports to stdout. It then polls until
+`SIGINT`/`SIGTERM`.
 
-- **Blocking** (default): long-running; polls until `SIGINT`/`SIGTERM`.
-- **Burst** (`--burst`): drain the current backlog, then exit `0` (cron / one-shot).
 - `--queue` (default `"default"`): which queue to consume.
-- `--concurrency N` (default `1`): max tasks in flight — sizes both the event-loop
-  concurrency and the sync thread pool. Other flags: `--claim-timeout`,
-  `--poll-interval`, `--batch-size`, and `--worker-id`.
+- `--concurrency N` (default `1`): number of tasks in flight at once. A slot is refilled
+  as soon as it frees, rather than waiting for the whole batch to finish — one slow task
+  no longer idles the others. Sizes both the event-loop concurrency and the sync thread
+  pool.
+- A stop signal (`SIGINT`/`SIGTERM`) stops claiming and lets in-flight tasks finish
+  before the worker exits. Other flags: `--claim-timeout`, `--poll-interval`,
+  `--batch-size`, and `--worker-id`.
 
 ## Scheduling recurring tasks
 
@@ -804,7 +807,7 @@ members:
 | `freeze_time(instant=None)`                 | context manager pinning durable time (`None` = real now at entry)                            |
 | `now`                                       | virtual now, timezone-aware, as Postgres itself reports it                                   |
 | `sync_queues()`                             | provision every declared queue (rarely needed; see below)                                    |
-| `drain(queue="default")`                    | burst-drain a queue, returning `list[RunSnapshot]`                                           |
+| `drain(queue="default")`                    | run a queue's claimable tasks to completion, returning `list[RunSnapshot]`                   |
 | `emit(name, payload=None, queue="default")` | deliver an event, resolving a task suspended in `await_event`                                |
 | `get_result(task_id, queue=...)`            | look up one task, returning `TaskSnapshot` (raises `TaskNotFoundError` on a miss; see below) |
 
@@ -848,12 +851,11 @@ catalog, so reach for this only when the test itself changed queue topology — 
 the queues.
 
 **`drain()`** runs every currently-claimable task on `queue` to completion, in-process —
-no [worker](#workers) subprocess, no polling loop to manage. It's the fixture
-counterpart of `absurd_worker --burst`: it drains the backlog present at call time, then
-returns one `RunSnapshot` per run executed, in claim order. It provisions nothing
-(unlike the CLI, which provisions declared queues on start): `migrate` provisions every
-declared queue already, so a test database arrives ready, but a queue a single test
-declares by overriding `TASKS` needs `dj_absurd.sync_queues()` first or `drain()` raises
+no [worker](#workers) subprocess, no polling loop to manage — one at a time, returning
+one `RunSnapshot` per run executed, in claim order. It provisions nothing (unlike the
+CLI, which provisions declared queues on start): `migrate` provisions every declared
+queue already, so a test database arrives ready, but a queue a single test declares by
+overriding `TASKS` needs `dj_absurd.sync_queues()` first or `drain()` raises
 `QueueNotProvisionedError` naming that command (a queue that isn't declared at all
 raises `QueueNotDeclaredError`) — see [Exceptions](#exceptions) above for the full
 typed-error taxonomy.

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -99,5 +99,18 @@ class Command(AbsurdReportCommand):
 
         elephant = console.build_glyph_prefix(self.stdout, "🐘")
         self.stdout.write(f"{elephant}Started worker on queue '{queue}'.")
-        run_worker(backend, queue, run_beat=options["beat"], options=worker_options)
+
+        def announce_stop_requested() -> None:
+            self.stdout.write(
+                f"{elephant}Stop requested on queue '{queue}'; "
+                "finishing in-flight tasks."
+            )
+
+        run_worker(
+            backend,
+            queue,
+            run_beat=options["beat"],
+            options=worker_options,
+            on_stop_requested=announce_stop_requested,
+        )
         self.stdout.write(f"{elephant}Stopped worker on queue '{queue}'.")

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -28,11 +28,6 @@ class Command(AbsurdReportCommand):
             help="Queue name to consume (default: 'default').",
         )
         parser.add_argument(
-            "--burst",
-            action="store_true",
-            help="Drain the queue then exit (no persistent blocking loop).",
-        )
-        parser.add_argument(
             "--concurrency",
             type=int,
             default=1,
@@ -67,10 +62,7 @@ class Command(AbsurdReportCommand):
         parser.add_argument(
             "--beat",
             action="store_true",
-            help=(
-                "Run the beat scheduler in the worker loop"
-                " (not compatible with --burst)."
-            ),
+            help="Run the beat scheduler in the worker loop.",
         )
 
     def handle(self, *args: t.Any, **options: t.Any) -> None:
@@ -80,10 +72,6 @@ class Command(AbsurdReportCommand):
         except BackendNotConfiguredError as exc:
             raise CommandError(str(exc)) from exc
         queue = options["queue"]
-
-        if options["burst"] and options["beat"]:
-            msg = "--beat is not compatible with --burst."
-            raise CommandError(msg)
 
         if options["beat"] and backend.scheduler == "pg_cron":
             raise CommandError(BEAT_DISABLED_UNDER_PG_CRON)
@@ -111,11 +99,5 @@ class Command(AbsurdReportCommand):
 
         elephant = console.build_glyph_prefix(self.stdout, "🐘")
         self.stdout.write(f"{elephant}Started worker on queue '{queue}'.")
-        run_worker(
-            backend,
-            queue,
-            burst=options["burst"],
-            run_beat=options["beat"],
-            options=worker_options,
-        )
+        run_worker(backend, queue, run_beat=options["beat"], options=worker_options)
         self.stdout.write(f"{elephant}Stopped worker on queue '{queue}'.")

--- a/django_absurd/pytest_plugin.py
+++ b/django_absurd/pytest_plugin.py
@@ -114,7 +114,7 @@ def _sweep_stranded_fake_now(request: pytest.FixtureRequest) -> None:
 
 @pytest.fixture
 def dj_absurd() -> t.Iterator[AbsurdTestRuntime]:
-    """Read/drain/clock facade for durable tests: snapshot task/run state, burst-drain a
+    """Read/drain/clock facade for durable tests: snapshot task/run state, drain a
     queue, and freeze Absurd's durable clock with ``freeze_time``.
 
     Requires ``@pytest.mark.django_db(transaction=True)`` — its reads run on a

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -454,7 +454,7 @@ class AbsurdTestRuntime:
         always lands Python-ahead — the benign side.
 
         Postgres-ahead is unrecoverable: the run is claimed, the SDK re-suspends on
-        replay, and the burst drain re-arms the same wake forever. Python-ahead just
+        replay, and the drain re-arms the same wake forever. Python-ahead just
         leaves a sleeping run unclaimed. Which order lands which side ahead flips with
         the move's direction:
 
@@ -528,7 +528,7 @@ class AbsurdTestRuntime:
     def _write_fake_now(self, instant: dt.datetime) -> None:
         """Set ``absurd.fake_now`` at DATABASE level, then on Django's live session.
 
-        Database level because the burst worker opens its OWN connection per drain —
+        Database level because a drain opens its OWN connection every time —
         only a database default reaches it; session level too because a default
         reaches only NEW sessions, so ``enqueue()`` on Django's already-open
         connection would keep stamping real time. ``ALTER DATABASE`` rejects bind
@@ -750,9 +750,9 @@ def run_off_event_loop[T](work: t.Callable[[], T]) -> T:
     With no loop running in this thread, ``work`` is simply called: the sync path is
     untouched, same thread, same connection, same traceback. Under a running loop it
     goes to a worker thread, where there IS no running loop, so both Django's
-    ``async_unsafe`` guards and ``asyncio.run`` inside the burst worker are legal
+    ``async_unsafe`` guards and ``asyncio.run`` inside the drain are legal
     again. Blocking the loop is safe here because a test is the only thing on it and
-    ``work`` never awaits it back — ``drain()``'s ``arun_worker`` builds a loop of its
+    ``work`` never awaits it back — ``drain()``'s ``drain_queue`` builds a loop of its
     own in the worker thread.
 
     Callers keep their guards on THEIR OWN thread and call this for the DB work only:

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -336,8 +336,8 @@ class AbsurdTestRuntime:
         run_off_event_loop(functools.partial(emit_event, name, payload, queue=queue))
 
     def drain(self, queue: str = "default") -> list[RunSnapshot]:
-        """Burst-drain ``queue`` synchronously, one ``RunSnapshot`` per run, in claim
-        order.
+        """Run every currently-claimable task on ``queue`` to completion, synchronously,
+        one at a time, returning one ``RunSnapshot`` per run in claim order.
 
         A suspended run (durable sleep, ``await_event``) is returned with
         ``state="sleeping"``. The same run can appear twice — an ``await_event``

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -92,9 +92,9 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
     The SDK reads _registry.get(task_name) in _execute_task, which every dispatch
     goes through — the drain and the blocking loop alike. Overriding .get intercepts
     all dispatch reads and resolves any importable Task on demand — no tasks.py scan
-    required. Value type
-    matches the SDK's own ``_registry: Dict[str, Dict[str, Any]]`` declaration — each
-    entry mixes str/None/Callable fields, so the inner ``Any`` is a genuine boundary.
+    required. Value type matches the SDK's own
+    ``_registry: Dict[str, Dict[str, Any]]`` declaration — each entry mixes
+    str/None/Callable fields, so the inner ``Any`` is a genuine boundary.
     """
 
     def __init__(self, queue: str, backend: AbsurdBackend) -> None:

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import inspect
 import logging
 import os
@@ -549,7 +550,7 @@ async def run_one_slot_at_a_time(
     while not stop.is_set():
         claimed = await client.claim_tasks(batch_size, options.claim_timeout, worker_id)
         if not claimed:
-            await asyncio.sleep(options.poll_interval)
+            await wait_for_stop_or_timeout(stop, options.poll_interval)
             continue
         for claimed_task in claimed:
             await client._execute_task(claimed_task, options.claim_timeout)  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
@@ -574,13 +575,13 @@ async def refill_slots_until_stopped(
             reap_finished_slots(executing)
             capacity = options.concurrency - len(executing)
             if capacity <= 0:
-                await wait_for_slot_progress(executing, options.poll_interval)
+                await wait_for_slot_progress(executing, stop, options.poll_interval)
                 continue
             claimed = await client.claim_tasks(
                 min(effective_batch_size, capacity), options.claim_timeout, worker_id
             )
             if not claimed:
-                await wait_for_slot_progress(executing, options.poll_interval)
+                await wait_for_slot_progress(executing, stop, options.poll_interval)
                 continue
             for claimed_task in claimed:
                 executing.add(
@@ -643,18 +644,32 @@ def reap_finished_slots(executing: set[asyncio.Task[None]]) -> None:
 
 
 async def wait_for_slot_progress(
-    executing: set[asyncio.Task[None]], poll_interval: float
+    executing: set[asyncio.Task[None]], stop: asyncio.Event, poll_interval: float
 ) -> None:
     """Wait until a slot frees, or ``poll_interval`` passes, whichever comes first.
 
-    ``asyncio.wait`` only observes; the loop head reaps what it reports.
+    ``asyncio.wait`` only observes; the loop head reaps what it reports. It needs no
+    stop of its own: waking early on one would only reach a ``finally`` that awaits
+    the very slots being waited on here. An EMPTY window has nothing to wait on, so
+    that arm is a plain idle and races the stop like every other idle does.
     """
     if not executing:
-        await asyncio.sleep(poll_interval)
+        await wait_for_stop_or_timeout(stop, poll_interval)
         return
     await asyncio.wait(
         executing, timeout=poll_interval, return_when=asyncio.FIRST_COMPLETED
     )
+
+
+async def wait_for_stop_or_timeout(stop: asyncio.Event, poll_interval: float) -> None:
+    """Idle for ``poll_interval``, returning the moment ``stop`` is set.
+
+    Sleeping blind instead would make an idle worker sit out the rest of its poll
+    interval before noticing a SIGTERM — and idle is exactly when a stop tends to
+    arrive, so that is the whole of the delay a shutdown shows.
+    """
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(stop.wait(), poll_interval)
 
 
 async def run_worker_with_beat(

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -566,9 +566,46 @@ async def refill_slots_until_stopped(
                         client._execute_task(claimed_task, options.claim_timeout)  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
                     )
                 )
+    except asyncio.CancelledError:
+        # The connection every one of these runs writes through is about to close, so
+        # none of them may outlive the loop. The sync worker gets this free from
+        # ThreadPoolExecutor.__exit__; the async loop has to do it by hand.
+        await cancel_and_drain_slots(executing)
+        raise
     finally:
         # A stop means stop CLAIMING: the window it already owns runs to completion.
-        await asyncio.gather(*executing)
+        await finish_remaining_slots(executing)
+
+
+async def cancel_and_drain_slots(executing: set[asyncio.Task[None]]) -> None:
+    """Cancel the whole in-flight window and wait for it to unwind.
+
+    Awaiting is the point: ``cancel()`` only requests, so returning without it leaves
+    handlers still on the loop. Emptying ``executing`` leaves nothing for the caller's
+    ``finally`` to await a second time — that pass is the graceful one, and it would
+    re-raise a slot's own ``CancelledError`` in place of the loop's.
+    """
+    for entry in executing:
+        entry.cancel()
+    await asyncio.gather(*executing, return_exceptions=True)
+    executing.clear()
+
+
+async def finish_remaining_slots(executing: set[asyncio.Task[None]]) -> None:
+    """Await the whole in-flight window, then surface the first machinery failure.
+
+    Two steps rather than one bare ``gather``: a gather raises the instant one slot
+    fails, abandoning its siblings mid-execution against a connection
+    ``aworker_client`` is about to close. ``asyncio.wait`` settles every slot first, so
+    the gather after it only re-raises — and it marks the other slots' exceptions
+    retrieved, so none resurfaces as "Task exception was never retrieved". What
+    surfaces here is never a task failing: ``_execute_task`` records a handler's own
+    failure against the run and returns normally.
+    """
+    if not executing:
+        return
+    await asyncio.wait(executing)
+    await asyncio.gather(*executing)
 
 
 def reap_finished_slots(executing: set[asyncio.Task[None]]) -> None:

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -171,10 +171,19 @@ def run_worker(
     *,
     run_beat: bool = False,
     options: WorkerOptions | None = None,
+    on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
     options = options or WorkerOptions()
     validate_backend(backend.database)
-    asyncio.run(arun_worker(backend, queue, run_beat=run_beat, options=options))
+    asyncio.run(
+        arun_worker(
+            backend,
+            queue,
+            run_beat=run_beat,
+            options=options,
+            on_stop_requested=on_stop_requested,
+        )
+    )
 
 
 async def arun_worker(
@@ -183,12 +192,17 @@ async def arun_worker(
     *,
     run_beat: bool = False,
     options: WorkerOptions,
+    on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
     async with open_worker_runtime(backend, queue, options) as client:
         if run_beat:
-            await run_worker_with_beat(client, options, backend)
+            await run_worker_with_beat(
+                client, options, backend, on_stop_requested=on_stop_requested
+            )
         else:
-            await run_blocking_worker(client, options)
+            await run_blocking_worker(
+                client, options, on_stop_requested=on_stop_requested
+            )
         logger.info(
             "worker stopped: alias=%s queue=%s database=%s",
             backend.alias,
@@ -507,13 +521,20 @@ def mark_task_result_failed(
 
 
 async def run_blocking_worker(
-    client: AsyncAbsurd, options: WorkerOptions, *, stop: asyncio.Event | None = None
+    client: AsyncAbsurd,
+    options: WorkerOptions,
+    *,
+    stop: asyncio.Event | None = None,
+    on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
     stop_signal = stop if stop is not None else asyncio.Event()
     loop = asyncio.get_running_loop()
 
     def handle_stop() -> None:
         stop_signal.set()
+        logger.info("worker stop requested: finishing in-flight tasks")
+        if on_stop_requested is not None:
+            on_stop_requested()
 
     loop.add_signal_handler(signal.SIGINT, handle_stop)
     loop.add_signal_handler(signal.SIGTERM, handle_stop)
@@ -676,6 +697,8 @@ async def run_worker_with_beat(
     client: AsyncAbsurd,
     options: WorkerOptions,
     backend: AbsurdBackend,
+    *,
+    on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
     stop = asyncio.Event()
     beat_stop = threading.Event()
@@ -684,7 +707,9 @@ async def run_worker_with_beat(
     )
     beat_thread.start()
     try:
-        await run_blocking_worker(client, options, stop=stop)
+        await run_blocking_worker(
+            client, options, stop=stop, on_stop_requested=on_stop_requested
+        )
     finally:
         beat_stop.set()
         await asyncio.get_running_loop().run_in_executor(None, beat_thread.join, 5)

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -65,7 +65,7 @@ class WorkerOptions:
 
 @dataclass(frozen=True)
 class DrainedRun:
-    """One run executed during a burst drain, in claim order.
+    """One run executed during a drain, in claim order.
 
     ``state``/``result``/``failure`` cost one read per run, taken immediately after
     THAT run executes — never batched at drain end, so a run that re-arms itself (an
@@ -89,9 +89,10 @@ class DrainedRun:
 class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
     """dict subclass that resolves tasks by import_string on first claim.
 
-    The SDK reads _registry.get(task_name) in both _execute_task (burst) and
-    start_worker (blocking). Overriding .get intercepts all dispatch reads and
-    resolves any importable Task on demand — no tasks.py scan required. Value type
+    The SDK reads _registry.get(task_name) in _execute_task, which every dispatch
+    goes through — the drain and the blocking loop alike. Overriding .get intercepts
+    all dispatch reads and resolves any importable Task on demand — no tasks.py scan
+    required. Value type
     matches the SDK's own ``_registry: Dict[str, Dict[str, Any]]`` declaration — each
     entry mixes str/None/Callable fields, so the inner ``Any`` is a genuine boundary.
     """
@@ -139,7 +140,7 @@ class LazyTaskRegistry(dict[str, dict[str, t.Any]]):
 
 
 def drain_queue(queue: str = "default") -> list[DrainedRun]:
-    """Burst-drain ``queue`` in-process, one ``DrainedRun`` per run, in claim order.
+    """Drain ``queue`` in-process, one ``DrainedRun`` per run, in claim order.
 
     The entry point behind ``AbsurdTestRuntime.drain``: resolves the backend itself
     and takes no ``WorkerOptions`` — worker knobs live on the ``absurd_worker`` CLI.
@@ -153,9 +154,10 @@ def drain_queue(queue: str = "default") -> list[DrainedRun]:
     backend = resolve_backend()
     if queue not in backend.queues:
         raise QueueNotDeclaredError(queue, backend.alias, backend.queues)
+    validate_backend(backend.database)
 
     try:
-        return run_worker(backend, queue, burst=True)
+        return asyncio.run(arun_drain(backend, queue, WorkerOptions()))
     except psycopg.errors.UndefinedTable as exc:
         if not names_a_queue_table(exc, queue):
             raise
@@ -166,58 +168,78 @@ def run_worker(
     backend: AbsurdBackend,
     queue: str,
     *,
-    burst: bool = False,
     run_beat: bool = False,
     options: WorkerOptions | None = None,
-) -> list[DrainedRun]:
+) -> None:
     options = options or WorkerOptions()
     validate_backend(backend.database)
-    return asyncio.run(
-        arun_worker(backend, queue, burst=burst, run_beat=run_beat, options=options)
-    )
+    asyncio.run(arun_worker(backend, queue, run_beat=run_beat, options=options))
 
 
 async def arun_worker(
     backend: AbsurdBackend,
     queue: str,
     *,
-    burst: bool = False,
     run_beat: bool = False,
     options: WorkerOptions,
+) -> None:
+    async with open_worker_runtime(backend, queue, options) as client:
+        if run_beat:
+            await run_worker_with_beat(client, options, backend)
+        else:
+            await run_blocking_worker(client, options)
+        logger.info(
+            "worker stopped: alias=%s queue=%s database=%s",
+            backend.alias,
+            queue,
+            backend.database,
+        )
+
+
+async def arun_drain(
+    backend: AbsurdBackend, queue: str, options: WorkerOptions
 ) -> list[DrainedRun]:
+    """Drain ``queue`` on the same runtime the blocking worker runs on.
+
+    The coroutine behind ``drain_queue``: same executor, same client, same started
+    line — it differs only in claiming until the queue is empty instead of until a
+    signal arrives, so its stopped line can report how many runs that took.
+    """
+    async with open_worker_runtime(backend, queue, options) as client:
+        drained = await adrain_queue(backend.database, client, queue, options)
+        logger.info(
+            "worker stopped: alias=%s queue=%s database=%s runs=%d",
+            backend.alias,
+            queue,
+            backend.database,
+            len(drained),
+        )
+        return drained
+
+
+@asynccontextmanager
+async def open_worker_runtime(
+    backend: AbsurdBackend, queue: str, options: WorkerOptions
+) -> t.AsyncGenerator[AsyncAbsurd, None]:
+    """Set up what every worker entry point needs, and announce it started.
+
+    A thread pool sized to ``concurrency`` installed as the loop's default executor
+    (every sync task body lands there), the SDK client on its own connection, and the
+    ``worker started`` line. Each caller logs its own ``worker stopped`` line, because
+    only a drain has a run count to report.
+    """
     with ThreadPoolExecutor(max_workers=options.concurrency) as executor:
         loop = asyncio.get_running_loop()
         loop.set_default_executor(executor)
         async with aworker_client(backend, queue) as client:
             logger.info(
-                "worker started: alias=%s queue=%s database=%s burst=%s concurrency=%d",
+                "worker started: alias=%s queue=%s database=%s concurrency=%d",
                 backend.alias,
                 queue,
                 backend.database,
-                burst,
                 options.concurrency,
             )
-            if burst:
-                drained = await adrain_queue(backend.database, client, queue, options)
-                logger.info(
-                    "worker stopped: alias=%s queue=%s database=%s runs=%d",
-                    backend.alias,
-                    queue,
-                    backend.database,
-                    len(drained),
-                )
-                return drained
-            if run_beat:
-                await run_worker_with_beat(client, options, backend)
-            else:
-                await run_blocking_worker(client, options)
-            logger.info(
-                "worker stopped: alias=%s queue=%s database=%s",
-                backend.alias,
-                queue,
-                backend.database,
-            )
-            return []
+            yield client
 
 
 @asynccontextmanager
@@ -327,7 +349,7 @@ async def fetch_run_outcome(
     No public SDK accessor keys a read by ``run_id`` (only ``task_id``, which
     collapses a retry's several runs), so read the run row through the same
     per-queue dynamic model the other reads use — no SQL of its own. ORM means
-    Django's connection via a ``sync_to_async`` hop; only burst drains pay it, and
+    Django's connection via a ``sync_to_async`` hop; only drains pay it, and
     next to executing the task it is noise. The row is committed by the time
     ``_execute_task`` returns (the SDK writes on autocommit). ``aget``, not
     ``afirst``: a missing just-executed run is a broken invariant that should raise.

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -1,7 +1,9 @@
 import asyncio
 import inspect
 import logging
+import os
 import signal
+import socket
 import threading
 import typing as t
 import uuid
@@ -481,25 +483,119 @@ def mark_task_result_failed(
     )
 
 
-async def run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions) -> None:
+async def run_blocking_worker(
+    client: AsyncAbsurd, options: WorkerOptions, *, stop: asyncio.Event | None = None
+) -> None:
+    stop_signal = stop if stop is not None else asyncio.Event()
     loop = asyncio.get_running_loop()
 
     def handle_stop() -> None:
-        client.stop_worker()
+        stop_signal.set()
 
     loop.add_signal_handler(signal.SIGINT, handle_stop)
     loop.add_signal_handler(signal.SIGTERM, handle_stop)
+    # Worker id as the SDK's own start_worker derives it, since we no longer call it.
+    worker_id = options.worker_id or f"{socket.gethostname()}:{os.getpid()}"
+    # Both loops below are ported from
+    # https://github.com/earendil-works/absurd/pull/137, because the SDK's
+    # AsyncAbsurd.start_worker awaits its whole claimed batch before claiming again —
+    # one slow task then idles every other slot. Delete them in favour of
+    # client.start_worker once a released SDK carries that fix.
     try:
-        await client.start_worker(
-            worker_id=options.worker_id,
-            claim_timeout=options.claim_timeout,
-            concurrency=options.concurrency,
-            batch_size=options.batch_size,
-            poll_interval=options.poll_interval,
-        )
+        if options.concurrency <= 1:
+            await run_one_slot_at_a_time(client, options, stop_signal, worker_id)
+        else:
+            await refill_slots_until_stopped(client, options, stop_signal, worker_id)
     finally:
         loop.remove_signal_handler(signal.SIGINT)
         loop.remove_signal_handler(signal.SIGTERM)
+
+
+async def run_one_slot_at_a_time(
+    client: AsyncAbsurd,
+    options: WorkerOptions,
+    stop: asyncio.Event,
+    worker_id: str,
+) -> None:
+    """Claim a whole batch and execute it sequentially — the single-slot fast path.
+
+    Straight from the SDK's SYNC worker, which has always had it. Without this branch
+    the windowed loop's cap of ``min(batch_size, free capacity)`` would silently turn
+    ``--batch-size N --concurrency 1`` from one round trip into N.
+    """
+    batch_size = options.batch_size or options.concurrency
+    while not stop.is_set():
+        claimed = await client.claim_tasks(batch_size, options.claim_timeout, worker_id)
+        if not claimed:
+            await asyncio.sleep(options.poll_interval)
+            continue
+        for claimed_task in claimed:
+            await client._execute_task(claimed_task, options.claim_timeout)  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
+
+
+async def refill_slots_until_stopped(
+    client: AsyncAbsurd,
+    options: WorkerOptions,
+    stop: asyncio.Event,
+    worker_id: str,
+) -> None:
+    """Keep ``concurrency`` slots busy, claiming again the moment one frees.
+
+    ONE ``executing`` window across iterations is the whole point: rebuilding it per
+    batch is what makes the SDK's async worker wait on its slowest claimed task before
+    claiming anything else.
+    """
+    effective_batch_size = options.batch_size or options.concurrency
+    executing: set[asyncio.Task[None]] = set()
+    try:
+        while not stop.is_set():
+            reap_finished_slots(executing)
+            capacity = options.concurrency - len(executing)
+            if capacity <= 0:
+                await wait_for_slot_progress(executing, options.poll_interval)
+                continue
+            claimed = await client.claim_tasks(
+                min(effective_batch_size, capacity), options.claim_timeout, worker_id
+            )
+            if not claimed:
+                await wait_for_slot_progress(executing, options.poll_interval)
+                continue
+            for claimed_task in claimed:
+                executing.add(
+                    asyncio.create_task(
+                        client._execute_task(claimed_task, options.claim_timeout)  # noqa: SLF001 -- SDK exposes no public counted dispatch; mirrors work_batch
+                    )
+                )
+    finally:
+        # A stop means stop CLAIMING: the window it already owns runs to completion.
+        await asyncio.gather(*executing)
+
+
+def reap_finished_slots(executing: set[asyncio.Task[None]]) -> None:
+    """Free every finished slot, re-raising whatever its task raised.
+
+    ``_execute_task`` records a handler's own failure against the run and returns, so
+    an exception surfacing here is the worker's own machinery breaking — never a task
+    failing — and must not be swallowed into a worker that keeps polling.
+    """
+    for finished in [entry for entry in executing if entry.done()]:
+        executing.discard(finished)
+        finished.result()
+
+
+async def wait_for_slot_progress(
+    executing: set[asyncio.Task[None]], poll_interval: float
+) -> None:
+    """Wait until a slot frees, or ``poll_interval`` passes, whichever comes first.
+
+    ``asyncio.wait`` only observes; the loop head reaps what it reports.
+    """
+    if not executing:
+        await asyncio.sleep(poll_interval)
+        return
+    await asyncio.wait(
+        executing, timeout=poll_interval, return_when=asyncio.FIRST_COMPLETED
+    )
 
 
 async def run_worker_with_beat(
@@ -507,13 +603,14 @@ async def run_worker_with_beat(
     options: WorkerOptions,
     backend: AbsurdBackend,
 ) -> None:
+    stop = asyncio.Event()
     beat_stop = threading.Event()
     beat_thread = threading.Thread(
         target=run_beat, args=(backend,), kwargs={"stop": beat_stop}, daemon=True
     )
     beat_thread.start()
     try:
-        await run_blocking_worker(client, options)
+        await run_blocking_worker(client, options, stop=stop)
     finally:
         beat_stop.set()
         await asyncio.get_running_loop().run_in_executor(None, beat_thread.join, 5)

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -69,18 +69,18 @@ Two consequences:
 - There is no post-persist seam at all on the blocking-worker path, which is the SDK's
   own claim → execute → gather loop.
 
-Needed wherever a worker must know how a run actually ended. Burst draining reads the
-outcome back from the database for exactly this reason (`fetch_run_outcome`), and any
-observer of an Absurd-side ending — a cancellation, an expired claim, a `max_duration`
-sweep — has no seam to learn of it from.
+Needed wherever a worker must know how a run actually ended. `dj_absurd.drain()` reads
+the outcome back from the database for exactly this reason (`fetch_run_outcome`), and
+any observer of an Absurd-side ending — a cancellation, an expired claim, a
+`max_duration` sweep — has no seam to learn of it from.
 
 ## Public API to execute one claimed run and return its outcome
 
-`work_batch` runs its own claim loop. Burst draining needs "execute exactly these
-claims, then stop", so `execute_claimed_run` calls `client._execute_task`. And because
-no public accessor keys by `run_id` — only by `task_id`, which collapses a retry's
-several runs into one answer — the outcome comes from a second read through the
-per-queue dynamic model.
+`work_batch` runs its own claim loop. The drain needs "execute exactly these claims,
+then stop", so `execute_claimed_run` calls `client._execute_task`. And because no public
+accessor keys by `run_id` — only by `task_id`, which collapses a retry's several runs
+into one answer — the outcome comes from a second read through the per-queue dynamic
+model.
 
 Ask: a public `execute(claimed) -> outcome`. It retires both workarounds at once; a read
 accessor keyed by `run_id` would retire half.

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -5,8 +5,9 @@ django-absurd currently compensates for. One section per **askable change**: wha
 would want, why, and which workaround it retires. Grouped that way on purpose, so a
 section can be filed as-is rather than re-derived from a list of symptoms.
 
-**Nothing here is filed yet.** When upstream ships one, delete the section rather than
-marking it done, and remove the workaround it names.
+Most of these are not filed yet. A section says explicitly when it has been. When
+upstream ships one — filed or not — delete the section rather than marking it done, and
+remove the workaround it names.
 
 Three of these are marked in code by the `noqa: SLF001` comments in
 `django_absurd/worker.py` — each names the private attribute it reaches and why.
@@ -123,3 +124,52 @@ carries `enqueued_at=None` — correct at enqueue, unknown at execution.
 Ask: public properties for all three.
 
 Retires: `read_sdk_claimed_task`, and the `enqueued_at=None` compromise.
+
+## Cap the async worker's claims by free capacity, not by batch
+
+`AsyncAbsurd.start_worker` rebuilds its in-flight set from scratch each iteration —
+claim a batch, run it, `await asyncio.gather(*executing)` — so one slow task in a batch
+idles every other slot until the whole batch finishes. Measured on this project's load
+harness at 4 slots with a mixed-duration backlog: one worker at `--concurrency 4` took
+47.99s (sync tasks) / 45.68s (async) against 16.36s / 15.12s for four workers at
+`--concurrency 1`; mean slots busy 1.06 of 4; 73% of offered capacity wasted while the
+backlog still held work. A uniform-duration control showed only 1.07x, which identifies
+the batch boundary as the cause, not task length.
+
+The SDK's sync worker does not have this: it keeps one `executing` set across iterations
+and claims `min(batch_size, concurrency - len(executing))`. That shape came from the fix
+for the sync-side version of the same bug (upstream issue
+https://github.com/earendil-works/absurd/issues/91) and was never applied to the async
+path. The TypeScript and Go workers already cap claims by free capacity.
+
+Retires: `django_absurd/worker.py`'s own rolling-window loop over the public
+`claim_tasks`, standing in for `client.start_worker`, plus its own `asyncio.Event` stop
+handle and `try/except asyncio.CancelledError` that cancels and drains the in-flight
+window — the sync worker gets that for free from `ThreadPoolExecutor.__exit__`.
+
+**Filed:** https://github.com/earendil-works/absurd/pull/137, open since 2026-08-03.
+
+## Wake idle waits on stop instead of sleeping out the poll interval
+
+Both SDK workers notice a stop only between polls. The async loop does
+`await asyncio.sleep(poll_interval)` on an empty claim; the sync one blocks in
+`concurrent.futures.wait(timeout=poll_interval)`. `stop_worker()` just flips a bool that
+is read on the next pass, so a `SIGTERM`/`SIGINT` arriving mid-sleep goes unacted on for
+up to a full `poll_interval` (default 0.25s). Measured against this project's own test
+suite: 16 signal-stopped tests ran about 4s slower in aggregate, roughly 30% on those
+modules — and the same bound delays every production shutdown.
+
+Ask: the idle waits should wake as soon as a stop is requested, rather than sleeping
+blind.
+
+What makes this a real design question rather than a one-line fix: `stop_worker()` is a
+plain synchronous public method, callable from any thread, and the client holds no loop
+reference — so an `asyncio.Event` cannot simply replace the flag, since setting one from
+another thread needs `call_soon_threadsafe`. That is upstream's call to make: an event
+plus a threadsafe setter, or sliced sleeps that re-check the flag. The sync worker
+shares the same lag and needs its own answer.
+
+Retires: `django_absurd/worker.py`'s `wait_for_stop_or_timeout`, which races
+`stop.wait()` against the poll timeout in both idle paths. Our own stop is an
+`asyncio.Event` set by the worker's own signal handler on the same loop, which is why we
+can do this safely and upstream's public API cannot trivially copy it.

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -143,21 +143,26 @@ https://github.com/earendil-works/absurd/issues/91) and was never applied to the
 path. The TypeScript and Go workers already cap claims by free capacity.
 
 Retires: `django_absurd/worker.py`'s own rolling-window loop over the public
-`claim_tasks`, standing in for `client.start_worker`, plus its own `asyncio.Event` stop
-handle and `try/except asyncio.CancelledError` that cancels and drains the in-flight
-window — the sync worker gets that for free from `ThreadPoolExecutor.__exit__`.
+`claim_tasks`, standing in for `client.start_worker`, and the
+`try/except asyncio.CancelledError` that cancels and drains that loop's in-flight window
+— the sync worker gets that for free from `ThreadPoolExecutor.__exit__`. Not the
+`asyncio.Event` stop handle: it is what makes an in-process stop testable, it survives
+either way, and the section below is built on it.
 
 **Filed:** https://github.com/earendil-works/absurd/pull/137, open since 2026-08-03.
 
 ## Wake idle waits on stop instead of sleeping out the poll interval
 
 Both SDK workers notice a stop only between polls. The async loop does
-`await asyncio.sleep(poll_interval)` on an empty claim; the sync one blocks in
-`concurrent.futures.wait(timeout=poll_interval)`. `stop_worker()` just flips a bool that
-is read on the next pass, so a `SIGTERM`/`SIGINT` arriving mid-sleep goes unacted on for
-up to a full `poll_interval` (default 0.25s). Measured against this project's own test
-suite: 16 signal-stopped tests ran about 4s slower in aggregate, roughly 30% on those
-modules — and the same bound delays every production shutdown.
+`await asyncio.sleep(poll_interval)` on an empty claim. The sync one has two idle arms:
+with nothing executing — which includes every `concurrency <= 1` worker, whose whole
+loop is that arm — it blocks in `time.sleep(poll_interval)`, and only with a non-empty
+window does it block in `concurrent.futures.wait(timeout=poll_interval)`.
+`stop_worker()` just flips a bool that is read on the next pass, so a `SIGTERM`/`SIGINT`
+arriving mid-sleep goes unacted on for up to a full `poll_interval` (default 0.25s).
+Measured against this project's own test suite: 16 signal-stopped tests ran about 4s
+slower in aggregate — a **+43% slowdown** on those modules against `origin/main` (9.22s
+→ 13.22s) — and the same bound delays every production shutdown.
 
 Ask: the idle waits should wake as soon as a stop is requested, rather than sleeping
 blind.

--- a/docs/plans/2026-08-06-worker-concurrency.md
+++ b/docs/plans/2026-08-06-worker-concurrency.md
@@ -1,0 +1,814 @@
+# One Worker Mode, With Working Concurrency — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `absurd_worker --concurrency N` keeps N tasks in flight instead of stalling on
+a batch barrier, and `--burst` — test scaffolding that leaked onto the CLI — is deleted.
+
+**Architecture:** Replace the `client.start_worker(...)` delegation in
+`run_blocking_worker` with a local rolling-window loop over the public `claim_tasks`,
+ported from
+[upstream absurd PR #137](https://github.com/earendil-works/absurd/pull/137). Loop
+carries its own `asyncio.Event` stop handle, since the SDK's `_worker_running` flag is
+only read by the SDK's own loop. Burst is removed after every test that used it moves to
+`dj_absurd.drain()` (execution) or a live-worker helper (command assertions), so the
+suite is green at every commit.
+
+**Tech Stack:** Python 3.12+, Django 6.0+, `absurd-sdk>=0.4.0,<0.5.0`, psycopg3,
+asyncio, pytest + pytest-django.
+
+**Spec:**
+[`docs/specs/2026-08-06-worker-concurrency-design.md`](../specs/2026-08-06-worker-concurrency-design.md).
+Read it before Task 1 — it records why each decision is what it is.
+
+## Global Constraints
+
+- Floor Django 6.0 / Python 3.12; psycopg (v3) backend only.
+- `import typing as t`, never `from typing import X`. Absolute imports only.
+- Functions carry a verb. No leading-underscore module constants/helpers. Helpers go
+  BELOW their caller.
+- Tests: pytest, function-based only, no class-based. No `unittest.mock.patch`, no
+  monkeypatching. Test through real entrypoints; never unit-test an internal helper.
+- Test fixture tasks defined locally in a test module must carry the verb themselves
+  (`hold_until_released`, not `slow`).
+- Alphabetize `@pytest.mark.parametrize` values and a test's own fixture parameters.
+- Assert COMPLETE message text, never a fragment.
+- Never add a ruff `noqa` or ignore without asking first.
+- Never `git commit --amend`. Every change is a new commit.
+- Iteration gate per task: `uv run pytest <path> -q --no-cov`, then
+  `uv run pre-commit run --all-files` (owns ruff + mypy + prettier — never invoke them
+  directly). `git add` new files first: `--all-files` skips untracked.
+- The full `uvx --with tox-uv tox -e dev` gate belongs to the coordinator after the
+  commit, NOT to the task implementer — it exceeds a subagent's foreground limit.
+- Postgres must be up before any suite: `docker compose up -d db db_pg_cron`.
+
+---
+
+## File Structure
+
+**Modified:**
+
+- `django_absurd/worker.py` — refill loop, `stop=` handle, burst removal. The whole
+  change to production behavior lives here.
+- `django_absurd/management/commands/absurd_worker.py` — drop `--burst` and the
+  `--burst`/`--beat` conflict check.
+- `django_absurd/test.py`, `django_absurd/pytest_plugin.py` — prose only ("burst drain"
+  → "drain").
+- `django_absurd/AGENTS.md`, `docs/web/testing.md` — one worker mode; honest
+  `--concurrency`.
+- `tests/utils.py` — `run_absurd_worker` switches to the drain; new
+  `run_worker_command_until` helper for command-level assertions.
+- ~20 test modules — migrate off `burst=True` (full inventory in Task 3 / Task 4).
+
+**Created:**
+
+- `tests/core/test_worker_slot_refill.py` — refill, stop, and shutdown behavior.
+
+---
+
+### Task 1: Refill loop and its own stop handle
+
+**Files:**
+
+- Create: `tests/core/test_worker_slot_refill.py`
+- Modify: `django_absurd/worker.py:484-503` (`run_blocking_worker`),
+  `django_absurd/worker.py:505-519` (`run_worker_with_beat`)
+- Modify: `tests/core/test_worker.py:446-469` (`test_blocking_worker_drains_then_stops`)
+
+**Interfaces:**
+
+- Consumes: `aworker_client(backend, queue)`, `WorkerOptions`,
+  `client.claim_tasks(batch_size, claim_timeout, worker_id)`,
+  `client._execute_task(claimed, claim_timeout)` — all already in `worker.py`.
+- Produces:
+  `run_blocking_worker(client: AsyncAbsurd, options: WorkerOptions, *, stop: asyncio.Event | None = None) -> None`.
+  Tasks 2 and 4 both drive shutdown through that `stop` keyword.
+
+- [ ] **Step 1: Write the failing refill test**
+
+Create `tests/core/test_worker_slot_refill.py`:
+
+```python
+import asyncio
+
+import pytest
+from django.core.management import call_command
+from django.tasks import task
+
+from django_absurd.backends import AbsurdBackend, get_absurd_backends
+from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
+
+pytestmark = [
+    pytest.mark.django_db(transaction=True),
+    pytest.mark.usefixtures("_isolate_queues"),
+]
+
+HOLD: dict[str, asyncio.Event] = {}
+STARTED: dict[str, asyncio.Event] = {}
+ORDER: list[str] = []
+
+
+def get_default_backend() -> AbsurdBackend:
+    return get_absurd_backends()["default"]
+
+
+@task(queue_name="default")
+async def hold_until_released(name: str) -> None:
+    """Occupy one worker slot until the test lets go of it."""
+    ORDER.append(name)
+    STARTED[name].set()
+    await HOLD["gate"].wait()
+
+
+@task(queue_name="default")
+async def record_started(name: str) -> None:
+    ORDER.append(name)
+    STARTED[name].set()
+
+
+def arm_events(*names: str) -> None:
+    ORDER.clear()
+    STARTED.clear()
+    HOLD["gate"] = asyncio.Event()
+    for name in names:
+        STARTED[name] = asyncio.Event()
+
+
+def test_worker_starts_a_later_task_while_a_slow_one_still_runs() -> None:
+    # A worker of C slots must keep claiming while one slot is busy. Enqueue C+1
+    # tasks so the extra one cannot ride in the same claim batch as the slow task:
+    # that is what forces a second claim, and a worker that joins its whole batch
+    # before claiming again never issues it.
+    #
+    # Deterministic, not timed: the slow task blocks on an Event the test owns, and
+    # each task announces its own start on another. The only clock is the wait_for
+    # that turns "never started" into a clean assertion failure instead of a hang.
+    # Time cannot be frozen here — a live worker loop and a real thread pool are the
+    # subject, so dj_absurd.freeze_time would deadlock rather than help.
+    call_command("absurd_sync_queues")
+    arm_events("fast-1", "fast-2", "slow")
+
+    hold_until_released.enqueue("slow")
+    record_started.enqueue("fast-1")
+    record_started.enqueue("fast-2")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def release_once_the_third_task_starts() -> None:
+                try:
+                    await asyncio.wait_for(STARTED["fast-2"].wait(), timeout=10)
+                finally:
+                    HOLD["gate"].set()
+                    stop.set()
+
+            outcomes = await asyncio.gather(
+                run_blocking_worker(client, WorkerOptions(concurrency=2), stop=stop),
+                release_once_the_third_task_starts(),
+                return_exceptions=True,
+            )
+            for outcome in outcomes:
+                if isinstance(outcome, BaseException) and not isinstance(
+                    outcome, TimeoutError
+                ):
+                    raise outcome
+
+    asyncio.run(drive())
+
+    assert STARTED["fast-2"].is_set(), (
+        "the worker never started the third task while the slow one held a slot: "
+        f"started {ORDER}"
+    )
+```
+
+- [ ] **Step 2: Add the one-slot guard test to the same file**
+
+This one must pass BEFORE and AFTER the change — it locks the `concurrency <= 1` fast
+path so the refill work cannot quietly turn a single-slot worker into something else.
+
+```python
+def test_one_slot_runs_a_claimed_batch_in_order() -> None:
+    call_command("absurd_sync_queues")
+    arm_events("first", "second", "third")
+
+    record_started.enqueue("first")
+    record_started.enqueue("second")
+    record_started.enqueue("third")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def stop_once_all_three_ran() -> None:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*(STARTED[n].wait() for n in STARTED)),
+                        timeout=10,
+                    )
+                finally:
+                    stop.set()
+
+            outcomes = await asyncio.gather(
+                run_blocking_worker(
+                    client, WorkerOptions(batch_size=3, concurrency=1), stop=stop
+                ),
+                stop_once_all_three_ran(),
+                return_exceptions=True,
+            )
+            for outcome in outcomes:
+                if isinstance(outcome, BaseException) and not isinstance(
+                    outcome, TimeoutError
+                ):
+                    raise outcome
+
+    asyncio.run(drive())
+
+    assert ORDER == ["first", "second", "third"]
+```
+
+- [ ] **Step 3: Run both tests to verify the first fails and the second passes**
+
+```bash
+uv run pytest tests/core/test_worker_slot_refill.py -q --no-cov
+```
+
+Expected: `test_worker_starts_a_later_task_while_a_slow_one_still_runs` FAILS with
+
+```
+TypeError: run_blocking_worker() got an unexpected keyword argument 'stop'
+```
+
+then, once `stop=` exists (Step 4), it fails for the real reason:
+
+```
+AssertionError: the worker never started the third task while the slow one held a slot:
+started ['slow', 'fast-1']
+```
+
+`test_one_slot_runs_a_claimed_batch_in_order` must pass at every point after `stop=`
+exists.
+
+- [ ] **Step 4: Implement the stop handle**
+
+In `django_absurd/worker.py`:
+
+- Give `run_blocking_worker` a keyword-only `stop: asyncio.Event | None = None`,
+  defaulting to a fresh `asyncio.Event()` when omitted.
+- The `SIGINT`/`SIGTERM` handlers set that event instead of calling
+  `client.stop_worker()`. Keep the existing `try/finally` that removes both handlers.
+- `run_worker_with_beat` creates the event, passes it to `run_blocking_worker`, and
+  still sets its `threading.Event` for the beat in the `finally` — one signal stops both
+  halves.
+
+Do not read or write `client._worker_running`: the SDK initializes it `False` and only
+`start_worker` flips it, so reusing it would mean writing another library's private
+attribute.
+
+- [ ] **Step 5: Implement the refill loop**
+
+Replace the `await client.start_worker(...)` call with a local loop, structured exactly
+as upstream PR #137 structures the SDK's:
+
+- `effective_batch_size = options.batch_size or options.concurrency`.
+- **Fast path**, `concurrency <= 1`: claim `effective_batch_size`, execute the claimed
+  tasks sequentially, and when a claim comes back empty sleep `poll_interval`. Without
+  this branch, capping claims by free capacity silently reduces
+  `--batch-size N --concurrency 1` from one round trip to N.
+- **Windowed path**, otherwise: keep ONE `executing` set of `asyncio.Task`s across
+  iterations. Each pass: reap finished entries (re-raising their exceptions), compute
+  free capacity as `concurrency - len(executing)`, and claim
+  `min(effective_batch_size, capacity)` when capacity allows. On an empty claim, wait
+  for progress with
+  `asyncio.wait(executing, return_when=FIRST_COMPLETED, timeout=poll_interval)`, or
+  sleep `poll_interval` when nothing is in flight.
+- Dispatch each claimed task through `client._execute_task(claimed, claim_timeout)` —
+  the counted path `adrain_queue` already uses. Its existing `noqa: SLF001` comment
+  explains why; the new call site needs the same, and that is a pre-approved ignore, not
+  a new one.
+- Head the loop with a comment naming its origin and its exit condition: ported from
+  `https://github.com/earendil-works/absurd/pull/137`, to be deleted in favour of
+  `client.start_worker` once a released SDK carries that fix. Full URL, not a bare
+  `#137` — repo convention for issue references in code.
+- `finally`: `await` the window so a graceful stop lets in-flight work finish. Task 2
+  adds the cancellation half.
+
+- [ ] **Step 6: Update the existing stop test**
+
+`tests/core/test_worker.py:446` (`test_blocking_worker_drains_then_stops`) drives
+shutdown through `client.stop_worker()`, which nothing reads any more — it would hang.
+Give it an `asyncio.Event`, pass it as `stop=`, and have the stopper set it after
+awaiting each task result. Update the comment: the flag it names no longer exists.
+
+- [ ] **Step 7: Run the worker tests**
+
+```bash
+uv run pytest tests/core/test_worker_slot_refill.py tests/core/test_worker.py tests/core/test_async_worker.py -q --no-cov
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/core/test_worker_slot_refill.py django_absurd/worker.py tests/core/test_worker.py
+uv run pre-commit run --all-files
+git commit -m "fix(worker): refill concurrency slots instead of joining each batch"
+```
+
+---
+
+### Task 2: Graceful stop and cancel-and-drain
+
+**Files:**
+
+- Modify: `tests/core/test_worker_slot_refill.py`
+- Modify: `django_absurd/worker.py` (the loop's `finally` from Task 1)
+
+**Interfaces:**
+
+- Consumes: `run_blocking_worker(..., *, stop=...)` from Task 1, `hold_until_released`,
+  `record_started`, `arm_events`, `get_default_backend` from that test module.
+- Produces: no new API. Locks two behaviors: stop → in-flight completes and nothing new
+  is claimed; cancel → in-flight is cancelled and awaited, leaving no orphan task on the
+  loop.
+
+- [ ] **Step 1: Write the graceful-stop test**
+
+Append to `tests/core/test_worker_slot_refill.py`:
+
+```python
+def test_stopping_lets_in_flight_work_finish_and_claims_nothing_new() -> None:
+    call_command("absurd_sync_queues")
+    arm_events("slow", "unclaimed")
+
+    slow = hold_until_released.enqueue("slow")
+    record_started.enqueue("unclaimed")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def stop_once_the_slow_task_holds_a_slot() -> None:
+                await asyncio.wait_for(STARTED["slow"].wait(), timeout=10)
+                stop.set()
+                HOLD["gate"].set()
+
+            await asyncio.gather(
+                run_blocking_worker(client, WorkerOptions(concurrency=1), stop=stop),
+                stop_once_the_slow_task_holds_a_slot(),
+            )
+
+    asyncio.run(drive())
+
+    assert ORDER == ["slow"]
+    assert not STARTED["unclaimed"].is_set()
+```
+
+Note the assertion pair: the run that was already executing reached its end (`ORDER`
+holds it), and the queued one was never claimed after the stop.
+
+- [ ] **Step 2: Write the cancellation test**
+
+```python
+def test_cancelling_the_worker_leaves_no_handler_running_on_the_loop() -> None:
+    call_command("absurd_sync_queues")
+    arm_events("slow")
+
+    hold_until_released.enqueue("slow")
+
+    async def drive() -> None:
+        async with aworker_client(get_default_backend(), "default") as client:
+            worker = asyncio.create_task(
+                run_blocking_worker(client, WorkerOptions(concurrency=2))
+            )
+            await asyncio.wait_for(STARTED["slow"].wait(), timeout=10)
+            worker.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await worker
+            leftovers = [
+                pending
+                for pending in asyncio.all_tasks()
+                if pending is not asyncio.current_task() and not pending.done()
+            ]
+            assert leftovers == []
+
+    asyncio.run(drive())
+```
+
+`aworker_client` closes the connection on exit; a handler still running there is exactly
+the failure this catches — the assertion runs INSIDE the context manager so a leftover
+handler is visible before the close.
+
+- [ ] **Step 3: Run both, expect the cancellation one to fail**
+
+```bash
+uv run pytest tests/core/test_worker_slot_refill.py -q --no-cov
+```
+
+Expected: `test_stopping_lets_in_flight_work_finish_and_claims_nothing_new` passes (Task
+1's `finally` already awaits the window);
+`test_cancelling_the_worker_leaves_no_handler_running_on_the_loop` FAILS with a
+non-empty `leftovers` list — `asyncio.wait` neither cancels nor awaits what it waits on.
+
+- [ ] **Step 4: Implement cancel-and-drain**
+
+Extend the loop's `finally` in `django_absurd/worker.py`: on `asyncio.CancelledError`,
+cancel every task still in the window and await them (swallowing their own
+`CancelledError`) before re-raising. The graceful path — stop set, no cancellation —
+keeps awaiting them to completion untouched. The sync worker gets this free from
+`ThreadPoolExecutor.__exit__`; the async loop has to do it by hand.
+
+- [ ] **Step 5: Run the file again**
+
+```bash
+uv run pytest tests/core/test_worker_slot_refill.py -q --no-cov
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/core/test_worker_slot_refill.py django_absurd/worker.py
+uv run pre-commit run --all-files
+git commit -m "fix(worker): cancel and drain in-flight runs when the worker is cancelled"
+```
+
+---
+
+### Task 3: Move execution-only tests onto `dj_absurd.drain()`
+
+Mechanical, and `--burst` still exists throughout — the suite stays green at every step.
+These tests only need their tasks executed; they assert nothing about the command.
+
+**Files:**
+
+- Modify: `tests/utils.py:68` (`run_absurd_worker`)
+- Modify: `tests/core/test_admin/test_run.py:39,41,105`,
+  `tests/core/test_admin/test_task.py:228,257,332`,
+  `tests/core/test_admin/utils.py:41,42,51`, `tests/core/test_admin_views.py:28,29`,
+  `tests/core/test_cleanup.py:59`, `tests/core/test_enqueue.py:115,148`,
+  `tests/core/test_orm_models.py:71,72`,
+  `tests/core/test_scheduler.py:191,221,281,316,339,365,389,391,421,423,544,795`
+
+**Interfaces:**
+
+- Consumes: `dj_absurd.drain(queue)` (`AbsurdTestRuntime.drain`, already public) and
+  `worker.drain_queue(queue)` for non-test-function helpers that have no fixture.
+- Produces: `run_absurd_worker(queue="default")` keeps its name and drops `concurrency`
+  — nothing that survives this task passes it.
+
+- [ ] **Step 1: Move the async-overlap proof onto the blocking worker first**
+
+`tests/core/test_async_worker.py:122` (`test_async_concurrency_is_not_serial`) is the
+only caller that passes `concurrency` to the helper, and it is the suite's only proof
+that async tasks overlap at all. It has to move before the helper changes: at
+`concurrency=1` its 1.5s bound cannot hold (4 × 0.5s serial is 2.0s).
+
+Rewrite it against `run_blocking_worker` with a `stop=` Event: four
+`atasks.asleeper(0.5)` enqueues, worker at `concurrency=4`, stop once all four results
+are terminal, assert the wall clock stays under 1.5s. Keep the existing comment's
+arithmetic — it explains the threshold. Drop the stale
+`# burst now drains CONCURRENTLY (gather)` comment.
+
+```bash
+uv run pytest tests/core/test_async_worker.py -q --no-cov
+```
+
+Expected: PASS, with `--burst` still present and untouched.
+
+- [ ] **Step 2: Repoint the shared helper**
+
+`tests/utils.py:68` currently calls
+`call_command("absurd_worker", queue=queue, burst=True, concurrency=concurrency)`. Make
+it call `django_absurd.worker.drain_queue(queue)` and drop the `concurrency` parameter —
+after Step 1 nothing passes it. Keep the function name; 34 call sites read
+`run_absurd_worker()` today.
+
+Then:
+
+```bash
+uv run pytest tests/core -q --no-cov -n4
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Convert the direct call sites in test modules that already request
+      `dj_absurd`**
+
+For each site listed under Files, replace
+`call_command("absurd_worker", queue=<q>, burst=True)` with `dj_absurd.drain(<q>)` where
+the test already takes the `dj_absurd` fixture, adding the fixture parameter where it
+does not (alphabetized among the test's other fixture parameters).
+
+Every one of these tests is already `transaction=True` — a burst worker on its own
+connection could only ever see committed rows — so no marker changes are needed. If any
+test turns out not to be, that is a finding: report it rather than adding the marker
+blind.
+
+- [ ] **Step 4: Convert the module-level helpers**
+
+`tests/core/test_admin/utils.py:41,42,51`, `tests/core/test_admin_views.py:28,29` and
+`tests/core/test_orm_models.py:71,72` call the command from plain helper functions with
+no fixture in scope. Those call `worker.drain_queue(<queue>)` directly — the same
+entrypoint `dj_absurd.drain` wraps.
+
+- [ ] **Step 5: Run every suite**
+
+```bash
+uv run pytest tests/core -q --no-cov -n4
+uv run pytest tests/multidb -q --no-cov
+uv run pytest tests/pg_cron -q --no-cov -n4
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/
+uv run pre-commit run --all-files
+git commit -m "test: drain through the fixture instead of the worker command"
+```
+
+---
+
+### Task 4: Live-worker helper for command-level assertions
+
+Command-test parity is a requirement: every assertion that runs the command today keeps
+running the command. With `--burst` gone the command's only stop is a signal, so this
+task builds the one helper that owns that shape and moves the command-level tests onto
+it — while `--burst` still exists, so each step is verifiable.
+
+**Files:**
+
+- Modify: `tests/utils.py` (new helper, placed below `run_absurd_worker`)
+- Modify: `tests/core/test_command_output.py:27,40,54`,
+  `tests/core/test_logging/test_handler.py:40,52`,
+  `tests/core/test_orm_views.py:95,110,112`,
+  `tests/core/test_worker.py:178,209,264,274,304,337,359,386`
+
+**Interfaces:**
+
+- Consumes: `call_command("absurd_worker", **options)`, the `django_absurd.worker`
+  logger, `signal.getsignal`.
+- Produces:
+  `run_worker_command_until(is_done: t.Callable[[], bool] | None = None, *, timeout: float = 15.0, **options: t.Any) -> None`
+  — runs the command in the calling thread and stops it with `SIGTERM` once `is_done()`
+  holds (default: as soon as the worker's loop is running).
+
+- [ ] **Step 1: Write the helper**
+
+Add to `tests/utils.py`, below `run_absurd_worker`. The module already imports
+`threading`, `typing as t` and `django.db.connections`; add `os`, `signal` and `time`.
+
+```python
+def run_worker_command_until(
+    is_done: "t.Callable[[], bool] | None" = None,
+    *,
+    timeout: float = 15.0,
+    **options: t.Any,
+) -> None:
+    """Run ``absurd_worker`` to completion, stopping it once ``is_done()`` holds.
+
+    The command runs in the calling thread so ``capsys``/``caplog`` see it; a watcher
+    thread fires the SIGTERM the worker's own signal handler turns into a graceful
+    stop. Waits for that handler to be installed first — a signal delivered before
+    then kills the test session instead.
+    """
+    previous_handler = signal.getsignal(signal.SIGTERM)
+
+    def stop_once_done() -> None:
+        deadline = time.monotonic() + timeout
+        try:
+            while time.monotonic() < deadline:
+                if signal.getsignal(signal.SIGTERM) is not previous_handler and (
+                    is_done is None or is_done()
+                ):
+                    break
+                time.sleep(0.05)
+            os.kill(os.getpid(), signal.SIGTERM)
+        finally:
+            connections.close_all()
+
+    watcher = threading.Thread(target=stop_once_done, daemon=True)
+    watcher.start()
+    try:
+        call_command("absurd_worker", **options)
+    finally:
+        watcher.join(timeout=5)
+```
+
+`connections.close_all()` is thread-local, so it closes only the watcher's own
+connection — the predicate may query the ORM from that thread.
+
+- [ ] **Step 2: Convert the simplest command test and run it**
+
+`tests/core/test_command_output.py:27` asserts the banner. Replace
+`call_command("absurd_worker", queue="default", burst=True, stdout=out)` with
+`utils.run_worker_command_until(queue="default", stdout=out)` — no predicate: the banner
+is printed before the loop starts.
+
+```bash
+uv run pytest tests/core/test_command_output.py -q --no-cov
+```
+
+Expected: PASS, and in well under the 15s timeout. If it hangs to the timeout, the
+handler-installed check is not seeing the worker's handler — stop and report rather than
+lowering the timeout.
+
+- [ ] **Step 3: Convert the remaining output/logging tests**
+
+Same substitution, no predicate, for `test_command_output.py:40,54` and
+`tests/core/test_logging/test_handler.py:40,52` (both assert what handler configuration
+the command left behind, not what ran).
+
+- [ ] **Step 4: Convert the tests that need work to have finished**
+
+These assert on rows the worker produced, so they pass a predicate:
+
+- `tests/core/test_worker.py:178` (`test_queue_defaults_to_default`) — predicate
+  `lambda: Group.objects.filter(name="dflt").exists()`. Its stdout assertion (exact
+  `🐘 Started` / `🐘 Stopped` pair) stays as-is: a graceful stop still prints the stop
+  line.
+- `tests/core/test_worker.py:264` (`test_command_burst_runs_task_end_to_end`) — same
+  shape, predicate on `Group.objects.filter(name="via-command").exists()`. Rename it
+  `test_command_runs_task_end_to_end`; "burst" is not a concept any more.
+- `tests/core/test_orm_views.py:95,110,112` — predicate on the admin model's rows for
+  the queue under test (`task_model.objects.filter(queue="other").exists()`).
+
+- [ ] **Step 5: Convert the provisioning and reconcile tests**
+
+`tests/core/test_worker.py:209,274,304,337,359,386` assert the sync report the command
+prints before the loop starts, so they need no predicate — the default (stop as soon as
+the loop is running) is right. `test_worker_command_warns_on_storage_mode_drift`
+additionally asserts the `worker started: … burst=True concurrency=1` log line at
+`test_worker.py:399`; leave that assertion untouched here, Task 5 changes the line
+itself.
+
+- [ ] **Step 6: Run the full core suite**
+
+```bash
+uv run pytest tests/core -q --no-cov -n4
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/
+uv run pre-commit run --all-files
+git commit -m "test: stop the worker command with a signal instead of burst"
+```
+
+---
+
+### Task 5: Remove `--burst`
+
+Nothing depends on it now except the tests that exist to describe it.
+
+**Files:**
+
+- Modify: `django_absurd/management/commands/absurd_worker.py:30-34,82-84,114-120`
+- Modify: `django_absurd/worker.py:139-160` (`drain_queue`), `163-218`
+  (`run_worker`/`arun_worker`), `66` and `90` (docstrings)
+- Modify: `django_absurd/test.py:457,531,753,755`, `django_absurd/pytest_plugin.py:117`
+  (prose)
+- Modify: `tests/core/test_worker.py:64,197,224,241,409,483` (drop the kwarg),
+  `tests/core/test_worker.py:399` and `tests/core/test_logging/test_maintenance.py:58`
+  (log-line assertions)
+- Delete: `tests/core/test_scheduler.py:663-671` (`test_worker_beat_rejects_burst`)
+- Modify: `tests/core/test_async_worker.py:122-128`
+  (`test_async_concurrency_is_not_serial`)
+
+**Interfaces:**
+
+- Consumes: `run_blocking_worker(..., *, stop=...)` (Task 1), `run_worker_command_until`
+  (Task 4).
+- Produces:
+  `run_worker(backend: AbsurdBackend, queue: str, *, run_beat: bool = False, options: WorkerOptions | None = None) -> None`
+  — no `burst` parameter, no return value.
+  `drain_queue(queue: str = "default") -> list[DrainedRun]` keeps its signature and
+  behavior.
+
+- [ ] **Step 1: Drop the flag from the command**
+
+In `django_absurd/management/commands/absurd_worker.py`: delete the `--burst` argument,
+the `--beat`/`--burst` conflict check and its `CommandError`, and the `burst=` argument
+in the `run_worker(...)` call.
+
+Delete `tests/core/test_scheduler.py:663-671` (`test_worker_beat_rejects_burst`) — it
+asserts the conflict message that no longer exists. Drop the now-unused `burst=True`
+kwarg from `tests/core/test_worker.py:64,197,224,241,409,483`; each of those raises
+before the worker loop, so they keep passing unchanged otherwise.
+
+- [ ] **Step 2: Drop the parameter from the worker module**
+
+- `run_worker` loses `burst`; it always runs the blocking worker (with or without beat)
+  and returns `None`.
+- `drain_queue` stops going through `run_worker`. It keeps its current guards
+  (`QueueNotDeclaredError` for an undeclared queue, the `UndefinedTable` →
+  `QueueNotProvisionedError` translation via `names_a_queue_table`) and runs the drain
+  through the same executor + `aworker_client` plumbing `arun_worker` uses, at
+  `concurrency=1`. `adrain_queue` itself is unchanged.
+- `arun_worker` loses its `burst` branch. Whatever plumbing both entrypoints still share
+  (thread pool sized to concurrency, client context, the started/stopped log pair) stays
+  in one place; do not duplicate it.
+
+- [ ] **Step 3: Fix the log line and the prose**
+
+- `worker.py:191` — drop ` burst=%s` and its argument from the `worker started:` format.
+- Update the two assertions that spell that line out verbatim:
+  `tests/core/test_worker.py:399` and `tests/core/test_logging/test_maintenance.py:58`.
+- Replace "burst drain"/"burst worker" wording with "drain" in `worker.py:66,90,328`,
+  `django_absurd/test.py:457,531,753,755`, `django_absurd/pytest_plugin.py:117`.
+
+- [ ] **Step 4: Prove the flag is gone**
+
+```bash
+uv run pytest tests/core tests/multidb -q --no-cov -n4
+grep -rn "burst" django_absurd/ tests/
+```
+
+Expected: suites pass; `grep` returns nothing outside `docs/` (specs and plans keep
+their historical references). A hit in `django_absurd/AGENTS.md` is Task 6's job.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/ tests/
+uv run pre-commit run --all-files
+git commit -m "feat!: remove absurd_worker --burst"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+
+- Modify: `django_absurd/AGENTS.md:249-267` (Workers section), `:852` (drain prose)
+- Modify: `docs/web/testing.md:122`
+- Modify: `tests/CLAUDE.md:40` (the freezegun note says "burst drain")
+
+**Interfaces:**
+
+- Consumes: the shipped behavior from Tasks 1-5.
+- Produces: no code.
+
+- [ ] **Step 1: Rewrite the Workers section**
+
+`django_absurd/AGENTS.md:249-267`: one worker mode. Delete the Blocking/Burst bullet
+pair and the `--burst` mention, including its "cron / one-shot" claim — that advertised
+test scaffolding as a deployment mode and was wrong when written. Describe
+`--concurrency N` as the number of tasks in flight, refilled as soon as a slot frees,
+and say a stop signal (`SIGINT`/`SIGTERM`) lets in-flight tasks finish before the worker
+exits.
+
+- [ ] **Step 2: Describe the drain on its own terms**
+
+`django_absurd/AGENTS.md:852` and `docs/web/testing.md:122` both explain
+`dj_absurd.drain()` as "the fixture counterpart of `absurd_worker --burst`". Say what it
+does instead: runs every currently-claimable task on the queue to completion,
+in-process, one at a time, returning one `RunSnapshot` per run in claim order.
+
+- [ ] **Step 3: Fix the test-conventions note**
+
+`tests/CLAUDE.md:40` warns that freezegun deadlocks "the burst drain". Same warning,
+current vocabulary: "the drain".
+
+- [ ] **Step 4: Verify no stale references**
+
+```bash
+grep -rn --hidden "burst" django_absurd/ docs/web/ tests/ README.md examples/
+```
+
+Expected: no hits. `--hidden` matters — a bare `ag`/`grep` sweep in this repo has missed
+stale references before.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add django_absurd/AGENTS.md docs/web/testing.md tests/CLAUDE.md
+uv run pre-commit run --all-files
+git commit -m "docs: one worker mode, with concurrency that refills"
+```
+
+---
+
+## Coordinator gate (after Task 6)
+
+Not a task — the coordinator runs these once, after the last commit:
+
+```bash
+docker compose up -d db db_pg_cron
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+```
+
+Then a `revdiff` pass against `origin/main` before any push, per the project's review
+flow. The branch stays local until then.

--- a/docs/plans/2026-08-06-worker-concurrency.md
+++ b/docs/plans/2026-08-06-worker-concurrency.md
@@ -40,6 +40,12 @@ Read it before Task 1 — it records why each decision is what it is.
 - Iteration gate per task: `uv run pytest <path> -q --no-cov`, then
   `uv run pre-commit run --all-files` (owns ruff + mypy + prettier — never invoke them
   directly). `git add` new files first: `--all-files` skips untracked.
+- **Run only the test modules your task touched.** Never `pytest tests/core` for a
+  single edit — coverage instrumentation dominates and the whole-suite run belongs to
+  the coordinator gate at the end. Each task below names its exact target modules; run
+  those. `tests/multidb` and `tests/pg_cron` touch none of this work (neither imports
+  `run_absurd_worker`; pg_cron's only worker call asserts the `--beat` refusal, which
+  raises before the loop) — leave them to the coordinator.
 - The full `uvx --with tox-uv tox -e dev` gate belongs to the coordinator after the
   commit, NOT to the task implementer — it exceeds a subagent's foreground limit.
 - Postgres must be up before any suite: `docker compose up -d db db_pg_cron`.
@@ -488,10 +494,10 @@ it call `django_absurd.worker.drain_queue(queue)` and drop the `concurrency` par
 after Step 1 nothing passes it. Keep the function name; 34 call sites read
 `run_absurd_worker()` today.
 
-Then:
+Then run only what reaches the helper:
 
 ```bash
-uv run pytest tests/core -q --no-cov -n4
+uv run pytest tests/core/test_absurd_fixture.py tests/core/test_async_worker.py tests/core/test_worker.py -q --no-cov
 ```
 
 Expected: all pass.
@@ -516,15 +522,18 @@ blind.
 no fixture in scope. Those call `worker.drain_queue(<queue>)` directly — the same
 entrypoint `dj_absurd.drain` wraps.
 
-- [ ] **Step 5: Run every suite**
+- [ ] **Step 5: Run the modules this task touched**
 
 ```bash
-uv run pytest tests/core -q --no-cov -n4
-uv run pytest tests/multidb -q --no-cov
-uv run pytest tests/pg_cron -q --no-cov -n4
+uv run pytest tests/core/test_admin tests/core/test_admin_views.py \
+  tests/core/test_cleanup.py tests/core/test_enqueue.py \
+  tests/core/test_orm_models.py tests/core/test_scheduler.py \
+  tests/core/test_absurd_fixture.py tests/core/test_async_worker.py \
+  tests/core/test_worker.py -q --no-cov
 ```
 
-Expected: all pass.
+Expected: all pass. Nothing else in the repo calls the worker command, so no whole-suite
+run here.
 
 - [ ] **Step 6: Commit**
 
@@ -649,13 +658,14 @@ additionally asserts the `worker started: … burst=True concurrency=1` log line
 `test_worker.py:399`; leave that assertion untouched here, Task 5 changes the line
 itself.
 
-- [ ] **Step 6: Run the full core suite**
+- [ ] **Step 6: Run the modules this task touched**
 
 ```bash
-uv run pytest tests/core -q --no-cov -n4
+uv run pytest tests/core/test_command_output.py tests/core/test_logging \
+  tests/core/test_orm_views.py tests/core/test_worker.py -q --no-cov
 ```
 
-Expected: all pass.
+Expected: all pass, none of them near the helper's 15s timeout.
 
 - [ ] **Step 7: Commit**
 
@@ -730,12 +740,15 @@ before the worker loop, so they keep passing unchanged otherwise.
 - [ ] **Step 4: Prove the flag is gone**
 
 ```bash
-uv run pytest tests/core tests/multidb -q --no-cov -n4
+uv run pytest tests/core/test_worker.py tests/core/test_worker_slot_refill.py \
+  tests/core/test_async_worker.py tests/core/test_scheduler.py \
+  tests/core/test_logging tests/core/test_command_output.py -q --no-cov
 grep -rn "burst" django_absurd/ tests/
 ```
 
-Expected: suites pass; `grep` returns nothing outside `docs/` (specs and plans keep
-their historical references). A hit in `django_absurd/AGENTS.md` is Task 6's job.
+Expected: those modules pass; `grep` returns nothing outside `docs/` (specs and plans
+keep their historical references). A hit in `django_absurd/AGENTS.md` is Task 6's job.
+The whole-suite check for this signature change is the coordinator's gate, not yours.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/specs/2026-08-06-worker-concurrency-design.md
+++ b/docs/specs/2026-08-06-worker-concurrency-design.md
@@ -1,0 +1,175 @@
+# One worker mode, with working concurrency
+
+Covers [#155](https://github.com/lincolnloop/django-absurd/issues/155) (slot refill)
+plus removal of `absurd_worker --burst`. One change: both touch the same loop, the same
+command, and the same ~50 test call sites, so splitting them means rebasing the test
+migration onto a rewritten loop.
+
+## Problem
+
+Two defects, one cause — the worker never re-claims until the whole claimed batch
+finishes.
+
+**Slot refill.** `run_blocking_worker` (`worker.py:493`) delegates to the SDK's
+`AsyncAbsurd.start_worker`, which rebuilds `executing` per batch and ends each iteration
+with `await asyncio.gather(*executing)` (`absurd_sdk/__init__.py:2190-2210`). One slow
+task idles every other slot. Measured on the load harness, 4 slots, mixed backlog: one
+worker at `--concurrency 4` took 47.99s (sync) / 45.68s (async) against 16.36s / 15.12s
+for four workers at `--concurrency 1`. Mean slots busy 1.06 of 4. Idle slot-seconds
+while the backlog still held work: 141 vs 13 — 73% of offered capacity wasted. Uniform
+durations showed only 1.07x, which identifies the batch boundary, not task length, as
+cause.
+
+The SDK's **sync** worker has no such bug (`__init__.py:1665-1706`): one `executing` set
+across iterations, claims of `min(effective_batch_size, concurrency - len(executing))`.
+That shape came from the fix for the sync-side bug
+([upstream #91](https://github.com/earendil-works/absurd/issues/91)) and was never
+applied to the async path. TypeScript and Go workers already cap claims by free
+capacity; async Python was the only worker without refill.
+
+**`--burst`.** Same barrier in `adrain_queue` (`worker.py:271`), with no windowing at
+all. Not fixed — removed. See below.
+
+## Decisions
+
+Locked in design discussion; do not re-derive.
+
+- **Carry a local loop now.**
+  [Upstream PR #137](https://github.com/earendil-works/absurd/pull/137) fixes this in
+  the SDK but has sat unreviewed since 2026-08-03. Port its structure into `worker.py`
+  over the public `claim_tasks`; drop the local loop when a released SDK carries the
+  fix.
+- **`--burst` is removed, not fixed.** Absurd has no burst concept to inherit: the SDK
+  offers `work_batch` (one batch, sequential, no drain-to-empty) and `start_worker`
+  (resident); `absurdctl` ships no worker command at all. `--burst` was invented here
+  for tests, and the drain-to-empty concept stays where it belongs — the test fixture.
+  Peers do ship it (RQ `--burst`, Procrastinate `wait=False`), so this forfeits the
+  scale-to-zero / cron-drain deployment story. Accepted: one worker mode is worth more
+  than a deployment mode nobody has asked for.
+- **`--concurrency` becomes a blocking-worker knob only.**
+- **Graceful stop; cancel only on cancellation.** Stop signal → stop claiming, await
+  in-flight to completion. Coroutine cancelled → cancel in-flight, then await them.
+- **Own stop handle, passed in.** `stop: asyncio.Event | None = None` keyword on
+  `run_blocking_worker`.
+- **Command-test parity is a requirement.** Every assertion that runs the command today
+  keeps running the command.
+- **`--concurrency < 1` stays out of scope.** Already dies in
+  `ThreadPoolExecutor(max_workers=0)` (`worker.py:186`) before the loop; ugly,
+  unchanged.
+
+## Non-goals
+
+Burst refill (no burst). Any change to `dj_absurd.drain()` semantics. Priority.
+`WorkerOptions` validation. Multi-queue workers.
+
+## Design
+
+### Refill loop
+
+Port #137's structure into `worker.py`, over `client.claim_tasks` and the SDK's
+`_execute_task`, keeping the existing signal wiring:
+
+- `concurrency <= 1`: claim `batch_size or concurrency`, execute sequentially. Fast
+  path, straight from the SDK's sync worker — without it, capping claims by free
+  capacity silently reduces `--batch-size N --concurrency 1` from one round trip to N.
+- otherwise: one `executing` set across iterations; reap finished tasks; claim
+  `min(effective_batch_size, concurrency - len(executing))`; on an empty claim, wait for
+  progress (`asyncio.wait`, `FIRST_COMPLETED`, `timeout=poll_interval`) or sleep
+  `poll_interval` when nothing is in flight.
+- `finally`: stop set → await the window; cancelled → cancel the window, then await it.
+  `asyncio.wait` neither cancels nor awaits what it waits on, so without this a
+  cancelled worker leaves handlers running against a connection about to close, and
+  their runs sit `running` until lease expiry. The sync loop gets this free from
+  `ThreadPoolExecutor.__exit__`.
+
+Dispatch stays `client._execute_task`, the counted path `adrain_queue` already uses — a
+third `SLF001` on the same rationale (SDK exposes no public counted dispatch), not a new
+kind of reach.
+
+**Claim-while-executing is safe.** The loop issues a claim while handlers run on the
+client's single `AsyncConnection`. psycopg3 serializes: `AsyncConnection` holds an
+`asyncio.Lock` (`psycopg/connection_async.py:81`) and `cursor_async.execute` acquires it
+(`cursor_async.py:112,168`). Not new either — at `concurrency > 1` the SDK already runs
+several `_execute_task`s against that one connection.
+
+### Stop signal
+
+`client.stop_worker()` sets `_worker_running`, read only by the SDK's own loop, and
+`_worker_running` initializes `False` (`__init__.py:1215`) — reusing it would mean
+writing another library's private attribute whose job we just took. So:
+`run_blocking_worker(client, options, *, stop=None)`, creating an `asyncio.Event` when
+omitted. `SIGINT`/`SIGTERM` handlers set it. `run_worker_with_beat` passes the same
+event it uses for the beat thread, so one signal stops both.
+
+### Burst removal
+
+- `absurd_worker` loses `--burst`, and with it the `--burst`/`--beat` conflict check.
+- `run_worker` loses `burst=`; blocking only.
+- `drain_queue` keeps `adrain_queue` as its private, sequential engine — behavior
+  unchanged, it already runs at `concurrency=1`. Public surface is `dj_absurd.drain()`.
+
+Straight removal, no deprecation: alpha, and the package says so.
+
+## Tests
+
+RED first, from the issue, verified failing on `origin/main` for the right reason —
+batch one claims `[slow, fast-1]` (`batch_size` defaults to `concurrency`), `fast-1`
+finishes, `fast-2` is never claimed because the loop joins the whole batch:
+
+```
+AssertionError: the worker never started the third task while the slow one held a slot:
+started ['slow', 'fast-1']
+```
+
+Deterministic: the slow task blocks on an `Event` the test owns, each task announces its
+own start, and the only `wait_for` exists to turn "never started" into an assertion
+failure instead of a hang. Adapted from the issue's version to drive shutdown through
+`stop=` rather than `client.stop_worker()`.
+
+**Time is not frozen here**, against the usual rule for tests that execute: a live
+blocking worker and a real thread pool are the subject, so `dj_absurd.freeze_time` would
+deadlock rather than help. `tests/core/test_scheduler.py` holds the same exemption for
+its live worker.
+
+Alongside it: graceful stop with work in flight (in-flight completes, no new claims),
+cancel-and-drain (cancelled worker leaves no run `running`), and
+`--batch-size N --concurrency 1` still claiming in one round trip.
+
+### Migrating the ~50 `burst=True` call sites
+
+Three classes:
+
+1. **Execution-only (~32)** — `test_enqueue`, `test_orm_*`, `test_admin*`,
+   `test_cleanup`, most of `test_scheduler`. Move to `dj_absurd.drain()`. One of those
+   sites is `run_absurd_worker` (`tests/utils.py:68`), reached by 34 tests, so a single
+   edit covers most of the class. Each test needs `transaction=True` (already true — a
+   burst worker on its own connection only ever saw committed rows) and the `dj_absurd`
+   fixture param.
+2. **Raise before the loop (~6)** — alias rejection, no/multiple backends, undeclared
+   queue, schema-absent. Drop the kwarg; the command validates and the schema probe
+   fires before the worker loop starts.
+3. **Command-level (~12)** — provisioning report, `Started/Stopped worker` lines, the
+   `worker started: …` log line, mutable-policy reconcile output. These keep calling
+   `call_command("absurd_worker", …)`; a shared helper in `tests/utils.py` runs a
+   watcher thread that waits on a **condition** (expected rows terminal, or the started
+   line) and then fires `SIGTERM`. Same shape as `test_scheduler.py:704-737`, which
+   already does this for `--beat`. Signals are the command's real stop path, so this is
+   more faithful than `--burst` was; the shape lives in one helper, and nothing sleeps
+   on a timer.
+
+`test_async_concurrency_is_not_serial` (`test_async_worker.py:122`) currently proves
+async overlap through `--burst --concurrency 4`. It moves onto the blocking worker,
+where `--concurrency` now lives.
+
+## Docs
+
+- `AGENTS.md:249-267` — one worker mode; drop the burst bullet; `--concurrency`
+  described honestly as refilling a slot as soon as it frees.
+- `AGENTS.md:852`, `docs/web/testing.md:122` — describe `dj_absurd.drain()` on its own
+  terms instead of as "the fixture counterpart of `absurd_worker --burst`".
+
+## Divergence
+
+Carrying the loop forfeits future SDK worker fixes. When a released SDK carries #137 (or
+an equivalent), prefer taking it via a version bump and deleting the local loop; the
+`stop=` handle stays either way, since it is what makes an in-process stop testable.

--- a/docs/specs/2026-08-06-worker-concurrency-design.md
+++ b/docs/specs/2026-08-06-worker-concurrency-design.md
@@ -7,8 +7,7 @@ migration onto a rewritten loop.
 
 ## Problem
 
-Two defects, one cause — the worker never re-claims until the whole claimed batch
-finishes.
+One defect: the worker never re-claims until the whole claimed batch finishes.
 
 **Slot refill.** `run_blocking_worker` (`worker.py:493`) delegates to the SDK's
 `AsyncAbsurd.start_worker`, which rebuilds `executing` per batch and ends each iteration
@@ -27,8 +26,9 @@ That shape came from the fix for the sync-side bug
 applied to the async path. TypeScript and Go workers already cap claims by free
 capacity; async Python was the only worker without refill.
 
-**`--burst`.** Same barrier in `adrain_queue` (`worker.py:271`), with no windowing at
-all. Not fixed — removed. See below.
+`adrain_queue` (`worker.py:271`) carries the same barrier, with no windowing at all —
+but it is not a second defect to fix, because `--burst` is being deleted and the drain
+that remains runs one task at a time. See below.
 
 ## Decisions
 
@@ -39,13 +39,13 @@ Locked in design discussion; do not re-derive.
   the SDK but has sat unreviewed since 2026-08-03. Port its structure into `worker.py`
   over the public `claim_tasks`; drop the local loop when a released SDK carries the
   fix.
-- **`--burst` is removed, not fixed.** Absurd has no burst concept to inherit: the SDK
-  offers `work_batch` (one batch, sequential, no drain-to-empty) and `start_worker`
-  (resident); `absurdctl` ships no worker command at all. `--burst` was invented here
-  for tests, and the drain-to-empty concept stays where it belongs — the test fixture.
-  Peers do ship it (RQ `--burst`, Procrastinate `wait=False`), so this forfeits the
-  scale-to-zero / cron-drain deployment story. Accepted: one worker mode is worth more
-  than a deployment mode nobody has asked for.
+- **`--burst` is removed, not fixed.** It was built as an entry point for the test
+  suite, never as a public API — nothing is lost by deleting it. Absurd has no burst
+  concept to inherit either: the SDK offers `work_batch` (one batch, sequential, no
+  drain-to-empty) and `start_worker` (resident), and `absurdctl` ships no worker command
+  at all. The drain-to-empty concept stays where it was always meant to live,
+  `dj_absurd.drain()`. Documenting the flag as a deployment mode ("cron / one-shot",
+  `AGENTS.md:263`) was wrong when written; removal corrects it.
 - **`--concurrency` becomes a blocking-worker knob only.**
 - **Graceful stop; cancel only on cancellation.** Stop signal → stop claiming, await
   in-flight to completion. Coroutine cancelled → cancel in-flight, then await them.
@@ -107,8 +107,12 @@ event it uses for the beat thread, so one signal stops both.
 - `run_worker` loses `burst=`; blocking only.
 - `drain_queue` keeps `adrain_queue` as its private, sequential engine — behavior
   unchanged, it already runs at `concurrency=1`. Public surface is `dj_absurd.drain()`.
+- The `worker started: … burst=%s …` log line (`worker.py:191`) loses its `burst` field,
+  which `test_worker.py:399` asserts verbatim.
+- Prose that calls the drain "burst" (`DrainedRun`'s docstring, `LazyTaskRegistry`'s,
+  `test.py`, `pytest_plugin.py`) says "drain" instead.
 
-Straight removal, no deprecation: alpha, and the package says so.
+Straight removal, no deprecation period: nothing public is being withdrawn.
 
 ## Tests
 
@@ -163,8 +167,9 @@ where `--concurrency` now lives.
 
 ## Docs
 
-- `AGENTS.md:249-267` — one worker mode; drop the burst bullet; `--concurrency`
-  described honestly as refilling a slot as soon as it frees.
+- `AGENTS.md:249-267` — one worker mode; drop the burst bullet, including its "cron /
+  one-shot" claim, which advertised test scaffolding as a deployment mode;
+  `--concurrency` described honestly as refilling a slot as soon as it frees.
 - `AGENTS.md:852`, `docs/web/testing.md:122` — describe `dj_absurd.drain()` on its own
   terms instead of as "the fixture counterpart of `absurd_worker --burst`".
 

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -118,9 +118,8 @@ the queues.
 ### `drain(queue="default")`
 
 Runs every currently-claimable task on `queue` to completion, in-process — no
-[worker](how-it-works.md#workers) subprocess, no polling loop to manage. It's the
-fixture counterpart of `absurd_worker --burst`: it drains the backlog present at call
-time, then returns one `RunSnapshot` per run executed, in claim order.
+[worker](how-it-works.md#workers) subprocess, no polling loop to manage — one at a time,
+returning one `RunSnapshot` per run executed, in claim order.
 
 It provisions nothing, unlike the CLI, which provisions declared queues on start.
 `migrate` provisions every declared queue already, so a test database arrives ready. A

--- a/examples/web/tests/test_add.py
+++ b/examples/web/tests/test_add.py
@@ -4,7 +4,7 @@ from app import add  # app.py's own `add` task
 from django_absurd.test import AbsurdTestRuntime
 
 
-# transaction=True (not plain `db`): the `dj_absurd` fixture's burst drain opens its
+# transaction=True (not plain `db`): the `dj_absurd` fixture's drain opens its
 # OWN dedicated DB connection (by design — see django_absurd/worker.py's
 # aworker_client), separate from Django's. Under the default `db` fixture the
 # test body runs inside an uncommitted atomic block, so the enqueue is invisible
@@ -12,7 +12,7 @@ from django_absurd.test import AbsurdTestRuntime
 # transaction=True commits for real, matching tests/core/test_pytest_plugin.py's
 # own drain test.
 @pytest.mark.django_db(transaction=True)
-def test_add_task_completes_via_a_burst_drain(dj_absurd: AbsurdTestRuntime) -> None:
+def test_add_task_completes_via_a_drain(dj_absurd: AbsurdTestRuntime) -> None:
     result = add.enqueue("2", "3")
     assert [run.state for run in dj_absurd.drain()] == ["completed"]
     result.refresh()

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -37,8 +37,8 @@ pre-commit gates), see [`../CLAUDE.md`](../CLAUDE.md).
   0). The one sanctioned ticking use is `tests/core/test_scheduler.py`'s live worker
   crossing a `*/1` boundary, which needs real time to pass.
 - **freezegun is banned** — it patches `time.monotonic`, which IS asyncio's event-loop
-  clock, so a frozen freezegun deadlocks the burst drain unkillably. Do not reintroduce
-  it. `pytest-asyncio` is a dev dependency for writing `async def` tests; nothing in
+  clock, so a frozen freezegun deadlocks the drain unkillably. Do not reintroduce it.
+  `pytest-asyncio` is a dev dependency for writing `async def` tests; nothing in
   `django_absurd/` may depend on it.
 - **No monkeypatching / `unittest.mock.patch`.** Test observable behavior, not
   internals. If a test needs to patch our own functions to reach a branch, restructure

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -3,11 +3,11 @@ import typing as t
 import pytest
 from django.contrib.admin.utils import quote
 from django.contrib.auth.models import User
-from django.core.management import call_command
 from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 from django_absurd.models import Run
+from django_absurd.test import AbsurdTestRuntime
 from tests import tasks
 from tests.core.test_admin.utils import parse_html, result_rows, seed_mixed
 
@@ -34,11 +34,12 @@ def run_for(result: "TaskResult[t.Any, t.Any]") -> t.Any:
 def test_changelist_shows_dates_ordered_by_recent_activity(
     admin_user: User,
     client: Client,
+    dj_absurd: AbsurdTestRuntime,
 ) -> None:
     older = tasks.add.enqueue(1, 1)
-    call_command("absurd_worker", queue="default", burst=True)  # older run starts
+    dj_absurd.drain()  # older run starts
     newer = tasks.add.enqueue(2, 2)
-    call_command("absurd_worker", queue="default", burst=True)  # newer run starts later
+    dj_absurd.drain()  # newer run starts later
     client.force_login(admin_user)
     response = client.get(CHANGELIST)
     soup = parse_html(response)
@@ -94,6 +95,7 @@ def test_detail_groups_fields_into_fieldsets(
 def test_changelist_and_detail_survive_indefinite_available_at(
     admin_user: User,
     client: Client,
+    dj_absurd: AbsurdTestRuntime,
 ) -> None:
     # await_event with no timeout writes Postgres's 'infinity' sentinel into
     # available_at (absurd.await_event, migrations/0001_initial_0_4_0.sql:1664:
@@ -102,7 +104,7 @@ def test_changelist_and_detail_survive_indefinite_available_at(
     # un-guarded available_at column crashes both the changelist and the detail
     # page with a DataError before anything renders.
     tasks.sawait_event_once.enqueue("admin-infinity-check")
-    call_command("absurd_worker", queue="default", burst=True)  # suspends indefinitely
+    dj_absurd.drain()  # suspends indefinitely
 
     client.force_login(admin_user)
     changelist_response = client.get(CHANGELIST)

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -12,6 +12,7 @@ from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.queues import get_absurd_client
+from django_absurd.test import AbsurdTestRuntime
 from tests import atasks, tasks
 from tests.core.test_admin.utils import (
     BACKEND,
@@ -221,11 +222,11 @@ def test_detail_groups_fields_and_inlines_runs(
 
 
 def test_detail_inlines_checkpoints_and_run_available_at(
-    admin_user: User, client: Client
+    admin_user: User, client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     atasks.DURABLE_STEP_CALLS["n"] = 0
     atasks.asleep_for_once.enqueue("admin-k")
-    call_command("absurd_worker", queue="default", burst=True)  # suspends
+    dj_absurd.drain()  # suspends
     client.force_login(admin_user)
 
     task = find_task("default", "tests.atasks.asleep_for_once")
@@ -251,10 +252,10 @@ def test_detail_inlines_checkpoints_and_run_available_at(
 
 
 def test_detail_inlines_waits_for_a_suspended_await_event(
-    admin_user: User, client: Client
+    admin_user: User, client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     tasks.sawait_event_once.enqueue("wait-admin-demo")
-    call_command("absurd_worker", queue="default", burst=True)  # suspends
+    dj_absurd.drain()  # suspends
     client.force_login(admin_user)
 
     task = find_task("default", "tests.tasks.sawait_event_once")
@@ -314,7 +315,10 @@ def test_changelist_degrades_when_view_dropped(
 
 
 def test_partitioned_queue_appears_in_changelist(
-    admin_user: User, client: Client, settings: SettingsWrapper
+    admin_user: User,
+    client: Client,
+    dj_absurd: AbsurdTestRuntime,
+    settings: SettingsWrapper,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -329,7 +333,7 @@ def test_partitioned_queue_appears_in_changelist(
     }
     call_command("absurd_sync_queues")
     tasks.add.using(queue_name="part").enqueue(1, 1)
-    call_command("absurd_worker", queue="part", burst=True)
+    dj_absurd.drain("part")
     client.force_login(admin_user)
     resp = client.get(CHANGELIST)
     soup = parse_html(resp)

--- a/tests/core/test_admin/utils.py
+++ b/tests/core/test_admin/utils.py
@@ -6,10 +6,9 @@ import typing as t
 from bs4 import BeautifulSoup, ResultSet, Tag
 from django.conf import settings
 from django.contrib import admin as djadmin
-from django.core.management import call_command
 from django.urls import clear_url_caches
 
-from django_absurd import absurd_params
+from django_absurd import absurd_params, worker
 from django_absurd.admin import register_absurd_admin
 from tests import tasks
 from tests.utils import HasContent
@@ -38,8 +37,8 @@ def seed() -> None:
     tasks.add.enqueue(2, 3)
     tasks.add.using(queue_name="other").enqueue(7, 8)
     tasks.boom.enqueue()
-    call_command("absurd_worker", queue="default", burst=True)
-    call_command("absurd_worker", queue="other", burst=True)
+    worker.drain_queue("default")
+    worker.drain_queue("other")
 
 
 def seed_mixed() -> tuple[
@@ -48,6 +47,6 @@ def seed_mixed() -> tuple[
     """Three default-queue tasks in distinct terminal/queued states."""
     completed = tasks.add.enqueue(2, 3)
     failed = absurd_params(max_attempts=1).bind(tasks.boom).enqueue()
-    call_command("absurd_worker", queue="default", burst=True)
-    pending = tasks.add.enqueue(5, 6)  # enqueued after the burst → never claimed
+    worker.drain_queue("default")
+    pending = tasks.add.enqueue(5, 6)  # enqueued after the drain → never claimed
     return completed, failed, pending

--- a/tests/core/test_admin_views.py
+++ b/tests/core/test_admin_views.py
@@ -2,9 +2,9 @@ import typing as t
 import uuid
 
 import pytest
-from django.core.management import call_command
 from django.db import connections
 
+from django_absurd import worker
 from django_absurd.admin_views import (
     ADMIN_ENTITY_SPECS,
     EntitySpec,
@@ -25,8 +25,8 @@ CHECKS_SPEC: EntitySpec = next(s for s in ADMIN_ENTITY_SPECS if s.name == "check
 def seed_two_queues() -> None:
     tasks.add.enqueue(2, 3)
     tasks.add.using(queue_name="other").enqueue(7, 8)
-    call_command("absurd_worker", queue="default", burst=True)
-    call_command("absurd_worker", queue="other", burst=True)
+    worker.drain_queue("default")
+    worker.drain_queue("other")
 
 
 def test_zero_queue_view_is_empty() -> None:

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -9,6 +9,7 @@ from django.tasks import TaskResultStatus
 from django_absurd import absurd_params
 from django_absurd.backends import get_absurd_backends
 from django_absurd.test import AbsurdTestRuntime
+from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
 from tests import atasks, tasks
 from tests.models import Payload
 from tests.utils import run_absurd_worker
@@ -120,9 +121,27 @@ def test_worker_does_not_poison_jsonfield_reads() -> None:
 
 
 def test_async_concurrency_is_not_serial() -> None:
-    for _ in range(4):
-        atasks.asleeper.enqueue(0.5)
+    results = [atasks.asleeper.enqueue(0.5) for _ in range(4)]
     start = time.monotonic()
-    run_absurd_worker(concurrency=4)  # burst now drains CONCURRENTLY (gather)
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        backend = get_absurd_backends()["default"]
+        async with aworker_client(backend, "default") as client:
+
+            async def stop_once_all_are_terminal() -> None:
+                while True:
+                    outcomes = [await backend.aget_result(r.id) for r in results]
+                    if all(outcome.is_finished for outcome in outcomes):
+                        break
+                    await asyncio.sleep(0.05)
+                stop.set()
+
+            await asyncio.gather(
+                run_blocking_worker(client, WorkerOptions(concurrency=4), stop=stop),
+                stop_once_all_are_terminal(),
+            )
+
+    asyncio.run(drive())
     elapsed = time.monotonic() - start
     assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent ~0.5s (well under)

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -157,7 +157,7 @@ def test_worker_command_concurrency_is_not_serial() -> None:
     backend = get_absurd_backends()["default"]
     start = time.monotonic()
 
-    utils.run_worker_command_until(
+    utils.start_worker_until_done(
         lambda: all(backend.get_result(r.id).is_finished for r in results),
         queue="default",
         concurrency=4,

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -144,3 +144,27 @@ def test_async_concurrency_is_not_serial() -> None:
     asyncio.run(drive())
     elapsed = time.monotonic() - start
     assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent ~0.5s (well under)
+    # is_finished alone would also hold for four instant FAILUREs, which settle fast
+    # enough to pass the bound above without anything having slept.
+    backend = get_absurd_backends()["default"]
+    assert [backend.get_result(r.id).status for r in results] == [
+        TaskResultStatus.SUCCESSFUL
+    ] * len(results)
+
+
+def test_worker_command_concurrency_is_not_serial() -> None:
+    results = [atasks.asleeper.enqueue(0.5) for _ in range(4)]
+    backend = get_absurd_backends()["default"]
+    start = time.monotonic()
+
+    utils.run_worker_command_until(
+        lambda: all(backend.get_result(r.id).is_finished for r in results),
+        queue="default",
+        concurrency=4,
+    )
+
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.5  # 4 * 0.5s serial == 2.0s; concurrent ~0.5s (well under)
+    assert [backend.get_result(r.id).status for r in results] == [
+        TaskResultStatus.SUCCESSFUL
+    ] * len(results)

--- a/tests/core/test_async_worker.py
+++ b/tests/core/test_async_worker.py
@@ -10,9 +10,8 @@ from django_absurd import absurd_params
 from django_absurd.backends import get_absurd_backends
 from django_absurd.test import AbsurdTestRuntime
 from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
-from tests import atasks, tasks
+from tests import atasks, tasks, utils
 from tests.models import Payload
-from tests.utils import run_absurd_worker
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -25,7 +24,7 @@ def test_async_return_value_round_trips(
     dj_absurd: AbsurdTestRuntime, value: JsonValue
 ) -> None:
     r = atasks.aecho.enqueue(value)
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.state == "completed"
     assert snap.result == value
@@ -33,14 +32,14 @@ def test_async_return_value_round_trips(
 
 def test_async_failure_recorded(dj_absurd: AbsurdTestRuntime) -> None:
     r = absurd_params(max_attempts=1).bind(atasks.aboom).enqueue()
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.state == "failed"
 
 
 def test_async_takes_context_attempt_is_one(dj_absurd: AbsurdTestRuntime) -> None:
     r = atasks.areport_attempt.enqueue()
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.result == 1
 
@@ -48,7 +47,7 @@ def test_async_takes_context_attempt_is_one(dj_absurd: AbsurdTestRuntime) -> Non
 def test_sync_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
     # ORM in a SYNC task (executor path) — matched pair with the async-ORM test below
     r = tasks.create_payload.enqueue({"sync": True, "x": [9, 8]})
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"sync": True, "x": [9, 8]}
@@ -57,7 +56,7 @@ def test_sync_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
 def test_async_orm_jsonfield_round_trips(dj_absurd: AbsurdTestRuntime) -> None:
     # ORM in an ASYNC task (loop path) — matched pair with the sync-ORM test above
     r = atasks.acreate_payload.enqueue({"async": True, "y": {"z": None}})
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     pk = t.cast("int", snap.result)
     assert Payload.objects.get(pk=pk).data == {"async": True, "y": {"z": None}}
@@ -67,7 +66,7 @@ def test_async_task_queries_payload(dj_absurd: AbsurdTestRuntime) -> None:
     # async QUERY path: a row created in the test, read back by an async task (aget)
     obj = Payload.objects.create(data={"q": [1, {"x": None}], "u": "ünï"})
     r = atasks.aread_payload.enqueue(obj.pk)
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.state == "completed"
     assert snap.result == {"q": [1, {"x": None}], "u": "ünï"}
@@ -77,7 +76,7 @@ def test_aenqueue_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> No
     # exercise the aenqueue (produce) path for an async task, end-to-end
     # through the worker
     r = asyncio.run(atasks.aecho.aenqueue("via-aenqueue"))
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.result == "via-aenqueue"
 
@@ -85,7 +84,7 @@ def test_aenqueue_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> No
 def test_aenqueue_sync_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     # aenqueue a SYNC task too — runs via the worker's executor path
     r = asyncio.run(tasks.echo.aenqueue({"via": "aenqueue-sync"}))
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.result == {"via": "aenqueue-sync"}
 
@@ -94,7 +93,7 @@ def test_full_async_workflow_aenqueue_to_aget_result() -> None:
     # The whole async pipeline in one flow: aenqueue (async produce) -> async task
     # on the loop doing async ORM (acreate) -> aget_result (async read of the result).
     r = asyncio.run(atasks.acreate_payload.aenqueue({"full": "async", "n": [1, 2]}))
-    run_absurd_worker()
+    utils.run_absurd_worker()
     got = asyncio.run(get_absurd_backends()["default"].aget_result(r.id))
     assert got.status == TaskResultStatus.SUCCESSFUL
     assert Payload.objects.filter(pk=got.return_value).exists()
@@ -103,7 +102,7 @@ def test_full_async_workflow_aenqueue_to_aget_result() -> None:
 def test_sync_and_async_in_one_worker_run(dj_absurd: AbsurdTestRuntime) -> None:
     rs = tasks.echo.enqueue({"mixed": "sync"})
     ra = atasks.aecho.enqueue({"mixed": "async"})
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap_s = dj_absurd.get_result(rs.id)
     snap_a = dj_absurd.get_result(ra.id)
     assert snap_s.result == {"mixed": "sync"}
@@ -115,7 +114,7 @@ def test_worker_does_not_poison_jsonfield_reads() -> None:
     # JSONField read on the shared connection after a worker run must still
     # decode (no SP6-style poison).
     atasks.aecho.enqueue("x")
-    run_absurd_worker()
+    utils.run_absurd_worker()
     obj = Payload.objects.create(data={"k": "v", "n": 7})
     assert Payload.objects.get(pk=obj.pk).data == {"k": "v", "n": 7}
 

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -13,6 +13,7 @@ from django.core.management import call_command
 from django.db import connection
 from django.utils import timezone
 
+from django_absurd import worker
 from django_absurd.backends import get_absurd_backends
 from django_absurd.cleanup import QueueCleanup, cleanup_queues
 from django_absurd.queues import get_absurd_client
@@ -56,7 +57,7 @@ def sync_queue(
 
 
 def drain(queue: str = "default") -> None:
-    call_command("absurd_worker", queue=queue, burst=True)
+    worker.drain_queue(queue)
 
 
 @pytest.fixture(params=["command", "direct"])

--- a/tests/core/test_command_output.py
+++ b/tests/core/test_command_output.py
@@ -24,7 +24,7 @@ def test_sync_queues_decorates_its_console_output(settings: SettingsWrapper) -> 
 def test_the_worker_banner_carries_the_elephant(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     out = io.StringIO()
-    utils.run_worker_command_until(queue="default", stdout=out)
+    utils.start_worker(queue="default", stdout=out)
 
     assert out.getvalue() == (
         "🐘 Started worker on queue 'default'.\n"
@@ -39,7 +39,7 @@ def test_worker_banner_keeps_the_elephant_on_a_utf8_stream(
     dj_absurd.sync_queues()
     buffer = io.BytesIO()
     out = io.TextIOWrapper(buffer, encoding="utf-8")
-    utils.run_worker_command_until(queue="default", stdout=out)
+    utils.start_worker(queue="default", stdout=out)
     out.flush()
 
     assert buffer.getvalue().decode("utf-8") == (
@@ -55,7 +55,7 @@ def test_worker_banner_drops_the_elephant_on_a_stream_that_cannot_encode_it(
     dj_absurd.sync_queues()
     buffer = io.BytesIO()
     out = io.TextIOWrapper(buffer, encoding="cp1252")
-    utils.run_worker_command_until(queue="default", stdout=out)
+    utils.start_worker(queue="default", stdout=out)
     out.flush()
 
     assert buffer.getvalue().decode("cp1252") == (

--- a/tests/core/test_command_output.py
+++ b/tests/core/test_command_output.py
@@ -24,7 +24,7 @@ def test_sync_queues_decorates_its_console_output(settings: SettingsWrapper) -> 
 def test_the_worker_banner_carries_the_elephant(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     out = io.StringIO()
-    call_command("absurd_worker", queue="default", burst=True, stdout=out)
+    utils.run_worker_command_until(queue="default", stdout=out)
 
     assert out.getvalue() == (
         "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
@@ -37,7 +37,7 @@ def test_worker_banner_keeps_the_elephant_on_a_utf8_stream(
     dj_absurd.sync_queues()
     buffer = io.BytesIO()
     out = io.TextIOWrapper(buffer, encoding="utf-8")
-    call_command("absurd_worker", queue="default", burst=True, stdout=out)
+    utils.run_worker_command_until(queue="default", stdout=out)
     out.flush()
 
     assert buffer.getvalue().decode("utf-8") == (
@@ -51,7 +51,7 @@ def test_worker_banner_drops_the_elephant_on_a_stream_that_cannot_encode_it(
     dj_absurd.sync_queues()
     buffer = io.BytesIO()
     out = io.TextIOWrapper(buffer, encoding="cp1252")
-    call_command("absurd_worker", queue="default", burst=True, stdout=out)
+    utils.run_worker_command_until(queue="default", stdout=out)
     out.flush()
 
     assert buffer.getvalue().decode("cp1252") == (

--- a/tests/core/test_command_output.py
+++ b/tests/core/test_command_output.py
@@ -27,7 +27,9 @@ def test_the_worker_banner_carries_the_elephant(dj_absurd: AbsurdTestRuntime) ->
     utils.run_worker_command_until(queue="default", stdout=out)
 
     assert out.getvalue() == (
-        "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
     )
 
 
@@ -41,7 +43,9 @@ def test_worker_banner_keeps_the_elephant_on_a_utf8_stream(
     out.flush()
 
     assert buffer.getvalue().decode("utf-8") == (
-        "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
     )
 
 
@@ -55,7 +59,9 @@ def test_worker_banner_drops_the_elephant_on_a_stream_that_cannot_encode_it(
     out.flush()
 
     assert buffer.getvalue().decode("cp1252") == (
-        "Started worker on queue 'default'.\nStopped worker on queue 'default'.\n"
+        "Started worker on queue 'default'.\n"
+        "Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "Stopped worker on queue 'default'.\n"
     )
 
 

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -15,6 +15,7 @@ from django_absurd.connection import register_jsonb_loader
 from django_absurd.exceptions import QueueNotDeclaredError
 from django_absurd.queues import get_absurd_client
 from django_absurd.tasks import AbsurdTask
+from django_absurd.test import AbsurdTestRuntime
 from tests import tasks, utils
 
 if t.TYPE_CHECKING:
@@ -108,11 +109,13 @@ def test_aenqueue_lands() -> None:
     assert len(get_absurd_client().claim_tasks(batch_size=1)) == 1
 
 
-def test_enqueue_auto_creates_declared_queue_and_runs() -> None:
+def test_enqueue_auto_creates_declared_queue_and_runs(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
     # 'default' declared but unprovisioned (no absurd_sync_queues). Enqueue auto-creates
     # it; the worker then runs the task end-to-end.
     tasks.make_group.enqueue("auto")
-    call_command("absurd_worker", queue="default", burst=True)
+    dj_absurd.drain()
     assert Group.objects.filter(name="auto").exists()
 
 
@@ -141,11 +144,13 @@ def test_enqueue_with_empty_queues_reports_undeclared(
     )
 
 
-def test_enqueue_auto_create_survives_outer_atomic() -> None:
+def test_enqueue_auto_create_survives_outer_atomic(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
     with transaction.atomic():
         tasks.make_group.enqueue("inatomic")
         assert Group.objects.count() == 0  # nothing committed yet
-    call_command("absurd_worker", queue="default", burst=True)
+    dj_absurd.drain()
     assert Group.objects.filter(name="inatomic").exists()
 
 

--- a/tests/core/test_logging/test_handler.py
+++ b/tests/core/test_logging/test_handler.py
@@ -3,7 +3,6 @@ import logging
 
 import pytest
 import pytest_django.fixtures
-from django.core.management import call_command
 
 from django_absurd import hooks
 from django_absurd import logging as absurd_logging
@@ -37,7 +36,7 @@ def test_enqueuing_attaches_nothing(dj_absurd: AbsurdTestRuntime) -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_running_the_worker_gives_the_package_a_console_handler() -> None:
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     logger = logging.getLogger("django_absurd")
     assert len(logger.handlers) == 1
     assert isinstance(logger.handlers[0], logging.StreamHandler)
@@ -49,7 +48,7 @@ def test_the_worker_defers_to_a_project_that_configured_this_package(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.LOGGING = CONSOLE_LOGGING
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     assert logging.getLogger("django_absurd").handlers == []
 
 

--- a/tests/core/test_logging/test_handler.py
+++ b/tests/core/test_logging/test_handler.py
@@ -36,7 +36,7 @@ def test_enqueuing_attaches_nothing(dj_absurd: AbsurdTestRuntime) -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_running_the_worker_gives_the_package_a_console_handler() -> None:
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     logger = logging.getLogger("django_absurd")
     assert len(logger.handlers) == 1
     assert isinstance(logger.handlers[0], logging.StreamHandler)
@@ -48,7 +48,7 @@ def test_the_worker_defers_to_a_project_that_configured_this_package(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     settings.LOGGING = CONSOLE_LOGGING
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     assert logging.getLogger("django_absurd").handlers == []
 
 

--- a/tests/core/test_logging/test_maintenance.py
+++ b/tests/core/test_logging/test_maintenance.py
@@ -55,7 +55,7 @@ def test_the_worker_logs_when_it_stops(
     ]
     started = (
         f"worker started: alias={backend.alias} queue=default"
-        f" database={backend.database} burst=True concurrency=1"
+        f" database={backend.database} concurrency=1"
     )
     stopped = (
         f"worker stopped: alias={backend.alias} queue=default"

--- a/tests/core/test_orm_models.py
+++ b/tests/core/test_orm_models.py
@@ -4,11 +4,10 @@ import typing as t
 
 import pytest
 from django.apps import apps as global_apps
-from django.core.management import call_command
 from django.db.models import Count
 
 import django_absurd.models
-from django_absurd import absurd_params
+from django_absurd import absurd_params, worker
 from django_absurd import models as dm
 from django_absurd.admin_views import (
     ADMIN_ENTITY_SPECS,
@@ -68,8 +67,8 @@ def seed_two_queues() -> None:
     tasks.add.enqueue(2, 3)
     tasks.add.using(queue_name="other").enqueue(7, 8)
     absurd_params(max_attempts=1).bind(tasks.boom).enqueue()
-    call_command("absurd_worker", queue="default", burst=True)
-    call_command("absurd_worker", queue="other", burst=True)
+    worker.drain_queue("default")
+    worker.drain_queue("other")
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -92,7 +92,7 @@ def test_sync_command_rebuilds_views_with_new_queue() -> None:
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     tasks.add.using(queue_name="other").enqueue(1, 1)
-    utils.run_worker_command_until(
+    utils.start_worker_until_done(
         lambda: task_model.objects.filter(queue="other").exists(), queue="other"
     )
     qs = task_model.objects.values_list("queue", flat=True).distinct()
@@ -109,9 +109,9 @@ def test_worker_start_rebuilds_when_it_created_queue() -> None:
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     get_absurd_client().drop_queue("other")
-    utils.run_worker_command_until(queue="other")
+    utils.start_worker(queue="other")
     tasks.add.using(queue_name="other").enqueue(7, 8)
-    utils.run_worker_command_until(
+    utils.start_worker_until_done(
         lambda: task_model.objects.filter(queue="other").exists(), queue="other"
     )
     assert task_model.objects.filter(queue="other").count() >= 1

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -16,7 +16,7 @@ from django_absurd.apps import provision_queues_after_migrate
 from django_absurd.exceptions import ViewNotProvisionedError
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
-from tests import tasks
+from tests import tasks, utils
 
 if t.TYPE_CHECKING:
     from django.apps.config import AppConfig
@@ -92,7 +92,9 @@ def test_sync_command_rebuilds_views_with_new_queue() -> None:
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     tasks.add.using(queue_name="other").enqueue(1, 1)
-    call_command("absurd_worker", queue="other", burst=True)
+    utils.run_worker_command_until(
+        lambda: task_model.objects.filter(queue="other").exists(), queue="other"
+    )
     qs = task_model.objects.values_list("queue", flat=True).distinct()
     assert "other" in set(qs)
 
@@ -107,9 +109,11 @@ def test_worker_start_rebuilds_when_it_created_queue() -> None:
         next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
     )
     get_absurd_client().drop_queue("other")
-    call_command("absurd_worker", queue="other", burst=True)
+    utils.run_worker_command_until(queue="other")
     tasks.add.using(queue_name="other").enqueue(7, 8)
-    call_command("absurd_worker", queue="other", burst=True)
+    utils.run_worker_command_until(
+        lambda: task_model.objects.filter(queue="other").exists(), queue="other"
+    )
     assert task_model.objects.filter(queue="other").count() >= 1
 
 

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -661,16 +661,6 @@ def test_absurd_beat_no_backend_errors(
     )
 
 
-def test_worker_beat_rejects_burst(
-    settings: pytest_django.fixtures.SettingsWrapper,
-) -> None:
-    settings.TASKS = make_tasks_setting(
-        {"g": {"task": "tests.tasks.make_group", "cron": "*/1 * * * *", "args": ["x"]}}
-    )
-    with pytest.raises(CommandError, match="--beat"):
-        call_command("absurd_worker", queue="default", burst=True, beat=True)
-
-
 def test_beat_stop_interrupts_long_sleep(
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
@@ -803,7 +793,7 @@ def test_plain_worker_runs_blocking_worker(
     caplog: pytest.LogCaptureFixture,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    # Covers worker.py line 114: else branch of arun_worker (no burst, no beat).
+    # Covers arun_worker's else branch: a worker started without --beat.
     settings.TASKS = make_tasks_setting(
         {
             "g": {

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -711,7 +711,7 @@ def test_worker_with_beat_runs_scheduled_task(
     with time_machine.travel(
         dt.datetime(2026, 1, 1, 0, 0, 59, tzinfo=dt.UTC), tick=True
     ):
-        utils.run_worker_command_until(
+        utils.start_worker_until_done(
             lambda: Group.objects.filter(name="beat-ran").exists(),
             beat=True,
             poll_interval=0.05,
@@ -801,7 +801,7 @@ def test_plain_worker_runs_blocking_worker(
     backend = get_absurd_backends()["default"]
 
     with caplog.at_level(logging.INFO, logger="django_absurd"):
-        utils.run_worker_command_until(
+        utils.start_worker_until_done(
             lambda: Group.objects.filter(name="plain-worker").exists(),
             poll_interval=0.05,
             queue="default",

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -188,7 +188,7 @@ def test_beat_fires_each_due_slot(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 2, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         expected_fires = 2  # slots 00:01 and 00:02
         assert Payload.objects.count() == expected_fires
 
@@ -218,7 +218,7 @@ def test_beat_fires_multiple_schedules_due_same_slot(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert set(Group.objects.values_list("name", flat=True)) == {"a", "b"}
 
 
@@ -278,7 +278,7 @@ def test_beat_isolates_failing_schedule(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         expected_good = 1  # "bad" raised in spawn (unimportable, logged); "good" ran
         assert Payload.objects.count() == expected_good
 
@@ -313,7 +313,7 @@ def test_beat_spawns_task_with_args(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert Group.objects.filter(name="beat-args").exists()
 
 
@@ -336,7 +336,7 @@ def test_beat_spawns_task_with_kwargs(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert Group.objects.filter(name="beat-kw").exists()
 
 
@@ -362,7 +362,7 @@ def test_beat_empty_queue_string_falls_back_to_task_queue(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert Group.objects.filter(name="beat-empty-q").exists()
 
 
@@ -386,9 +386,9 @@ def test_beat_routes_task_to_queue(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert not Group.objects.filter(name="beat-routed").exists()
-        call_command("absurd_worker", queue="other", burst=True)
+        dj_absurd.drain(queue="other")
         assert Group.objects.filter(name="beat-routed").exists()
 
 
@@ -418,9 +418,9 @@ def test_beat_routes_task_to_queue_non_default_alias(
         run_beat_until(
             frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert not Group.objects.filter(name="beat-non-default").exists()
-        call_command("absurd_worker", queue="other", burst=True)
+        dj_absurd.drain(queue="other")
         assert Group.objects.filter(name="beat-non-default").exists()
 
 
@@ -520,6 +520,7 @@ def test_settings_provider_sets_backend_alias(
 
 
 def test_idempotency_key_dedups_same_slot(
+    dj_absurd: AbsurdTestRuntime,
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     # The command/loop never re-fires a single slot; this tests spawn_scheduled
@@ -541,7 +542,7 @@ def test_idempotency_key_dedups_same_slot(
     slot = dt.datetime(2026, 1, 1, 0, 1, tzinfo=dt.UTC)
     spawn_scheduled(schedule, slot)
     spawn_scheduled(schedule, slot)
-    call_command("absurd_worker", queue="default", burst=True)
+    dj_absurd.drain()
     assert Payload.objects.count() == 1
 
 
@@ -792,7 +793,7 @@ def test_beat_skips_not_yet_due_schedule(
             backend,
             dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC),
         )
-        call_command("absurd_worker", queue="default", burst=True)
+        dj_absurd.drain()
         assert Payload.objects.count() == 1
         assert Payload.objects.filter(data="due").exists()
         assert not Payload.objects.filter(data="later").exists()

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -26,7 +26,7 @@ from django_absurd.scheduler import (
     spawn_scheduled,
 )
 from django_absurd.test import AbsurdTestRuntime, FrozenTime
-from tests import tasks
+from tests import tasks, utils
 from tests.models import Payload
 from tests.utils import make_tasks_settings
 
@@ -706,24 +706,17 @@ def test_worker_with_beat_runs_scheduled_task(
     )
     call_command("absurd_sync_queues")
 
-    def watch() -> None:
-        deadline = time.monotonic() + 15
-        while time.monotonic() < deadline:  # pragma: no branch
-            if Group.objects.filter(name="beat-ran").exists():
-                break
-            time.sleep(0.05)
-        # stop worker + beat (main-thread handler)
-        os.kill(os.getpid(), signal.SIGTERM)
-
-    watcher = threading.Thread(target=watch, daemon=True)
-    watcher.start()
     # tick=True near a boundary: next "*/1" slot is ~1s away in real time, so beat fires
     # almost immediately; the live worker (fast poll) drains it.
     with time_machine.travel(
         dt.datetime(2026, 1, 1, 0, 0, 59, tzinfo=dt.UTC), tick=True
     ):
-        call_command("absurd_worker", queue="default", beat=True, poll_interval=0.05)
-    watcher.join(timeout=5)
+        utils.run_worker_command_until(
+            lambda: Group.objects.filter(name="beat-ran").exists(),
+            beat=True,
+            poll_interval=0.05,
+            queue="default",
+        )
 
     assert Group.objects.filter(name="beat-ran").exists()
 
@@ -807,19 +800,12 @@ def test_plain_worker_runs_blocking_worker(
     tasks.make_group.enqueue("plain-worker")
     backend = get_absurd_backends()["default"]
 
-    def watch() -> None:
-        deadline = time.monotonic() + 15
-        while time.monotonic() < deadline:  # pragma: no branch
-            if Group.objects.filter(name="plain-worker").exists():
-                break
-            time.sleep(0.05)
-        os.kill(os.getpid(), signal.SIGTERM)
-
-    watcher = threading.Thread(target=watch, daemon=True)
-    watcher.start()
     with caplog.at_level(logging.INFO, logger="django_absurd"):
-        call_command("absurd_worker", queue="default", poll_interval=0.05)
-    watcher.join(timeout=5)
+        utils.run_worker_command_until(
+            lambda: Group.objects.filter(name="plain-worker").exists(),
+            poll_interval=0.05,
+            queue="default",
+        )
 
     assert Group.objects.filter(name="plain-worker").exists()
     stopped = [

--- a/tests/core/test_signals_finished_failure.py
+++ b/tests/core/test_signals_finished_failure.py
@@ -57,7 +57,7 @@ def test_unbounded_attempts_never_report_terminal(
 ) -> None:
     finished = utils.RecordingReceiver()
     # A backoff is mandatory here: with max_attempts=None and the default delay-0
-    # strategy, the burst drain re-claims the failing task forever and the test hangs
+    # strategy, the drain re-claims the failing task forever and the test hangs
     # until pytest-timeout kills it.
     unbounded = params_module.absurd_params(
         max_attempts=None,

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -1,6 +1,10 @@
 import asyncio
 import datetime as dt
 import logging
+import os
+import signal
+import threading
+import time
 
 import psycopg.errors
 import pytest
@@ -9,6 +13,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command, load_command_class
 from django.core.management.base import CommandError
 from django.db import connection
+from django.tasks import task
 from pytest_django.fixtures import SettingsWrapper
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
@@ -25,6 +30,7 @@ from django_absurd.worker import (
     aworker_client,
     drain_queue,
     run_blocking_worker,
+    run_worker,
 )
 from tests import atasks, tasks, utils
 from tests.jobs import record_from_jobs
@@ -179,7 +185,9 @@ def test_queue_defaults_to_default(
     )
     out = capsys.readouterr().out
     assert out == (
-        "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
     )
     assert Group.objects.filter(name="dflt").exists()
 
@@ -274,13 +282,18 @@ def test_worker_start_provisions_all_declared_queues(
 ) -> None:
     # full provision on start: every declared queue, not just the served one
     utils.run_worker_command_until(queue="default")
-    created_line, started_line, stopped_line = capsys.readouterr().out.splitlines()
+    created_line, started_line, stop_requested_line, stopped_line = (
+        capsys.readouterr().out.splitlines()
+    )
     assert set(created_line.removeprefix("Created: ").split(", ")) == {
         "default",
         "other",
         "reports",
     }
     assert started_line == "🐘 Started worker on queue 'default'."
+    assert stop_requested_line == (
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks."
+    )
     assert stopped_line == "🐘 Stopped worker on queue 'default'."
     assert Queue.objects.filter(queue_name="default").exists()
     assert Queue.objects.filter(queue_name="other").exists()
@@ -308,6 +321,7 @@ def test_worker_command_reconciles_changed_mutable_option(
     assert out == (
         "Reconciled: default\n"
         "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
         "🐘 Stopped worker on queue 'default'.\n"
     )
     assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
@@ -341,6 +355,7 @@ def test_worker_command_reconciles_changed_interval_option(
     assert out == (
         "Reconciled: default\n"
         "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
         "🐘 Stopped worker on queue 'default'.\n"
     )
     assert Queue.objects.get(queue_name="default").cleanup_ttl == dt.timedelta(days=60)
@@ -363,7 +378,9 @@ def test_worker_command_no_reconcile_when_unchanged(
     # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just
     # the start and stop lines.
     assert out == (
-        "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
     )
     assert Queue.objects.get(queue_name="default").cleanup_ttl == before
 
@@ -388,7 +405,9 @@ def test_worker_command_warns_on_storage_mode_drift(
     utils.run_worker_command_until(queue="default")
     cap = capsys.readouterr()
     assert cap.out == (
-        "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
     )
     # The command's own warning shares stderr with the console handler the worker
     # attaches, whose StreamHandler defaults to stderr as Django's own console
@@ -399,6 +418,7 @@ def test_worker_command_warns_on_storage_mode_drift(
         "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
         "worker started: alias=default queue=default database=default"
         " concurrency=1\n"
+        "worker stop requested: finishing in-flight tasks\n"
         "worker stopped: alias=default queue=default database=default\n"
     )
 
@@ -563,3 +583,118 @@ def test_non_task_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> None:
     utils.run_absurd_worker()
     snap = dj_absurd.get_result(spawn["task_id"])
     assert snap.state != "failed"
+
+
+STOP_REQUESTED_LOG = "worker stop requested: finishing in-flight tasks"
+
+TASK_STARTED: dict[str, threading.Event] = {}
+RELEASE_GATE: dict[str, threading.Event] = {}
+
+
+@task(queue_name="default")
+async def wait_for_release(name: str) -> None:
+    """Announce it started, then park on a `threading.Event` a signal-sending OS
+    thread can set — an `asyncio.Event` would not be thread-safe to set from there."""
+    TASK_STARTED[name].set()
+    await asyncio.to_thread(RELEASE_GATE[name].wait)
+
+
+def test_worker_command_reports_the_stop_request_on_both_channels(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    dj_absurd.sync_queues()
+    with caplog.at_level(logging.INFO, logger="django_absurd"):
+        utils.run_worker_command_until(queue="default")
+
+    assert capsys.readouterr().out == (
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
+    )
+    messages = [
+        r.getMessage() for r in caplog.records if r.name == "django_absurd.worker"
+    ]
+    assert messages == [
+        "worker started: alias=default queue=default database=default concurrency=1",
+        STOP_REQUESTED_LOG,
+        "worker stopped: alias=default queue=default database=default",
+    ]
+
+
+def test_worker_command_logs_the_stop_request_again_on_a_second_signal(
+    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+) -> None:
+    # A held task keeps the worker mid-shutdown (looping never re-checked, handler
+    # still installed) long enough to deliver a SECOND signal deterministically —
+    # gated on the first stop-requested log line landing, never on a sleep — and
+    # proves the operator's second Ctrl-C gets answered too, not swallowed.
+    dj_absurd.sync_queues()
+    TASK_STARTED["repeat"] = threading.Event()
+    RELEASE_GATE["repeat"] = threading.Event()
+    wait_for_release.enqueue("repeat")
+    previous_handler = signal.getsignal(signal.SIGTERM)
+
+    def count_stop_requested() -> int:
+        return sum(
+            1
+            for r in caplog.records
+            if r.name == "django_absurd.worker" and r.getMessage() == STOP_REQUESTED_LOG
+        )
+
+    def deliver_two_signals_then_release() -> None:
+        assert TASK_STARTED["repeat"].wait(5)
+        os.kill(os.getpid(), signal.SIGTERM)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:  # pragma: no branch
+            if count_stop_requested() >= 1:
+                break
+            time.sleep(0.005)
+        os.kill(os.getpid(), signal.SIGTERM)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:  # pragma: no branch
+            if count_stop_requested() >= 2:
+                break
+            time.sleep(0.005)
+        RELEASE_GATE["repeat"].set()
+
+    killer = threading.Thread(target=deliver_two_signals_then_release, daemon=True)
+    with caplog.at_level(logging.INFO, logger="django_absurd"):
+        killer.start()
+        try:
+            call_command("absurd_worker", poll_interval=0.05, queue="default")
+        finally:
+            killer.join(timeout=5)
+            signal.signal(signal.SIGTERM, previous_handler)
+
+    assert count_stop_requested() == 2
+
+
+def test_run_worker_without_on_stop_requested_writes_nothing_to_stdout(
+    capsys: pytest.CaptureFixture[str], dj_absurd: AbsurdTestRuntime
+) -> None:
+    # run_worker (the library entrypoint, not the command) is the "default stays
+    # silent" case: nothing under django_absurd/ writes to stdout on its own, so a
+    # real stop signal through it must produce no output even though the log line
+    # still fires.
+    dj_absurd.sync_queues()
+    previous_handler = signal.getsignal(signal.SIGTERM)
+
+    def fire_sigterm_once_installed() -> None:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:  # pragma: no branch
+            if signal.getsignal(signal.SIGTERM) is not previous_handler:
+                break
+            time.sleep(0.005)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    killer = threading.Thread(target=fire_sigterm_once_installed, daemon=True)
+    try:
+        killer.start()
+        run_worker(backend(), "default", options=WorkerOptions(poll_interval=0.05))
+    finally:
+        killer.join(timeout=5)
+        signal.signal(signal.SIGTERM, previous_handler)
+
+    assert capsys.readouterr().out == ""

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -405,12 +405,15 @@ def test_worker_command_warns_on_storage_mode_drift(
 
 def test_worker_command_schema_absent_errors_migrate() -> None:
     # The provision_backend/ImproperlyConfigured translation errors before ever
-    # reaching the blocking worker loop.
+    # reaching the blocking worker loop. Driven through the live-worker helper: a
+    # command that fails this early installs no signal handler, so the stop signal
+    # that helper exists to send must never go out — it would land on pytest's own
+    # SIGTERM handler and take the session down with it.
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
         with pytest.raises(CommandError, match="migrate"):
-            call_command("absurd_worker", queue="default")
+            utils.run_worker_command_until(queue="default")
     finally:
         call_command("migrate", "django_absurd", "zero", verbosity=0)
         call_command("migrate", verbosity=0)  # restore absurd schema

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -26,7 +26,7 @@ from django_absurd.worker import (
     drain_queue,
     run_blocking_worker,
 )
-from tests import atasks, tasks
+from tests import atasks, tasks, utils
 from tests.jobs import record_from_jobs
 from tests.utils import run_absurd_worker
 
@@ -175,7 +175,9 @@ def test_queue_defaults_to_default(
         }
     }
     tasks.make_group.enqueue("dflt")  # auto-creates the default queue
-    call_command("absurd_worker", burst=True)  # no --queue -> "default"
+    utils.run_worker_command_until(  # no --queue -> "default"
+        lambda: Group.objects.filter(name="dflt").exists()
+    )
     out = capsys.readouterr().out
     assert out == (
         "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
@@ -206,7 +208,7 @@ def test_worker_uses_single_backend_at_nondefault_alias(
             "QUEUES": ["default"],
         }
     }
-    call_command("absurd_worker", burst=True)
+    utils.run_worker_command_until()
     assert "Started worker on queue 'default'." in capsys.readouterr().out
 
 
@@ -258,10 +260,12 @@ def test_command_parses_all_flags_with_defaults() -> None:
     assert opts["worker_id"] is None
 
 
-def test_command_burst_runs_task_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
+def test_command_runs_task_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     result = tasks.make_group.enqueue("via-command")
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(
+        lambda: Group.objects.filter(name="via-command").exists(), queue="default"
+    )
     assert Group.objects.filter(name="via-command").exists()
     snap = dj_absurd.get_result(result.id)
     assert snap.state == "completed"
@@ -271,7 +275,7 @@ def test_worker_start_provisions_all_declared_queues(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # full provision on start: every declared queue, not just the served one
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     created_line, started_line, stopped_line = capsys.readouterr().out.splitlines()
     assert set(created_line.removeprefix("Created: ").split(", ")) == {
         "default",
@@ -301,7 +305,7 @@ def test_worker_command_reconciles_changed_mutable_option(
         }
     }
     capsys.readouterr()  # drop sync output
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     out = capsys.readouterr().out
     assert out == (
         "Reconciled: default\n"
@@ -334,7 +338,7 @@ def test_worker_command_reconciles_changed_interval_option(
         }
     }
     capsys.readouterr()
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     out = capsys.readouterr().out
     assert out == (
         "Reconciled: default\n"
@@ -356,7 +360,7 @@ def test_worker_command_no_reconcile_when_unchanged(
     call_command("absurd_sync_queues")
     before = Queue.objects.get(queue_name="default").cleanup_ttl
     capsys.readouterr()
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     out = capsys.readouterr().out
     # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just
     # the start and stop lines.
@@ -383,7 +387,7 @@ def test_worker_command_warns_on_storage_mode_drift(
         }
     }
     capsys.readouterr()
-    call_command("absurd_worker", queue="default", burst=True)
+    utils.run_worker_command_until(queue="default")
     cap = capsys.readouterr()
     assert cap.out == (
         "🐘 Started worker on queue 'default'.\n🐘 Stopped worker on queue 'default'.\n"
@@ -396,8 +400,8 @@ def test_worker_command_warns_on_storage_mode_drift(
         "Queue 'default': storage_mode cannot be changed "
         "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
         "worker started: alias=default queue=default database=default"
-        " burst=True concurrency=1\n"
-        "worker stopped: alias=default queue=default database=default runs=0\n"
+        " burst=False concurrency=1\n"
+        "worker stopped: alias=default queue=default database=default\n"
     )
 
 

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -624,7 +624,9 @@ def test_worker_command_reports_the_stop_request_on_both_channels(
 
 
 def test_worker_command_logs_the_stop_request_again_on_a_second_signal(
-    caplog: pytest.LogCaptureFixture, dj_absurd: AbsurdTestRuntime
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    dj_absurd: AbsurdTestRuntime,
 ) -> None:
     # A held task keeps the worker mid-shutdown (looping never re-checked, handler
     # still installed) long enough to deliver a SECOND signal deterministically —
@@ -645,13 +647,15 @@ def test_worker_command_logs_the_stop_request_again_on_a_second_signal(
 
     def deliver_two_signals_then_release() -> None:
         assert TASK_STARTED["repeat"].wait(5)
-        os.kill(os.getpid(), signal.SIGTERM)
+        if utils.stop_handler_is_installed(previous_handler):
+            os.kill(os.getpid(), signal.SIGTERM)
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:  # pragma: no branch
             if count_stop_requested() >= 1:
                 break
             time.sleep(0.005)
-        os.kill(os.getpid(), signal.SIGTERM)
+        if utils.stop_handler_is_installed(previous_handler):
+            os.kill(os.getpid(), signal.SIGTERM)
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:  # pragma: no branch
             if count_stop_requested() >= 2:
@@ -669,6 +673,12 @@ def test_worker_command_logs_the_stop_request_again_on_a_second_signal(
             signal.signal(signal.SIGTERM, previous_handler)
 
     assert count_stop_requested() == 2
+    assert capsys.readouterr().out == (
+        "🐘 Started worker on queue 'default'.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
+        "🐘 Stopped worker on queue 'default'.\n"
+    )
 
 
 def test_run_worker_without_on_stop_requested_writes_nothing_to_stdout(
@@ -684,10 +694,10 @@ def test_run_worker_without_on_stop_requested_writes_nothing_to_stdout(
     def fire_sigterm_once_installed() -> None:
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:  # pragma: no branch
-            if signal.getsignal(signal.SIGTERM) is not previous_handler:
+            if utils.stop_handler_is_installed(previous_handler):
+                os.kill(os.getpid(), signal.SIGTERM)
                 break
             time.sleep(0.005)
-        os.kill(os.getpid(), signal.SIGTERM)
 
     killer = threading.Thread(target=fire_sigterm_once_installed, daemon=True)
     try:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -28,7 +28,6 @@ from django_absurd.worker import (
 )
 from tests import atasks, tasks, utils
 from tests.jobs import record_from_jobs
-from tests.utils import run_absurd_worker
 
 pytestmark = [
     pytest.mark.django_db(transaction=True),
@@ -61,7 +60,7 @@ def test_worker_client_rejects_non_psycopg3(settings: SettingsWrapper) -> None:
         }
     }
     with pytest.raises(CommandError, match="psycopg"):
-        call_command("absurd_worker", queue="default", burst=True)
+        call_command("absurd_worker", queue="default")
 
 
 def test_worker_client_opens_without_provisioning_check() -> None:
@@ -93,7 +92,7 @@ def test_worker_client_absent_schema_errors() -> None:
 def test_end_to_end_executes_and_records_result(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     result = tasks.make_group.enqueue("alpha")
-    run_absurd_worker()
+    utils.run_absurd_worker()
     assert Group.objects.filter(name="alpha").exists()
     snap = dj_absurd.get_result(result.id)
     assert snap.state == "completed"
@@ -103,7 +102,7 @@ def test_end_to_end_executes_and_records_result(dj_absurd: AbsurdTestRuntime) ->
 def test_failing_task_records_failure(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     result = tasks.boom.enqueue()
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(result.id)
     assert snap.state == "failed"
 
@@ -113,7 +112,7 @@ def test_takes_context_attempt_is_one_on_first_run(
 ) -> None:
     dj_absurd.sync_queues()
     result = tasks.report_attempt.enqueue()
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(result.id)
     assert snap.result == 1
 
@@ -123,7 +122,7 @@ def test_takes_context_task_result_carries_real_args(
 ) -> None:
     dj_absurd.sync_queues()
     result = tasks.report_args.enqueue("x", "y")
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(result.id)
     assert snap.result == ["x", "y"]
 
@@ -131,7 +130,7 @@ def test_takes_context_task_result_carries_real_args(
 def test_using_queue_name_routes_to_worker_queue() -> None:
     call_command("absurd_sync_queues")
     tasks.routed.using(queue_name="default").enqueue()
-    run_absurd_worker()
+    utils.run_absurd_worker()
     assert Group.objects.filter(name="routed").exists()
 
 
@@ -139,7 +138,7 @@ def test_handler_logs_task_outcome(caplog: pytest.LogCaptureFixture) -> None:
     call_command("absurd_sync_queues")
     tasks.make_group.enqueue("logged")
     with caplog.at_level(logging.INFO, logger="django_absurd"):
-        run_absurd_worker()
+        utils.run_absurd_worker()
     assert "tests.tasks.make_group" in caplog.text
     assert "completed" in caplog.text
 
@@ -149,7 +148,7 @@ def test_unregistered_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> N
     spawn = get_absurd_client("default").spawn(
         "not.a.real.task", {"args": [], "kwargs": {}}, queue="default"
     )
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(spawn["task_id"])
     assert snap.state != "failed"
 
@@ -159,7 +158,7 @@ def test_task_outside_tasks_py_runs(dj_absurd: AbsurdTestRuntime) -> None:
     # never find it (it would defer forever). Lazy resolution runs it by module_path.
     dj_absurd.sync_queues()
     result = record_from_jobs.enqueue("from-jobs")
-    run_absurd_worker()
+    utils.run_absurd_worker()
     assert Group.objects.filter(name="from-jobs").exists()
     snap = dj_absurd.get_result(result.id)
     assert snap.result == "from-jobs"
@@ -196,7 +195,7 @@ def test_unknown_queue_errors_listing_valid(settings: SettingsWrapper) -> None:
 
 def test_worker_rejects_alias_flag(settings: SettingsWrapper) -> None:
     with pytest.raises(CommandError):
-        call_command("absurd_worker", "--alias", "default", burst=True)
+        call_command("absurd_worker", "--alias", "default")
 
 
 def test_worker_uses_single_backend_at_nondefault_alias(
@@ -223,7 +222,7 @@ def test_worker_no_backend_errors(settings: SettingsWrapper) -> None:
             r"django_absurd\.backends\.AbsurdBackend entry to TASKS\."
         ),
     ):
-        call_command("absurd_worker", burst=True)
+        call_command("absurd_worker")
 
 
 def test_worker_multiple_backends_errors(settings: SettingsWrapper) -> None:
@@ -240,7 +239,7 @@ def test_worker_multiple_backends_errors(settings: SettingsWrapper) -> None:
         },
     }
     with pytest.raises(CommandError) as exc:
-        call_command("absurd_worker", burst=True)
+        call_command("absurd_worker")
     assert str(exc.value) == (
         "django-absurd supports one Absurd backend per project; "
         "configure exactly one AbsurdBackend in TASKS."
@@ -252,7 +251,6 @@ def test_command_parses_all_flags_with_defaults() -> None:
     parser = cmd.create_parser("manage.py", "absurd_worker")
     opts = vars(parser.parse_args([]))
     assert opts["queue"] == "default"  # --queue defaults to "default"
-    assert opts["burst"] is False
     assert opts["concurrency"] == 1
     assert opts["claim_timeout"] == 120
     assert opts["poll_interval"] == 0.25
@@ -400,23 +398,12 @@ def test_worker_command_warns_on_storage_mode_drift(
         "Queue 'default': storage_mode cannot be changed "
         "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
         "worker started: alias=default queue=default database=default"
-        " burst=False concurrency=1\n"
+        " concurrency=1\n"
         "worker stopped: alias=default queue=default database=default\n"
     )
 
 
 def test_worker_command_schema_absent_errors_migrate() -> None:
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
-        with pytest.raises(CommandError, match="migrate"):
-            call_command("absurd_worker", queue="default", burst=True)
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=0)  # restore absurd schema
-
-
-def test_worker_non_burst_command_schema_absent_errors_migrate() -> None:
     # The provision_backend/ImproperlyConfigured translation errors before ever
     # reaching the blocking worker loop.
     with connection.cursor() as cur:
@@ -434,14 +421,14 @@ def test_start_worker_drains_concurrently() -> None:
     for i in range(5):
         tasks.make_group.enqueue(f"g{i}")
 
-    run_absurd_worker()
+    utils.run_absurd_worker()
     assert Group.objects.filter(name__startswith="g").count() == 5
 
 
 def test_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     r = atasks.aecho.enqueue("hi-async")
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(r.id)
     assert snap.state == "completed"
     assert snap.result == "hi-async"
@@ -485,7 +472,7 @@ def test_undeclared_queue_is_rejected(
     # raises CommandError, drain_queue raises the package's own QueueNotDeclaredError.
     def invoke() -> None:
         if entrypoint == "command":
-            call_command("absurd_worker", queue="nope", burst=True)
+            call_command("absurd_worker", queue="nope")
         else:
             drain_queue("nope")
 
@@ -569,6 +556,6 @@ def test_non_task_name_defers_not_crashes(dj_absurd: AbsurdTestRuntime) -> None:
     spawn = get_absurd_client("default").spawn(
         "tests.atasks.asleep", {"args": [], "kwargs": {}}, queue="default"
     )
-    run_absurd_worker()
+    utils.run_absurd_worker()
     snap = dj_absurd.get_result(spawn["task_id"])
     assert snap.state != "failed"

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -407,8 +407,9 @@ def test_worker_command_schema_absent_errors_migrate() -> None:
     # The provision_backend/ImproperlyConfigured translation errors before ever
     # reaching the blocking worker loop. Driven through the live-worker helper: a
     # command that fails this early installs no signal handler, so the stop signal
-    # that helper exists to send must never go out — it would land on pytest's own
-    # SIGTERM handler and take the session down with it.
+    # that helper exists to send must never go out — pytest installs no SIGTERM
+    # handler of its own, so a stray kill would hit Python's default (SIG_DFL) and
+    # take the session down with it.
     with connection.cursor() as cur:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -647,14 +647,14 @@ def test_worker_command_logs_the_stop_request_again_on_a_second_signal(
 
     def deliver_two_signals_then_release() -> None:
         assert TASK_STARTED["repeat"].wait(5)
-        if utils.stop_handler_is_installed(previous_handler):
+        if utils.stop_handler_is_installed(previous_handler):  # pragma: no branch
             os.kill(os.getpid(), signal.SIGTERM)
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:  # pragma: no branch
             if count_stop_requested() >= 1:
                 break
             time.sleep(0.005)
-        if utils.stop_handler_is_installed(previous_handler):
+        if utils.stop_handler_is_installed(previous_handler):  # pragma: no branch
             os.kill(os.getpid(), signal.SIGTERM)
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:  # pragma: no branch

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -446,22 +446,23 @@ def test_async_task_runs_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
 def test_blocking_worker_drains_then_stops() -> None:
     # Exercises the blocking (live-worker) path deterministically — no sleeps:
     # the stopper awaits each task to a terminal state (SDK await_task_result),
-    # THEN calls stop_worker() (the flag start_worker's loop polls).
+    # THEN sets the stop event the worker loop polls.
     # run_blocking_worker returns once stopped.
     call_command("absurd_sync_queues")
     results = [tasks.make_group.enqueue(f"blk-{i}") for i in range(3)]
     task_ids = [r.id.rsplit(":", 1)[-1] for r in results]
 
     async def drive() -> None:
+        stop = asyncio.Event()
         async with aworker_client(backend(), "default") as client:
 
             async def stopper() -> None:
                 for tid in task_ids:
                     await client.await_task_result(tid)
-                client.stop_worker()
+                stop.set()
 
             await asyncio.gather(
-                run_blocking_worker(client, WorkerOptions(concurrency=2)),
+                run_blocking_worker(client, WorkerOptions(concurrency=2), stop=stop),
                 stopper(),
             )
 

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -180,7 +180,7 @@ def test_queue_defaults_to_default(
         }
     }
     tasks.make_group.enqueue("dflt")  # auto-creates the default queue
-    utils.run_worker_command_until(  # no --queue -> "default"
+    utils.start_worker_until_done(  # no --queue -> "default"
         lambda: Group.objects.filter(name="dflt").exists()
     )
     out = capsys.readouterr().out
@@ -215,7 +215,7 @@ def test_worker_uses_single_backend_at_nondefault_alias(
             "QUEUES": ["default"],
         }
     }
-    utils.run_worker_command_until()
+    utils.start_worker()
     assert "Started worker on queue 'default'." in capsys.readouterr().out
 
 
@@ -269,7 +269,7 @@ def test_command_parses_all_flags_with_defaults() -> None:
 def test_command_runs_task_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     dj_absurd.sync_queues()
     result = tasks.make_group.enqueue("via-command")
-    utils.run_worker_command_until(
+    utils.start_worker_until_done(
         lambda: Group.objects.filter(name="via-command").exists(), queue="default"
     )
     assert Group.objects.filter(name="via-command").exists()
@@ -281,7 +281,7 @@ def test_worker_start_provisions_all_declared_queues(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # full provision on start: every declared queue, not just the served one
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     created_line, started_line, stop_requested_line, stopped_line = (
         capsys.readouterr().out.splitlines()
     )
@@ -316,7 +316,7 @@ def test_worker_command_reconciles_changed_mutable_option(
         }
     }
     capsys.readouterr()  # drop sync output
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     out = capsys.readouterr().out
     assert out == (
         "Reconciled: default\n"
@@ -350,7 +350,7 @@ def test_worker_command_reconciles_changed_interval_option(
         }
     }
     capsys.readouterr()
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     out = capsys.readouterr().out
     assert out == (
         "Reconciled: default\n"
@@ -373,7 +373,7 @@ def test_worker_command_no_reconcile_when_unchanged(
     call_command("absurd_sync_queues")
     before = Queue.objects.get(queue_name="default").cleanup_ttl
     capsys.readouterr()
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     out = capsys.readouterr().out
     # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just
     # the start and stop lines.
@@ -402,7 +402,7 @@ def test_worker_command_warns_on_storage_mode_drift(
         }
     }
     capsys.readouterr()
-    utils.run_worker_command_until(queue="default")
+    utils.start_worker(queue="default")
     cap = capsys.readouterr()
     assert cap.out == (
         "🐘 Started worker on queue 'default'.\n"
@@ -434,7 +434,7 @@ def test_worker_command_schema_absent_errors_migrate() -> None:
         cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
     try:
         with pytest.raises(CommandError, match="migrate"):
-            utils.run_worker_command_until(queue="default")
+            utils.start_worker(queue="default")
     finally:
         call_command("migrate", "django_absurd", "zero", verbosity=0)
         call_command("migrate", verbosity=0)  # restore absurd schema
@@ -606,7 +606,7 @@ def test_worker_command_reports_the_stop_request_on_both_channels(
 ) -> None:
     dj_absurd.sync_queues()
     with caplog.at_level(logging.INFO, logger="django_absurd"):
-        utils.run_worker_command_until(queue="default")
+        utils.start_worker(queue="default")
 
     assert capsys.readouterr().out == (
         "🐘 Started worker on queue 'default'.\n"

--- a/tests/core/test_worker_slot_refill.py
+++ b/tests/core/test_worker_slot_refill.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 
 import pytest
 from django.core.management import call_command
@@ -66,22 +67,15 @@ def test_worker_starts_a_later_task_while_a_slow_one_still_runs() -> None:
         async with aworker_client(get_default_backend(), "default") as client:
 
             async def release_once_the_third_task_starts() -> None:
-                try:
+                with contextlib.suppress(TimeoutError):
                     await asyncio.wait_for(STARTED["fast-2"].wait(), timeout=5)
-                finally:
-                    HOLD["gate"].set()
-                    stop.set()
+                HOLD["gate"].set()
+                stop.set()
 
-            outcomes = await asyncio.gather(
+            await asyncio.gather(
                 run_blocking_worker(client, WorkerOptions(concurrency=2), stop=stop),
                 release_once_the_third_task_starts(),
-                return_exceptions=True,
             )
-            for outcome in outcomes:
-                if isinstance(outcome, BaseException) and not isinstance(
-                    outcome, TimeoutError
-                ):
-                    raise outcome
 
     asyncio.run(drive())
 
@@ -104,26 +98,19 @@ def test_one_slot_runs_a_claimed_batch_in_order() -> None:
         async with aworker_client(get_default_backend(), "default") as client:
 
             async def stop_once_all_three_ran() -> None:
-                try:
+                with contextlib.suppress(TimeoutError):
                     await asyncio.wait_for(
                         asyncio.gather(*(STARTED[n].wait() for n in STARTED)),
                         timeout=5,
                     )
-                finally:
-                    stop.set()
+                stop.set()
 
-            outcomes = await asyncio.gather(
+            await asyncio.gather(
                 run_blocking_worker(
                     client, WorkerOptions(batch_size=3, concurrency=1), stop=stop
                 ),
                 stop_once_all_three_ran(),
-                return_exceptions=True,
             )
-            for outcome in outcomes:
-                if isinstance(outcome, BaseException) and not isinstance(
-                    outcome, TimeoutError
-                ):
-                    raise outcome
 
     asyncio.run(drive())
 

--- a/tests/core/test_worker_slot_refill.py
+++ b/tests/core/test_worker_slot_refill.py
@@ -1,0 +1,130 @@
+import asyncio
+
+import pytest
+from django.core.management import call_command
+from django.tasks import task
+
+from django_absurd.backends import AbsurdBackend, get_absurd_backends
+from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
+
+pytestmark = [
+    pytest.mark.django_db(transaction=True),
+    pytest.mark.usefixtures("_isolate_queues"),
+]
+
+HOLD: dict[str, asyncio.Event] = {}
+STARTED: dict[str, asyncio.Event] = {}
+ORDER: list[str] = []
+
+
+def get_default_backend() -> AbsurdBackend:
+    return get_absurd_backends()["default"]
+
+
+@task(queue_name="default")
+async def hold_until_released(name: str) -> None:
+    """Occupy one worker slot until the test lets go of it."""
+    ORDER.append(name)
+    STARTED[name].set()
+    await HOLD["gate"].wait()
+
+
+@task(queue_name="default")
+async def record_started(name: str) -> None:
+    ORDER.append(name)
+    STARTED[name].set()
+
+
+def arm_events(*names: str) -> None:
+    ORDER.clear()
+    STARTED.clear()
+    HOLD["gate"] = asyncio.Event()
+    for name in names:
+        STARTED[name] = asyncio.Event()
+
+
+def test_worker_starts_a_later_task_while_a_slow_one_still_runs() -> None:
+    # A worker of C slots must keep claiming while one slot is busy. Enqueue C+1
+    # tasks so the extra one cannot ride in the same claim batch as the slow task:
+    # that is what forces a second claim, and a worker that joins its whole batch
+    # before claiming again never issues it.
+    #
+    # Deterministic, not timed: the slow task blocks on an Event the test owns, and
+    # each task announces its own start on another. The only clock is the wait_for
+    # that turns "never started" into a clean assertion failure instead of a hang.
+    # Time cannot be frozen here — a live worker loop and a real thread pool are the
+    # subject, so dj_absurd.freeze_time would deadlock rather than help.
+    call_command("absurd_sync_queues")
+    arm_events("fast-1", "fast-2", "slow")
+
+    hold_until_released.enqueue("slow")
+    record_started.enqueue("fast-1")
+    record_started.enqueue("fast-2")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def release_once_the_third_task_starts() -> None:
+                try:
+                    await asyncio.wait_for(STARTED["fast-2"].wait(), timeout=5)
+                finally:
+                    HOLD["gate"].set()
+                    stop.set()
+
+            outcomes = await asyncio.gather(
+                run_blocking_worker(client, WorkerOptions(concurrency=2), stop=stop),
+                release_once_the_third_task_starts(),
+                return_exceptions=True,
+            )
+            for outcome in outcomes:
+                if isinstance(outcome, BaseException) and not isinstance(
+                    outcome, TimeoutError
+                ):
+                    raise outcome
+
+    asyncio.run(drive())
+
+    assert STARTED["fast-2"].is_set(), (
+        "the worker never started the third task while the slow one held a slot: "
+        f"started {ORDER}"
+    )
+
+
+def test_one_slot_runs_a_claimed_batch_in_order() -> None:
+    call_command("absurd_sync_queues")
+    arm_events("first", "second", "third")
+
+    record_started.enqueue("first")
+    record_started.enqueue("second")
+    record_started.enqueue("third")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def stop_once_all_three_ran() -> None:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*(STARTED[n].wait() for n in STARTED)),
+                        timeout=5,
+                    )
+                finally:
+                    stop.set()
+
+            outcomes = await asyncio.gather(
+                run_blocking_worker(
+                    client, WorkerOptions(batch_size=3, concurrency=1), stop=stop
+                ),
+                stop_once_all_three_ran(),
+                return_exceptions=True,
+            )
+            for outcome in outcomes:
+                if isinstance(outcome, BaseException) and not isinstance(
+                    outcome, TimeoutError
+                ):
+                    raise outcome
+
+    asyncio.run(drive())
+
+    assert ORDER == ["first", "second", "third"]

--- a/tests/core/test_worker_slot_refill.py
+++ b/tests/core/test_worker_slot_refill.py
@@ -37,6 +37,24 @@ async def record_started(name: str) -> None:
     STARTED[name].set()
 
 
+@task(queue_name="default")
+async def hold_until_released_then_unwind(name: str) -> None:
+    """Occupy one slot, and finish unwinding only after yielding once more.
+
+    The cleanup arm is the point: a handler that awaits anything while unwinding —
+    a durable step, an async close — is still on the loop after ``cancel()`` merely
+    requests its cancellation, and only an await of the cancelled slot reaches its
+    ``-unwound`` line.
+    """
+    ORDER.append(name)
+    STARTED[name].set()
+    try:
+        await HOLD["gate"].wait()
+    finally:
+        await asyncio.sleep(0)
+        ORDER.append(f"{name}-unwound")
+
+
 def arm_events(*names: str) -> None:
     ORDER.clear()
     STARTED.clear()
@@ -203,5 +221,30 @@ def test_cancelling_the_worker_leaves_no_handler_running_on_the_loop() -> None:
                 if pending is not asyncio.current_task() and not pending.done()
             ]
             assert leftovers == []
+
+    asyncio.run(drive())
+
+
+def test_cancelling_the_worker_waits_for_each_slot_to_finish_unwinding() -> None:
+    # What the test above cannot see: a handler parked on an Event unwinds in the same
+    # loop turn that resolves ``await worker``, so a cancel-without-await still leaves
+    # no leftover task behind. Here the handler yields once while unwinding, which the
+    # worker only outlives if it never awaited what it cancelled — so the last thing
+    # the handler records lands after the worker's cancellation, or not at all.
+    call_command("absurd_sync_queues")
+    arm_events("slow")
+
+    hold_until_released_then_unwind.enqueue("slow")
+
+    async def drive() -> None:
+        async with aworker_client(get_default_backend(), "default") as client:
+            worker = asyncio.create_task(
+                run_blocking_worker(client, WorkerOptions(concurrency=2))
+            )
+            await asyncio.wait_for(STARTED["slow"].wait(), timeout=5)
+            worker.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await worker
+            assert ORDER == ["slow", "slow-unwound"]
 
     asyncio.run(drive())

--- a/tests/core/test_worker_slot_refill.py
+++ b/tests/core/test_worker_slot_refill.py
@@ -128,3 +128,55 @@ def test_one_slot_runs_a_claimed_batch_in_order() -> None:
     asyncio.run(drive())
 
     assert ORDER == ["first", "second", "third"]
+
+
+def test_stopping_lets_in_flight_work_finish_and_claims_nothing_new() -> None:
+    call_command("absurd_sync_queues")
+    arm_events("slow", "unclaimed")
+
+    hold_until_released.enqueue("slow")
+    record_started.enqueue("unclaimed")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def stop_once_the_slow_task_holds_a_slot() -> None:
+                await asyncio.wait_for(STARTED["slow"].wait(), timeout=5)
+                stop.set()
+                HOLD["gate"].set()
+
+            await asyncio.gather(
+                run_blocking_worker(client, WorkerOptions(concurrency=1), stop=stop),
+                stop_once_the_slow_task_holds_a_slot(),
+            )
+
+    asyncio.run(drive())
+
+    assert ORDER == ["slow"]
+    assert not STARTED["unclaimed"].is_set()
+
+
+def test_cancelling_the_worker_leaves_no_handler_running_on_the_loop() -> None:
+    call_command("absurd_sync_queues")
+    arm_events("slow")
+
+    hold_until_released.enqueue("slow")
+
+    async def drive() -> None:
+        async with aworker_client(get_default_backend(), "default") as client:
+            worker = asyncio.create_task(
+                run_blocking_worker(client, WorkerOptions(concurrency=2))
+            )
+            await asyncio.wait_for(STARTED["slow"].wait(), timeout=5)
+            worker.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await worker
+            leftovers = [
+                pending
+                for pending in asyncio.all_tasks()
+                if pending is not asyncio.current_task() and not pending.done()
+            ]
+            assert leftovers == []
+
+    asyncio.run(drive())

--- a/tests/core/test_worker_slot_refill.py
+++ b/tests/core/test_worker_slot_refill.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.tasks import task
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
+from django_absurd.test import AbsurdTestRuntime
 from django_absurd.worker import WorkerOptions, aworker_client, run_blocking_worker
 
 pytestmark = [
@@ -142,6 +143,43 @@ def test_stopping_lets_in_flight_work_finish_and_claims_nothing_new() -> None:
 
     assert ORDER == ["slow"]
     assert not STARTED["unclaimed"].is_set()
+
+
+def test_stopping_at_concurrency_above_one_still_finishes_a_held_slot(
+    dj_absurd: AbsurdTestRuntime,
+) -> None:
+    # The concurrency=1 stop test above takes the other code path entirely, so only
+    # this one pins the windowed loop's contract: a stop stops CLAIMING, it never
+    # cancels the window already claimed. The release is deliberately late — the stop
+    # has to land while the task is still parked on the gate, because a worker that
+    # cancels on stop leaves that run un-completed while one that waits does not.
+    call_command("absurd_sync_queues")
+    arm_events("slow")
+
+    result = hold_until_released.enqueue("slow")
+
+    async def drive() -> None:
+        stop = asyncio.Event()
+        async with aworker_client(get_default_backend(), "default") as client:
+
+            async def release_once_the_worker_has_stopped_claiming() -> None:
+                await asyncio.wait_for(STARTED["slow"].wait(), timeout=5)
+                stop.set()
+                await asyncio.sleep(0.1)
+                HOLD["gate"].set()
+
+            await asyncio.gather(
+                run_blocking_worker(
+                    client,
+                    WorkerOptions(concurrency=2, poll_interval=0.01),
+                    stop=stop,
+                ),
+                release_once_the_worker_has_stopped_claiming(),
+            )
+
+    asyncio.run(drive())
+
+    assert dj_absurd.get_result(result.id).state == "completed"
 
 
 def test_cancelling_the_worker_leaves_no_handler_running_on_the_loop() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,10 +6,10 @@ import uuid
 import psycopg
 import psycopg.sql
 from absurd_sdk import Absurd, CreateQueueOptions
-from django.core.management import call_command
 from django.db import connections
 from django.dispatch import Signal
 
+from django_absurd import worker
 from django_absurd.test import open_test_connection
 
 if t.TYPE_CHECKING:
@@ -64,8 +64,8 @@ def make_tasks_settings(
     return {"default": {"BACKEND": ABSURD_BACKEND, "OPTIONS": options}}
 
 
-def run_absurd_worker(queue: str = "default", concurrency: int = 1) -> None:
-    call_command("absurd_worker", queue=queue, burst=True, concurrency=concurrency)
+def run_absurd_worker(queue: str = "default") -> None:
+    worker.drain_queue(queue)
 
 
 def claim_one_run(queue: str = "default", *, claim_timeout: int) -> uuid.UUID:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,15 @@
 import contextlib
+import os
+import signal
 import threading
+import time
 import typing as t
 import uuid
 
 import psycopg
 import psycopg.sql
 from absurd_sdk import Absurd, CreateQueueOptions
+from django.core.management import call_command
 from django.db import connections
 from django.dispatch import Signal
 
@@ -66,6 +70,44 @@ def make_tasks_settings(
 
 def run_absurd_worker(queue: str = "default") -> None:
     worker.drain_queue(queue)
+
+
+def run_worker_command_until(
+    is_done: t.Callable[[], bool] | None = None,
+    *,
+    timeout: float = 15.0,
+    **options: t.Any,
+) -> None:
+    """Run ``absurd_worker`` to completion, stopping it once ``is_done()`` holds.
+
+    The command runs in the calling thread so ``capsys``/``caplog`` see it; a watcher
+    thread fires the SIGTERM the worker's own signal handler turns into a graceful
+    stop. Waits for that handler to be installed first — a signal delivered before
+    then kills the test session instead.
+    """
+    previous_handler = signal.getsignal(signal.SIGTERM)
+
+    def stop_once_done() -> None:
+        deadline = time.monotonic() + timeout
+        try:
+            while time.monotonic() < deadline:  # pragma: no branch
+                if signal.getsignal(signal.SIGTERM) is not previous_handler and (
+                    is_done is None or is_done()
+                ):
+                    break
+                time.sleep(0.05)
+            os.kill(os.getpid(), signal.SIGTERM)
+        finally:
+            # Thread-local, so this closes only the connection the predicate's ORM
+            # read opened on this thread.
+            connections.close_all()
+
+    watcher = threading.Thread(target=stop_once_done, daemon=True)
+    watcher.start()
+    try:
+        call_command("absurd_worker", **options)
+    finally:
+        watcher.join(timeout=5)
 
 
 def claim_one_run(queue: str = "default", *, claim_timeout: int) -> uuid.UUID:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,29 +75,39 @@ def run_absurd_worker(queue: str = "default") -> None:
 def run_worker_command_until(
     is_done: t.Callable[[], bool] | None = None,
     *,
-    timeout: float = 15.0,
+    timeout: float = 5.0,
     **options: t.Any,
 ) -> None:
     """Run ``absurd_worker`` to completion, stopping it once ``is_done()`` holds.
 
     The command runs in the calling thread so ``capsys``/``caplog`` see it; a watcher
     thread fires the SIGTERM the worker's own signal handler turns into a graceful
-    stop. Waits for that handler to be installed first — a signal delivered before
-    then kills the test session instead.
+    stop, and only ever while that handler is the one installed — see
+    ``stop_handler_is_installed``. A command that errors out before the worker loop
+    gets no signal at all.
+
+    The stop lives in a ``finally``, so a predicate that raises still stops the worker
+    (the exception then surfaces through pytest's unhandled-thread-exception hook)
+    rather than leaving the command running with nothing left to end it. ``timeout``
+    stays under the suite's per-test cap so an unreachable predicate stops the worker
+    and fails its own test, instead of the cap firing first.
     """
     previous_handler = signal.getsignal(signal.SIGTERM)
+    returned = threading.Event()
 
     def stop_once_done() -> None:
         deadline = time.monotonic() + timeout
         try:
             while time.monotonic() < deadline:  # pragma: no branch
-                if signal.getsignal(signal.SIGTERM) is not previous_handler and (
+                if stop_handler_is_installed(previous_handler) and (
                     is_done is None or is_done()
                 ):
                     break
-                time.sleep(0.05)
-            os.kill(os.getpid(), signal.SIGTERM)
+                if returned.wait(0.05):
+                    break
         finally:
+            if not returned.is_set() and stop_handler_is_installed(previous_handler):
+                os.kill(os.getpid(), signal.SIGTERM)
             # Thread-local, so this closes only the connection the predicate's ORM
             # read opened on this thread.
             connections.close_all()
@@ -107,7 +117,21 @@ def run_worker_command_until(
     try:
         call_command("absurd_worker", **options)
     finally:
+        returned.set()
         watcher.join(timeout=5)
+
+
+def stop_handler_is_installed(previous_handler: object) -> bool:
+    """Whether the SIGTERM handler currently installed is the worker's own.
+
+    Anything else means a signal would land somewhere that is not a graceful stop:
+    whatever pytest had installed before the command reached the worker loop, or
+    Python's default — which terminates the session outright — after asyncio removes
+    the worker's handler on the way out. Both are exactly what a stray SIGTERM from a
+    watcher thread must not hit.
+    """
+    handler = signal.getsignal(signal.SIGTERM)
+    return handler is not previous_handler and callable(handler)
 
 
 def claim_one_run(queue: str = "default", *, claim_timeout: int) -> uuid.UUID:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,13 +72,16 @@ def run_absurd_worker(queue: str = "default") -> None:
     worker.drain_queue(queue)
 
 
-def run_worker_command_until(
-    is_done: t.Callable[[], bool] | None = None,
+def start_worker_until_done(
+    is_done: t.Callable[[], bool],
     *,
     timeout: float = 5.0,
     **options: t.Any,
 ) -> None:
     """Run ``absurd_worker`` to completion, stopping it once ``is_done()`` holds.
+
+    ``is_done`` gates on real work — a row the task wrote, a beat firing — so this is
+    for tests asserting an OUTCOME of running the worker, not just that it started.
 
     The command runs in the calling thread so ``capsys``/``caplog`` see it; a watcher
     thread fires the SIGTERM the worker's own signal handler turns into a graceful
@@ -99,9 +102,7 @@ def run_worker_command_until(
         deadline = time.monotonic() + timeout
         try:
             while time.monotonic() < deadline:  # pragma: no branch
-                if stop_handler_is_installed(previous_handler) and (
-                    is_done is None or is_done()
-                ):
+                if stop_handler_is_installed(previous_handler) and is_done():
                     break
                 if returned.wait(0.05):
                     break
@@ -119,6 +120,20 @@ def run_worker_command_until(
     finally:
         returned.set()
         watcher.join(timeout=5)
+
+
+def start_worker(*, timeout: float = 5.0, **options: t.Any) -> None:
+    """Run ``absurd_worker`` just long enough to see its signal handler installed, then
+    stop it — for tests asserting something that happens before the worker loop ever
+    claims a run: the provisioning report, the startup banner, the logging handler the
+    command attaches. Nothing about the worker's actual work is waited on; a test that
+    needs a row or a beat to have landed wants ``start_worker_until_done`` instead.
+
+    Delegates to ``start_worker_until_done`` with an always-true predicate so there is
+    one implementation of the watcher thread, the handler-installed guard, and the
+    thread-local ``connections.close_all()``.
+    """
+    start_worker_until_done(lambda: True, timeout=timeout, **options)
 
 
 def stop_handler_is_installed(previous_handler: object) -> bool:


### PR DESCRIPTION
`--concurrency N` now keeps N tasks in flight: the worker refills a slot as it frees instead of joining each claimed batch. Measured on the load harness, 4 slots, mixed backlog: 47.99s → 16.36s, mean slots busy 1.06 → ~3.4 of 4.

**Breaking:** `absurd_worker --burst` is removed. It was scaffolding for this project's own tests that leaked onto the CLI and was documented as a cron/one-shot deployment mode it never was. The drain concept stays as `dj_absurd.drain()`.

Also: SIGINT/SIGTERM stops claiming and lets in-flight tasks finish, now acknowledged on stdout and the `django_absurd` logger and acted on immediately rather than up to a `--poll-interval` later; the `worker started:` log line drops its `burst=` field.

Local worker loop is ported from https://github.com/earendil-works/absurd/pull/137; `docs/UPSTREAM.md` records it and the stop-latency gap, with the condition for deleting the local loop.

Closes #155