### PR TITLE
ci: run every suite under pytest-xdist, worker count from the environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
       PGDATABASE: postgres
       PGPORT: "5432"
       PGPORT_PGCRON: "5434"
+      # Worker count for tox's `-n auto`; a runner has more cores than the suites
+      # profitably use, and 2 is enough to keep the parallel path exercised.
+      PYTEST_XDIST_AUTO_NUM_WORKERS: "2"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install uv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,20 @@ duplicate that material here.
 - **Absolute imports only** — no relative imports. Enforced by ruff
   (`ban-relative-imports = "all"`).
 
+## Comments
+
+- **A comment answers "why this, not the obvious alternative" — in ≤2 lines.** Longer
+  reasoning goes in the commit message (why we changed it), `docs/WHY.md` (why the
+  design is this shape), or a spec.
+- **Delete-test:** if removing it costs a reader nothing the code already tells them,
+  delete it. Never restate what the code does, narrate rejected alternatives, or
+  describe what the code used to be.
+- **Exception: write it out when the reason lives outside the code.**
+  `names_a_queue_table` in `queues.py` explains that Postgres populates no
+  `diag.table_name` for that error, which is why the match reads `message_primary`.
+  Nothing in the code says that, so deleting the comment invites the next edit to undo
+  it.
+
 ## Django system-check messages
 
 - `msg` states the PROBLEM only; `hint` states the RESOLUTION. Never duplicate fix text
@@ -97,10 +111,14 @@ writing or editing any test file. Running the suites:
     prettier. Never invoke `ruff` or `mypy` directly; pre-commit already runs them, and
     a hand-rolled invocation drifts from the hook's flags and exclusions.
   - Iterating on one file is still `uv run pytest <path> -v`.
-- `pytest-xdist` is a dev dependency; every suite — including `tests/pg_cron`, now that
-  its test DB is ordinary and cross-DB — runs safely under `-n<N>` (e.g.
-  `uv run pytest tests/pg_cron -n4`). Pass `-n` directly; it isn't baked into any
-  suite's `addopts`.
+- **Every tox test env runs the suites under `pytest-xdist`** (`-n auto` on each
+  `pytest` command line, mypy envs excluded), so parallel safety is exercised on every
+  push instead of only when someone remembers to pass `-n`. Worker count is xdist's own
+  `PYTEST_XDIST_AUTO_NUM_WORKERS`, which applies to `auto` only: CI pins it to 2 in
+  `test.yml`, a workstation sets it in a git-ignored `.envrc`, and unset takes every
+  core. `tox -e dev -- -n0` gives a serial baseline for telling a real failure from an
+  xdist-only one. A bare `uv run pytest <path>` is unaffected — `-n` is in no suite's
+  `addopts`, so pass it there yourself.
 - Each suite runs with `--reuse-db` (addopts); add `--create-db` to rebuild after a
   migration change — including `tests/pg_cron`: its test DB is an ordinary one that
   pg_cron's launcher holds no session on (the launcher only ever connects to the central

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -159,6 +159,11 @@ Measured on this repo; the point is to spend the slow gate once, not per edit.
 - **Reach for `--create-db` when failures stop making sense.** A killed frozen test can
   leave a database-level `absurd.fake_now` behind, which makes later durable tests
   unclaimable for reasons invisible in their own code. Rebuild before diagnosing.
+- **Changing the worker count needs `--create-db` once.** `--reuse-db` keys test
+  databases per worker (`…_gw0`), so going from 2 workers to 6 reuses two and builds
+  four, and the mixed state surfaces as
+  `DuplicateFunction: function "current_time" already exists` — a migration error that
+  reads like a code bug and is not one.
 - **A test asserting `Created: <queue>` needs `_isolate_queues`** or a queue name unique
   to its file. The catalog row outlives the per-test flush, so the second `--reuse-db`
   run of that file reports nothing created. Passes alone, fails on repeat.

--- a/tox.ini
+++ b/tox.ini
@@ -18,16 +18,20 @@ deps =
 uv_resolution =
     py312: lowest-direct
     py3{13,14}: highest
-pass_env = PG*
+pass_env =
+    PG*
+    PYTEST_XDIST_AUTO_NUM_WORKERS
+# `-n auto` because xdist reads PYTEST_XDIST_AUTO_NUM_WORKERS for `auto` alone: CI pins 2,
+# a workstation sets its own. Here rather than a suite's addopts so bare pytest stays serial.
 commands =
-    !mypy: pytest tests/core -m "not packaging" {posargs}
-    !mypy: pytest tests/pg_cron {posargs}
-    !mypy: pytest tests/multidb {posargs}
+    !mypy: pytest tests/core -m "not packaging" -n auto {posargs}
+    !mypy: pytest tests/pg_cron -n auto {posargs}
+    !mypy: pytest tests/multidb -n auto {posargs}
     mypy: mypy .
 
 [testenv:dev]
 runner = uv-venv-lock-runner
 commands =
-    pytest tests/core {posargs}
-    pytest tests/pg_cron {posargs}
-    pytest tests/multidb {posargs}
+    pytest tests/core -n auto {posargs}
+    pytest tests/pg_cron -n auto {posargs}
+    pytest tests/multidb -n auto {posargs}


### PR DESCRIPTION
Closes #117.

All tox test envs run the suites with `-n auto`; worker count comes from xdist's own `PYTEST_XDIST_AUTO_NUM_WORKERS` — CI pins 2, a workstation sets its own in `.envrc`. No new matrix cell, nothing re-run.

Slowest cell 250s → 167s; tox step alone 178s → 115s.