### PR TITLE
feat!: translate configuration failures to CommandError in one command base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,7 @@ duplicate that material here.
   the short name reads as the SDK's.
 - Be honest about coverage: `except DjangoAbsurdError` catches the typed errors, not
   every error the package can raise — plain `ImproperlyConfigured`/`RuntimeError`/
-  `TypeError` remain in `checks.py`, `connection.py`, `queues.py`, and `test.py`'s
-  guards for now.
+  `TypeError` remain in `checks.py`, `connection.py`, and `test.py`'s guards for now.
 
 ## Exception chaining
 

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1254,9 +1254,12 @@ except DjangoAbsurdError:
   unset; with `QUEUES` configured, a typo'd name is rejected earlier as Django's own
   `InvalidTask`.
 - Every `absurd_*` management command inherits `AbsurdCommand` (or its
-  `AbsurdReportCommand` subclass) and turns a configuration failure —
-  `ImproperlyConfigured` or any `DjangoAbsurdError` — into a clean `CommandError`;
-  `--traceback` still shows the original chain.
+  `AbsurdReportCommand` subclass), which turns a fixed set of configuration failures —
+  `ImproperlyConfigured`, `BackendNotConfiguredError`, `SchemaNotInstalledError`,
+  `QueueNotDeclaredError`, `QueueNotProvisionedError` — into a clean `CommandError`;
+  `--traceback` still shows the original chain. Every other error, including any other
+  `DjangoAbsurdError` subclass, keeps its own type and full traceback — it signals a
+  bug, not a configuration mistake.
 - The hierarchy is not total. Catch `DjangoAbsurdError` for django-absurd's own typed
   errors; other failures — config validation, clock misuse — still raise plain
   `ImproperlyConfigured` / `RuntimeError` / `TypeError`.

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1241,6 +1241,7 @@ except DjangoAbsurdError:
 
 | Type                        | Raised when                                                                                         |
 | --------------------------- | --------------------------------------------------------------------------------------------------- |
+| `SchemaNotInstalledError`   | The Absurd Postgres schema itself isn't installed — run `manage.py migrate`                         |
 | `QueueNotDeclaredError`     | A queue name matches no queue declared for the backend                                              |
 | `QueueNotProvisionedError`  | A queue is declared but its Absurd table isn't provisioned yet — run `manage.py absurd_sync_queues` |
 | `BackendNotConfiguredError` | No `AbsurdBackend`, or more than one, is configured in `TASKS`                                      |
@@ -1252,11 +1253,13 @@ except DjangoAbsurdError:
 - `enqueue` raises `QueueNotDeclaredError` only when the backend's `QUEUES` is empty or
   unset; with `QUEUES` configured, a typo'd name is rejected earlier as Django's own
   `InvalidTask`.
-- The `absurd_worker` / `absurd_beat` / `absurd_sync_crons` commands translate
-  `BackendNotConfiguredError` into a `CommandError`.
+- Every `absurd_*` management command inherits `AbsurdCommand` (or its
+  `AbsurdReportCommand` subclass) and turns a configuration failure —
+  `ImproperlyConfigured` or any `DjangoAbsurdError` — into a clean `CommandError`;
+  `--traceback` still shows the original chain.
 - The hierarchy is not total. Catch `DjangoAbsurdError` for django-absurd's own typed
-  errors; other failures — schema not installed, config validation, clock misuse — still
-  raise plain `ImproperlyConfigured` / `RuntimeError` / `TypeError`.
+  errors; other failures — config validation, clock misuse — still raise plain
+  `ImproperlyConfigured` / `RuntimeError` / `TypeError`.
 
 ## Database setup
 

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -8,6 +8,7 @@ from django.db.utils import OperationalError, ProgrammingError
 
 from django_absurd.admin_views import PRIVATE_ADMIN_APPS
 from django_absurd.backends import get_absurd_backends
+from django_absurd.exceptions import SchemaNotInstalledError
 from django_absurd.queues import provision_backend
 
 
@@ -42,9 +43,16 @@ def provision_queues_after_migrate(
     for alias, backend in get_absurd_backends().items():
         try:
             result = provision_backend(backend)
-        except (ImproperlyConfigured, OperationalError, ProgrammingError):
+        except (
+            ImproperlyConfigured,
+            OperationalError,
+            ProgrammingError,
+            SchemaNotInstalledError,
+        ):
             # Best-effort: skip when the schema isn't installed on the target DB
-            # (e.g. a faked/adopted migration, or a non-Absurd database).
+            # (e.g. a faked/adopted migration, or a non-Absurd database). This is
+            # a signal receiver, not a command — it never runs through the
+            # command base, so this except tuple is permanent, not a stopgap.
             continue
         lines = [f"  Created {name!r}" for name in result.created]
         lines += [f"  Reconciled {name!r}" for name in result.reconciled]

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -21,7 +21,7 @@ from django_absurd import dispatch
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
 from django_absurd.deferred import DEFER_NAME_SUFFIX
-from django_absurd.exceptions import QueueNotDeclaredError
+from django_absurd.exceptions import QueueNotDeclaredError, SchemaNotInstalledError
 from django_absurd.tasks import AbsurdTask, SpawnKwargs, build_merged_spawn_options
 
 if t.TYPE_CHECKING:
@@ -197,8 +197,7 @@ class AbsurdBackend(BaseTaskBackend):
                 psycopg.errors.UndefinedFunction,
                 psycopg.errors.InvalidSchemaName,
             ) as exc:
-                msg = "Absurd schema is not installed. Run: manage.py migrate"
-                raise ImproperlyConfigured(msg) from exc
+                raise SchemaNotInstalledError from exc
             with transaction.atomic(using=self.database, savepoint=True):
                 spawn_result = client.spawn(
                     spawn_name,

--- a/django_absurd/cleanup.py
+++ b/django_absurd/cleanup.py
@@ -1,8 +1,11 @@
 import logging
 import typing as t
 
+import psycopg.errors
 from django.db import connections
+from django.db.utils import ProgrammingError
 
+from django_absurd.exceptions import SchemaNotInstalledError
 from django_absurd.queues import resolve_absurd_database
 
 logger = logging.getLogger(__name__)
@@ -20,19 +23,30 @@ def cleanup_queues(queues: list[str] | None = None) -> list[QueueCleanup]:
     targets: list[str | None] = list(queues) if queues is not None else [None]
     using = resolve_absurd_database()
     rows: list[QueueCleanup] = []
-    with connections[using].cursor() as cur:
-        for target in targets:
-            cur.execute(
-                "select queue_name, tasks_deleted, events_deleted "
-                "from absurd.cleanup_all_queues(%s)",
-                [target],
-            )
-            rows.extend(
-                QueueCleanup(
-                    queue_name=queue_name, tasks_deleted=tasks, events_deleted=events
+    try:
+        with connections[using].cursor() as cur:
+            for target in targets:
+                cur.execute(
+                    "select queue_name, tasks_deleted, events_deleted "
+                    "from absurd.cleanup_all_queues(%s)",
+                    [target],
                 )
-                for queue_name, tasks, events in cur.fetchall()
-            )
+                rows.extend(
+                    QueueCleanup(
+                        queue_name=queue_name,
+                        tasks_deleted=tasks,
+                        events_deleted=events,
+                    )
+                    for queue_name, tasks, events in cur.fetchall()
+                )
+    except ProgrammingError as exc:
+        cause = exc.__cause__
+        if not isinstance(
+            cause,
+            (psycopg.errors.InvalidSchemaName, psycopg.errors.UndefinedFunction),
+        ):
+            raise
+        raise SchemaNotInstalledError from exc
     log_cleanup_result(rows)
     return rows
 

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -105,6 +105,10 @@ class SchemaNotInstalledError(DjangoAbsurdError):
     cleanup, and flush whenever a query hits a missing Absurd relation.
     ``migrate``'s ``post_migrate`` hook is what provisions declared queues, so
     the message names ``migrate`` alone — not ``absurd_sync_queues`` after it.
+
+    Each raising call site classifies with its own psycopg exception tuple, not a
+    shared one — the tuple is chosen for what that site's own statement can
+    actually hit, so the tuples differing from each other is by design, not drift.
     """
 
     def __init__(self) -> None:

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -98,6 +98,20 @@ class TaskNotFoundError(DjangoAbsurdError):
         super().__init__(msg)
 
 
+class SchemaNotInstalledError(DjangoAbsurdError):
+    """The Absurd Postgres schema is not installed on the target database.
+
+    Raised by queue reconcile, the enqueue path, the worker's client probe,
+    cleanup, and flush whenever a query hits a missing Absurd relation.
+    ``migrate``'s ``post_migrate`` hook is what provisions declared queues, so
+    the message names ``migrate`` alone — not ``absurd_sync_queues`` after it.
+    """
+
+    def __init__(self) -> None:
+        msg = "Absurd schema is not installed. Run: manage.py migrate"
+        super().__init__(msg)
+
+
 class BackendNotConfiguredError(DjangoAbsurdError):
     """No single Absurd backend could be resolved — zero or several configured. One
     type for both counts: the package supports exactly one Absurd backend per

--- a/django_absurd/flush.py
+++ b/django_absurd/flush.py
@@ -92,10 +92,18 @@ def reset_fake_now(alias: str) -> None:
 
 def clear_queues(*, drop_schema: bool) -> None:
     """Drop (``drop_schema=True``) or truncate (``drop_schema=False``) every queue's
-    tables. Queue-only — never touches pg_cron. No-op on an unmigrated/absent schema.
+    tables. Queue-only — never touches pg_cron. No-op on an unreachable database, an
+    unmigrated/absent schema, or a partial one — a queue whose catalog row survives
+    but one of its own tables does not.
     """
     try:
         names = list_provisioned_queues()
+        client = get_absurd_client()
+        for name in names:
+            if drop_schema:
+                client.drop_queue(name)
+            else:
+                truncate_queue_tables(name)
     except (
         OperationalError,
         ProgrammingError,
@@ -103,12 +111,6 @@ def clear_queues(*, drop_schema: bool) -> None:
         SchemaNotInstalledError,
     ):
         return  # absurd schema not present (unmigrated / schema-absent)
-    client = get_absurd_client()
-    for name in names:
-        if drop_schema:
-            client.drop_queue(name)
-        else:
-            truncate_queue_tables(name)
 
 
 def teardown_owned_pg_cron_jobs() -> None:

--- a/django_absurd/flush.py
+++ b/django_absurd/flush.py
@@ -21,9 +21,11 @@ from django.db import connections
 from django.db.utils import OperationalError, ProgrammingError
 
 from django_absurd.backends import PG_CRON_APP_NAME
+from django_absurd.exceptions import SchemaNotInstalledError
 from django_absurd.queues import (
     QUEUE_TABLE_PREFIXES,
     get_absurd_client,
+    list_provisioned_queues,
     resolve_absurd_database,
 )
 
@@ -93,14 +95,20 @@ def clear_queues(*, drop_schema: bool) -> None:
     tables. Queue-only — never touches pg_cron. No-op on an unmigrated/absent schema.
     """
     try:
-        client = get_absurd_client()
-        for name in client.list_queues():
-            if drop_schema:
-                client.drop_queue(name)
-            else:
-                truncate_queue_tables(name)
-    except (OperationalError, ProgrammingError, ImproperlyConfigured):
-        pass  # absurd schema not present (unmigrated / schema-absent)
+        names = list_provisioned_queues()
+    except (
+        OperationalError,
+        ProgrammingError,
+        ImproperlyConfigured,
+        SchemaNotInstalledError,
+    ):
+        return  # absurd schema not present (unmigrated / schema-absent)
+    client = get_absurd_client()
+    for name in names:
+        if drop_schema:
+            client.drop_queue(name)
+        else:
+            truncate_queue_tables(name)
 
 
 def teardown_owned_pg_cron_jobs() -> None:

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -4,8 +4,26 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand, CommandError
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
-from django_absurd.exceptions import BackendNotConfiguredError, DjangoAbsurdError
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+    SchemaNotInstalledError,
+)
 from django_absurd.queues import SyncResult
+
+# Each of these five owns a message that already names the fix (an add/run/configure
+# instruction), so translating it into an untyped CommandError with no traceback loses
+# nothing an operator needs. Any other DjangoAbsurdError subclass — and anything
+# unforeseen — signals a bug, not a configuration mistake, and keeps its own type and
+# full traceback.
+CONFIGURATION_ERRORS: tuple[type[Exception], ...] = (
+    ImproperlyConfigured,
+    BackendNotConfiguredError,
+    SchemaNotInstalledError,
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+)
 
 BEAT_DISABLED_UNDER_PG_CRON = (
     "the pg_cron app is installed: schedules run in the database via pg_cron,"
@@ -35,7 +53,7 @@ class AbsurdCommand(BaseCommand):
     def execute(self, *args: t.Any, **options: t.Any) -> t.Any:
         try:
             return super().execute(*args, **options)
-        except (ImproperlyConfigured, DjangoAbsurdError) as exc:
+        except CONFIGURATION_ERRORS as exc:
             raise CommandError(str(exc)) from exc
 
 

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -26,9 +26,10 @@ class AbsurdCommand(BaseCommand):
     """Base for every ``absurd_*`` command: translates configuration failures into
     a clean ``CommandError`` instead of a raw traceback.
 
-    Overrides ``execute()`` rather than ``handle()``: ``execute()`` also wraps
-    Django's system-check phase, no command needs to rename its own ``handle``, and
-    ``--traceback`` still prints the original chain via ``from exc``.
+    Overrides ``execute()`` rather than ``handle()``: no command needs to rename its
+    own ``handle``, ``call_command`` and ``run_from_argv`` both route through
+    ``execute()`` so both get the same contract, and ``--traceback`` still prints the
+    original chain via ``from exc``.
     """
 
     def execute(self, *args: t.Any, **options: t.Any) -> t.Any:

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -1,7 +1,10 @@
-from django.core.management.base import BaseCommand
+import typing as t
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand, CommandError
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
-from django_absurd.exceptions import BackendNotConfiguredError
+from django_absurd.exceptions import BackendNotConfiguredError, DjangoAbsurdError
 from django_absurd.queues import SyncResult
 
 BEAT_DISABLED_UNDER_PG_CRON = (
@@ -19,7 +22,23 @@ def resolve_backend() -> AbsurdBackend:
     raise BackendNotConfiguredError(len(backends))
 
 
-class AbsurdReportCommand(BaseCommand):
+class AbsurdCommand(BaseCommand):
+    """Base for every ``absurd_*`` command: translates configuration failures into
+    a clean ``CommandError`` instead of a raw traceback.
+
+    Overrides ``execute()`` rather than ``handle()``: ``execute()`` also wraps
+    Django's system-check phase, no command needs to rename its own ``handle``, and
+    ``--traceback`` still prints the original chain via ``from exc``.
+    """
+
+    def execute(self, *args: t.Any, **options: t.Any) -> t.Any:
+        try:
+            return super().execute(*args, **options)
+        except (ImproperlyConfigured, DjangoAbsurdError) as exc:
+            raise CommandError(str(exc)) from exc
+
+
+class AbsurdReportCommand(AbsurdCommand):
     """Base for commands that report a queue SyncResult to stdout/stderr."""
 
     def report_sync_result(

--- a/django_absurd/management/commands/absurd_beat.py
+++ b/django_absurd/management/commands/absurd_beat.py
@@ -3,24 +3,24 @@ import threading
 import typing as t
 from types import FrameType
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import CommandError
 
 from django_absurd import console
 from django_absurd import logging as absurd_logging
-from django_absurd.exceptions import BackendNotConfiguredError
-from django_absurd.management.base import BEAT_DISABLED_UNDER_PG_CRON, resolve_backend
+from django_absurd.management.base import (
+    BEAT_DISABLED_UNDER_PG_CRON,
+    AbsurdCommand,
+    resolve_backend,
+)
 from django_absurd.scheduler import get_settings_schedules, run_beat
 
 
-class Command(BaseCommand):
+class Command(AbsurdCommand):
     help = "Start the Absurd beat scheduler."
 
     def handle(self, *args: t.Any, **options: t.Any) -> None:
         absurd_logging.attach_console_handler()
-        try:
-            backend = resolve_backend()
-        except BackendNotConfiguredError as exc:
-            raise CommandError(str(exc)) from exc
+        backend = resolve_backend()
 
         if backend.scheduler == "pg_cron":
             raise CommandError(BEAT_DISABLED_UNDER_PG_CRON)

--- a/django_absurd/management/commands/absurd_cleanup.py
+++ b/django_absurd/management/commands/absurd_cleanup.py
@@ -1,12 +1,13 @@
 import typing as t
 
-from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import CommandParser
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.cleanup import cleanup_queues
+from django_absurd.management.base import AbsurdCommand
 
 
-class Command(BaseCommand):
+class Command(AbsurdCommand):
     help = "Delete expired task and event history per each queue's retention policy."
 
     def add_arguments(self, parser: CommandParser) -> None:

--- a/django_absurd/management/commands/absurd_flush.py
+++ b/django_absurd/management/commands/absurd_flush.py
@@ -1,11 +1,12 @@
-from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import CommandParser
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.flush import clear_queues
+from django_absurd.management.base import AbsurdCommand
 from django_absurd.queues import get_absurd_client
 
 
-class Command(BaseCommand):
+class Command(AbsurdCommand):
     help = (
         "Drop ALL Absurd queues and their data (the schema and functions are kept)."
         " Destructive."

--- a/django_absurd/management/commands/absurd_flush.py
+++ b/django_absurd/management/commands/absurd_flush.py
@@ -3,7 +3,7 @@ from django.core.management.base import CommandParser
 from django_absurd.backends import get_absurd_backends
 from django_absurd.flush import clear_queues
 from django_absurd.management.base import AbsurdCommand
-from django_absurd.queues import get_absurd_client
+from django_absurd.queues import list_provisioned_queues
 
 
 class Command(AbsurdCommand):
@@ -25,8 +25,7 @@ class Command(AbsurdCommand):
         if not get_absurd_backends():
             self.stdout.write("No Absurd task backends configured.")
             return
-        client = get_absurd_client()
-        queues = sorted(client.list_queues())
+        queues = list_provisioned_queues()
         if not queues:
             self.stdout.write("No queues to flush.")
             return

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -8,7 +8,11 @@ if t.TYPE_CHECKING:
 
 from django_absurd import console
 from django_absurd import logging as absurd_logging
-from django_absurd.exceptions import BackendNotConfiguredError, QueueNotDeclaredError
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueNotDeclaredError,
+    SchemaNotInstalledError,
+)
 from django_absurd.management.base import (
     BEAT_DISABLED_UNDER_PG_CRON,
     AbsurdReportCommand,
@@ -93,7 +97,7 @@ class Command(AbsurdReportCommand):
             # Full provision on start so the admin views reflect every declared
             # queue, not just the one this worker serves.
             result = provision_backend(backend)
-        except ImproperlyConfigured as exc:
+        except (ImproperlyConfigured, SchemaNotInstalledError) as exc:
             raise CommandError(str(exc)) from exc
         self.report_sync_result(result)
 

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -1,6 +1,5 @@
 import typing as t
 
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import CommandError
 
 if t.TYPE_CHECKING:
@@ -8,11 +7,7 @@ if t.TYPE_CHECKING:
 
 from django_absurd import console
 from django_absurd import logging as absurd_logging
-from django_absurd.exceptions import (
-    BackendNotConfiguredError,
-    QueueNotDeclaredError,
-    SchemaNotInstalledError,
-)
+from django_absurd.exceptions import QueueNotDeclaredError
 from django_absurd.management.base import (
     BEAT_DISABLED_UNDER_PG_CRON,
     AbsurdReportCommand,
@@ -71,10 +66,7 @@ class Command(AbsurdReportCommand):
 
     def handle(self, *args: t.Any, **options: t.Any) -> None:
         absurd_logging.attach_console_handler()
-        try:
-            backend = resolve_backend()
-        except BackendNotConfiguredError as exc:
-            raise CommandError(str(exc)) from exc
+        backend = resolve_backend()
         queue = options["queue"]
 
         if options["beat"] and backend.scheduler == "pg_cron":
@@ -93,12 +85,9 @@ class Command(AbsurdReportCommand):
                 str(QueueNotDeclaredError(queue, backend.alias, backend.queues))
             )
 
-        try:
-            # Full provision on start so the admin views reflect every declared
-            # queue, not just the one this worker serves.
-            result = provision_backend(backend)
-        except (ImproperlyConfigured, SchemaNotInstalledError) as exc:
-            raise CommandError(str(exc)) from exc
+        # Full provision on start so the admin views reflect every declared queue,
+        # not just the one this worker serves.
+        result = provision_backend(backend)
         self.report_sync_result(result)
 
         elephant = console.build_glyph_prefix(self.stdout, "🐘")

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -81,9 +81,7 @@ class Command(AbsurdReportCommand):
         )
 
         if queue not in backend.queues:
-            raise CommandError(
-                str(QueueNotDeclaredError(queue, backend.alias, backend.queues))
-            )
+            raise QueueNotDeclaredError(queue, backend.alias, backend.queues)
 
         # Full provision on start so the admin views reflect every declared queue,
         # not just the one this worker serves.

--- a/django_absurd/pg_cron/management/commands/absurd_sync_crons.py
+++ b/django_absurd/pg_cron/management/commands/absurd_sync_crons.py
@@ -1,9 +1,8 @@
 import typing as t
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import CommandError
 
-from django_absurd.exceptions import BackendNotConfiguredError
-from django_absurd.management.base import resolve_backend
+from django_absurd.management.base import AbsurdCommand, resolve_backend
 from django_absurd.pg_cron.detection import is_pg_cron_inert
 from django_absurd.pg_cron.reconcile import (
     sync_admin_crons,
@@ -15,7 +14,7 @@ if t.TYPE_CHECKING:
     from django.core.management.base import CommandParser
 
 
-class Command(BaseCommand):
+class Command(AbsurdCommand):
     help = "Reconcile pg_cron jobs for all declared SCHEDULE entries."
 
     def add_arguments(self, parser: "CommandParser") -> None:
@@ -33,10 +32,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: t.Any, **options: t.Any) -> str | None:
-        try:
-            backend = resolve_backend()
-        except BackendNotConfiguredError as exc:
-            raise CommandError(str(exc)) from exc
+        backend = resolve_backend()
 
         if is_pg_cron_inert(backend.database):
             msg = (

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -68,6 +68,18 @@ def get_absurd_client(using: str | None = None) -> Absurd:
     return build_absurd_client(using or resolve_absurd_database())
 
 
+def list_provisioned_queues(using: str | None = None) -> list[str]:
+    client = get_absurd_client(using)
+    try:
+        return sorted(client.list_queues())
+    except (
+        psycopg.errors.InvalidSchemaName,
+        psycopg.errors.UndefinedFunction,
+        psycopg.errors.UndefinedTable,
+    ) as exc:
+        raise SchemaNotInstalledError from exc
+
+
 def names_a_queue_table(exc: psycopg.errors.UndefinedTable, queue: str) -> bool:
     """Report whether ``exc`` is about one of ``queue``'s own Absurd tables.
 

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -121,6 +121,12 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
     try:
         existing = Queue.objects.using(db).filter(queue_name=queue_name).first()
     except ProgrammingError as exc:
+        cause = exc.__cause__
+        if not isinstance(
+            cause,
+            (psycopg.errors.InvalidSchemaName, psycopg.errors.UndefinedTable),
+        ):
+            raise
         raise SchemaNotInstalledError from exc
     if existing is None:
         client.create_queue(queue_name, **opts)

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass, field
 
 import psycopg.errors
 from absurd_sdk import Absurd, QueuePolicyOptions
-from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.utils import ProgrammingError
 
 from django_absurd import backends
 from django_absurd.admin_views import rebuild_views
 from django_absurd.connection import build_absurd_client, validate_backend
+from django_absurd.exceptions import SchemaNotInstalledError
 
 if t.TYPE_CHECKING:
     from django_absurd.models import Queue
@@ -109,8 +109,7 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
     try:
         existing = Queue.objects.using(db).filter(queue_name=queue_name).first()
     except ProgrammingError as exc:
-        msg = "Absurd schema is not installed. Run: manage.py migrate"
-        raise ImproperlyConfigured(msg) from exc
+        raise SchemaNotInstalledError from exc
     if existing is None:
         client.create_queue(queue_name, **opts)
         result.created.append(queue_name)

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -26,7 +26,6 @@ from absurd_sdk import (
     SuspendTask,
 )
 from asgiref.sync import sync_to_async
-from django.core.exceptions import ImproperlyConfigured
 from django.db import close_old_connections, connections
 from django.tasks import Task, TaskContext, TaskResult, TaskResultStatus
 from django.tasks.base import TaskError
@@ -40,7 +39,11 @@ from django_absurd.backends import AbsurdBackend, RunModel, TaskParams
 from django_absurd.connection import register_jsonb_loader, validate_backend
 from django_absurd.context import WORKER_LOOP
 from django_absurd.deferred import DEFER_NAME_SUFFIX, build_deferred_handler
-from django_absurd.exceptions import QueueNotDeclaredError, QueueNotProvisionedError
+from django_absurd.exceptions import (
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+    SchemaNotInstalledError,
+)
 from django_absurd.hooks import (
     log_before_spawn,
     log_task_execution,
@@ -290,11 +293,7 @@ async def aworker_client(
             psycopg.errors.UndefinedTable,
             psycopg.errors.UndefinedFunction,
         ) as err:
-            msg = (
-                "Absurd schema is not installed."
-                " Run: manage.py migrate then manage.py absurd_sync_queues"
-            )
-            raise ImproperlyConfigured(msg) from err
+            raise SchemaNotInstalledError from err
         yield client
     finally:
         await conn.close()

--- a/docs/plans/2026-08-15-command-error-translation.md
+++ b/docs/plans/2026-08-15-command-error-translation.md
@@ -229,17 +229,14 @@ pytestmark = pytest.mark.django_db(transaction=True)
 SCHEMA_ABSENT = "Absurd schema is not installed. Run: manage.py migrate"
 
 
-@pytest.mark.parametrize(
-    "command",
-    ["absurd_cleanup", "absurd_flush", "absurd_sync_queues", "absurd_worker"],
-)
+@pytest.mark.parametrize("command", ["absurd_sync_queues", "absurd_worker"])
 def test_a_command_names_the_missing_schema_without_a_traceback(
     command: str,
     settings: Settings,
 ) -> None:
     settings.TASKS = utils.make_tasks_settings(queues={"default": {}})
     with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
-        call_command(command, *(["--noinput"] if command == "absurd_flush" else []))
+        call_command(command)
     assert str(excinfo.value) == SCHEMA_ABSENT
 
 
@@ -257,9 +254,9 @@ def test_beat_reports_a_missing_backend_without_a_traceback(
     )
 ```
 
-`absurd_cleanup` and `absurd_flush` fail this run for a second reason — their probes
-land in Task 3. Expect them to stay red until then and say so in the commit; do NOT
-weaken the assertion to get them green here.
+`absurd_cleanup` and `absurd_flush` are deliberately absent from the parametrize list —
+their probes land in Task 3, which adds their cases to this same file. Never commit a
+test this task cannot turn green.
 
 In `tests/pg_cron/test_absurd_sync_crons_command.py`, add the same no-backend case for
 `absurd_sync_crons`, asserting the identical complete message.
@@ -270,10 +267,8 @@ In `tests/pg_cron/test_absurd_sync_crons_command.py`, add the same no-backend ca
 uv run pytest tests/core/test_command_errors.py -q --no-cov
 ```
 
-Expected: the four schema cases FAIL — two with `SchemaNotInstalledError` escaping
-uncaught (`absurd_sync_queues`, `absurd_worker`), two with raw psycopg /
-`ProgrammingError` (`absurd_cleanup`, `absurd_flush`). The beat case passes already; it
-is a regression guard for the handler this task deletes.
+Expected: both schema cases FAIL with `SchemaNotInstalledError` escaping uncaught. The
+beat case passes already; it is a regression guard for the handler this task deletes.
 
 - [ ] **Step 3: Add the base**
 
@@ -309,8 +304,7 @@ Then re-parent `AbsurdReportCommand` onto `AbsurdCommand`. Its body does not cha
 uv run pytest tests/core/test_command_errors.py tests/pg_cron/test_absurd_sync_crons_command.py -q --no-cov
 ```
 
-Expected: every case PASSES except `absurd_cleanup` and `absurd_flush`, which Task 3
-fixes.
+Expected: every case PASSES.
 
 - [ ] **Step 6: Run the command-driving tests**
 
@@ -331,8 +325,6 @@ git add django_absurd/management django_absurd/pg_cron/management \
 git commit -m 'feat: translate configuration failures to CommandError in one command base'
 ```
 
-Note in the commit body that two parametrized cases stay red until the next commit.
-
 ---
 
 ### Task 3: cleanup and flush stop leaking raw psycopg errors
@@ -342,7 +334,7 @@ Note in the commit body that two parametrized cases stay red until the next comm
 - Modify: `django_absurd/cleanup.py`
 - Modify: `django_absurd/queues.py`
 - Modify: `django_absurd/management/commands/absurd_flush.py`
-- Test: `tests/core/test_command_errors.py` (already written in Task 2)
+- Test: `tests/core/test_command_errors.py` (extend Task 2's parametrize list)
 
 **Interfaces:**
 
@@ -351,16 +343,34 @@ Note in the commit body that two parametrized cases stay red until the next comm
   `django_absurd.queues.list_provisioned_queues(using: str | None = None) -> list[str]`,
   used by `absurd_flush`.
 
-- [ ] **Step 1: Confirm the two cases are still red**
+- [ ] **Step 1: Add the two cases (RED)**
+
+In `tests/core/test_command_errors.py`, extend the existing parametrize list to
+`["absurd_cleanup", "absurd_flush", "absurd_sync_queues", "absurd_worker"]`
+(alphabetical, per the conventions) and pass `absurd_flush` its non-interactive flag,
+since the command prompts before dropping anything:
+
+```python
+@pytest.mark.parametrize(
+    "command",
+    ["absurd_cleanup", "absurd_flush", "absurd_sync_queues", "absurd_worker"],
+)
+def test_a_command_names_the_missing_schema_without_a_traceback(
+    command: str,
+    settings: Settings,
+) -> None:
+    settings.TASKS = utils.make_tasks_settings(queues={"default": {}})
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
+        call_command(command, *(["--noinput"] if command == "absurd_flush" else []))
+    assert str(excinfo.value) == SCHEMA_ABSENT
+```
 
 ```bash
-uv run pytest tests/core/test_command_errors.py -q --no-cov \
-  -k "cleanup or flush"
+uv run pytest tests/core/test_command_errors.py -q --no-cov -k "cleanup or flush"
 ```
 
 Expected: FAIL — `django.db.utils.ProgrammingError: schema "absurd" does not exist` from
-cleanup, `psycopg.errors.InvalidSchemaName` from flush. These are the RED for this task;
-no new test is needed.
+cleanup, `psycopg.errors.InvalidSchemaName` from flush.
 
 - [ ] **Step 2: Classify in the cleanup path**
 
@@ -411,7 +421,8 @@ would break every suite's teardown, so treat a failure here as this task's own b
 
 ```bash
 git add django_absurd/cleanup.py django_absurd/queues.py \
-        django_absurd/management/commands/absurd_flush.py
+        django_absurd/management/commands/absurd_flush.py \
+        tests/core/test_command_errors.py
 git commit -m 'fix: report an unmigrated database from absurd_cleanup and absurd_flush'
 ```
 

--- a/docs/plans/2026-08-15-command-error-translation.md
+++ b/docs/plans/2026-08-15-command-error-translation.md
@@ -35,9 +35,13 @@ Issue: [#128](https://github.com/lincolnloop/django-absurd/issues/128).
   `_enable_db` gives DB access — add `@pytest.mark.django_db(transaction=True)` only for
   commits/DDL. Alphabetize fixture params and parametrize values.
 - 100% statement + branch coverage on lines this plan adds or changes.
-- Gates before each commit: `uv run pytest <path> -q --no-cov` while iterating; the
-  coordinator owns `uvx --with tox-uv tox -e dev` and
-  `uv run pre-commit run --all-files`. Never invoke ruff/mypy directly.
+- **Test runs are targeted, never the full matrix.** While iterating, run the single
+  test under change: `uv run pytest <path>::<test> -q --no-cov`. When several fail at
+  once, close the gap with `uv run pytest <path> -q --no-cov --lf` rather than widening
+  to a suite. Before a commit, the touched files only. `uvx --with tox-uv tox -e dev` is
+  the coordinator's, run once at the end — never between commits, and never the bare
+  `tox` matrix. Never invoke ruff/mypy directly; `uv run pre-commit run --files <paths>`
+  covers them.
 - `docker compose up -d db db_pg_cron` must be running.
 - Commit titles are the changelog. The type-switch commit is `feat!`.
 
@@ -130,10 +134,11 @@ assert the whole message rather than `match="migrate"`:
 - [ ] **Step 2: Run them and watch them fail**
 
 ```bash
-uv run pytest tests/core/test_queue_sync.py tests/core/test_worker.py tests/core/test_enqueue.py -q --no-cov
+uv run pytest tests/core/test_queue_sync.py::test_sync_command_names_the_missing_schema -q --no-cov
 ```
 
-Expected: `ImportError` on `SchemaNotInstalledError` — the name does not exist yet.
+Expected: `ImportError` on `SchemaNotInstalledError` — the name does not exist yet. Same
+for the other two amended tests; run each by node id rather than the whole file.
 
 - [ ] **Step 3: Add the exception**
 
@@ -159,10 +164,11 @@ its text now.
 - [ ] **Step 5: Run the three files again**
 
 ```bash
-uv run pytest tests/core/test_queue_sync.py tests/core/test_worker.py tests/core/test_enqueue.py -q --no-cov
+uv run pytest tests/core/test_queue_sync.py tests/core/test_worker.py tests/core/test_enqueue.py -q --no-cov --lf
 ```
 
-Expected: PASS.
+Expected: PASS. `--lf` re-runs only what failed in the previous step; drop it for the
+final pre-commit pass over the three touched files.
 
 - [ ] **Step 6: Sweep for stale references**
 
@@ -306,11 +312,10 @@ uv run pytest tests/core/test_command_errors.py tests/pg_cron/test_absurd_sync_c
 Expected: every case PASSES except `absurd_cleanup` and `absurd_flush`, which Task 3
 fixes.
 
-- [ ] **Step 6: Run everything that drives a command**
+- [ ] **Step 6: Run the command-driving tests**
 
 ```bash
-uv run pytest tests/core/test_worker.py tests/core/test_queue_sync.py \
-              tests/core/test_command_output.py tests/core/test_scheduler.py \
+uv run pytest tests/core/test_worker.py tests/core/test_command_output.py \
               tests/pg_cron/test_absurd_sync_crons_command.py -q --no-cov
 ```
 
@@ -458,7 +463,7 @@ git commit -m 'docs: document the command-error contract and SchemaNotInstalledE
 ## Final gate (coordinator)
 
 ```bash
-uvx --with tox-uv tox -e dev
+uvx --with tox-uv tox -e dev   # once, here only
 uv run pre-commit run --all-files
 ```
 

--- a/docs/plans/2026-08-15-command-error-translation.md
+++ b/docs/plans/2026-08-15-command-error-translation.md
@@ -1,0 +1,465 @@
+# Command error translation — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every django-absurd management command turns a configuration failure into a
+clean `CommandError` instead of a traceback.
+
+**Architecture:** One `AbsurdCommand` base overrides `execute`, catching
+`ImproperlyConfigured` and `DjangoAbsurdError` and re-raising `CommandError` chained
+`from exc`; all six commands inherit it. One typed `SchemaNotInstalledError` replaces
+the three hand-rolled `ImproperlyConfigured` schema messages and covers two paths that
+leak raw psycopg errors today.
+
+**Tech Stack:** Django 6.0 management commands, absurd-sdk, psycopg 3, pytest +
+pytest-django.
+
+Spec:
+[`../specs/2026-08-15-command-error-translation-design.md`](../specs/2026-08-15-command-error-translation-design.md).
+Issue: [#128](https://github.com/lincolnloop/django-absurd/issues/128).
+
+## Global Constraints
+
+- Django 6.0+ / Python 3.12+; psycopg (v3) backend only.
+- `import typing as t` — never `from typing import X`. Absolute imports only.
+- Functions carry a verb. No leading-underscore module constants or helpers. Helpers go
+  BELOW the public function that uses them.
+- Re-raising inside an `except` always chains `from exc` — never `from None`. Classify
+  first; re-raise the original untouched when the error is not what the curated message
+  claims.
+- Exceptions own their messages; callers never assemble text.
+- Tests: pytest, function-based, integration-level through real entrypoints. Assert the
+  COMPLETE error message, never a fragment. No mocks/monkeypatching. Autouse
+  `_enable_db` gives DB access — add `@pytest.mark.django_db(transaction=True)` only for
+  commits/DDL. Alphabetize fixture params and parametrize values.
+- 100% statement + branch coverage on lines this plan adds or changes.
+- Gates before each commit: `uv run pytest <path> -q --no-cov` while iterating; the
+  coordinator owns `uvx --with tox-uv tox -e dev` and
+  `uv run pre-commit run --all-files`. Never invoke ruff/mypy directly.
+- `docker compose up -d db db_pg_cron` must be running.
+- Commit titles are the changelog. The type-switch commit is `feat!`.
+
+## File Structure
+
+| File                                                                 | Responsibility                                                                   |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `django_absurd/exceptions.py`                                        | gains `SchemaNotInstalledError`                                                  |
+| `django_absurd/management/base.py`                                   | gains `AbsurdCommand`; `AbsurdReportCommand` re-parents onto it                  |
+| `django_absurd/management/commands/*.py` (5)                         | inherit the base, lose their hand-rolled translations                            |
+| `django_absurd/pg_cron/management/commands/absurd_sync_crons.py`     | same                                                                             |
+| `django_absurd/queues.py`                                            | schema probe raises the typed error; gains a classified queue-listing entrypoint |
+| `django_absurd/backends.py`, `django_absurd/worker.py`               | schema probes raise the typed error                                              |
+| `django_absurd/cleanup.py`                                           | new classified schema probe                                                      |
+| `tests/core/test_command_errors.py`                                  | NEW — one case per core command on a hidden schema                               |
+| `tests/pg_cron/test_absurd_sync_crons_command.py`                    | gains the pg_cron command's case                                                 |
+| `tests/core/test_queue_sync.py`, `test_worker.py`, `test_enqueue.py` | three existing assertions change type                                            |
+
+---
+
+### Task 1: `SchemaNotInstalledError` replaces the three hand-rolled messages
+
+No behavior change beyond the exception type — the three sites already raise on the same
+condition. This task exists on its own so the type switch is reviewable apart from the
+base class.
+
+**Files:**
+
+- Modify: `django_absurd/exceptions.py`
+- Modify: `django_absurd/queues.py:113`, `django_absurd/backends.py:200`,
+  `django_absurd/worker.py:297`
+- Test: `tests/core/test_queue_sync.py:45`, `tests/core/test_worker.py:92`,
+  `tests/core/test_enqueue.py:160`
+
+**Interfaces:**
+
+- Produces: `django_absurd.exceptions.SchemaNotInstalledError`, a `DjangoAbsurdError`
+  subclass taking NO constructor arguments, whose message is exactly
+  `Absurd schema is not installed. Run: manage.py migrate`. Tasks 2 and 3 raise and
+  assert it.
+
+- [ ] **Step 1: Change the three existing assertions to the new type (RED)**
+
+`tests/core/test_queue_sync.py` — only the first of the two nearby cases changes;
+`test_migrate_screams_on_non_postgres_backend` is the psycopg3 check, a different
+condition, and keeps `ImproperlyConfigured`:
+
+```python
+@pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)
+def test_sync_command_screams_on_non_postgres_backend(
+    settings: Settings,
+) -> None:
+    settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
+    with pytest.raises(ImproperlyConfigured):
+        call_command("absurd_sync_queues")
+```
+
+Leave that one alone. Add a schema-absent case beside it asserting the new type and the
+complete message:
+
+```python
+def test_sync_command_names_the_missing_schema(settings: Settings) -> None:
+    settings.TASKS = build_tasks_setting({"x": {}})
+    with (
+        utils.hide_absurd_schema(),
+        pytest.raises(
+            SchemaNotInstalledError,
+            match=r"^Absurd schema is not installed\. Run: manage\.py migrate$",
+        ),
+    ):
+        call_command("absurd_sync_queues")
+```
+
+`tests/core/test_worker.py:92` — the async client probe. Swap the expected type and
+assert the whole message rather than `match="migrate"`:
+
+```python
+    with (
+        utils.hide_absurd_schema(),
+        pytest.raises(
+            SchemaNotInstalledError,
+            match=r"^Absurd schema is not installed\. Run: manage\.py migrate$",
+        ),
+    ):
+        asyncio.run(_enter())
+```
+
+`tests/core/test_enqueue.py:160` — the enqueue path. Same swap, same full-message match.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+uv run pytest tests/core/test_queue_sync.py tests/core/test_worker.py tests/core/test_enqueue.py -q --no-cov
+```
+
+Expected: `ImportError` on `SchemaNotInstalledError` — the name does not exist yet.
+
+- [ ] **Step 3: Add the exception**
+
+In `django_absurd/exceptions.py`, beside the other typed errors: a `DjangoAbsurdError`
+subclass named `SchemaNotInstalledError`, no `__init__` parameters, passing the fixed
+message up to `super().__init__`. Give it a docstring saying what raises it (queue
+reconcile, the enqueue path, the worker's client probe, cleanup, flush) and that
+`migrate`'s `post_migrate` provisions declared queues — which is why the message names
+`migrate` alone and not `absurd_sync_queues` after it.
+
+- [ ] **Step 4: Raise it at the three sites**
+
+Each site keeps its existing `except` clause and its `from exc` chaining; only the
+raised type changes and the local `msg` assignment goes away, because the exception owns
+its text now.
+
+- `queues.py:113` — the `ProgrammingError` handler around the catalog read.
+- `backends.py:200` — the psycopg handler inside `enqueue`, the branch reached when the
+  queue IS declared.
+- `worker.py:297` — the async `list_queues` probe. Its longer wording
+  (`then manage.py absurd_sync_queues`) disappears with the switch; that is intended.
+
+- [ ] **Step 5: Run the three files again**
+
+```bash
+uv run pytest tests/core/test_queue_sync.py tests/core/test_worker.py tests/core/test_enqueue.py -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Sweep for stale references**
+
+```bash
+grep -rn "schema is not installed" django_absurd tests docs README.md
+```
+
+Expected: only the exception class. Use `grep -rn`, not `ag` — ag under-reports in this
+repo (it silently skips `django_absurd/pg_cron/` and `tests/`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add django_absurd/exceptions.py django_absurd/queues.py django_absurd/backends.py \
+        django_absurd/worker.py tests/core/test_queue_sync.py \
+        tests/core/test_worker.py tests/core/test_enqueue.py
+git commit -m 'feat!: raise SchemaNotInstalledError, not ImproperlyConfigured, when Absurd is unmigrated'
+```
+
+---
+
+### Task 2: `AbsurdCommand` base, six commands, four handlers deleted
+
+**Files:**
+
+- Modify: `django_absurd/management/base.py`
+- Modify: `django_absurd/management/commands/absurd_beat.py`, `absurd_cleanup.py`,
+  `absurd_flush.py`, `absurd_sync_queues.py`, `absurd_worker.py`
+- Modify: `django_absurd/pg_cron/management/commands/absurd_sync_crons.py`
+- Create: `tests/core/test_command_errors.py`
+- Modify: `tests/pg_cron/test_absurd_sync_crons_command.py`
+
+**Interfaces:**
+
+- Consumes: `SchemaNotInstalledError` from Task 1.
+- Produces: `django_absurd.management.base.AbsurdCommand`, a `BaseCommand` subclass
+  overriding `execute(self, *args: t.Any, **options: t.Any) -> t.Any`.
+  `AbsurdReportCommand` becomes `AbsurdCommand`'s subclass and keeps
+  `report_sync_result` unchanged. Task 3 relies on both names.
+
+- [ ] **Step 1: Write the failing tests (RED)**
+
+New file `tests/core/test_command_errors.py`. Five core commands, one case each, driven
+through `call_command` with the schema hidden. `absurd_beat` gets the no-backend
+condition instead — it touches no database at start, so a hidden schema proves nothing
+about it:
+
+```python
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from pytest_django.fixtures import Settings
+
+from tests import utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+SCHEMA_ABSENT = "Absurd schema is not installed. Run: manage.py migrate"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["absurd_cleanup", "absurd_flush", "absurd_sync_queues", "absurd_worker"],
+)
+def test_a_command_names_the_missing_schema_without_a_traceback(
+    command: str,
+    settings: Settings,
+) -> None:
+    settings.TASKS = utils.make_tasks_settings(queues={"default": {}})
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
+        call_command(command, *(["--noinput"] if command == "absurd_flush" else []))
+    assert str(excinfo.value) == SCHEMA_ABSENT
+
+
+def test_beat_reports_a_missing_backend_without_a_traceback(
+    settings: Settings,
+) -> None:
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}
+    }
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_beat")
+    assert str(excinfo.value) == (
+        "No Absurd backend configured. Add a "
+        "django_absurd.backends.AbsurdBackend entry to TASKS."
+    )
+```
+
+`absurd_cleanup` and `absurd_flush` fail this run for a second reason — their probes
+land in Task 3. Expect them to stay red until then and say so in the commit; do NOT
+weaken the assertion to get them green here.
+
+In `tests/pg_cron/test_absurd_sync_crons_command.py`, add the same no-backend case for
+`absurd_sync_crons`, asserting the identical complete message.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+uv run pytest tests/core/test_command_errors.py -q --no-cov
+```
+
+Expected: the four schema cases FAIL — two with `SchemaNotInstalledError` escaping
+uncaught (`absurd_sync_queues`, `absurd_worker`), two with raw psycopg /
+`ProgrammingError` (`absurd_cleanup`, `absurd_flush`). The beat case passes already; it
+is a regression guard for the handler this task deletes.
+
+- [ ] **Step 3: Add the base**
+
+In `django_absurd/management/base.py`, above `AbsurdReportCommand`: `AbsurdCommand`,
+subclassing `BaseCommand`, overriding `execute` to call
+`super().execute(*args, **options)` inside a `try`, catching `ImproperlyConfigured` and
+`DjangoAbsurdError`, re-raising `CommandError(str(exc)) from exc`. Return `super()`'s
+value on the happy path — `absurd_sync_crons.handle` returns `str | None` and Django
+writes a non-`None` return to stdout.
+
+Comment the reason for `execute` over `handle`: it covers the system-check phase, needs
+no command to rename its `handle`, and `--traceback` still prints the original chain.
+
+Then re-parent `AbsurdReportCommand` onto `AbsurdCommand`. Its body does not change.
+
+- [ ] **Step 4: Move all six commands onto it and delete the handlers**
+
+- `absurd_beat`, `absurd_cleanup`, `absurd_flush`, `absurd_sync_crons`: `BaseCommand` →
+  `AbsurdCommand`.
+- `absurd_sync_queues`, `absurd_worker`: already `AbsurdReportCommand`, now transitively
+  covered — no class change.
+- Delete the four hand-rolled translations: the `BackendNotConfiguredError` handlers in
+  `absurd_beat`, `absurd_worker` and `absurd_sync_crons`, and the `ImproperlyConfigured`
+  handler around `provision_backend` in `absurd_worker`. Each becomes a bare call.
+- Drop the imports those handlers left behind (`BackendNotConfiguredError`,
+  `ImproperlyConfigured`, and `CommandError` where nothing else raises it —
+  `absurd_beat`, `absurd_worker` and `absurd_sync_crons` all still raise `CommandError`
+  directly elsewhere, so check each before removing).
+
+- [ ] **Step 5: Run the command tests**
+
+```bash
+uv run pytest tests/core/test_command_errors.py tests/pg_cron/test_absurd_sync_crons_command.py -q --no-cov
+```
+
+Expected: every case PASSES except `absurd_cleanup` and `absurd_flush`, which Task 3
+fixes.
+
+- [ ] **Step 6: Run everything that drives a command**
+
+```bash
+uv run pytest tests/core/test_worker.py tests/core/test_queue_sync.py \
+              tests/core/test_command_output.py tests/core/test_scheduler.py \
+              tests/pg_cron/test_absurd_sync_crons_command.py -q --no-cov
+```
+
+Expected: PASS. `tests/core/test_worker.py:424` already asserts `CommandError` on the
+schema condition and must stay green — the base now produces what the deleted handler
+did.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add django_absurd/management django_absurd/pg_cron/management \
+        tests/core/test_command_errors.py tests/pg_cron/test_absurd_sync_crons_command.py
+git commit -m 'feat: translate configuration failures to CommandError in one command base'
+```
+
+Note in the commit body that two parametrized cases stay red until the next commit.
+
+---
+
+### Task 3: cleanup and flush stop leaking raw psycopg errors
+
+**Files:**
+
+- Modify: `django_absurd/cleanup.py`
+- Modify: `django_absurd/queues.py`
+- Modify: `django_absurd/management/commands/absurd_flush.py`
+- Test: `tests/core/test_command_errors.py` (already written in Task 2)
+
+**Interfaces:**
+
+- Consumes: `SchemaNotInstalledError` (Task 1), `AbsurdCommand` (Task 2).
+- Produces:
+  `django_absurd.queues.list_provisioned_queues(using: str | None = None) -> list[str]`,
+  used by `absurd_flush`.
+
+- [ ] **Step 1: Confirm the two cases are still red**
+
+```bash
+uv run pytest tests/core/test_command_errors.py -q --no-cov \
+  -k "cleanup or flush"
+```
+
+Expected: FAIL — `django.db.utils.ProgrammingError: schema "absurd" does not exist` from
+cleanup, `psycopg.errors.InvalidSchemaName` from flush. These are the RED for this task;
+no new test is needed.
+
+- [ ] **Step 2: Classify in the cleanup path**
+
+`cleanup.py`'s `cleanup_queues` runs `select ... from absurd.cleanup_all_queues(%s)` on
+a Django cursor, so an absent schema arrives as `django.db.utils.ProgrammingError`
+wrapping the psycopg error. Wrap the cursor block: catch `ProgrammingError`, raise
+`SchemaNotInstalledError` chained `from exc` ONLY when the wrapped cause is
+`psycopg.errors.InvalidSchemaName` or `psycopg.errors.UndefinedFunction`; re-raise the
+original untouched otherwise. `names_a_queue_table` in `queues.py` is the worked example
+of classify-then-chain.
+
+- [ ] **Step 3: Classify in the flush path**
+
+`absurd_flush` calls `client.list_queues()` directly, on the SDK's own cursor, so the
+error arrives as a RAW psycopg error that never passes through Django's wrapper — which
+is why `flush.py`'s existing tolerant
+`except (OperationalError, ProgrammingError, ImproperlyConfigured)` in `clear_queues`
+never sees it. Leave `clear_queues` alone: it backs the automatic test cleanup and its
+tolerance is deliberate.
+
+Add `list_provisioned_queues` to `queues.py`, below `get_absurd_client`. It builds the
+client, returns `sorted(client.list_queues())`, and translates
+`psycopg.errors.InvalidSchemaName` / `UndefinedFunction` / `UndefinedTable` into
+`SchemaNotInstalledError` chained `from exc`. Point `absurd_flush` at it, dropping its
+own `get_absurd_client` + `sorted(...)` lines.
+
+- [ ] **Step 4: Run the command tests**
+
+```bash
+uv run pytest tests/core/test_command_errors.py -q --no-cov
+```
+
+Expected: all five cases PASS.
+
+- [ ] **Step 5: Run the suites that exercise these paths**
+
+```bash
+uv run pytest tests/core/test_cleanup.py tests/core/test_pytest_plugin.py \
+              tests/core/test_absurd_fixture.py -q --no-cov
+uv run pytest tests/pg_cron/test_flush_scoped.py tests/pg_cron/test_cleanup_schedule.py -q --no-cov
+```
+
+Expected: PASS. The flush-related ones prove the automatic test-cleanup path still
+tolerates an absent schema — a `SchemaNotInstalledError` escaping `flush_absurd_state`
+would break every suite's teardown, so treat a failure here as this task's own bug.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add django_absurd/cleanup.py django_absurd/queues.py \
+        django_absurd/management/commands/absurd_flush.py
+git commit -m 'fix: report an unmigrated database from absurd_cleanup and absurd_flush'
+```
+
+---
+
+### Task 4: docs
+
+**Files:**
+
+- Modify: `django_absurd/AGENTS.md`
+- Modify: `docs/web/configuration.md`
+
+- [ ] **Step 1: Update the integration guide**
+
+In `django_absurd/AGENTS.md`:
+
+- Add `SchemaNotInstalledError` to the exception table, described as the Absurd schema
+  being absent, resolved by `manage.py migrate`.
+- Replace the bullet reading "The `absurd_worker` / `absurd_beat` / `absurd_sync_crons`
+  commands translate `BackendNotConfiguredError` into a `CommandError`" with the base's
+  actual contract: every `absurd_*` command turns a configuration failure —
+  `ImproperlyConfigured` or any `DjangoAbsurdError` — into a `CommandError`, and
+  `--traceback` still shows the original.
+- Amend the "hierarchy is not total" bullet: schema-absent is now typed, so it comes off
+  the list of conditions that still raise plain `ImproperlyConfigured`.
+
+- [ ] **Step 2: Update the documentation site**
+
+Mirror all three edits in `docs/web/configuration.md`'s exceptions section.
+
+- [ ] **Step 3: Verify the tables render**
+
+```bash
+uv run pre-commit run --files django_absurd/AGENTS.md docs/web/configuration.md
+```
+
+Then re-read both tables AFTER the hook runs — prettier reflows markdown tables, and a
+long cell can lose trailing syntax to a wrap.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add django_absurd/AGENTS.md docs/web/configuration.md
+git commit -m 'docs: document the command-error contract and SchemaNotInstalledError'
+```
+
+---
+
+## Final gate (coordinator)
+
+```bash
+uvx --with tox-uv tox -e dev
+uv run pre-commit run --all-files
+```
+
+Both green before the branch is offered for review.

--- a/docs/specs/2026-08-15-command-error-translation-design.md
+++ b/docs/specs/2026-08-15-command-error-translation-design.md
@@ -1,0 +1,125 @@
+# Command error translation — design
+
+Closes [#128](https://github.com/lincolnloop/django-absurd/issues/128).
+
+## Problem
+
+Six management commands, two bases. `absurd_sync_queues` and `absurd_worker` inherit
+`AbsurdReportCommand`; `absurd_beat`, `absurd_cleanup`, `absurd_flush` and
+`absurd_sync_crons` inherit `BaseCommand`. `AbsurdReportCommand` only reports a
+`SyncResult` to stdout — it never touches `handle`, so error translation is per-command
+and uneven:
+
+- `ImproperlyConfigured` → `CommandError` in exactly one place, wrapping
+  `provision_backend` in `absurd_worker`.
+- `BackendNotConfiguredError` → `CommandError` hand-rolled three times, in
+  `absurd_beat`, `absurd_worker`, `absurd_sync_crons`.
+
+Measured against an unmigrated database (2026-08-15, all six commands, three configs):
+
+| command              | unmigrated DB                                  | 0 backends      | 2 backends    |
+| -------------------- | ---------------------------------------------- | --------------- | ------------- |
+| `absurd_sync_queues` | traceback — `ImproperlyConfigured`             | message, exit 0 | `absurd.E004` |
+| `absurd_cleanup`     | traceback — `django.db.utils.ProgrammingError` | message, exit 0 | `absurd.E004` |
+| `absurd_flush`       | traceback — `psycopg.errors.InvalidSchemaName` | message, exit 0 | `absurd.E004` |
+| `absurd_beat`        | fine — touches no DB at start                  | `CommandError`  | `absurd.E004` |
+| `absurd_worker`      | `CommandError`                                 | `CommandError`  | `absurd.E004` |
+
+Two findings redirect the issue as filed:
+
+1. **The `BackendNotConfiguredError` half buys no user-visible improvement.** The
+   multiple-backend count is unreachable from a command — `absurd.E004` fires in system
+   checks first — and the zero count already reports cleanly everywhere. Worth doing as
+   dedup, not as a fix.
+2. **The `ImproperlyConfigured` half alone fixes only `absurd_sync_queues`.** The two
+   commands that leak worst raise raw psycopg / `ProgrammingError`, which a base
+   catching `ImproperlyConfigured` never sees. The issue's guess that the other five
+   commands are the wins is wrong: `absurd_beat` was never broken.
+
+So a base class alone leaves the ugliest failures ugly. The schema probe has to become a
+typed error at the same time.
+
+## Ship
+
+### One base
+
+```
+AbsurdCommand(BaseCommand)               # overrides execute()
+└── AbsurdReportCommand(AbsurdCommand)   # keeps report_sync_result
+```
+
+`AbsurdCommand.execute` wraps `super().execute()`, catches `ImproperlyConfigured` and
+`DjangoAbsurdError`, re-raises `CommandError` chained `from exc`. All six commands
+inherit it; the four hand-rolled translations go.
+
+Overriding `execute` rather than `handle`: one override, no command renames its
+`handle`, and the system-check phase is covered too. Nothing is lost — Django's
+`--traceback` still prints the original chain, and `CommandError` is what Django's own
+commands raise.
+
+`call_command` runs through `execute` as well, so programmatic callers see
+`CommandError` too. That is the same contract Django's built-in commands offer, and
+three existing tests that assert the pre-translation type move to the new one.
+
+Alternative dropped: a report mixin beside the base. Two levels of plain inheritance is
+less machinery for the same result when one method is shared.
+
+### One typed schema error
+
+`SchemaNotInstalledError(DjangoAbsurdError)`, no constructor arguments, owning the
+message `Absurd schema is not installed. Run: manage.py migrate`.
+
+Raised wherever the absent schema is probed:
+
+- the three sites hand-rolling `ImproperlyConfigured` today — queue reconcile, the
+  enqueue path, the worker's client probe. Two different wordings collapse to one; the
+  worker's `then manage.py absurd_sync_queues` tail is redundant because `post_migrate`
+  provisions declared queues.
+- new probes in the cleanup and flush paths, which raise raw psycopg errors today. Each
+  classifies only the errors that name a missing Absurd object, chains `from exc`, and
+  re-raises anything else untouched — narrow catch, per the exception-chaining
+  convention.
+
+The enqueue path switches type too, so one condition has one type everywhere. That is a
+break for anyone catching `ImproperlyConfigured` around `enqueue`, and
+`DjangoAbsurdError` deliberately does not subclass it, so there is no soft landing. The
+commit is `feat!` and names the change.
+
+### After
+
+Every command on an unmigrated database:
+
+```
+CommandError: Absurd schema is not installed. Run: manage.py migrate
+```
+
+exit 1, no traceback. In a web process the enqueue path still raises, still with a
+traceback, but the type names the condition instead of surfacing as a psycopg internal.
+
+## Out of scope
+
+- **The exit-code split.** `absurd_cleanup` / `absurd_flush` print
+  `No Absurd task backends configured.` and exit 0; `absurd_beat` / `absurd_worker` /
+  `absurd_sync_crons` raise `CommandError` and exit 1. Defensible — an idempotent
+  maintenance no-op versus a process that cannot start — and undocumented. Leave both,
+  note it if the docs sweep finds a place for it.
+- Broadening translation beyond configuration failures. Task errors inside a running
+  worker keep their current handling.
+
+## Testing
+
+Integration only, through real entrypoints — `call_command` under the existing
+schema-hiding helper, one case per command, asserting the complete `CommandError` text.
+No test calls the base class or the probe helpers directly.
+
+The three existing assertions on the schema condition change type. The check that
+`migrate` refuses a non-psycopg3 backend is a different condition and keeps
+`ImproperlyConfigured`.
+
+## Docs
+
+- The exception table and the "commands translate `BackendNotConfiguredError`" bullet in
+  the integration guide, which becomes the base's contract.
+- The same table on the documentation site.
+- The honesty note about the hierarchy not being total: schema-absent moves out of the
+  "still raises plain `ImproperlyConfigured`" list.

--- a/docs/specs/2026-08-15-command-error-translation-design.md
+++ b/docs/specs/2026-08-15-command-error-translation-design.md
@@ -48,9 +48,13 @@ AbsurdCommand(BaseCommand)               # overrides execute()
 └── AbsurdReportCommand(AbsurdCommand)   # keeps report_sync_result
 ```
 
-`AbsurdCommand.execute` wraps `super().execute()`, catches `ImproperlyConfigured` and
-`DjangoAbsurdError`, re-raises `CommandError` chained `from exc`. All six commands
-inherit it; the four hand-rolled translations go.
+`AbsurdCommand.execute` wraps `super().execute()`, catches a named tuple of
+configuration conditions — `ImproperlyConfigured`, `BackendNotConfiguredError`,
+`SchemaNotInstalledError`, `QueueNotDeclaredError`, `QueueNotProvisionedError` — and
+re-raises `CommandError` chained `from exc`. Any other `DjangoAbsurdError` subclass, and
+anything unforeseen, keeps its own type and full traceback: it signals a bug, not a
+configuration mistake. All six commands inherit the base; the four hand-rolled
+translations go.
 
 Overriding `execute` rather than `handle`: one override, no command renames its
 `handle`, and the system-check phase is covered too. Nothing is lost — Django's

--- a/docs/specs/2026-08-15-command-error-translation-design.md
+++ b/docs/specs/2026-08-15-command-error-translation-design.md
@@ -57,9 +57,8 @@ configuration mistake. All six commands inherit the base; the four hand-rolled
 translations go.
 
 Overriding `execute` rather than `handle`: one override, no command renames its
-`handle`, and the system-check phase is covered too. Nothing is lost — Django's
-`--traceback` still prints the original chain, and `CommandError` is what Django's own
-commands raise.
+`handle`. Nothing is lost — Django's `--traceback` still prints the original chain, and
+`CommandError` is what Django's own commands raise.
 
 `call_command` runs through `execute` as well, so programmatic callers see
 `CommandError` too. That is the same contract Django's built-in commands offer, and

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -125,8 +125,10 @@ Absurd schema itself isn't installed — run `manage.py migrate`).
 
 - `enqueue` raises `QueueNotDeclaredError` only when `QUEUES` is empty or unset. With
   `QUEUES` configured, a typo is rejected earlier as Django's own `InvalidTask`.
-- Every `absurd_*` management command turns a configuration failure —
-  `ImproperlyConfigured` or any `DjangoAbsurdError` — into a `CommandError`;
-  `--traceback` still shows the original.
+- Every `absurd_*` management command turns a fixed set of configuration failures —
+  `ImproperlyConfigured`, `BackendNotConfiguredError`, `SchemaNotInstalledError`,
+  `QueueNotDeclaredError`, `QueueNotProvisionedError` — into a `CommandError`;
+  `--traceback` still shows the original. Every other error, including any other
+  `DjangoAbsurdError` subclass, keeps its own type and full traceback.
 - The hierarchy isn't total — other failures still raise plain `ImproperlyConfigured` /
   `RuntimeError` / `TypeError`.

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -119,10 +119,14 @@ except DjangoAbsurdError:
 
 Typed errors under `DjangoAbsurdError`: `QueueNotDeclaredError` (never declared) and
 `QueueNotProvisionedError` (declared, no table yet — run
-`manage.py absurd_sync_queues`). Raised by [`emit_event`](workflows.md#emit-from-a-view)
-and the test fixture's [`drain()`](testing.md#drain).
+`manage.py absurd_sync_queues`), raised by [`emit_event`](workflows.md#emit-from-a-view)
+and the test fixture's [`drain()`](testing.md#drain); and `SchemaNotInstalledError` (the
+Absurd schema itself isn't installed — run `manage.py migrate`).
 
 - `enqueue` raises `QueueNotDeclaredError` only when `QUEUES` is empty or unset. With
   `QUEUES` configured, a typo is rejected earlier as Django's own `InvalidTask`.
+- Every `absurd_*` management command turns a configuration failure —
+  `ImproperlyConfigured` or any `DjangoAbsurdError` — into a `CommandError`;
+  `--traceback` still shows the original.
 - The hierarchy isn't total — other failures still raise plain `ImproperlyConfigured` /
   `RuntimeError` / `TypeError`.

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -7,9 +7,12 @@ import re
 import sys
 import typing as t
 
+import psycopg.errors
 import pytest
 from django.contrib.auth.models import Group
 from django.core.management import call_command
+from django.db import connection
+from django.db.utils import ProgrammingError
 from django.utils import timezone
 
 from django_absurd import worker
@@ -181,6 +184,35 @@ def test_cleanup_command_reports_per_queue_counts(
     capsys.readouterr()  # discard sync/worker output
     call_command("absurd_cleanup")
     assert capsys.readouterr().out == "default: 1 tasks, 0 events deleted\n"
+
+
+def test_cleanup_does_not_relabel_an_unrelated_missing_relation(
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    """A missing relation inside ``absurd.cleanup_all_queues`` that is not the
+    schema-absent shape (``InvalidSchemaName``/``UndefinedFunction``) surfaces as
+    itself. Relabeling it "run migrate" would send the reader to the wrong door, and
+    dropping the cause would hide which relation is actually missing.
+
+    Driven the way it happens in production: a queue's own table renamed out from
+    under the cleanup RPC, e.g. mid-migration or by an operator error — a case
+    ``cleanup_queues`` never classifies as schema-absent, since the exception is a
+    plain ``UndefinedTable``, not ``InvalidSchemaName``/``UndefinedFunction``.
+    """
+    sync_queue(settings)
+    with connection.cursor() as cur:
+        cur.execute("alter table absurd.t_default rename to t_default_probe")
+    try:
+        with pytest.raises(ProgrammingError) as excinfo:
+            call_command("absurd_cleanup")
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, psycopg.errors.UndefinedTable)
+        assert (
+            cause.diag.message_primary == 'relation "absurd.t_default" does not exist'
+        )
+    finally:
+        with connection.cursor() as cur:
+            cur.execute("alter table absurd.t_default_probe rename to t_default")
 
 
 def test_cleanup_command_reports_no_backends(

--- a/tests/core/test_command_errors.py
+++ b/tests/core/test_command_errors.py
@@ -3,6 +3,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from pytest_django.fixtures import Settings
 
+from django_absurd.exceptions import BackendNotConfiguredError, SchemaNotInstalledError
 from tests import utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -20,8 +21,9 @@ def test_a_command_names_the_missing_schema_without_a_traceback(
 ) -> None:
     settings.TASKS = utils.make_tasks_settings(queues={"default": {}})
     with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
-        call_command(command, *(["--noinput"] if command == "absurd_flush" else []))
+        call_command(command)
     assert str(excinfo.value) == SCHEMA_ABSENT
+    assert isinstance(excinfo.value.__cause__, SchemaNotInstalledError)
 
 
 def test_beat_reports_a_missing_backend_without_a_traceback(
@@ -36,3 +38,4 @@ def test_beat_reports_a_missing_backend_without_a_traceback(
         "No Absurd backend configured. Add a "
         "django_absurd.backends.AbsurdBackend entry to TASKS."
     )
+    assert isinstance(excinfo.value.__cause__, BackendNotConfiguredError)

--- a/tests/core/test_command_errors.py
+++ b/tests/core/test_command_errors.py
@@ -10,14 +10,17 @@ pytestmark = pytest.mark.django_db(transaction=True)
 SCHEMA_ABSENT = "Absurd schema is not installed. Run: manage.py migrate"
 
 
-@pytest.mark.parametrize("command", ["absurd_sync_queues", "absurd_worker"])
+@pytest.mark.parametrize(
+    "command",
+    ["absurd_cleanup", "absurd_flush", "absurd_sync_queues", "absurd_worker"],
+)
 def test_a_command_names_the_missing_schema_without_a_traceback(
     command: str,
     settings: Settings,
 ) -> None:
     settings.TASKS = utils.make_tasks_settings(queues={"default": {}})
     with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
-        call_command(command)
+        call_command(command, *(["--noinput"] if command == "absurd_flush" else []))
     assert str(excinfo.value) == SCHEMA_ABSENT
 
 

--- a/tests/core/test_command_errors.py
+++ b/tests/core/test_command_errors.py
@@ -3,7 +3,11 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from pytest_django.fixtures import Settings
 
-from django_absurd.exceptions import BackendNotConfiguredError, SchemaNotInstalledError
+from django_absurd.exceptions import (
+    BackendNotConfiguredError,
+    QueueReadOnlyError,
+    SchemaNotInstalledError,
+)
 from tests import utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -39,3 +43,8 @@ def test_beat_reports_a_missing_backend_without_a_traceback(
         "django_absurd.backends.AbsurdBackend entry to TASKS."
     )
     assert isinstance(excinfo.value.__cause__, BackendNotConfiguredError)
+
+
+def test_a_non_configuration_error_escapes_untranslated() -> None:
+    with pytest.raises(QueueReadOnlyError):
+        call_command("raises_uncaught_error")

--- a/tests/core/test_command_errors.py
+++ b/tests/core/test_command_errors.py
@@ -1,0 +1,35 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from pytest_django.fixtures import Settings
+
+from tests import utils
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+SCHEMA_ABSENT = "Absurd schema is not installed. Run: manage.py migrate"
+
+
+@pytest.mark.parametrize("command", ["absurd_sync_queues", "absurd_worker"])
+def test_a_command_names_the_missing_schema_without_a_traceback(
+    command: str,
+    settings: Settings,
+) -> None:
+    settings.TASKS = utils.make_tasks_settings(queues={"default": {}})
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
+        call_command(command)
+    assert str(excinfo.value) == SCHEMA_ABSENT
+
+
+def test_beat_reports_a_missing_backend_without_a_traceback(
+    settings: Settings,
+) -> None:
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}
+    }
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_beat")
+    assert str(excinfo.value) == (
+        "No Absurd backend configured. Add a "
+        "django_absurd.backends.AbsurdBackend entry to TASKS."
+    )

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -3,7 +3,6 @@ import typing as t
 
 import pytest
 from django.contrib.auth.models import Group
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db import connections, transaction
 from django.tasks import TaskResultStatus, task
@@ -12,7 +11,7 @@ from pytest_django.fixtures import Settings
 
 from django_absurd import absurd_params
 from django_absurd.connection import register_jsonb_loader
-from django_absurd.exceptions import QueueNotDeclaredError
+from django_absurd.exceptions import QueueNotDeclaredError, SchemaNotInstalledError
 from django_absurd.queues import get_absurd_client
 from django_absurd.tasks import AbsurdTask
 from django_absurd.test import AbsurdTestRuntime
@@ -157,7 +156,10 @@ def test_enqueue_auto_create_survives_outer_atomic(
 def test_enqueue_with_absent_schema_raises_clear_error() -> None:
     with (
         utils.hide_absurd_schema(),
-        pytest.raises(ImproperlyConfigured, match="migrate"),
+        pytest.raises(
+            SchemaNotInstalledError,
+            match=r"^Absurd schema is not installed\. Run: manage\.py migrate$",
+        ),
     ):
         tasks.add.enqueue(1, 2)
 

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -100,6 +100,15 @@ def test_flush_absurd_state_is_a_noop_on_an_unmigrated_schema(
         connections["default"].close()
 
 
+def test_flush_absurd_state_is_a_noop_on_a_hidden_schema() -> None:
+    # A schema that is present-but-unreachable (renamed, as an operator's own DDL or a
+    # mid-migration state would leave it) is a different shape than the unmigrated-DB
+    # case above: it raises SchemaNotInstalledError, not OperationalError/
+    # ProgrammingError, so clear_queues must tolerate it on its own terms.
+    with utils.hide_absurd_schema():
+        flush_absurd_state()  # must not raise
+
+
 def test_flush_absurd_state_resets_a_stranded_fake_now() -> None:
     utils.set_database_fake_now("2036-01-01T00:00:00+00:00")
     try:

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -109,6 +109,23 @@ def test_flush_absurd_state_is_a_noop_on_a_hidden_schema() -> None:
         flush_absurd_state()  # must not raise
 
 
+@pytest.mark.usefixtures("_isolate_queues")
+def test_flush_absurd_state_tolerates_a_missing_queue_table() -> None:
+    # A catalog row can outlive one of its own queue's tables — exactly what
+    # test_results.py::test_get_result_inside_atomic_does_not_poison_txn leaves behind
+    # by dropping t_other without restoring it. get_absurd_client() and the per-queue
+    # drop/truncate loop must tolerate a missing table the same way the listing probe
+    # already does; _isolate_queues drops what remains of "other" afterwards so later
+    # tests provision it fresh.
+    call_command("absurd_sync_queues")
+    with connections["default"].cursor() as cur:
+        cur.execute("DROP TABLE absurd.t_other CASCADE")
+
+    flush_absurd_state()  # must not raise
+
+    assert Queue.objects.filter(queue_name="other").exists()  # catalog row untouched
+
+
 def test_flush_absurd_state_resets_a_stranded_fake_now() -> None:
     utils.set_database_fake_now("2036-01-01T00:00:00+00:00")
     try:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -10,8 +10,10 @@ from django.core.management import call_command
 from django.db import connection
 from pytest_django.fixtures import Settings
 
+from django_absurd.exceptions import SchemaNotInstalledError
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client, resolve_absurd_database
+from tests import utils
 from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -44,6 +46,18 @@ def test_sync_command_screams_on_non_postgres_backend(
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
     with pytest.raises(ImproperlyConfigured):
+        call_command("absurd_sync_queues")
+
+
+def test_sync_command_names_the_missing_schema(settings: Settings) -> None:
+    settings.TASKS = build_tasks_setting({"x": {}})
+    with (
+        utils.hide_absurd_schema(),
+        pytest.raises(
+            SchemaNotInstalledError,
+            match=r"^Absurd schema is not installed\. Run: manage\.py migrate$",
+        ),
+    ):
         call_command("absurd_sync_queues")
 
 

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db import connection
+from django.db.utils import ProgrammingError
 from pytest_django.fixtures import Settings
 
 from django_absurd.models import Queue
@@ -66,6 +67,47 @@ def test_migrate_provisions_declared_queue(settings: Settings) -> None:
     settings.TASKS = build_tasks_setting({"alpha": {}})
     call_command("migrate", "django_absurd", verbosity=0)
     assert Queue.objects.filter(queue_name="alpha").exists()
+
+
+def test_reconcile_does_not_relabel_an_unrelated_missing_column(
+    settings: Settings,
+) -> None:
+    """A ``ProgrammingError`` from ``reconcile_queue``'s own catalog query that
+    isn't the schema-absent shape (``InvalidSchemaName``/``UndefinedTable``)
+    surfaces as itself. Relabeling it "run migrate" would send the reader to the
+    wrong door.
+
+    Driven the way it could happen in production: an operator alters the catalog
+    table's own column out from under ``reconcile_queue``, e.g. mid-migration — a
+    case ``reconcile_queue`` never classifies as schema-absent, since the
+    exception is a plain ``UndefinedColumn``, not
+    ``InvalidSchemaName``/``UndefinedTable``.
+    """
+    settings.TASKS = build_tasks_setting({"probe": {}})
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute(
+            "alter table absurd.queues rename column queue_name to queue_name_probe"
+        )
+    try:
+        with pytest.raises(ProgrammingError) as excinfo:
+            call_command("absurd_sync_queues")
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, psycopg.errors.UndefinedColumn)
+    finally:
+        with connection.cursor() as cur:
+            cur.execute(
+                "alter table absurd.queues rename column queue_name_probe to queue_name"
+            )
+
+
+def test_migrate_tolerates_an_absent_schema(settings: Settings) -> None:
+    # The migration is already recorded as applied, so `migrate` replays no DDL
+    # but still fires `post_migrate` — which must swallow SchemaNotInstalledError
+    # from provisioning rather than blowing up `migrate` itself.
+    settings.TASKS = build_tasks_setting({"alpha": {}})
+    with utils.hide_absurd_schema():
+        call_command("migrate", "django_absurd", verbosity=0)
 
 
 def test_sync_creates_with_options_and_model_maps(settings: Settings) -> None:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -7,10 +7,10 @@ import pytest
 from absurd_sdk import CreateQueueOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db import connection
 from pytest_django.fixtures import Settings
 
-from django_absurd.exceptions import SchemaNotInstalledError
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client, resolve_absurd_database
 from tests import utils
@@ -44,20 +44,21 @@ def test_sync_command_screams_on_non_postgres_backend(
     settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(CommandError) as excinfo:
         call_command("absurd_sync_queues")
+    assert str(excinfo.value) == (
+        "django-absurd requires the psycopg (v3) PostgreSQL backend. "
+        "See https://www.psycopg.org/psycopg3/docs/"
+    )
 
 
 def test_sync_command_names_the_missing_schema(settings: Settings) -> None:
     settings.TASKS = build_tasks_setting({"x": {}})
-    with (
-        utils.hide_absurd_schema(),
-        pytest.raises(
-            SchemaNotInstalledError,
-            match=r"^Absurd schema is not installed\. Run: manage\.py migrate$",
-        ),
-    ):
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
         call_command("absurd_sync_queues")
+    assert (
+        str(excinfo.value) == "Absurd schema is not installed. Run: manage.py migrate"
+    )
 
 
 @pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -14,7 +14,6 @@ from django_absurd.exceptions import SchemaNotInstalledError
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client, resolve_absurd_database
 from tests import utils
-from tests.utils import make_tasks_settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -25,7 +24,7 @@ def build_tasks_setting(
     queues: dict[str, CreateQueueOptions],
     database: str = "default",
 ) -> dict[str, dict[str, t.Any]]:
-    return make_tasks_settings(queues=queues, database=database)
+    return utils.make_tasks_settings(queues=queues, database=database)
 
 
 def table_exists(name: str) -> bool:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -52,15 +52,6 @@ def test_sync_command_screams_on_non_postgres_backend(
     )
 
 
-def test_sync_command_names_the_missing_schema(settings: Settings) -> None:
-    settings.TASKS = build_tasks_setting({"x": {}})
-    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
-        call_command("absurd_sync_queues")
-    assert (
-        str(excinfo.value) == "Absurd schema is not installed. Run: manage.py migrate"
-    )
-
-
 @pytest.mark.django_db(databases=["default", "sqlite"], transaction=True)
 def test_migrate_screams_on_non_postgres_backend(
     settings: Settings,

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -647,20 +647,6 @@ def test_absurd_beat_rejects_alias_flag(
         call_command("absurd_beat", "--alias", "default")
 
 
-def test_absurd_beat_no_backend_errors(
-    settings: pytest_django.fixtures.Settings,
-) -> None:
-    settings.TASKS = {
-        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
-    }
-    with pytest.raises(CommandError) as exc:
-        call_command("absurd_beat")
-    assert str(exc.value) == (
-        "No Absurd backend configured. Add a django_absurd.backends.AbsurdBackend "
-        "entry to TASKS."
-    )
-
-
 def test_beat_stop_interrupts_long_sleep(
     settings: pytest_django.fixtures.Settings,
 ) -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -432,11 +432,11 @@ def test_worker_command_schema_absent_errors_migrate() -> None:
     # that helper exists to send must never go out — pytest installs no SIGTERM
     # handler of its own, so a stray kill would hit Python's default (SIG_DFL) and
     # take the session down with it.
-    with (
-        utils.hide_absurd_schema(),
-        pytest.raises(CommandError, match="migrate"),
-    ):
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
         utils.start_worker(queue="default")
+    assert (
+        str(excinfo.value) == "Absurd schema is not installed. Run: manage.py migrate"
+    )
 
 
 def test_start_worker_drains_concurrently() -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -10,7 +10,6 @@ import time
 import psycopg.errors
 import pytest
 from django.contrib.auth.models import Group
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command, load_command_class
 from django.core.management.base import CommandError
 from django.db import connection
@@ -22,6 +21,7 @@ from django_absurd.exceptions import (
     DjangoAbsurdError,
     QueueNotDeclaredError,
     QueueNotProvisionedError,
+    SchemaNotInstalledError,
 )
 from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
@@ -89,7 +89,10 @@ def test_worker_client_absent_schema_errors() -> None:
 
     with (
         utils.hide_absurd_schema(),
-        pytest.raises(ImproperlyConfigured, match="migrate"),
+        pytest.raises(
+            SchemaNotInstalledError,
+            match=r"^Absurd schema is not installed\. Run: manage\.py migrate$",
+        ),
     ):
         asyncio.run(_enter())
 

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -426,7 +426,7 @@ def test_worker_command_warns_on_storage_mode_drift(
 
 
 def test_worker_command_schema_absent_errors_migrate() -> None:
-    # The provision_backend/ImproperlyConfigured translation errors before ever
+    # The provision_backend error translation errors before ever
     # reaching the blocking worker loop. Driven through the live-worker helper: a
     # command that fails this early installs no signal handler, so the stop signal
     # that helper exists to send must never go out — pytest installs no SIGTERM

--- a/tests/management/commands/raises_uncaught_error.py
+++ b/tests/management/commands/raises_uncaught_error.py
@@ -1,0 +1,13 @@
+import typing as t
+
+from django_absurd.exceptions import QUEUE_READONLY_MSG, QueueReadOnlyError
+from django_absurd.management.base import AbsurdCommand
+
+
+class Command(AbsurdCommand):
+    """Test-only command: raises an out-of-tuple ``DjangoAbsurdError`` from
+    ``handle`` to prove ``AbsurdCommand.execute`` leaves it untranslated.
+    """
+
+    def handle(self, *args: t.Any, **options: t.Any) -> None:
+        raise QueueReadOnlyError(QUEUE_READONLY_MSG)


### PR DESCRIPTION
Closes #128.

All six `absurd_*` commands inherit `AbsurdCommand`, whose `execute` turns a narrow `CONFIGURATION_ERRORS` tuple into a `CommandError`; anything else keeps its type and traceback. New `SchemaNotInstalledError` replaces three hand-rolled messages and two raw-psycopg leaks.

Breaking: the enqueue path raises `SchemaNotInstalledError` instead of `ImproperlyConfigured`, and `call_command` callers now get `CommandError`.

Also fixes two pre-existing bugs: a raw `InvalidSchemaName` could escape `flush_absurd_state()`, and `reconcile_queue` relabelled every `ProgrammingError` as "run migrate".