### PR TITLE
feat(pg_cron): report a scheduler app with no backend

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -156,6 +156,8 @@ System check IDs:
 - `absurd.E012` — the central `cron.database_name` database (auto-discovered) is
   unreachable or missing the `pg_cron` extension; a deploy-time check, see
   [Validate schedules](#validate-schedules).
+- `absurd.E013` — `"django_absurd.pg_cron"` is installed but no `AbsurdBackend` is
+  configured, so schedules would save without ever being scheduled.
 - `absurd.W002` (Warning) — a queue's declared `storage_mode` differs from the database;
   `storage_mode` is immutable once the queue exists.
 - `absurd.W003` (Warning) — `"django_absurd.pg_cron"` is in `INSTALLED_APPS` but ordered

--- a/django_absurd/pg_cron/checks.py
+++ b/django_absurd/pg_cron/checks.py
@@ -31,12 +31,13 @@ E007_HINT_PG_CRON_CRON = (
 
 E013_MSG = (
     "django-absurd: 'django_absurd.pg_cron' is installed, but no AbsurdBackend is"
-    " configured."
+    " configured, so a schedule would save without ever being scheduled."
 )
 E013_HINT = (
     "Point a TASKS entry at django_absurd.backends.AbsurdBackend, or remove"
-    " 'django_absurd.pg_cron' from INSTALLED_APPS. Without a backend a ScheduledTask"
-    " row saves normally and never gets a pg_cron job."
+    " 'django_absurd.pg_cron' from INSTALLED_APPS. To keep the app installed with"
+    " another backend deliberately (a dev or CI settings module), add 'absurd.E013' to"
+    " SILENCED_SYSTEM_CHECKS."
 )
 
 E011_MSG = (

--- a/django_absurd/pg_cron/checks.py
+++ b/django_absurd/pg_cron/checks.py
@@ -29,6 +29,16 @@ E007_HINT_PG_CRON_CRON = (
     " scheduler's 6-field leading-seconds form is not pg_cron syntax."
 )
 
+E013_MSG = (
+    "django-absurd: 'django_absurd.pg_cron' is installed, but no AbsurdBackend is"
+    " configured."
+)
+E013_HINT = (
+    "Point a TASKS entry at django_absurd.backends.AbsurdBackend, or remove"
+    " 'django_absurd.pg_cron' from INSTALLED_APPS. Without a backend a ScheduledTask"
+    " row saves normally and never gets a pg_cron job."
+)
+
 E011_MSG = (
     "django-absurd: OPTIONS['SYNC_SCHEDULES_ON_TEST_DB'] is True without"
     " OPTIONS['PG_CRON_ON_TEST_DB']."
@@ -163,6 +173,22 @@ def check_pg_cron_cleanup_schedule(
                 )
             )
     return errors
+
+
+@register("absurd")
+def check_pg_cron_has_a_backend(
+    *,
+    app_configs: Sequence[AppConfig] | None,
+    **kwargs: t.Any,
+) -> list[CheckMessage]:
+    """The scheduler app is installed for a backend that does not resolve.
+
+    Everything downstream degrades quietly in that state — validation skips its
+    backend-dependent rules and emission returns early — so the misconfiguration is
+    reported here, where it is still cheap to fix."""
+    if get_absurd_backends():
+        return []
+    return [Error(E013_MSG, hint=E013_HINT, id="absurd.E013")]
 
 
 @register("absurd")

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -1,3 +1,4 @@
+import logging
 import typing as t
 
 from django.core.exceptions import ValidationError
@@ -31,6 +32,8 @@ CRON_HELP_TEXT = (
     ' See <a href="https://github.com/citusdata/pg_cron" target="_blank"'
     ' rel="noopener">pg_cron</a> for the exact schedule syntax.'
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_default_max_attempts() -> int:
@@ -126,9 +129,15 @@ class ScheduledTask(models.Model):
 
     def clean(self) -> None:
         errors: dict[str, list[str]] = {}
+        # The grammar rule needs no backend — only the queue rule does — so a
+        # misconfigured TASKS does not buy a row a free pass on its cron.
+        try:
+            validate_pg_cron_schedule(self.cron)
+        except ValidationError as exc:
+            errors["cron"] = exc.messages
         backend = get_absurd_backend()
         if backend is not None:
-            errors.update(self.validate_against_backend(backend))
+            errors.update(self.validate_queue_against_backend(backend))
 
         retry_timing_fields = (
             "retry_base_seconds",
@@ -145,11 +154,12 @@ class ScheduledTask(models.Model):
         if errors:
             raise ValidationError(errors)
 
-    def validate_against_backend(
+    def validate_queue_against_backend(
         self, backend: "AbsurdBackend"
     ) -> dict[str, list[str]]:
-        """Validate queue + cron against the single pg_cron backend. Returns field
-        errors (empty if OK)."""
+        """Validate the effective queue against the single pg_cron backend. Returns
+        field errors (empty if OK). The cron grammar is checked in clean(), which needs
+        no backend to do it."""
         errors: dict[str, list[str]] = {}
         # Validate the effective queue (explicit override, else the task's own
         # queue_name) against the backend's declared queues.
@@ -159,10 +169,6 @@ class ScheduledTask(models.Model):
             )
         except ValidationError as exc:
             errors["queue"] = exc.messages
-        try:
-            validate_pg_cron_schedule(self.cron)
-        except ValidationError as exc:
-            errors["cron"] = exc.messages
         return errors
 
     def schedule_pg_cron_job(self) -> None:
@@ -170,6 +176,13 @@ class ScheduledTask(models.Model):
         catalog seam. Called by the post_save signal for every write; a no-op when no
         Absurd backend is configured (and, on a test DB, unless pg_cron is opted in)."""
         if get_absurd_backend() is None:
+            # Best-effort by design (see signals), so this stays a return rather than a
+            # raise — but say it, or the row looks scheduled and never fires. The
+            # deploy-time report is absurd.E013.
+            logger.warning(
+                "pg_cron job not scheduled for %r: no AbsurdBackend is configured",
+                str(self),
+            )
             return
         alias = resolve_absurd_database()
         catalog.schedule_job(

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -180,8 +180,8 @@ class ScheduledTask(models.Model):
             # raise — but say it, or the row looks scheduled and never fires. The
             # deploy-time report is absurd.E013.
             logger.warning(
-                "pg_cron job not scheduled for %r: no AbsurdBackend is configured",
-                str(self),
+                "pg_cron job not scheduled for '%s': no AbsurdBackend is configured",
+                self,
             )
             return
         alias = resolve_absurd_database()
@@ -196,10 +196,16 @@ class ScheduledTask(models.Model):
 
     def unschedule_pg_cron_job(self) -> None:
         """Remove this row's pg_cron job via the catalog seam, tolerating an
-        already-gone job. Called by the post_delete signal for every deletion; a no-op
-        when no Absurd backend is configured (symmetric with schedule_pg_cron_job) — so
-        deletes don't error on a DB without one."""
+        already-gone job. Called by the post_delete signal for every deletion; when no
+        Absurd backend is configured it warns and returns, symmetric with
+        schedule_pg_cron_job — so deletes don't error on a DB without one, but a job
+        left firing for a row that no longer exists is not silent."""
         if get_absurd_backend() is None:
+            logger.warning(
+                "pg_cron job not unscheduled for '%s': no AbsurdBackend is configured;"
+                " it keeps firing until the next reconcile",
+                self,
+            )
             return
         catalog.unschedule_job(
             resolve_absurd_database(), name=self.name, source=self.source

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -98,9 +98,9 @@ Verifies the configuration. Fix what it reports rather than silencing it:
 | `absurd.E007` | Invalid `SCHEDULE` entry (see [Cron Jobs](cron-jobs.md)).                                                                                                                                     |
 | `absurd.E009` | `OPTIONS["DEFAULT_MAX_ATTEMPTS"]` is not an integer `>= 1`.                                                                                                                                   |
 | `absurd.E010` | Invalid `CLEANUP` configuration (not a `{"schedule": …}` map, unknown keys, or a cron expression the configured scheduler cannot run) (see [Cleanup](cleanup.md#schedule-recurring-cleanup)). |
-| `absurd.E013` | `"django_absurd.pg_cron"` is installed but no `AbsurdBackend` is configured — schedules would save and never fire (see [Cron Jobs](cron-jobs.md#postgres-side-pg_cron)).                      |
 | `absurd.E011` | `SYNC_SCHEDULES_ON_TEST_DB` is `True` without `PG_CRON_ON_TEST_DB` (see [Cron Jobs](cron-jobs.md#test-databases)).                                                                            |
 | `absurd.E012` | The central `cron.database_name` database is unreachable or missing the `pg_cron` extension — a deploy-time check (see [Cron Jobs](cron-jobs.md#operator-setup)).                             |
+| `absurd.E013` | `"django_absurd.pg_cron"` is installed but no `AbsurdBackend` is configured — schedules would save and never fire (see [Cron Jobs](cron-jobs.md#postgres-side-pg_cron)).                      |
 | `absurd.W002` | (Warning) A queue's declared `storage_mode` differs from the database; `storage_mode` is immutable once the queue exists.                                                                     |
 | `absurd.W003` | (Warning) `django_absurd.pg_cron` is ordered before `django_absurd` in `INSTALLED_APPS` (see [Cron Jobs](cron-jobs.md)).                                                                      |
 

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -98,6 +98,7 @@ Verifies the configuration. Fix what it reports rather than silencing it:
 | `absurd.E007` | Invalid `SCHEDULE` entry (see [Cron Jobs](cron-jobs.md)).                                                                                                                                     |
 | `absurd.E009` | `OPTIONS["DEFAULT_MAX_ATTEMPTS"]` is not an integer `>= 1`.                                                                                                                                   |
 | `absurd.E010` | Invalid `CLEANUP` configuration (not a `{"schedule": …}` map, unknown keys, or a cron expression the configured scheduler cannot run) (see [Cleanup](cleanup.md#schedule-recurring-cleanup)). |
+| `absurd.E013` | `"django_absurd.pg_cron"` is installed but no `AbsurdBackend` is configured — schedules would save and never fire (see [Cron Jobs](cron-jobs.md#postgres-side-pg_cron)).                      |
 | `absurd.E011` | `SYNC_SCHEDULES_ON_TEST_DB` is `True` without `PG_CRON_ON_TEST_DB` (see [Cron Jobs](cron-jobs.md#test-databases)).                                                                            |
 | `absurd.E012` | The central `cron.database_name` database is unreachable or missing the `pg_cron` extension — a deploy-time check (see [Cron Jobs](cron-jobs.md#operator-setup)).                             |
 | `absurd.W002` | (Warning) A queue's declared `storage_mode` differs from the database; `storage_mode` is immutable once the queue exists.                                                                     |

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -85,7 +85,8 @@ django-absurd's schema and queries there.
 python manage.py check django_absurd
 ```
 
-Verifies the configuration. Fix what it reports rather than silencing it:
+Verifies the configuration. Fix what it reports rather than silencing it, unless a
+check's own hint says otherwise:
 
 | ID            | Means                                                                                                                                                                                         |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -97,6 +97,11 @@ pre-commit gates), see [`../CLAUDE.md`](../CLAUDE.md).
   `call_command("check", "django_absurd")` / `call_command("absurd_sync_queues")`,
   capture output with pytest `capsys`, and **assert on the full emitted message text**
   (not on internal return values).
+- **A check test that must ERROR uses `pytest.raises(SystemCheckError)`**, not a helper
+  that captures output — a helper passes whether or not the check fired, and the
+  `try/except/else` shape it invites leaves an unreachable `else` that fails the
+  patch-coverage gate (this recurred twice). The output-capturing helpers are for
+  tolerant sweeps: asserting an ID is ABSENT, or reading several messages at once.
 - Drive check/command states with real DB conditions (sync via the command; drop the
   schema; `override_settings` for an unreachable DB) — not mocks.
 - HTTP mocking (when ever needed): the `responses` library, not `mock`.

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -1,4 +1,7 @@
+import logging
+
 import pytest
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from pytest_django.fixtures import SettingsWrapper
 
@@ -23,16 +26,16 @@ def test_long_schedule_name_passes_full_clean(settings: SettingsWrapper) -> None
 def test_full_clean_skips_backend_validation_when_no_backend_configured(
     settings: SettingsWrapper,
 ) -> None:
-    # With no Absurd backend configured at all, there is nothing to validate the
-    # queue/cron against, so full_clean must skip cleanly (and not raise) rather
-    # than reject an otherwise-valid row.
+    # With no Absurd backend there is nothing to validate the QUEUE against, so that
+    # rule is skipped rather than rejecting an otherwise-valid row. The cron is still
+    # checked — see test_cron_is_validated_even_with_no_backend_configured.
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }
     ScheduledTask(
         source="a",
         name="beatrow",
-        task="tests.tasks.add",
+        task="tests.pg_cron.tasks.add",
         queue="default",
         cron="0 2 * * *",
     ).full_clean()
@@ -155,3 +158,50 @@ def test_scheduledtask_unique_per_source_name() -> None:
         task="demo.tasks.ping",
         cron="* * * * *",
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_cron_is_validated_even_with_no_backend_configured(
+    settings: SettingsWrapper,
+) -> None:
+    # The queue rule needs a backend to know what is declared; the grammar rule needs
+    # nothing, so a misconfigured TASKS must not buy a row a free pass on its cron.
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    row = ScheduledTask(
+        source=Source.ADMIN,
+        name="s",
+        task="tests.pg_cron.tasks.add",
+        cron="*/30 * * * * *",
+        queue="default",
+    )
+    with pytest.raises(ValidationError) as exc:
+        row.full_clean()
+    assert exc.value.message_dict["cron"] == [
+        "Expected a 5-field cron expression; got 6 fields."
+    ]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_saving_with_no_backend_says_why_no_job_was_scheduled(
+    caplog: pytest.LogCaptureFixture,
+    settings: SettingsWrapper,
+) -> None:
+    # The emission path is best-effort by design, so it returns early rather than
+    # raising — but a row that saves and never gets a job must not be silent.
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    row = ScheduledTask(
+        source=Source.ADMIN,
+        name="orphan",
+        task="tests.pg_cron.tasks.add",
+        queue="default",
+        cron="0 2 * * *",
+    )
+    with caplog.at_level(logging.WARNING, logger="django_absurd.pg_cron.models"):
+        row.save()
+    assert [record.getMessage() for record in caplog.records] == [
+        "pg_cron job not scheduled for 'a:orphan': no AbsurdBackend is configured"
+    ]

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -205,3 +205,30 @@ def test_saving_with_no_backend_says_why_no_job_was_scheduled(
     assert [record.getMessage() for record in caplog.records] == [
         "pg_cron job not scheduled for 'a:orphan': no AbsurdBackend is configured"
     ]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_deleting_with_no_backend_says_the_job_keeps_firing(
+    caplog: pytest.LogCaptureFixture,
+    settings: SettingsWrapper,
+) -> None:
+    # The worse half of the silence: the row goes, its job does not, and it fires on
+    # against a row that no longer exists.
+    settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=True)
+    row = ScheduledTask.objects.create(
+        source=Source.ADMIN,
+        name="doomed",
+        task="tests.pg_cron.tasks.add",
+        queue="default",
+        cron="0 2 * * *",
+    )
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    with caplog.at_level(logging.WARNING, logger="django_absurd.pg_cron.models"):
+        row.delete()
+    expected = (
+        "pg_cron job not unscheduled for 'a:doomed': no AbsurdBackend is configured;"
+        " it keeps firing until the next reconcile"
+    )
+    assert [record.getMessage() for record in caplog.records] == [expected]

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -110,7 +110,6 @@ def test_pg_cron_app_config_path_before_core_warns(
 
 
 def test_pg_cron_installed_without_an_absurd_backend_is_reported(
-    capsys: pytest.CaptureFixture[str],
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
     # A TASKS pointing somewhere other than an AbsurdBackend leaves the scheduler app

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -113,22 +113,21 @@ def test_pg_cron_installed_without_an_absurd_backend_is_reported(
     capsys: pytest.CaptureFixture[str],
     settings: pytest_django.fixtures.SettingsWrapper,
 ) -> None:
-    # A typo'd BACKEND, a wrong alias, or an app-ordering slip leaves the scheduler app
+    # A TASKS pointing somewhere other than an AbsurdBackend leaves the scheduler app
     # installed with nothing to schedule for. Every ScheduledTask then saves normally
-    # and never gets a job, so say it at check time — before any row exists.
+    # and never gets a job, so say it at check time — before any row exists. (A path
+    # that does not import at all raises InvalidTaskBackend from Django before any
+    # check of ours runs; loud either way, just not as this message.)
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }
-    try:
+    with pytest.raises(SystemCheckError) as exc_info:
         call_command("check", "django_absurd")
-    except SystemCheckError as exc:
-        out = capsys.readouterr().err + str(exc)
-    else:
-        out = capsys.readouterr().err
+    out = str(exc_info.value)
     assert "absurd.E013" in out
     assert (
-        "django-absurd: 'django_absurd.pg_cron' is installed, but no AbsurdBackend"
-        " is configured." in out
+        "django-absurd: 'django_absurd.pg_cron' is installed, but no AbsurdBackend is"
+        " configured, so a schedule would save without ever being scheduled." in out
     )
 
 

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -107,3 +107,33 @@ def test_pg_cron_app_config_path_before_core_warns(
     assert (
         "Place 'django_absurd.pg_cron' after 'django_absurd' in INSTALLED_APPS." in out
     )
+
+
+def test_pg_cron_installed_without_an_absurd_backend_is_reported(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    # A typo'd BACKEND, a wrong alias, or an app-ordering slip leaves the scheduler app
+    # installed with nothing to schedule for. Every ScheduledTask then saves normally
+    # and never gets a job, so say it at check time — before any row exists.
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    try:
+        call_command("check", "django_absurd")
+    except SystemCheckError as exc:
+        out = capsys.readouterr().err + str(exc)
+    else:
+        out = capsys.readouterr().err
+    assert "absurd.E013" in out
+    assert (
+        "django-absurd: 'django_absurd.pg_cron' is installed, but no AbsurdBackend"
+        " is configured." in out
+    )
+
+
+def test_pg_cron_installed_with_a_backend_is_not_reported(
+    capsys: pytest.CaptureFixture[str],
+    settings: pytest_django.fixtures.SettingsWrapper,
+) -> None:
+    assert "absurd.E013" not in run_check(capsys, settings)


### PR DESCRIPTION
With `django_absurd.pg_cron` installed and no `AbsurdBackend` resolving, a `ScheduledTask` saved normally, skipped its validation, and never got a job — silently, at every stage.

- **`absurd.E013`** reports it at check time, before a row exists.
- **The cron rule no longer waits on a backend.** Validating grammar stopped needing one when the database probe went (#163), so only the queue rule is backend-scoped now.
- **The emission paths say why they skipped.** Both of them — the delete side is the worse half, since the row goes and its job keeps firing against a row that no longer exists.

Left as-is deliberately: the `max_attempts` default and queue choices still fall back (they run at migration-state time and must not raise), and emission still does not raise — it is best-effort by design, with reconcile as the safety net.

**Upgrade note:** E013 is an Error, and `migrate`/`runserver` run system checks, so a project that keeps the app installed while pointing dev or CI `TASKS` at another backend will now fail to start. That is the point of the issue, but it is a behavior change — the hint names `SILENCED_SYSTEM_CHECKS` for the deliberate case.

Closes #80