### PR TITLE
feat: move to Absurd 0.5.0

### DIFF
--- a/.claude/skills/bump-absurd-version/SKILL.md
+++ b/.claude/skills/bump-absurd-version/SKILL.md
@@ -40,7 +40,7 @@ Miss one and the failure is silent or lands in CI, not here:
 | `ABSURD_SCHEMA_VERSION` | `django_absurd/__init__.py`   | adopting-an-existing-DB guidance lies               |
 | Root lockfile           | `uv.lock`                     | `--locked` fails in CI                              |
 | **Example lockfiles**   | `examples/*/uv.lock` (three)  | **`uv sync --locked` fails all three example jobs** |
-| Scratch-schema helper   | `tests/pg_cron/utils.py`      | the pg_cron scratch DB is built at the old version  |
+| SDK bounds in comments  | anything naming an SDK range  | a stale bound reads as a verified one               |
 
 The example lockfiles embed the root package's `requires-dist`, because each example
 depends on django-absurd by path. Any root dependency change invalidates all three. Run

--- a/.claude/skills/bump-absurd-version/SKILL.md
+++ b/.claude/skills/bump-absurd-version/SKILL.md
@@ -74,12 +74,12 @@ depends on django-absurd by path. Any root dependency change invalidates all thr
      generate; a hand-written reverse is unverifiable and rots, and `RunSQL.noop` lets a
      rollback claim success while leaving the database at the newer schema. A delta with
      no downgrade SQL is genuinely irreversible, and says so.
-   - **Know what that costs.** Django's executor requires every operation in an unapply
-     chain to be reversible, so ONE irreversible delta blocks
-     `migrate django_absurd zero` as well — not just a one-step-back. That is accepted
-     here: `migrate <app> zero` is stock Django, never a django-absurd feature, and
-     nothing in this package may depend on it. See "Tests that need the schema absent"
-     below.
+   - **Know what that costs.** What is irreversible is the SQL operation — but an
+     unapply chain is only as reversible as its least reversible step, so one such
+     operation blocks `migrate django_absurd zero` too, not just a one-step-back. That
+     is accepted here: `migrate <app> zero` is stock Django, never a django-absurd
+     feature, and nothing in this package may depend on it. See "Tests that need the
+     schema absent" below.
    - Set `atomic = False` **only** if the delta contains non-transactional DDL. Grep for
      `concurrently` as a statement, not as a word — it appears inside error-message
      strings, and a false positive here costs you transactional safety for nothing.
@@ -122,17 +122,13 @@ depends on django-absurd by path. Any root dependency change invalidates all thr
 
 ## Tests that need the schema absent
 
-Express absence by RENAMING the schema, not by unapplying migrations — two statements,
-no DDL replay, and no migration state involved:
+Express absence by RENAMING the schema, not by unapplying migrations — one rename each
+way, no DDL replay, and no migration state involved. `tests.utils.hide_absurd_schema` is
+that context manager:
 
 ```python
-with connection.cursor() as cursor:
-    cursor.execute("ALTER SCHEMA absurd RENAME TO absurd_absent")
-try:
-    ...                                     # assert the schema-absent behaviour
-finally:
-    with connection.cursor() as cursor:
-        cursor.execute("ALTER SCHEMA absurd_absent RENAME TO absurd")
+with utils.hide_absurd_schema():
+    ...  # assert the schema-absent behaviour
 ```
 
 `flush_absurd_state(drop_schema=True)` is NOT this — it drops each queue's tables, not
@@ -149,16 +145,15 @@ Two neighbouring cases are different, and conflating them is what previously mad
 
 ## Common mistakes
 
-| Mistake                                              | Why it happens                                                                               | Do instead                                                                                                                                                                                                                                    |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Hand-writing a reverse migration                     | `absurdctl` refuses downgrades, so it looks like your job                                    | Omit `reverse_sql` — see step 4                                                                                                                                                                                                               |
-| Adding `reverse_sql` so a test can reach zero        | 13 tests once used migrate-zero to mean "schema absent"                                      | Rename the schema instead — see above                                                                                                                                                                                                         |
-| Committing without the example lockfiles             | `git status` shows them, `git commit -am` on named paths misses them                         | `uv lock --project examples/<name>` ×3, and stage them                                                                                                                                                                                        |
-| Trusting a `concurrently` grep                       | The word appears in error strings                                                            | Read the match before setting `atomic = False`                                                                                                                                                                                                |
-| Silencing Renovate's cooloff to land it today        | The pin looks blocked                                                                        | Leave the cooloff alone; a dated `exclude-newer` is a trap nobody removes                                                                                                                                                                     |
-| Fighting `uv` for a release younger than the cooloff | `exclude-newer = "7 days"` in `pyproject.toml` blocks resolution of a just-published version | Pass a scoped one-off `uv lock --exclude-newer-package` and note it, or wait out the window — never edit the repo-wide setting. A lockfile generated that way records the override, so `uv sync --locked` fails in CI until the window clears |
-| Treating it as dependency-only                       | Nothing obviously breaks                                                                     | Read the delta's comments (step 3) and run `sync-docs`                                                                                                                                                                                        |
-| Believing green tests mean it applied                | The suite reuses a database that may predate the delta                                       | Do step 6's from-empty check                                                                                                                                                                                                                  |
+| Mistake                                                              | Why it happens                                                       | Do instead                                                                                                                                                                                         |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hand-writing a reverse migration                                     | `absurdctl` refuses downgrades, so it looks like your job            | Omit `reverse_sql` — see step 4                                                                                                                                                                    |
+| Adding `reverse_sql` so a test can reach zero                        | 13 tests once used migrate-zero to mean "schema absent"              | Rename the schema instead — see above                                                                                                                                                              |
+| Committing without the example lockfiles                             | `git status` shows them, `git commit -am` on named paths misses them | `uv lock --project examples/<name>` ×3, and stage them                                                                                                                                             |
+| Trusting a `concurrently` grep                                       | The word appears in error strings                                    | Read the match before setting `atomic = False`                                                                                                                                                     |
+| Reaching for a one-off `--exclude-newer-package` on the command line | The release looks blocked by a cooloff                               | It is not: Absurd is exempt from both cooloffs, in `pyproject.toml` and `renovate.json`. A command-line override instead records a dated one in the lockfile, which fails `uv sync --locked` in CI |
+| Treating it as dependency-only                                       | Nothing obviously breaks                                             | Read the delta's comments (step 3) and run `sync-docs`                                                                                                                                             |
+| Believing green tests mean it applied                                | The suite reuses a database that may predate the delta               | Do step 6's from-empty check                                                                                                                                                                       |
 
 ## Red flags
 

--- a/.claude/skills/bump-absurd-version/SKILL.md
+++ b/.claude/skills/bump-absurd-version/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: bump-absurd-version
+description:
+  Use when moving django-absurd to a new upstream Absurd release — a Renovate PR bumping
+  the `absurdctl` pin, an `absurd-sdk` floor change, `ABSURD_SCHEMA_VERSION` drift, or a
+  report that `manage.py migrate` ships an older schema than the pinned version. Covers
+  generating the delta migration offline, the artifacts that must move together, and
+  what a schema change forces in code, tests, and user docs.
+---
+
+# bump-absurd-version
+
+## Overview
+
+Absurd's schema ships as ordinary Django migrations, generated offline from the pinned
+`absurdctl` wheel — never hand-written, never fetched at migrate time. A version bump is
+therefore codegen plus a set of artifacts that must move together, and the delta itself
+tells you what else changed.
+
+**One migration per Absurd release. `0001` is frozen.**
+
+## When to use
+
+- A Renovate PR bumps `absurdctl==` in `pyproject.toml`
+- Upstream announces a release and `ABSURD_SCHEMA_VERSION` no longer matches it
+- Anything reports a schema version mismatch between the SDK, the pin, and the database
+
+Not for: a Renovate bump of any other dependency, or an `absurd-sdk` patch release with
+no schema change (check the delta is empty first — step 2 tells you).
+
+## The artifacts that move together
+
+Miss one and the failure is silent or lands in CI, not here:
+
+| Artifact                | Where                         | Miss it and                                         |
+| ----------------------- | ----------------------------- | --------------------------------------------------- |
+| `absurdctl` pin         | `pyproject.toml` dev deps     | you generate the delta from the OLD bundled SQL     |
+| `absurd-sdk` floor      | `pyproject.toml` dependencies | the SDK and schema can drift apart at install time  |
+| Delta SQL + wrapper     | `django_absurd/migrations/`   | nothing ships                                       |
+| `ABSURD_SCHEMA_VERSION` | `django_absurd/__init__.py`   | adopting-an-existing-DB guidance lies               |
+| Root lockfile           | `uv.lock`                     | `--locked` fails in CI                              |
+| **Example lockfiles**   | `examples/*/uv.lock` (three)  | **`uv sync --locked` fails all three example jobs** |
+| Scratch-schema helper   | `tests/pg_cron/utils.py`      | the pg_cron scratch DB is built at the old version  |
+
+The example lockfiles embed the root package's `requires-dist`, because each example
+depends on django-absurd by path. Any root dependency change invalidates all three. Run
+`uv lock --project examples/<name>` for each.
+
+## Procedure
+
+1. **Bump the `absurdctl` pin first**, then `uv sync`. The delta comes from the wheel's
+   bundled SQL, so the old pin can only generate the old range.
+
+2. **Generate the delta, offline:**
+
+   ```bash
+   absurdctl migrate --from <current> --to <new> --dump-sql \
+     > django_absurd/migrations/000N_absurd_<new_with_underscores>.sql
+   ```
+
+   `--dump-sql` needs no database and makes no network call — verify it printed SQL and
+   exited 0. An empty or header-only bundle means there is no schema change: stop, and
+   bump only the pins.
+
+3. **Read the delta's own comments before writing any wrapper.** Upstream states what a
+   release changes at the top of each bundled migration, and that is your list of
+   downstream work. A release that drops an extension dependency, changes a function
+   signature, or renames a column has consequences in this package's code and in user
+   docs that no test will find for you.
+
+4. **Wrap it** as `000N_absurd_<version>.py`, mirroring `0001`: read the `.sql` with
+   `importlib.resources`, depend on the previous migration.
+   - **No `reverse_sql`.** `absurdctl` refuses downgrades, so there is nothing to
+     generate; a hand-written reverse is unverifiable and rots, and `RunSQL.noop` lets a
+     rollback claim success while leaving the database at the newer schema. A delta with
+     no downgrade SQL is genuinely irreversible, and says so.
+   - **Know what that costs.** Django's executor requires every operation in an unapply
+     chain to be reversible, so ONE irreversible delta blocks
+     `migrate django_absurd zero` as well — not just a one-step-back. That is accepted
+     here: `migrate <app> zero` is stock Django, never a django-absurd feature, and
+     nothing in this package may depend on it. See "Tests that need the schema absent"
+     below.
+   - Set `atomic = False` **only** if the delta contains non-transactional DDL. Grep for
+     `concurrently` as a statement, not as a word — it appears inside error-message
+     strings, and a false positive here costs you transactional safety for nothing.
+
+5. **Update the remaining artifacts** from the table above.
+
+6. **Verify against a real database**, not just the suite:
+
+   ```bash
+   uv run pytest tests/core tests/pg_cron -q --no-cov        # both suites
+   ```
+
+   Then prove the migration actually applies from empty and the schema reports the new
+   version:
+
+   ```bash
+   uv run python -c "
+   import django, os
+   os.environ['DJANGO_SETTINGS_MODULE']='tests.settings'
+   django.setup()
+   from django.core.management import call_command
+   call_command('migrate', 'django_absurd')
+   from django.db import connection
+   with connection.cursor() as c:
+       c.execute('select absurd.get_schema_version()')
+       print('schema reports:', c.fetchone()[0])
+   "
+   ```
+
+   That printed version must equal `ABSURD_SCHEMA_VERSION`. This is the one check that
+   catches a wrapper reading the wrong file, a stale pin, and a half-applied delta.
+
+7. **Run `sync-docs`.** A schema change is a user-facing change: privileges, extensions,
+   and supported syntax all live in `AGENTS.md` and `docs/web/`.
+
+   Do not document stock Django behaviour as a django-absurd feature while you are in
+   there. `migrate <app> zero` is Django's, not ours; describing it as a teardown
+   feature is what made an irreversible delta look like a regression rather than a
+   property of having no downgrade SQL.
+
+## Tests that need the schema absent
+
+Express absence by RENAMING the schema, not by unapplying migrations — two statements,
+no DDL replay, and no migration state involved:
+
+```python
+with connection.cursor() as cursor:
+    cursor.execute("ALTER SCHEMA absurd RENAME TO absurd_absent")
+try:
+    ...                                     # assert the schema-absent behaviour
+finally:
+    with connection.cursor() as cursor:
+        cursor.execute("ALTER SCHEMA absurd_absent RENAME TO absurd")
+```
+
+`flush_absurd_state(drop_schema=True)` is NOT this — it drops each queue's tables, not
+the `absurd` schema.
+
+Two neighbouring cases are different, and conflating them is what previously made
+`reverse_sql` look load-bearing:
+
+- **"Watch `migrate` provision from scratch"** needs no absence at all. `post_migrate`
+  fires unconditionally on every `migrate`, so drop the queues, run `migrate`, and
+  assert the end state.
+- **"Unapplying is refused"** is a real contract test of our own migration: assert that
+  unapplying raises, rather than arranging a teardown.
+
+## Common mistakes
+
+| Mistake                                              | Why it happens                                                                               | Do instead                                                                                                                                                                                                                                    |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hand-writing a reverse migration                     | `absurdctl` refuses downgrades, so it looks like your job                                    | Omit `reverse_sql` — see step 4                                                                                                                                                                                                               |
+| Adding `reverse_sql` so a test can reach zero        | 13 tests once used migrate-zero to mean "schema absent"                                      | Rename the schema instead — see above                                                                                                                                                                                                         |
+| Committing without the example lockfiles             | `git status` shows them, `git commit -am` on named paths misses them                         | `uv lock --project examples/<name>` ×3, and stage them                                                                                                                                                                                        |
+| Trusting a `concurrently` grep                       | The word appears in error strings                                                            | Read the match before setting `atomic = False`                                                                                                                                                                                                |
+| Silencing Renovate's cooloff to land it today        | The pin looks blocked                                                                        | Leave the cooloff alone; a dated `exclude-newer` is a trap nobody removes                                                                                                                                                                     |
+| Fighting `uv` for a release younger than the cooloff | `exclude-newer = "7 days"` in `pyproject.toml` blocks resolution of a just-published version | Pass a scoped one-off `uv lock --exclude-newer-package` and note it, or wait out the window — never edit the repo-wide setting. A lockfile generated that way records the override, so `uv sync --locked` fails in CI until the window clears |
+| Treating it as dependency-only                       | Nothing obviously breaks                                                                     | Read the delta's comments (step 3) and run `sync-docs`                                                                                                                                                                                        |
+| Believing green tests mean it applied                | The suite reuses a database that may predate the delta                                       | Do step 6's from-empty check                                                                                                                                                                                                                  |
+
+## Red flags
+
+- You are typing SQL rather than redirecting `--dump-sql` into a file
+- You are copying function bodies out of `0001` for any reason
+- You edited `0001` — it is frozen; deltas only
+- You are adding `reverse_sql` so that a test can migrate to zero — fix the test
+- `git status` shows `examples/*/uv.lock` at commit time
+- You cannot say what the release changed in one sentence (you skipped step 3)

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1041,9 +1041,12 @@ Neither logger is the complete record. Postgres is:
   **experimental — not tested yet**, with no automated partition lifecycle. Only queues
   declared in `QUEUES` are created — an undeclared queue name is rejected, not silently
   created.
-- **Migrations do not roll back.** Absurd publishes no downgrade SQL, so each schema
-  migration after the first is irreversible and `migrate django_absurd <earlier>` is
-  refused. Restore from a backup instead.
+- **The Absurd SQL does not roll back.** Absurd publishes no downgrade SQL, so the SQL
+  each schema delta applies is an irreversible operation. Django refuses to unapply a
+  migration containing one, and refuses the whole chain behind it, so
+  `migrate django_absurd <earlier>` fails and a restore is the way back. Everything else
+  reverses normally — the initial migration, and `django_absurd.pg_cron`'s own model
+  migrations.
 
 ## Adopting an existing Absurd database
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1024,6 +1024,12 @@ Neither logger is the complete record. Postgres is:
   and `CREATE SCHEMA IF NOT EXISTS absurd`, so the migrating role needs rights to create
   extensions and schemas (a superuser, or a role granted those — with `uuid-ossp`
   allow-listed on managed Postgres). The schema name `absurd` is fixed.
+- **`uuid-ossp` is created and then dropped again.** Absurd stopped needing it, so a
+  later migration drops the extension unless other objects in the database depend on it
+  (in which case it is left alone). The privileges above are still required — the first
+  migration creates it — and the role must OWN the extension for the drop to succeed, so
+  an operator-installed `uuid-ossp` owned by another role fails that migration with a
+  privilege error. Drop it yourself first, or grant ownership.
 - **At-least-once delivery.** A task may run more than once (e.g. a crash between the
   handler committing and Absurd's bookkeeping). Keep handlers idempotent; use
   `idempotency_key` where it helps.
@@ -1035,8 +1041,9 @@ Neither logger is the complete record. Postgres is:
   **experimental — not tested yet**, with no automated partition lifecycle. Only queues
   declared in `QUEUES` are created — an undeclared queue name is rejected, not silently
   created.
-- **Teardown is destructive.** `migrate django_absurd zero` drops the `absurd` schema
-  and all data in it.
+- **Migrations do not roll back.** Absurd publishes no downgrade SQL, so each schema
+  migration after the first is irreversible and `migrate django_absurd <earlier>` is
+  refused. Restore from a backup instead.
 
 ## Adopting an existing Absurd database
 

--- a/django_absurd/__init__.py
+++ b/django_absurd/__init__.py
@@ -21,7 +21,7 @@ from django_absurd.context import (
 from django_absurd.events import emit_event
 from django_absurd.params import absurd_params
 
-ABSURD_SCHEMA_VERSION = "0.4.0"
+ABSURD_SCHEMA_VERSION = "0.5.0"
 
 __all__ = [
     "ABSURD_SCHEMA_VERSION",

--- a/django_absurd/migrations/0002_absurd_0_5_0.py
+++ b/django_absurd/migrations/0002_absurd_0_5_0.py
@@ -8,8 +8,8 @@ from django.db import migrations
 class Migration(migrations.Migration):
     dependencies = [("django_absurd", "0001_initial_0_4_0")]
 
-    # No reverse_sql: Absurd publishes no downgrade SQL, so this delta is irreversible
-    # rather than reporting a rollback that left the database at the newer schema.
+    # No reverse_sql: Absurd publishes no downgrade SQL, so this operation is left
+    # irreversible rather than reporting a rollback that left the database at 0.5.0.
     operations = [
         migrations.RunSQL(
             sql=importlib.resources.files("django_absurd.migrations")

--- a/django_absurd/migrations/0002_absurd_0_5_0.py
+++ b/django_absurd/migrations/0002_absurd_0_5_0.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib.resources
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("django_absurd", "0001_initial_0_4_0")]
+
+    # No reverse_sql: Absurd publishes no downgrade SQL, so this delta is irreversible
+    # rather than reporting a rollback that left the database at the newer schema.
+    operations = [
+        migrations.RunSQL(
+            sql=importlib.resources.files("django_absurd.migrations")
+            .joinpath("0002_absurd_0_5_0.sql")
+            .read_text(encoding="utf-8"),
+        ),
+    ]

--- a/django_absurd/migrations/0002_absurd_0_5_0.sql
+++ b/django_absurd/migrations/0002_absurd_0_5_0.sql
@@ -1,0 +1,427 @@
+-- Absurd migration SQL bundle
+-- Range: 0.4.0 -> 0.5.0
+
+-- begin migration: 0.4.0-0.5.0.sql [bundled]
+-- Migration from 0.4.0 to main
+--
+-- Adds bounded retry-strategy validation and removes Absurd's uuid-ossp
+-- dependency without deleting workflow data.
+
+create or replace function absurd.get_schema_version ()
+  returns text
+  language sql
+as $$
+  select '0.5.0'::text;
+$$;
+
+create or replace function absurd.retry_delay_seconds (
+  p_strategy jsonb,
+  p_attempt integer
+)
+  returns double precision
+  language plpgsql
+  immutable
+as $$
+declare
+  v_limit constant double precision := 86400;
+  v_kind text;
+  v_base double precision;
+  v_factor double precision;
+  v_max_seconds double precision;
+  v_exponent integer := greatest(coalesce(p_attempt, 1) - 1, 0);
+begin
+  if p_strategy is null then
+    return 0;
+  end if;
+  if jsonb_typeof(p_strategy) <> 'object' then
+    raise exception sqlstate 'AB003'
+      using message = 'retry_strategy must be a JSON object';
+  end if;
+
+  v_kind := coalesce(p_strategy->>'kind', 'none');
+  if v_kind not in ('none', 'fixed', 'exponential') then
+    raise exception sqlstate 'AB003'
+      using message = format('Unsupported retry strategy kind "%s"', v_kind);
+  end if;
+  if v_kind = 'none' then
+    return 0;
+  end if;
+
+  v_base := coalesce(
+    (p_strategy->>'base_seconds')::double precision,
+    case when v_kind = 'fixed' then 60 else 30 end
+  );
+  if v_base not between 0 and v_limit then
+    raise exception sqlstate 'AB003'
+      using message = 'retry_strategy.base_seconds must be between 0 and 86400';
+  end if;
+  if v_kind = 'fixed' then
+    return v_base;
+  end if;
+
+  v_factor := coalesce((p_strategy->>'factor')::double precision, 2);
+  v_max_seconds := coalesce(
+    (p_strategy->>'max_seconds')::double precision,
+    v_limit
+  );
+  if v_factor < 0 or v_factor::text in ('NaN', 'Infinity', '-Infinity') then
+    raise exception sqlstate 'AB003'
+      using message = 'retry_strategy.factor must be a finite non-negative number';
+  end if;
+  if v_max_seconds not between 0 and v_limit then
+    raise exception sqlstate 'AB003'
+      using message = 'retry_strategy.max_seconds must be between 0 and 86400';
+  end if;
+  if v_base = 0 then
+    return 0;
+  end if;
+
+  begin
+    return least(v_base * power(v_factor, v_exponent), v_max_seconds);
+  exception
+    when numeric_value_out_of_range then
+      return case when v_factor < 1 then 0 else v_max_seconds end;
+  end;
+exception
+  when invalid_text_representation or numeric_value_out_of_range then
+    raise exception sqlstate 'AB003'
+      using message = 'retry_strategy contains an invalid number';
+end;
+$$;
+
+create or replace function absurd.portable_uuidv7 ()
+  returns uuid
+  language plpgsql
+  volatile
+as $$
+declare
+  ts_ms bigint;
+  b bytea;
+  rnd bytea;
+  i int;
+begin
+  if to_regprocedure('pg_catalog.uuidv7()') is not null then
+    return pg_catalog.uuidv7 ();
+  end if;
+  ts_ms := floor(extract(epoch from absurd.current_time()) * 1000)::bigint;
+  rnd := uuid_send(pg_catalog.gen_random_uuid ());
+  b := repeat(E'\\000', 16)::bytea;
+  for i in 0..5 loop
+    b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);
+  end loop;
+  for i in 6..15 loop
+    b := set_byte(b, i, get_byte(rnd, i));
+  end loop;
+  b := set_byte(b, 6, ((get_byte(b, 6) & 15) | (7 << 4)));
+  b := set_byte(b, 8, ((get_byte(b, 8) & 63) | 128));
+  return encode(b, 'hex')::uuid;
+end;
+$$;
+
+-- Absurd no longer requires uuid-ossp. Drop the extension when it is only
+-- present from earlier Absurd installs; leave it alone if other database
+-- objects depend on it. Never use CASCADE here.
+do $$
+begin
+  drop extension if exists "uuid-ossp";
+exception
+  when dependent_objects_still_exist then
+    raise notice 'uuid-ossp was not dropped because other database objects depend on it';
+end;
+$$;
+
+create or replace function absurd.spawn_task (
+  p_queue_name text,
+  p_task_name text,
+  p_params jsonb,
+  p_options jsonb default '{}'::jsonb
+)
+  returns table (
+    task_id uuid,
+    run_id uuid,
+    attempt integer,
+    created boolean
+  )
+  language plpgsql
+as $$
+declare
+  v_task_id uuid := absurd.portable_uuidv7();
+  v_run_id uuid := absurd.portable_uuidv7();
+  v_attempt integer := 1;
+  v_headers jsonb;
+  v_retry_strategy jsonb;
+  v_max_attempts integer;
+  v_cancellation jsonb;
+  v_idempotency_key text;
+  v_existing_task_id uuid;
+  v_existing_run_id uuid;
+  v_existing_attempt integer;
+  v_row_count integer;
+  v_storage_mode text := 'unpartitioned';
+  v_task_inserted boolean := false;
+  v_now timestamptz := absurd.current_time();
+  v_params jsonb := coalesce(p_params, 'null'::jsonb);
+begin
+  if p_task_name is null or length(trim(p_task_name)) = 0 then
+    raise exception 'task_name must be provided';
+  end if;
+
+  if p_options is not null then
+    v_headers := p_options->'headers';
+    v_retry_strategy := p_options->'retry_strategy';
+    perform absurd.retry_delay_seconds(v_retry_strategy, 1);
+    if p_options ? 'max_attempts' then
+      v_max_attempts := (p_options->>'max_attempts')::int;
+      if v_max_attempts is not null and v_max_attempts < 1 then
+        raise exception 'max_attempts must be >= 1';
+      end if;
+    end if;
+    v_cancellation := p_options->'cancellation';
+    v_idempotency_key := p_options->>'idempotency_key';
+  end if;
+
+  if v_idempotency_key is not null then
+    select storage_mode into v_storage_mode
+    from absurd.queues
+    where queue_name = p_queue_name;
+
+    v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+    if v_storage_mode not in ('unpartitioned', 'partitioned') then
+      raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+    end if;
+
+    if v_storage_mode = 'partitioned' then
+      -- Reserve idempotency key via dedicated side table.
+      execute format(
+        'insert into absurd.%I (idempotency_key, task_id)
+         values ($1, $2)
+         on conflict (idempotency_key) do nothing',
+        'i_' || p_queue_name
+      )
+      using v_idempotency_key, v_task_id;
+
+      get diagnostics v_row_count = row_count;
+
+      if v_row_count = 0 then
+        execute format(
+          'select i.task_id, t.last_attempt_run, t.attempts
+             from absurd.%I i
+             join absurd.%I t on t.task_id = i.task_id
+            where i.idempotency_key = $1
+              for key share of i',
+          'i_' || p_queue_name,
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+        if v_existing_task_id is null then
+          raise exception 'Idempotency key "%" in queue "%" was concurrently cleaned up', v_idempotency_key, p_queue_name
+            using errcode = '40001',
+                  hint = 'Retry spawn_task with the same idempotency key.';
+        end if;
+
+        if v_existing_run_id is null then
+          raise exception 'Idempotency key "%" in queue "%" resolved to task "%" without a run', v_idempotency_key, p_queue_name, v_existing_task_id;
+        end if;
+
+        return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+        return;
+      end if;
+    else
+      -- Unpartitioned queues keep the original unique(idempotency_key)
+      -- behavior directly on t_<queue>.
+      execute format(
+        'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
+         on conflict (idempotency_key) do nothing',
+        't_' || p_queue_name
+      )
+      using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+
+      get diagnostics v_row_count = row_count;
+
+      if v_row_count = 0 then
+        execute format(
+          'select task_id, last_attempt_run, attempts
+             from absurd.%I
+            where idempotency_key = $1',
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+        return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+        return;
+      end if;
+
+      v_task_inserted := true;
+    end if;
+  end if;
+
+  if not v_task_inserted then
+    execute format(
+      'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)',
+      't_' || p_queue_name
+    )
+    using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+  end if;
+
+  execute format(
+    'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+     values ($1, $2, $3, ''pending'', $4, null, null, null, null)',
+    'r_' || p_queue_name
+  )
+  using v_run_id, v_task_id, v_attempt, v_now;
+
+  return query select v_task_id, v_run_id, v_attempt, true;
+end;
+$$;
+
+create or replace function absurd.fail_run (
+  p_queue_name text,
+  p_run_id uuid,
+  p_reason jsonb,
+  p_retry_at timestamptz default null
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_task_id uuid;
+  v_attempt integer;
+  v_run_state text;
+  v_retry_strategy jsonb;
+  v_max_attempts integer;
+  v_now timestamptz := absurd.current_time();
+  v_next_attempt integer;
+  v_delay_seconds double precision := 0;
+  v_next_available timestamptz;
+  v_first_started timestamptz;
+  v_cancellation jsonb;
+  v_max_duration bigint;
+  v_task_cancel boolean := false;
+  v_new_run_id uuid;
+  v_task_state_after text;
+  v_recorded_attempt integer;
+  v_last_attempt_run uuid := p_run_id;
+  v_cancelled_at timestamptz := null;
+begin
+  execute format(
+    'select r.task_id, r.attempt, r.state
+       from absurd.%I r
+      where r.run_id = $1
+      for update',
+    'r_' || p_queue_name
+  )
+  into v_task_id, v_attempt, v_run_state
+  using p_run_id;
+
+  if v_task_id is null then
+    raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
+  end if;
+
+  if v_run_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+  end if;
+
+  if v_run_state = 'failed' then
+    raise exception sqlstate 'AB002' using message = format('Run "%s" has already failed in queue "%s"', p_run_id, p_queue_name);
+  end if;
+
+  if v_run_state not in ('running', 'sleeping') then
+    raise exception 'Run "%" cannot be failed in queue "%"', p_run_id, p_queue_name;
+  end if;
+
+  execute format(
+    'select retry_strategy, max_attempts, first_started_at, cancellation
+       from absurd.%I
+      where task_id = $1
+      for update',
+    't_' || p_queue_name
+  )
+  into v_retry_strategy, v_max_attempts, v_first_started, v_cancellation
+  using v_task_id;
+
+  execute format(
+    'update absurd.%I
+        set state = ''failed'',
+            wake_event = null,
+            failed_at = $2,
+            failure_reason = $3
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, v_now, p_reason;
+
+  v_next_attempt := v_attempt + 1;
+  v_task_state_after := 'failed';
+  v_recorded_attempt := v_attempt;
+
+  if v_max_attempts is null or v_next_attempt <= v_max_attempts then
+    if p_retry_at is not null then
+      v_next_available := p_retry_at;
+    else
+      -- Legacy tasks may contain retry strategies that predate validation. If
+      -- one is invalid, fail the task permanently rather than wedging the queue.
+      begin
+        v_delay_seconds := absurd.retry_delay_seconds(v_retry_strategy, v_attempt);
+        v_next_available := v_now + (v_delay_seconds * interval '1 second');
+      exception
+        when sqlstate 'AB003' then
+          v_next_available := null;
+      end;
+    end if;
+
+    if v_next_available < v_now then
+      v_next_available := v_now;
+    end if;
+
+    if v_cancellation is not null then
+      v_max_duration := (v_cancellation->>'max_duration')::bigint;
+      if v_max_duration is not null and v_first_started is not null then
+        if extract(epoch from (v_next_available - v_first_started)) >= v_max_duration then
+          v_task_cancel := true;
+        end if;
+      end if;
+    end if;
+
+    if not v_task_cancel and v_next_available is not null then
+      v_task_state_after := case when v_next_available > v_now then 'sleeping' else 'pending' end;
+      v_new_run_id := absurd.portable_uuidv7();
+      v_recorded_attempt := v_next_attempt;
+      v_last_attempt_run := v_new_run_id;
+      execute format(
+        'insert into absurd.%I (run_id, task_id, attempt, state, available_at, wake_event, event_payload, result, failure_reason)
+         values ($1, $2, $3, $4, $5, null, null, null, null)',
+        'r_' || p_queue_name
+      )
+      using v_new_run_id, v_task_id, v_next_attempt, v_task_state_after, v_next_available;
+    end if;
+  end if;
+
+  if v_task_cancel then
+    v_task_state_after := 'cancelled';
+    v_cancelled_at := v_now;
+    v_recorded_attempt := greatest(v_recorded_attempt, v_attempt);
+    v_last_attempt_run := p_run_id;
+  end if;
+
+  execute format(
+    'update absurd.%I
+        set state = $2,
+            attempts = greatest(attempts, $3),
+            last_attempt_run = $4,
+            cancelled_at = coalesce(cancelled_at, $5)
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using v_task_id, v_task_state_after, v_recorded_attempt, v_last_attempt_run, v_cancelled_at;
+
+  execute format(
+    'delete from absurd.%I where run_id = $1',
+    'w_' || p_queue_name
+  ) using p_run_id;
+end;
+$$;
+
+-- end migration: 0.4.0-0.5.0.sql

--- a/django_absurd/pg_cron/reconcile.py
+++ b/django_absurd/pg_cron/reconcile.py
@@ -40,7 +40,7 @@ def resolve_spawn_options(backend: AbsurdBackend, task_path: str) -> JsonObject:
     defaults win over the backend's configured DEFAULT_MAX_ATTEMPTS fallback.
     """
     # absurd_sdk._normalize_spawn_options is a module-level helper (bound:
-    # absurd-sdk>=0.4.0,<0.5.0) that normalises spawn options into the jsonb dict
+    # absurd-sdk>=0.5.0,<0.6.0) that normalises spawn options into the jsonb dict
     # passed to absurd.spawn_task. We import it directly instead of routing through
     # client.spawn so we get the exact same serialisation without creating a client
     # or touching the DB — and lazily, so an SDK drift breaks pg_cron sync rather

--- a/django_absurd/tasks.py
+++ b/django_absurd/tasks.py
@@ -24,14 +24,13 @@ class SpawnKwargs(t.TypedDict, total=False):
     type-check per field instead of collapsing to a union."""
 
     max_attempts: int | None
-    # Two known gaps we deliberately do not guard. An unrecognised ``kind`` is
-    # validated NOWHERE: absurd.fail_run does coalesce(v_retry_strategy->>'kind',
-    # 'none') and falls through to v_delay_seconds := 0, so a typo retries with no
-    # backoff instead of erroring (type checkers catch it — the SDK types kind as a
-    # Literal). And an OMITTED ``kind`` raises, though RetryStrategy is total=False:
-    # _serialize_retry_strategy indexes strategy["kind"] unconditionally, so
-    # {"base_seconds": 5} type-checks and then dies at enqueue with KeyError: 'kind'.
-    # No checker can flag that one.
+    # One known gap we deliberately do not guard: an OMITTED ``kind`` raises, though
+    # RetryStrategy is total=False — _serialize_retry_strategy indexes
+    # strategy["kind"] unconditionally, so {"base_seconds": 5} type-checks and then
+    # dies at enqueue with KeyError: 'kind'. No checker can flag that one. An
+    # unrecognised kind, or an out-of-range base_seconds/factor/max_seconds, needs no
+    # guard from us: absurd.spawn_task validates the strategy up front and raises
+    # SQLSTATE AB003, so the enqueue fails instead of quietly retrying with no backoff.
     retry_strategy: RetryStrategy
     cancellation: CancellationPolicy
     headers: JsonObject

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -31,9 +31,19 @@ Maintainer process: migrations are not hand-written. When bumping the pinned Abs
 version, regenerate the SQL with `absurdctl` as the delta between the currently pinned
 schema and the new target version.
 
+Upstream publishes no downgrade SQL, so a delta migration is irreversible rather than
+carrying a hand-written reverse nobody can verify or a no-op reverse that would report a
+successful rollback while leaving the database at the newer schema. Django needs every
+step of an unapply chain to be reversible, so one such delta means the schema cannot be
+migrated backwards at all — recovery is a restore, not a downgrade. Nothing in the
+package may depend on unapplying migrations, and a test that needs the schema out of
+reach renames it instead, which destroys nothing.
+
 The schema lives in a fixed, non-relocatable namespace, and applying it needs a role
-allowed to create that namespace and the UUID extension it depends on — so locked-down
-deployments must grant those rights or pre-create the namespace.
+allowed to create that namespace and the UUID extension the earliest pinned version
+depends on — so locked-down deployments must grant those rights or pre-create the
+namespace. A later version dropped that dependency and drops the extension again unless
+something else in the database needs it, which requires owning it.
 
 ## Tasks, enqueue & the worker
 
@@ -539,13 +549,13 @@ the way the configuration paths do: it is a maintenance operation, so the raw da
 error is allowed to surface rather than adding a guard that implies the call was safe.
 
 Wiping everything is a separate, guarded command that drops queues and their data while
-leaving the schema, functions, and migration history intact — because a full schema
-teardown is already what running migrations backwards achieves, and the migration system
-should stay the sole owner of the schema. It follows the framework's own
-destructive-command convention (confirm interactively, skip with a no-input flag) so the
-safety model is one users already know. Dropping a queue removes only that queue's own
-maintenance jobs and data; user-defined recurring schedules live elsewhere and survive,
-so a reset never silently cancels recurring work.
+leaving the schema, functions, and migration history intact — the migration system stays
+the sole owner of the schema, and since migrations do not run backwards, a reset that
+also removed the schema would leave no supported way to get it back. It follows the
+framework's own destructive-command convention (confirm interactively, skip with a
+no-input flag) so the safety model is one users already know. Dropping a queue removes
+only that queue's own maintenance jobs and data; user-defined recurring schedules live
+elsewhere and survive, so a reset never silently cancels recurring work.
 
 ## Admin & ORM introspection
 

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -31,13 +31,14 @@ Maintainer process: migrations are not hand-written. When bumping the pinned Abs
 version, regenerate the SQL with `absurdctl` as the delta between the currently pinned
 schema and the new target version.
 
-Upstream publishes no downgrade SQL, so a delta migration is irreversible rather than
-carrying a hand-written reverse nobody can verify or a no-op reverse that would report a
-successful rollback while leaving the database at the newer schema. Django needs every
-step of an unapply chain to be reversible, so one such delta means the schema cannot be
-migrated backwards at all — recovery is a restore, not a downgrade. Nothing in the
-package may depend on unapplying migrations, and a test that needs the schema out of
-reach renames it instead, which destroys nothing.
+Upstream publishes no downgrade SQL, so the SQL applying a delta is left irreversible
+rather than given a hand-written reverse nobody can verify, or a no-op reverse that
+would report a successful rollback while leaving the database at the newer schema. Since
+an unapply chain is only as reversible as its least reversible step, one such operation
+takes the whole schema with it: it cannot be migrated backwards at all, and recovery is
+a restore rather than a downgrade. Nothing in the package may depend on unapplying
+migrations, and a test that needs the schema out of reach renames it instead, which
+destroys nothing.
 
 The schema lives in a fixed, non-relocatable namespace, and applying it needs a role
 allowed to create that namespace and the UUID extension the earliest pinned version

--- a/examples/beat/uv.lock
+++ b/examples/beat/uv.lock
@@ -4,14 +4,14 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "absurd-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "psycopg", extra = ["binary"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/bc/db387fbe419df975ac674d1c7926b19574c33f0afe5a8fa3a30f656c2d18/absurd_sdk-0.4.0.tar.gz", hash = "sha256:2c17c81c9ead963c8596fc65e0a68ad1a4bd5b917745a5b2390d0e962f78dd02", size = 14815, upload-time = "2026-05-27T12:06:44.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/6a/2d4199ddc3d846ba13c51aa9c8614b9ee42a5af5144ef456ef11f4f6aa20/absurd_sdk-0.5.0.tar.gz", hash = "sha256:b22fbe8d10f649d0ed427ba16d885a4a452e4240f412591e7f087fe8584a6f00", size = 14973, upload-time = "2026-08-04T13:06:40.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/8e/472b63aaa20306e734d45983dea61aefd202fa5e4fc4aa99d51b081c0dac/absurd_sdk-0.4.0-py3-none-any.whl", hash = "sha256:e2bc7e0abfd6b293e07594905039636fcd77ef2e1481b98954d7fe3b344a0dab", size = 15362, upload-time = "2026-05-27T12:06:42.634Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/12/0d1c4e23dc00069a4666fc25c165514657fc62eb723a7bee3ce22ef416ae/absurd_sdk-0.5.0-py3-none-any.whl", hash = "sha256:a21465deaf159ba29ab4d15d87f429ae5dcf6f0e3098bce11ae9bc3e267fd03a", size = 15407, upload-time = "2026-08-04T13:06:39.406Z" },
 ]
 
 [[package]]
@@ -151,14 +151,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "absurd-sdk", specifier = ">=0.4.0,<0.5.0" },
+    { name = "absurd-sdk", specifier = ">=0.5.0,<0.6.0" },
     { name = "croniter", specifier = ">=6.0" },
     { name = "django", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "absurdctl", specifier = "==0.4.0" },
+    { name = "absurdctl", specifier = "==0.5.0" },
     { name = "beautifulsoup4", specifier = "==4.15.0" },
     { name = "build", specifier = "==1.5.0" },
     { name = "django-coverage-plugin", specifier = "==3.2.2" },

--- a/examples/pg_cron/uv.lock
+++ b/examples/pg_cron/uv.lock
@@ -4,14 +4,14 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "absurd-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "psycopg", extra = ["binary"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/bc/db387fbe419df975ac674d1c7926b19574c33f0afe5a8fa3a30f656c2d18/absurd_sdk-0.4.0.tar.gz", hash = "sha256:2c17c81c9ead963c8596fc65e0a68ad1a4bd5b917745a5b2390d0e962f78dd02", size = 14815, upload-time = "2026-05-27T12:06:44.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/6a/2d4199ddc3d846ba13c51aa9c8614b9ee42a5af5144ef456ef11f4f6aa20/absurd_sdk-0.5.0.tar.gz", hash = "sha256:b22fbe8d10f649d0ed427ba16d885a4a452e4240f412591e7f087fe8584a6f00", size = 14973, upload-time = "2026-08-04T13:06:40.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/8e/472b63aaa20306e734d45983dea61aefd202fa5e4fc4aa99d51b081c0dac/absurd_sdk-0.4.0-py3-none-any.whl", hash = "sha256:e2bc7e0abfd6b293e07594905039636fcd77ef2e1481b98954d7fe3b344a0dab", size = 15362, upload-time = "2026-05-27T12:06:42.634Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/12/0d1c4e23dc00069a4666fc25c165514657fc62eb723a7bee3ce22ef416ae/absurd_sdk-0.5.0-py3-none-any.whl", hash = "sha256:a21465deaf159ba29ab4d15d87f429ae5dcf6f0e3098bce11ae9bc3e267fd03a", size = 15407, upload-time = "2026-08-04T13:06:39.406Z" },
 ]
 
 [[package]]
@@ -151,14 +151,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "absurd-sdk", specifier = ">=0.4.0,<0.5.0" },
+    { name = "absurd-sdk", specifier = ">=0.5.0,<0.6.0" },
     { name = "croniter", specifier = ">=6.0" },
     { name = "django", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "absurdctl", specifier = "==0.4.0" },
+    { name = "absurdctl", specifier = "==0.5.0" },
     { name = "beautifulsoup4", specifier = "==4.15.0" },
     { name = "build", specifier = "==1.5.0" },
     { name = "django-coverage-plugin", specifier = "==3.2.2" },

--- a/examples/web/uv.lock
+++ b/examples/web/uv.lock
@@ -4,14 +4,14 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "absurd-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "psycopg", extra = ["binary"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/bc/db387fbe419df975ac674d1c7926b19574c33f0afe5a8fa3a30f656c2d18/absurd_sdk-0.4.0.tar.gz", hash = "sha256:2c17c81c9ead963c8596fc65e0a68ad1a4bd5b917745a5b2390d0e962f78dd02", size = 14815, upload-time = "2026-05-27T12:06:44.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/6a/2d4199ddc3d846ba13c51aa9c8614b9ee42a5af5144ef456ef11f4f6aa20/absurd_sdk-0.5.0.tar.gz", hash = "sha256:b22fbe8d10f649d0ed427ba16d885a4a452e4240f412591e7f087fe8584a6f00", size = 14973, upload-time = "2026-08-04T13:06:40.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/8e/472b63aaa20306e734d45983dea61aefd202fa5e4fc4aa99d51b081c0dac/absurd_sdk-0.4.0-py3-none-any.whl", hash = "sha256:e2bc7e0abfd6b293e07594905039636fcd77ef2e1481b98954d7fe3b344a0dab", size = 15362, upload-time = "2026-05-27T12:06:42.634Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/12/0d1c4e23dc00069a4666fc25c165514657fc62eb723a7bee3ce22ef416ae/absurd_sdk-0.5.0-py3-none-any.whl", hash = "sha256:a21465deaf159ba29ab4d15d87f429ae5dcf6f0e3098bce11ae9bc3e267fd03a", size = 15407, upload-time = "2026-08-04T13:06:39.406Z" },
 ]
 
 [[package]]
@@ -151,14 +151,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "absurd-sdk", specifier = ">=0.4.0,<0.5.0" },
+    { name = "absurd-sdk", specifier = ">=0.5.0,<0.6.0" },
     { name = "croniter", specifier = ">=6.0" },
     { name = "django", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "absurdctl", specifier = "==0.4.0" },
+    { name = "absurdctl", specifier = "==0.5.0" },
     { name = "beautifulsoup4", specifier = "==4.15.0" },
     { name = "build", specifier = "==1.5.0" },
     { name = "django-coverage-plugin", specifier = "==3.2.2" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,3 +180,10 @@ max-args = 6
 [tool.uv]
 # Mirror Renovate's minimumReleaseAge cooloff for local/CI resolution.
 exclude-newer = "7 days"
+
+# Absurd itself is exempt, in both places (see renovate.json). The schema this package
+# ships comes from the pinned absurdctl wheel, so a cooloff on it only delays adopting a
+# schema we intend to adopt deliberately anyway.
+[tool.uv.exclude-newer-package]
+absurd-sdk = "0 days"
+absurdctl = "0 days"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatch-vcs==0.5.0", "hatchling==1.31.0"]
 
 [dependency-groups]
 dev = [
-  "absurdctl==0.4.0",
+  "absurdctl==0.5.0",
   "beautifulsoup4==4.15.0",
   "build==1.5.0",
   "django-coverage-plugin==3.2.2",
@@ -48,7 +48,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "absurd-sdk>=0.4.0,<0.5.0",
+  "absurd-sdk>=0.5.0,<0.6.0",
   "croniter>=6.0",
   "Django>=6.0",
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,11 @@
       "groupName": "type checking"
     },
     {
+      "description": "Absurd releases are adopted deliberately; skip cooloff.",
+      "matchPackageNames": ["absurd-sdk", "absurdctl"],
+      "minimumReleaseAge": "0"
+    },
+    {
       "description": "uv has no release timestamps; skip cooloff.",
       "matchPackageNames": ["ghcr.io/astral-sh/**"],
       "minimumReleaseAge": "0"

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -13,7 +13,7 @@ from pytest_django.fixtures import SettingsWrapper
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.queues import get_absurd_client
 from django_absurd.test import AbsurdTestRuntime
-from tests import atasks, tasks
+from tests import atasks, tasks, utils
 from tests.core.test_admin.utils import (
     BACKEND,
     parse_html,
@@ -167,16 +167,11 @@ def test_changelist_survives_staleness_detection_failure(
     django_db_blocker: "DjangoDbBlocker",
 ) -> None:
     client.force_login(admin_user)
-    with django_db_blocker.unblock():
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-    try:
+    with utils.hide_absurd_schema():
         resp = client.get(CHANGELIST)
-        assert resp.status_code == 200
-        # detection failure degrades silently — no spurious staleness warning
-        assert parse_html(resp).select_one("ul.messagelist li.warning") is None
-    finally:
-        with django_db_blocker.unblock():
-            call_command("migrate", "django_absurd", verbosity=0)
+    assert resp.status_code == 200
+    # detection failure degrades silently — no spurious staleness warning
+    assert parse_html(resp).select_one("ul.messagelist li.warning") is None
 
 
 def test_detail_shows_state(admin_user: User, client: Client) -> None:

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -4,12 +4,13 @@ import pytest
 from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
-from django.db import connection, connections
+from django.db import connections
 
 if t.TYPE_CHECKING:
     import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
+from tests import utils
 from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -129,15 +130,10 @@ def test_schema_absent_check_is_silent(
     settings: "pytest_django.fixtures.SettingsWrapper",
 ) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
+    with utils.hide_absurd_schema():
         out = run_absurd_check(capsys, databases=["default"])
-        assert "absurd.W001" not in out
-        assert "absurd.W002" not in out
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=0)  # restore absurd schema
+    assert "absurd.W001" not in out
+    assert "absurd.W002" not in out
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"])

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -10,7 +10,6 @@ import typing as t
 import pytest
 from django.contrib.auth.models import Group
 from django.core.management import call_command
-from django.db import connection
 from django.utils import timezone
 
 from django_absurd import worker
@@ -19,7 +18,7 @@ from django_absurd.cleanup import QueueCleanup, cleanup_queues
 from django_absurd.queues import get_absurd_client
 from django_absurd.scheduler import run_beat
 from django_absurd.test import AbsurdTestRuntime, FrozenTime
-from tests import tasks
+from tests import tasks, utils
 
 if t.TYPE_CHECKING:
     import pytest_django.fixtures
@@ -314,21 +313,16 @@ def test_beat_isolates_failing_cleanup(
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
-        with (
-            dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time,
-            caplog.at_level(logging.ERROR, logger="django_absurd"),
-        ):
-            run_beat_until(
-                frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
-            )
-        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
-        assert [r.getMessage() for r in errors] == ["cleanup failed"]
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=0)  # restore absurd schema
+    with (
+        utils.hide_absurd_schema(),
+        dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time,
+        caplog.at_level(logging.ERROR, logger="django_absurd"),
+    ):
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert [r.getMessage() for r in errors] == ["cleanup failed"]
 
 
 def test_beat_fires_cleanup_and_task_same_slot(

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -5,7 +5,7 @@ import pytest
 from django.contrib.auth.models import Group
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
-from django.db import connection, connections, transaction
+from django.db import connections, transaction
 from django.tasks import TaskResultStatus, task
 from django.tasks.exceptions import InvalidTask
 from pytest_django.fixtures import SettingsWrapper
@@ -155,14 +155,11 @@ def test_enqueue_auto_create_survives_outer_atomic(
 
 
 def test_enqueue_with_absent_schema_raises_clear_error() -> None:
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
-        with pytest.raises(ImproperlyConfigured, match="migrate"):
-            tasks.add.enqueue(1, 2)
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=0)  # restore absurd schema
+    with (
+        utils.hide_absurd_schema(),
+        pytest.raises(ImproperlyConfigured, match="migrate"),
+    ):
+        tasks.add.enqueue(1, 2)
 
 
 def test_max_attempts_uses_backend_default_when_unset() -> None:

--- a/tests/core/test_migrations.py
+++ b/tests/core/test_migrations.py
@@ -23,10 +23,10 @@ def test_migrate_installs_absurd_schema_at_pinned_version() -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_unapplying_a_delta_migration_is_refused() -> None:
-    # Absurd publishes no downgrade SQL, so every delta is irreversible and the whole
-    # chain unapplies no further than the delta on top of it. Nothing in this package
-    # may reach for `migrate django_absurd zero`; a test wanting the schema gone renames
-    # it (tests.utils.hide_absurd_schema) instead.
+    # Absurd publishes no downgrade SQL, so the SQL each delta applies is irreversible
+    # and no unapply reaches past it. Nothing in this package may reach for
+    # `migrate django_absurd zero`; a test wanting the schema gone renames it
+    # (tests.utils.hide_absurd_schema) instead.
     with pytest.raises(IrreversibleError):
         call_command("migrate", "django_absurd", "0001", verbosity=0)
     assert fetch_scalar("SELECT absurd.get_schema_version()") == ABSURD_SCHEMA_VERSION

--- a/tests/core/test_migrations.py
+++ b/tests/core/test_migrations.py
@@ -3,6 +3,7 @@ import typing as t
 import pytest
 from django.core.management import call_command
 from django.db import connection
+from django.db.migrations.exceptions import IrreversibleError
 
 from django_absurd import ABSURD_SCHEMA_VERSION
 
@@ -21,8 +22,11 @@ def test_migrate_installs_absurd_schema_at_pinned_version() -> None:
 
 
 @pytest.mark.django_db(transaction=True)
-def test_reverse_drops_absurd_schema() -> None:
-    call_command("migrate", "django_absurd", "zero", verbosity=0)
-    assert fetch_scalar("SELECT to_regnamespace('absurd') IS NULL") is True
-    call_command("migrate", verbosity=0)  # restore absurd schema
+def test_unapplying_a_delta_migration_is_refused() -> None:
+    # Absurd publishes no downgrade SQL, so every delta is irreversible and the whole
+    # chain unapplies no further than the delta on top of it. Nothing in this package
+    # may reach for `migrate django_absurd zero`; a test wanting the schema gone renames
+    # it (tests.utils.hide_absurd_schema) instead.
+    with pytest.raises(IrreversibleError):
+        call_command("migrate", "django_absurd", "0001", verbosity=0)
     assert fetch_scalar("SELECT absurd.get_schema_version()") == ABSURD_SCHEMA_VERSION

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -14,6 +14,7 @@ from django_absurd.admin_views import (
 )
 from django_absurd.apps import provision_queues_after_migrate
 from django_absurd.exceptions import ViewNotProvisionedError
+from django_absurd.flush import flush_absurd_state
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
 from tests import tasks, utils
@@ -57,9 +58,9 @@ def test_migrate_provisions_declared_queues_and_views(
     # `migrate` fires post_migrate → sync_queues: declared queues created + views
     # built, reported on stdout in Django's migrate style.
     buf = StringIO()
+    flush_absurd_state(drop_schema=True)  # unprovisioned, schema intact
     with django_db_blocker.unblock():
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=1, stdout=buf)  # restores absurd schema
+        call_command("migrate", verbosity=1, stdout=buf)
     out = buf.getvalue()
     assert "Provisioning Absurd queues" in out
     assert "Created 'default'" in out
@@ -77,14 +78,9 @@ def test_provision_skips_when_schema_absent(
     django_db_blocker: "DjangoDbBlocker",
 ) -> None:
     # post_migrate: best-effort; missing schema swallowed, not raised
-    with django_db_blocker.unblock():
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-    try:
+    with utils.hide_absurd_schema():
         config: AppConfig = apps.get_app_config("django_absurd")
         provision_queues_after_migrate(config)
-    finally:
-        with django_db_blocker.unblock():
-            call_command("migrate", verbosity=0)  # restore absurd schema
 
 
 def test_sync_command_rebuilds_views_with_new_queue() -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import datetime as dt
 import logging
 import os
@@ -81,8 +82,10 @@ def test_worker_client_opens_without_provisioning_check() -> None:
 
 def test_worker_client_absent_schema_errors() -> None:
     async def _enter() -> None:
-        async with aworker_client(backend(), "default"):
-            pass
+        # Entering is what raises, so the entry is the whole body — a statement after it
+        # would never run.
+        async with contextlib.AsyncExitStack() as stack:
+            await stack.enter_async_context(aworker_client(backend(), "default"))
 
     with (
         utils.hide_absurd_schema(),

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -80,19 +80,15 @@ def test_worker_client_opens_without_provisioning_check() -> None:
 
 
 def test_worker_client_absent_schema_errors() -> None:
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
+    async def _enter() -> None:
+        async with aworker_client(backend(), "default"):
+            pass
 
-        async def _enter() -> None:
-            async with aworker_client(backend(), "default"):
-                pass
-
-        with pytest.raises(ImproperlyConfigured, match="migrate"):
-            asyncio.run(_enter())
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=0)  # restore absurd schema
+    with (
+        utils.hide_absurd_schema(),
+        pytest.raises(ImproperlyConfigured, match="migrate"),
+    ):
+        asyncio.run(_enter())
 
 
 def test_end_to_end_executes_and_records_result(dj_absurd: AbsurdTestRuntime) -> None:
@@ -430,14 +426,11 @@ def test_worker_command_schema_absent_errors_migrate() -> None:
     # that helper exists to send must never go out — pytest installs no SIGTERM
     # handler of its own, so a stray kill would hit Python's default (SIG_DFL) and
     # take the session down with it.
-    with connection.cursor() as cur:
-        cur.execute("DROP SCHEMA IF EXISTS absurd CASCADE")
-    try:
-        with pytest.raises(CommandError, match="migrate"):
-            utils.start_worker(queue="default")
-    finally:
-        call_command("migrate", "django_absurd", "zero", verbosity=0)
-        call_command("migrate", verbosity=0)  # restore absurd schema
+    with (
+        utils.hide_absurd_schema(),
+        pytest.raises(CommandError, match="migrate"),
+    ):
+        utils.start_worker(queue="default")
 
 
 def test_start_worker_drains_concurrently() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -197,6 +197,25 @@ def get_absurd_connection_params() -> dict[str, t.Any]:
     return params
 
 
+@contextlib.contextmanager
+def hide_absurd_schema() -> t.Iterator[None]:
+    """Make the Absurd schema unreachable inside the block, then restore it.
+
+    A rename, not a drop: nothing is destroyed, so the schema comes back with its
+    functions, tables and rows intact and Django's migration records stay true the whole
+    time. Unapplying the migrations would be the other way to get here and is not
+    available — a delta migration carries no downgrade SQL, so the chain is irreversible
+    by design (see ``django_absurd/migrations/0002_absurd_0_5_0.py``).
+    """
+    with connections["default"].cursor() as cursor:
+        cursor.execute("ALTER SCHEMA absurd RENAME TO absurd_hidden")
+    try:
+        yield
+    finally:
+        with connections["default"].cursor() as cursor:
+            cursor.execute("ALTER SCHEMA absurd_hidden RENAME TO absurd")
+
+
 def set_database_fake_now(value: str) -> None:
     """Plant a database-level ``absurd.fake_now``, as a killed frozen test would leave.
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -204,8 +204,8 @@ def hide_absurd_schema() -> t.Iterator[None]:
     A rename, not a drop: nothing is destroyed, so the schema comes back with its
     functions, tables and rows intact and Django's migration records stay true the whole
     time. Unapplying the migrations would be the other way to get here and is not
-    available — a delta migration carries no downgrade SQL, so the chain is irreversible
-    by design (see ``django_absurd/migrations/0002_absurd_0_5_0.py``).
+    available — Absurd's SQL deltas carry no downgrade SQL, so no unapply reaches past
+    one (see ``django_absurd/migrations/0002_absurd_0_5_0.py``).
     """
     with connections["default"].cursor() as cursor:
         cursor.execute("ALTER SCHEMA absurd RENAME TO absurd_hidden")

--- a/uv.lock
+++ b/uv.lock
@@ -10,25 +10,29 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+absurd-sdk = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+absurdctl = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
 [[package]]
 name = "absurd-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "psycopg", extra = ["binary"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/bc/db387fbe419df975ac674d1c7926b19574c33f0afe5a8fa3a30f656c2d18/absurd_sdk-0.4.0.tar.gz", hash = "sha256:2c17c81c9ead963c8596fc65e0a68ad1a4bd5b917745a5b2390d0e962f78dd02", size = 14815, upload-time = "2026-05-27T12:06:44.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/6a/2d4199ddc3d846ba13c51aa9c8614b9ee42a5af5144ef456ef11f4f6aa20/absurd_sdk-0.5.0.tar.gz", hash = "sha256:b22fbe8d10f649d0ed427ba16d885a4a452e4240f412591e7f087fe8584a6f00", size = 14973, upload-time = "2026-08-04T13:06:40.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/8e/472b63aaa20306e734d45983dea61aefd202fa5e4fc4aa99d51b081c0dac/absurd_sdk-0.4.0-py3-none-any.whl", hash = "sha256:e2bc7e0abfd6b293e07594905039636fcd77ef2e1481b98954d7fe3b344a0dab", size = 15362, upload-time = "2026-05-27T12:06:42.634Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/12/0d1c4e23dc00069a4666fc25c165514657fc62eb723a7bee3ce22ef416ae/absurd_sdk-0.5.0-py3-none-any.whl", hash = "sha256:a21465deaf159ba29ab4d15d87f429ae5dcf6f0e3098bce11ae9bc3e267fd03a", size = 15407, upload-time = "2026-08-04T13:06:39.406Z" },
 ]
 
 [[package]]
 name = "absurdctl"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/48/8cd04b054aba4b3f8354a5b4213ae7b60fffd2e27a503b7fd0022d8cae9c/absurdctl-0.4.0.tar.gz", hash = "sha256:060500f84ae0ac27af737e0e70d6e16e3cb12c5aed56a53f7f27841c1a7005a7", size = 67593, upload-time = "2026-05-27T12:05:37.679Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/da/f6317eed184d5b1421bd7cbf2d4591137b1315ecccf31a7a861f326eb7eb/absurdctl-0.5.0.tar.gz", hash = "sha256:3d26a1b922fe979e4dcbb81403db967877383888ca82aa0e3e28c3017672f93b", size = 70883, upload-time = "2026-08-04T13:06:34.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/d0/336f4250e1746b7001c8d67169ac9db4c156d858f00d9a45412295e96f27/absurdctl-0.4.0-py3-none-any.whl", hash = "sha256:cfbb2d6b72bbf8fef0f4da4f9f1210deae84b8c553317d506b6597f9203ff45d", size = 68406, upload-time = "2026-05-27T12:05:36.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3c/00521a4337acc1015842ff3b34879929252be21a0bf0af15385c31b6332f/absurdctl-0.5.0-py3-none-any.whl", hash = "sha256:4d1547532da9816f8d87e78d3b09e7916505916acb3dca37e923c9cb74114f5c", size = 71835, upload-time = "2026-08-04T13:06:33.007Z" },
 ]
 
 [[package]]
@@ -268,14 +272,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "absurd-sdk", specifier = ">=0.4.0,<0.5.0" },
+    { name = "absurd-sdk", specifier = ">=0.5.0,<0.6.0" },
     { name = "croniter", specifier = ">=6.0" },
     { name = "django", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "absurdctl", specifier = "==0.4.0" },
+    { name = "absurdctl", specifier = "==0.5.0" },
     { name = "beautifulsoup4", specifier = "==4.15.0" },
     { name = "build", specifier = "==1.5.0" },
     { name = "django-coverage-plugin", specifier = "==3.2.2" },


### PR DESCRIPTION
Delta migration `0002` generated offline from the pinned `absurdctl` wheel. No
`reverse_sql` — upstream publishes no downgrade SQL, so tests express schema absence by
renaming the schema instead of unapplying.

Also: `absurd-sdk`/`absurdctl` exempt from the release cooloff (uv + Renovate), and a
`bump-absurd-version` maintainer skill for the next one.

User-visible: an unrecognised `retry_strategy.kind` now fails the enqueue (SQLSTATE
AB003) instead of retrying with no backoff; `uuid-ossp` is dropped again after the first
migration creates it, which needs the migrating role to own it.