### PR TITLE
ci: re-lock the example projects after a root dependency bump

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -54,3 +54,8 @@ jobs:
           LOG_LEVEL: debug
           RENOVATE_TOKEN: ${{ steps.get_token.outputs.token }}
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+          # Allow-list for the postUpgradeTasks in renovate.json that re-lock
+          # the examples. Self-hosted-only option, so it cannot live in the
+          # repo config; without it the tasks are silently skipped.
+          # yamllint disable-line rule:line-length
+          RENOVATE_ALLOWED_COMMANDS: '["^uv lock --project examples/(beat|pg_cron|web)$"]'

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,23 @@
       "groupName": "dev dependencies"
     },
     {
+      "description": "The examples depend on django-absurd by path, so each examples/*/uv.lock records the ROOT manifest's requires-dev. Any root dependency bump makes all three stale, their Dockerfiles run `uv sync --locked`, and the PR fails CI. Renovate's uv manager only refreshes the lockfile beside the manifest it edited, so re-lock the examples in the same branch.",
+      "matchFileNames": ["pyproject.toml"],
+      "postUpgradeTasks": {
+        "commands": [
+          "uv lock --project examples/beat",
+          "uv lock --project examples/pg_cron",
+          "uv lock --project examples/web"
+        ],
+        "fileFilters": ["examples/*/uv.lock"],
+        "executionMode": "branch",
+        "installTools": {
+          "python": {},
+          "uv": {}
+        }
+      }
+    },
+    {
       "matchPackageNames": ["hatch*"],
       "groupName": "hatch"
     },


### PR DESCRIPTION
Every `examples/*/uv.lock` records the root manifest's `requires-dev` (path dep), so any root dependency bump stales all three at once and `uv sync --locked` fails their suites — see #175, where Renovate re-locked only `examples/web`.

Adds a `postUpgradeTask`, scoped to the root manifest, that re-locks the three examples in the same branch. `allowedCommands` is self-hosted-only, so the allow-list lives in the workflow env.

Renovate reads config from the base branch, so this is inert until merged.