### PR TITLE
fix: quote string values in the logfmt-style log lines

### DIFF
--- a/django_absurd/context.py
+++ b/django_absurd/context.py
@@ -261,37 +261,37 @@ class AsyncAbsurdTaskContext:
 
 
 def describe_step_replayed(checkpoint_name: str, task_id: str) -> str:
-    return f"step replayed: name={checkpoint_name} task_id={task_id}"
+    return f'step replayed: name="{checkpoint_name}" task_id="{task_id}"'
 
 
 def describe_step_completed(checkpoint_name: str, task_id: str, duration: float) -> str:
     return (
-        f"step completed: name={checkpoint_name} task_id={task_id}"
+        f'step completed: name="{checkpoint_name}" task_id="{task_id}"'
         f" duration={duration:.3f}s"
     )
 
 
 def describe_sleep_for_suspended(step_name: str, task_id: str, duration: float) -> str:
-    return f"sleep suspended: step={step_name} task_id={task_id} for={duration}s"
+    return f'sleep suspended: step="{step_name}" task_id="{task_id}" for={duration}s'
 
 
 def describe_sleep_until_suspended(
     step_name: str, task_id: str, wake_at: "dt.datetime | int | float"
 ) -> str:
-    return f"sleep suspended: step={step_name} task_id={task_id} until={wake_at}"
+    return f'sleep suspended: step="{step_name}" task_id="{task_id}" until="{wake_at}"'
 
 
 def describe_sleep_resumed(step_name: str, task_id: str) -> str:
-    return f"sleep resumed: step={step_name} task_id={task_id}"
+    return f'sleep resumed: step="{step_name}" task_id="{task_id}"'
 
 
 def describe_event_awaiting(event_name: str, task_id: str, timeout: int | None) -> str:
-    return f"event awaiting: name={event_name} task_id={task_id} timeout={timeout}"
+    return f'event awaiting: name="{event_name}" task_id="{task_id}" timeout={timeout}'
 
 
 def describe_event_received(event_name: str, task_id: str) -> str:
-    return f"event received: name={event_name} task_id={task_id}"
+    return f'event received: name="{event_name}" task_id="{task_id}"'
 
 
 def describe_event_emitted(event_name: str, task_id: str) -> str:
-    return f"event emitted: name={event_name} task_id={task_id}"
+    return f'event emitted: name="{event_name}" task_id="{task_id}"'

--- a/django_absurd/dispatch.py
+++ b/django_absurd/dispatch.py
@@ -38,7 +38,7 @@ def send_task_signal(
         # A missing name degrades to the generic word: a KeyError raised here would
         # escape the containment and reach the task.
         logger.exception(
-            "%s receiver failed for task result id=%s",
+            '%s receiver failed for task result id="%s"',
             SIGNAL_NAMES.get(signal, "signal"),
             task_result.id,
         )

--- a/django_absurd/hooks.py
+++ b/django_absurd/hooks.py
@@ -44,14 +44,14 @@ def log_before_spawn(
     try:
         # max_attempts/idempotency_key are absent from options entirely when the caller
         # didn't set them, so they're reported only when present.
-        detail = f"name={task_name} queue={options.get('queue')}"
+        detail = f'name="{task_name}" queue="{options.get("queue")}"'
         if "max_attempts" in options:
             detail += f" max_attempts={options['max_attempts']}"
         if "idempotency_key" in options:
-            detail += f" idempotency_key={options['idempotency_key']}"
+            detail += f' idempotency_key="{options["idempotency_key"]}"'
         logger.debug("spawn requested: %s", detail)
     except Exception:
-        logger.exception("failed to log spawn: name=%s", task_name)
+        logger.exception('failed to log spawn: name="%s"', task_name)
     return options
 
 
@@ -116,7 +116,7 @@ def report_run_event(
         # apart.
         claimed = read_sdk_claimed_task(ctx)
         detail = (
-            f"name={claimed['task_name']} task_id={ctx.task_id}"
+            f'name="{claimed["task_name"]}" task_id="{ctx.task_id}"'
             f" attempt={claimed['attempt']} max_attempts={claimed['max_attempts']}"
         )
         if started is not None:
@@ -126,7 +126,7 @@ def report_run_event(
         # Last resort: reporting the fault is itself what failed, and raising from here
         # would reach the SDK and consume the attempt.
         with contextlib.suppress(Exception):
-            logger.exception("failed to log a run lifecycle event: event=%s", event)
+            logger.exception('failed to log a run lifecycle event: event="%s"', event)
 
 
 def read_sdk_claimed_task(ctx: "TaskContext | AsyncTaskContext") -> "ClaimedTask":

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -166,7 +166,7 @@ def log_sync_result(result: SyncResult) -> None:
         logger.info("queues provisioned: no changes")
         return
     logger.info(
-        "queues provisioned: created=%s reconciled=%s",
+        'queues provisioned: created="%s" reconciled="%s"',
         ", ".join(result.created),
         ", ".join(result.reconciled),
     )

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -101,7 +101,7 @@ def run_beat(
         return
 
     logger.info(
-        "beat started: schedules=%d cleanup=%s",
+        'beat started: schedules=%d cleanup="%s"',
         len(schedules),
         cleanup_cron or "off",
     )
@@ -166,7 +166,7 @@ def fire_cleanup(backend: AbsurdBackend, slot: dt.datetime) -> None:
         logger.exception("cleanup failed")
     else:
         logger.info(
-            "cleanup ran: slot=%s",
+            'cleanup ran: slot="%s"',
             slot.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         )
     finally:
@@ -177,10 +177,10 @@ def fire_schedule(schedule: Schedule, slot: dt.datetime) -> None:
     try:
         spawn_scheduled(schedule, slot)
     except Exception:
-        logger.exception("schedule failed: name=%s", schedule.name)
+        logger.exception('schedule failed: name="%s"', schedule.name)
     else:
         logger.info(
-            "schedule enqueued: name=%s slot=%s",
+            'schedule enqueued: name="%s" slot="%s"',
             schedule.name,
             slot.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         )

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -207,7 +207,7 @@ async def arun_worker(
                 client, options, on_stop_requested=on_stop_requested
             )
         logger.info(
-            "worker stopped: alias=%s queue=%s database=%s",
+            'worker stopped: alias="%s" queue="%s" database="%s"',
             backend.alias,
             queue,
             backend.database,
@@ -226,7 +226,7 @@ async def arun_drain(
     async with open_worker_runtime(backend, queue, options) as client:
         drained = await adrain_queue(backend.database, client, queue, options)
         logger.info(
-            "worker stopped: alias=%s queue=%s database=%s runs=%d",
+            'worker stopped: alias="%s" queue="%s" database="%s" runs=%d',
             backend.alias,
             queue,
             backend.database,
@@ -251,7 +251,7 @@ async def open_worker_runtime(
         loop.set_default_executor(executor)
         async with aworker_client(backend, queue) as client:
             logger.info(
-                "worker started: alias=%s queue=%s database=%s concurrency=%d",
+                'worker started: alias="%s" queue="%s" database="%s" concurrency=%d',
                 backend.alias,
                 queue,
                 backend.database,

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -335,7 +335,7 @@ def test_beat_fires_cleanup_on_cadence(
         for r in caplog.records
         if r.name == "django_absurd.scheduler" and r.getMessage().startswith("cleanup")
     ]
-    assert ran == ["cleanup ran: slot=2026-01-01T00:01:00Z"]
+    assert ran == ['cleanup ran: slot="2026-01-01T00:01:00Z"']
 
 
 def test_beat_isolates_failing_cleanup(

--- a/tests/core/test_durable.py
+++ b/tests/core/test_durable.py
@@ -157,8 +157,8 @@ def test_suspend_logged_as_lifecycle_not_failure(
     suspended = [m for m in messages if m.startswith("task suspended: ")]
     assert len(suspended) == 1
     assert re.fullmatch(
-        rf"task suspended: name={re.escape(atasks.asleep_for_once.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=5 duration=\d+\.\d{{3}}s",
+        rf"task suspended: name=\"{re.escape(atasks.asleep_for_once.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration=\d+\.\d{{3}}s",
         suspended[0],
     )
     assert not [m for m in messages if m.startswith("task failed")]

--- a/tests/core/test_logging/test_durable.py
+++ b/tests/core/test_logging/test_durable.py
@@ -31,7 +31,7 @@ def test_an_async_step_logs_completed_with_a_duration(
     messages = read_context_messages(caplog)
     assert len(messages) == 1
     assert re.fullmatch(
-        rf"step completed: name=echo task_id={task_id} duration={DURATION}",
+        rf"step completed: name=\"echo\" task_id=\"{task_id}\" duration={DURATION}",
         messages[0],
     )
 
@@ -55,10 +55,10 @@ def test_an_async_replayed_step_logs_replayed_not_completed(
     completed = [m for m in messages if m.startswith("step completed: ")]
     assert len(completed) == 1
     assert re.fullmatch(
-        rf"step completed: name=charge task_id={task_id} duration={DURATION}",
+        rf"step completed: name=\"charge\" task_id=\"{task_id}\" duration={DURATION}",
         completed[0],
     )
-    assert messages.count(f"step replayed: name=charge task_id={task_id}") == 1
+    assert messages.count(f'step replayed: name="charge" task_id="{task_id}"') == 1
     assert len(messages) == 2
 
 
@@ -76,7 +76,7 @@ def test_a_sync_step_logs_completed_with_a_duration(
     messages = read_context_messages(caplog)
     assert len(messages) == 1
     assert re.fullmatch(
-        rf"step completed: name=echo task_id={task_id} duration={DURATION}",
+        rf"step completed: name=\"echo\" task_id=\"{task_id}\" duration={DURATION}",
         messages[0],
     )
 
@@ -96,7 +96,7 @@ def test_a_sync_replayed_step_logs_replayed_not_completed(
 
     task_id = result.id.rsplit(":", 1)[-1]
     messages = read_context_messages(caplog)
-    assert messages.count(f"step replayed: name=charge task_id={task_id}") == 1
+    assert messages.count(f'step replayed: name="charge" task_id="{task_id}"') == 1
     assert len([m for m in messages if m.startswith("step completed: ")]) == 1
     assert len(messages) == 2
 
@@ -117,11 +117,11 @@ def test_an_async_sleep_logs_suspended_then_resumed(
     messages = read_context_messages(caplog)
     assert (
         messages.count(
-            f"sleep suspended: step=nap task_id={task_id} for={tasks.WEEK_SECONDS}s"
+            f'sleep suspended: step="nap" task_id="{task_id}" for={tasks.WEEK_SECONDS}s'
         )
         == 1
     )
-    assert messages.count(f"sleep resumed: step=nap task_id={task_id}") == 1
+    assert messages.count(f'sleep resumed: step="nap" task_id="{task_id}"') == 1
 
 
 def test_a_sync_sleep_logs_suspended_then_resumed(
@@ -140,11 +140,11 @@ def test_a_sync_sleep_logs_suspended_then_resumed(
     messages = read_context_messages(caplog)
     assert (
         messages.count(
-            f"sleep suspended: step=nap task_id={task_id} for={tasks.WEEK_SECONDS}s"
+            f'sleep suspended: step="nap" task_id="{task_id}" for={tasks.WEEK_SECONDS}s'
         )
         == 1
     )
-    assert messages.count(f"sleep resumed: step=nap task_id={task_id}") == 1
+    assert messages.count(f'sleep resumed: step="nap" task_id="{task_id}"') == 1
 
 
 def test_an_async_sleep_until_reports_its_wake_time(
@@ -164,9 +164,9 @@ def test_an_async_sleep_until_reports_its_wake_time(
     suspended = [m for m in messages if m.startswith("sleep suspended: ")]
     assert len(suspended) == 1
     assert re.fullmatch(
-        rf"sleep suspended: step=nap task_id={task_id} until=\S+", suspended[0]
+        rf"sleep suspended: step=\"nap\" task_id=\"{task_id}\" until=\S+", suspended[0]
     )
-    assert messages.count(f"sleep resumed: step=nap task_id={task_id}") == 1
+    assert messages.count(f'sleep resumed: step="nap" task_id="{task_id}"') == 1
 
 
 def test_a_sleep_until_reports_its_wake_time(
@@ -186,9 +186,9 @@ def test_a_sleep_until_reports_its_wake_time(
     suspended = [m for m in messages if m.startswith("sleep suspended: ")]
     assert len(suspended) == 1
     assert re.fullmatch(
-        rf"sleep suspended: step=nap task_id={task_id} until=\S+", suspended[0]
+        rf"sleep suspended: step=\"nap\" task_id=\"{task_id}\" until=\S+", suspended[0]
     )
-    assert messages.count(f"sleep resumed: step=nap task_id={task_id}") == 1
+    assert messages.count(f'sleep resumed: step="nap" task_id="{task_id}"') == 1
 
 
 def test_an_async_event_wait_logs_awaiting_then_received(
@@ -208,13 +208,15 @@ def test_an_async_event_wait_logs_awaiting_then_received(
     emitter_task_id = emitter_result.id.rsplit(":", 1)[-1]
     messages = read_context_messages(caplog)
     assert (
-        messages.count(f"event awaiting: name=probe.go task_id={task_id} timeout=3600")
+        messages.count(
+            f'event awaiting: name="probe.go" task_id="{task_id}" timeout=3600'
+        )
         == 1
     )
-    assert messages.count(f"event received: name=probe.go task_id={task_id}") == 1
+    assert messages.count(f'event received: name="probe.go" task_id="{task_id}"') == 1
     emitted = [m for m in messages if m.startswith("event emitted: ")]
     assert len(emitted) == 1
-    assert emitted[0] == f"event emitted: name=probe.go task_id={emitter_task_id}"
+    assert emitted[0] == f'event emitted: name="probe.go" task_id="{emitter_task_id}"'
 
 
 def test_a_sync_event_wait_logs_awaiting_then_received(
@@ -234,13 +236,15 @@ def test_a_sync_event_wait_logs_awaiting_then_received(
     emitter_task_id = emitter_result.id.rsplit(":", 1)[-1]
     messages = read_context_messages(caplog)
     assert (
-        messages.count(f"event awaiting: name=probe.go task_id={task_id} timeout=3600")
+        messages.count(
+            f'event awaiting: name="probe.go" task_id="{task_id}" timeout=3600'
+        )
         == 1
     )
-    assert messages.count(f"event received: name=probe.go task_id={task_id}") == 1
+    assert messages.count(f'event received: name="probe.go" task_id="{task_id}"') == 1
     emitted = [m for m in messages if m.startswith("event emitted: ")]
     assert len(emitted) == 1
-    assert emitted[0] == f"event emitted: name=probe.go task_id={emitter_task_id}"
+    assert emitted[0] == f'event emitted: name="probe.go" task_id="{emitter_task_id}"'
 
 
 def test_no_durable_primitive_log_record_contains_a_non_ascii_character(

--- a/tests/core/test_logging/test_lifecycle.py
+++ b/tests/core/test_logging/test_lifecycle.py
@@ -72,7 +72,7 @@ def test_a_successful_run_logs_started_then_completed(
         for m in messages
         if m
         == (
-            f"task started: name={tasks.add.module_path} task_id={task_id}"
+            f'task started: name="{tasks.add.module_path}" task_id="{task_id}"'
             " attempt=1 max_attempts=5"
         )
     ]
@@ -80,8 +80,8 @@ def test_a_successful_run_logs_started_then_completed(
     completed = [m for m in messages if m.startswith("task completed: ")]
     assert len(completed) == 1
     assert re.fullmatch(
-        rf"task completed: name={re.escape(tasks.add.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=5 duration={DURATION}",
+        rf"task completed: name=\"{re.escape(tasks.add.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration={DURATION}",
         completed[0],
     )
     assert len(messages) == 2
@@ -102,22 +102,22 @@ def test_a_suspended_run_logs_suspended_and_starts_again_on_wake(
     task_id = result.id.rsplit(":", 1)[-1]
     messages = read_hook_messages(caplog)
     started_line = (
-        f"task started: name={tasks.sleep_a_week.module_path} task_id={task_id}"
+        f'task started: name="{tasks.sleep_a_week.module_path}" task_id="{task_id}"'
         " attempt=1 max_attempts=5"
     )
     assert messages.count(started_line) == 2
     suspended = [m for m in messages if m.startswith("task suspended: ")]
     assert len(suspended) == 1
     assert re.fullmatch(
-        rf"task suspended: name={re.escape(tasks.sleep_a_week.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=5 duration={DURATION}",
+        rf"task suspended: name=\"{re.escape(tasks.sleep_a_week.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration={DURATION}",
         suspended[0],
     )
     completed = [m for m in messages if m.startswith("task completed: ")]
     assert len(completed) == 1
     assert re.fullmatch(
-        rf"task completed: name={re.escape(tasks.sleep_a_week.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=5 duration={DURATION}",
+        rf"task completed: name=\"{re.escape(tasks.sleep_a_week.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration={DURATION}",
         completed[0],
     )
     assert len(messages) == 4
@@ -143,14 +143,14 @@ def test_a_retryable_failure_logs_error_with_the_attempt_count(
     assert len(failures) == 2
     assert failures[0].exc_info is not None
     assert re.fullmatch(
-        rf"task failed: name={re.escape(tasks.boom.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=2 duration={DURATION}",
+        rf"task failed: name=\"{re.escape(tasks.boom.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=2 duration={DURATION}",
         failures[0].getMessage(),
     )
     assert failures[1].exc_info is not None
     assert re.fullmatch(
-        rf"task failed: name={re.escape(tasks.boom.module_path)}"
-        rf" task_id={task_id} attempt=2 max_attempts=2 duration={DURATION}",
+        rf"task failed: name=\"{re.escape(tasks.boom.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=2 max_attempts=2 duration={DURATION}",
         failures[1].getMessage(),
     )
 
@@ -173,8 +173,8 @@ def test_a_cancelled_run_logs_a_warning_not_a_failure(
     ]
     assert len(warnings) == 1
     assert re.fullmatch(
-        rf"task cancelled: name={re.escape(cancel_itself_then_heartbeat.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=5 duration={DURATION}",
+        rf'task cancelled: name="{re.escape(cancel_itself_then_heartbeat.module_path)}"'
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration={DURATION}",
         warnings[0].getMessage(),
     )
     assert not [m for m in read_hook_messages(caplog) if m.startswith("task failed: ")]
@@ -199,8 +199,8 @@ def test_a_run_already_failed_elsewhere_logs_a_warning(
     assert len(warnings) == 1
     assert re.fullmatch(
         "run already failed elsewhere: "
-        rf"name={re.escape(fail_its_own_run_then_heartbeat.module_path)}"
-        rf" task_id={task_id} attempt=1 max_attempts=5 duration={DURATION}",
+        rf"name=\"{re.escape(fail_its_own_run_then_heartbeat.module_path)}\""
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration={DURATION}",
         warnings[0].getMessage(),
     )
 
@@ -226,18 +226,18 @@ def test_the_deferred_wrapper_is_visible_without_its_own_log_line(
         for m in messages
         if m
         == (
-            f"task started: name={wrapper_name} task_id={wrapper_task_id}"
+            f'task started: name="{wrapper_name}" task_id="{wrapper_task_id}"'
             " attempt=1 max_attempts=5"
         )
     ]
     assert len(started) == 1
     completed = [
-        m for m in messages if m.startswith(f"task completed: name={wrapper_name} ")
+        m for m in messages if m.startswith(f'task completed: name="{wrapper_name}" ')
     ]
     assert len(completed) == 1
     assert re.fullmatch(
-        rf"task completed: name={re.escape(wrapper_name)}"
-        rf" task_id={wrapper_task_id} attempt=1 max_attempts=5 duration={DURATION}",
+        rf"task completed: name=\"{re.escape(wrapper_name)}\""
+        rf" task_id=\"{wrapper_task_id}\" attempt=1 max_attempts=5 duration={DURATION}",
         completed[0],
     )
     assert not [r for r in caplog.records if r.name == "django_absurd.deferred"]
@@ -295,7 +295,7 @@ def test_a_logging_fault_in_the_hook_does_not_fail_the_task(
     assert len(faults) == 1
     assert (
         faults[0].getMessage()
-        == "failed to log a run lifecycle event: event=task completed"
+        == 'failed to log a run lifecycle event: event="task completed"'
     )
 
 

--- a/tests/core/test_logging/test_maintenance.py
+++ b/tests/core/test_logging/test_maintenance.py
@@ -54,11 +54,11 @@ def test_the_worker_logs_when_it_stops(
         r.getMessage() for r in caplog.records if r.name == "django_absurd.worker"
     ]
     started = (
-        f"worker started: alias={backend.alias} queue=default"
-        f" database={backend.database} concurrency=1"
+        f'worker started: alias="{backend.alias}" queue="default"'
+        f' database="{backend.database}" concurrency=1'
     )
     stopped = (
-        f"worker stopped: alias={backend.alias} queue=default"
-        f" database={backend.database} runs=0"
+        f'worker stopped: alias="{backend.alias}" queue="default"'
+        f' database="{backend.database}" runs=0'
     )
     assert messages == [started, stopped]

--- a/tests/core/test_logging/test_spawn.py
+++ b/tests/core/test_logging/test_spawn.py
@@ -18,7 +18,8 @@ def test_enqueue_logs_the_spawn_with_absurd_side_detail(
     assert len(spawns) == 1
     assert spawns[0].levelno == logging.DEBUG
     assert spawns[0].getMessage() == (
-        f"spawn requested: name={tasks.add.module_path} queue=default max_attempts=5"
+        f'spawn requested: name="{tasks.add.module_path}" queue="default"'
+        " max_attempts=5"
     )
 
 
@@ -37,8 +38,8 @@ def test_enqueue_logs_a_dedup_key_as_the_caller_wrote_it(
     spawns = [r for r in caplog.records if r.name == "django_absurd.hooks"]
     assert len(spawns) == 1
     assert spawns[0].getMessage() == (
-        f"spawn requested: name={tasks.add.module_path} queue=default"
-        " max_attempts=5 idempotency_key=café-42"
+        f'spawn requested: name="{tasks.add.module_path}" queue="default"'
+        ' max_attempts=5 idempotency_key="café-42"'
     )
 
 
@@ -85,7 +86,7 @@ def test_a_hook_that_fails_to_log_still_returns_the_options(
     ]
     assert len(failures) == 1
     assert failures[0].getMessage() == (
-        f"failed to log spawn: name={tasks.add.module_path}"
+        f'failed to log spawn: name="{tasks.add.module_path}"'
     )
 
 

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -160,7 +160,8 @@ def test_sync_reports_no_queues_when_all_in_sync(
     records = [r for r in caplog.records if r.name == "django_absurd.queues"]
     assert len(records) == 1
     assert (
-        records[0].getMessage() == "queues provisioned: created=freshsync reconciled="
+        records[0].getMessage()
+        == 'queues provisioned: created="freshsync" reconciled=""'
     )
     capsys.readouterr()
     call_command("absurd_sync_queues")  # freshsync exists, no drift -> empty result

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -251,7 +251,7 @@ def test_beat_started_logs_schedule_count_and_cleanup(
     records = [r for r in caplog.records if r.name == "django_absurd.scheduler"]
     started = [r for r in records if r.getMessage().startswith("beat started")]
     assert len(started) == 1
-    assert started[0].getMessage() == "beat started: schedules=1 cleanup=17 * * * *"
+    assert started[0].getMessage() == 'beat started: schedules=1 cleanup="17 * * * *"'
 
 
 def test_beat_isolates_failing_schedule(
@@ -286,11 +286,11 @@ def test_beat_isolates_failing_schedule(
     failed = [r for r in records if r.getMessage().startswith("schedule failed")]
     enqueued = [r for r in records if r.getMessage().startswith("schedule enqueued")]
     assert len(failed) == 1
-    assert failed[0].getMessage() == "schedule failed: name=bad"
+    assert failed[0].getMessage() == 'schedule failed: name="bad"'
     assert len(enqueued) == 1
     assert (
         enqueued[0].getMessage()
-        == "schedule enqueued: name=good slot=2026-01-01T00:01:00Z"
+        == 'schedule enqueued: name="good" slot="2026-01-01T00:01:00Z"'
     )
 
 
@@ -801,7 +801,7 @@ def test_plain_worker_runs_blocking_worker(
         and r.getMessage().startswith("worker stopped")
     ]
     expected = (
-        f"worker stopped: alias={backend.alias} queue=default"
-        f" database={backend.database}"
+        f'worker stopped: alias="{backend.alias}" queue="default"'
+        f' database="{backend.database}"'
     )
     assert stopped == [expected]

--- a/tests/core/test_signals_enqueue.py
+++ b/tests/core/test_signals_enqueue.py
@@ -62,7 +62,7 @@ def test_enqueue_survives_a_receiver_that_raises(
     assert len(errors) == 1
     assert errors[0].exc_info is not None
     assert errors[0].getMessage() == (
-        f"task_enqueued receiver failed for task result id={result.id}"
+        f'task_enqueued receiver failed for task result id="{result.id}"'
     )
 
 

--- a/tests/core/test_signals_started.py
+++ b/tests/core/test_signals_started.py
@@ -91,5 +91,5 @@ def test_a_raising_receiver_does_not_fail_the_task(
     ]
     assert len(contained) == 1
     assert contained[0].getMessage() == (
-        f"task_started receiver failed for task result id={result.id}"
+        f'task_started receiver failed for task result id="{result.id}"'
     )

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -418,10 +418,10 @@ def test_worker_command_warns_on_storage_mode_drift(
         "queues provisioned: no changes\n"
         "Queue 'default': storage_mode cannot be changed "
         "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
-        "worker started: alias=default queue=default database=default"
+        'worker started: alias="default" queue="default" database="default"'
         " concurrency=1\n"
         "worker stop requested: finishing in-flight tasks\n"
-        "worker stopped: alias=default queue=default database=default\n"
+        'worker stopped: alias="default" queue="default" database="default"\n'
     )
 
 
@@ -616,9 +616,12 @@ def test_worker_command_reports_the_stop_request_on_both_channels(
         r.getMessage() for r in caplog.records if r.name == "django_absurd.worker"
     ]
     assert messages == [
-        "worker started: alias=default queue=default database=default concurrency=1",
+        (
+            'worker started: alias="default" queue="default" database="default"'
+            " concurrency=1"
+        ),
         STOP_REQUESTED_LOG,
-        "worker stopped: alias=default queue=default database=default",
+        'worker stopped: alias="default" queue="default" database="default"',
     ]
 
 


### PR DESCRIPTION
An unquoted value containing a space split into two fields for anything parsing these lines, and an empty one vanished — a two-queue sync emitted `created=alpha, beta`, and the lifecycle-logging fallback emitted `event=task completed`.

String values are now quoted across `worker`, `queues`, `scheduler`, `hooks`, `dispatch`, and `context`. Numeric fields (`attempt`, `max_attempts`, `concurrency`, `runs`, `schedules`, `timeout`, `duration`) stay bare.