### PR TITLE
fix(ci): scope the Pages lock to the deploy job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,6 @@ name: docs
 permissions:
   contents: read # to fetch code (actions/checkout)
 
-concurrency:
-  # Allow one Pages run at a time; never cancel an in-progress deployment.
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   build:
     name: build docs site
@@ -41,6 +36,13 @@ jobs:
       || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      # One deployment at a time; never cancel one in progress. Scoped to this job
+      # because only it touches Pages — a workflow-level group would also serialize
+      # every pull request's build behind it, and `build docs site` is a required
+      # check, so one wedged deployment blocks every merge in the repository.
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write # to deploy to Pages
       id-token: write # to verify the deploy originates from this workflow


### PR DESCRIPTION
Only `deploy` touches Pages, but the concurrency group was workflow-level, so every PR build queued behind it. A deploy job wedged for 12h therefore blocked every merge — `build docs site` is a required check.

Deployments still serialize, never cancelled in flight.