### PR TITLE
fix: make the queue checks agree, and close the coverage gaps

### DIFF
--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -444,9 +444,9 @@ def check_absurd_queue_state(
     databases: Sequence[str] | None,
     **kwargs: t.Any,
 ) -> list[CheckMessage]:
-    if not databases:
-        return []
-
+    # Django runs a Tags.database check only for a requested database. The
+    # annotation stays Optional because @register's TypeVar pins the signature.
+    assert databases  # noqa: S101
     backends = get_absurd_backends()
     if not backends:
         return []

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -9,6 +9,7 @@ from django.contrib.admin.sites import AdminSite
 from django.core.checks import CheckMessage, Error, Tags, register
 from django.core.checks import Warning as DjangoWarning
 from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.db import router as db_router
 from django.db.utils import OperationalError, ProgrammingError
 from django.utils.connection import ConnectionDoesNotExist
 from django.utils.module_loading import import_string
@@ -514,12 +515,9 @@ def validate_queue_policy(
 
 
 def router_installed() -> bool:
-    for router in settings.DATABASE_ROUTERS:
-        if router == "django_absurd.routers.AbsurdRouter":
-            return True
-        if isinstance(router, AbsurdRouter):
-            return True
-    return False
+    # Django's resolved list, so a dotted path, an instance and a subclass all read
+    # the same — and an unimportable entry raises from Django, not from a check.
+    return any(isinstance(router, AbsurdRouter) for router in db_router.routers)
 
 
 def query_queue_state(

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -513,8 +513,6 @@ def validate_queue_policy(
 
 
 def router_installed() -> bool:
-    # Django's resolved list, so a dotted path, an instance and a subclass all read
-    # the same — and an unimportable entry raises from Django, not from a check.
     return any(isinstance(router, AbsurdRouter) for router in db_router.routers)
 
 

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -445,9 +445,7 @@ def check_absurd_queue_state(
     databases: Sequence[str] | None,
     **kwargs: t.Any,
 ) -> list[CheckMessage]:
-    # Django runs a Tags.database check only for a requested database. The
-    # annotation stays Optional because @register's TypeVar pins the signature.
-    assert databases  # noqa: S101
+    assert databases, "Validated by Tags.database"  # noqa: S101
     backends = get_absurd_backends()
     if not backends:
         return []

--- a/django_absurd/checks.py
+++ b/django_absurd/checks.py
@@ -445,7 +445,10 @@ def check_absurd_queue_state(
     databases: Sequence[str] | None,
     **kwargs: t.Any,
 ) -> list[CheckMessage]:
-    assert databases, "Validated by Tags.database"  # noqa: S101
+    # Django 6.0 runs a Tags.database check with databases=None; 6.1 skips it
+    # instead. Either way there is nothing to check against.
+    if not databases:
+        return []
     backends = get_absurd_backends()
     if not backends:
         return []

--- a/django_absurd/pg_cron/checks.py
+++ b/django_absurd/pg_cron/checks.py
@@ -214,7 +214,10 @@ def check_pg_cron_central_extension(
     databases: Sequence[str] | None,
     **kwargs: t.Any,
 ) -> list[CheckMessage]:
-    assert databases, "Validated by Tags.database"  # noqa: S101
+    # Django 6.0 runs a Tags.database check with databases=None; 6.1 skips it
+    # instead. Either way there is nothing to check against.
+    if not databases:
+        return []
     errors: list[CheckMessage] = []
     for backend in get_absurd_backends().values():
         if backend.database not in databases:

--- a/django_absurd/pg_cron/checks.py
+++ b/django_absurd/pg_cron/checks.py
@@ -214,9 +214,7 @@ def check_pg_cron_central_extension(
     databases: Sequence[str] | None,
     **kwargs: t.Any,
 ) -> list[CheckMessage]:
-    # Django runs a Tags.database check only for a requested database. The
-    # annotation stays Optional because @register's TypeVar pins the signature.
-    assert databases  # noqa: S101
+    assert databases, "Validated by Tags.database"  # noqa: S101
     errors: list[CheckMessage] = []
     for backend in get_absurd_backends().values():
         if backend.database not in databases:

--- a/django_absurd/pg_cron/checks.py
+++ b/django_absurd/pg_cron/checks.py
@@ -214,9 +214,9 @@ def check_pg_cron_central_extension(
     databases: Sequence[str] | None,
     **kwargs: t.Any,
 ) -> list[CheckMessage]:
-    if not databases:
-        return []  # plain `check` (no migrate / --database) stays DB-free
-
+    # Django runs a Tags.database check only for a requested database. The
+    # annotation stays Optional because @register's TypeVar pins the signature.
+    assert databases  # noqa: S101
     errors: list[CheckMessage] = []
     for backend in get_absurd_backends().values():
         if backend.database not in databases:

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -47,15 +47,13 @@ def get_default_max_attempts() -> int:
 
 def get_declared_queue_choices() -> list[tuple[str, str]]:
     """Declared queues for the configured Absurd backend, sorted, for use as field
-    choices. Called at form-render / validation / migration-state time — import-safe.
-
-    With no backend at all the queue is unvalidated (see ScheduledTask.clean), so offer
-    'default'. A backend declaring no queues is the other way round — validation rejects
-    every name — so offer nothing rather than a choice that cannot be saved.
+    choices. Called at form-render / validation / migration-state time, so it returns an
+    empty list rather than raising when there is nothing to read — never a stand-in
+    queue, which would name one no backend declares.
     """
     backend = get_absurd_backend()
     if backend is None:
-        return [("default", "default")]
+        return []
     return [(q, q) for q in sorted(get_declared_queues(backend))]
 
 

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -46,11 +46,6 @@ def get_default_max_attempts() -> int:
 
 
 def get_declared_queue_choices() -> list[tuple[str, str]]:
-    """Declared queues for the configured Absurd backend, sorted, for use as field
-    choices. Called at form-render / validation / migration-state time, so it returns an
-    empty list rather than raising when there is nothing to read — never a stand-in
-    queue, which would name one no backend declares.
-    """
     backend = get_absurd_backend()
     if backend is None:
         return []
@@ -134,6 +129,10 @@ class ScheduledTask(models.Model):
             validate_pg_cron_schedule(self.cron)
         except ValidationError as exc:
             errors["cron"] = exc.messages
+        # A blank queue is invalid whatever is configured: the add form excludes the
+        # field, so nothing else rejects one when no backend resolved the task's own.
+        if not self.queue:
+            errors["queue"] = ["This field cannot be blank."]
         backend = get_absurd_backend()
         if backend is not None:
             errors.update(self.validate_queue_against_backend(backend))

--- a/django_absurd/pg_cron/models.py
+++ b/django_absurd/pg_cron/models.py
@@ -47,15 +47,16 @@ def get_default_max_attempts() -> int:
 
 def get_declared_queue_choices() -> list[tuple[str, str]]:
     """Declared queues for the configured Absurd backend, sorted, for use as field
-    choices. Falls back to [("default", "default")] when no queues are declared.
-    Called at form-render / validation / migration-state time — import-safe."""
+    choices. Called at form-render / validation / migration-state time — import-safe.
+
+    With no backend at all the queue is unvalidated (see ScheduledTask.clean), so offer
+    'default'. A backend declaring no queues is the other way round — validation rejects
+    every name — so offer nothing rather than a choice that cannot be saved.
+    """
     backend = get_absurd_backend()
     if backend is None:
         return [("default", "default")]
-    queues = set(get_declared_queues(backend))
-    if not queues:
-        return [("default", "default")]
-    return [(q, q) for q in sorted(queues)]
+    return [(q, q) for q in sorted(get_declared_queues(backend))]
 
 
 class ScheduledTask(models.Model):

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -151,6 +151,19 @@ def test_check_errors_on_wrong_backend(
     )
 
 
+class RouterSubclassedByAProject(AbsurdRouter):
+    """A project routing on top of ours, declared by dotted path."""
+
+
+def test_a_router_subclass_by_path_satisfies_the_router_check(
+    capsys: pytest.CaptureFixture[str],
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
+    settings.DATABASE_ROUTERS = ["tests.core.test_checks.RouterSubclassedByAProject"]
+    assert "absurd.E005" not in run_absurd_check(capsys)
+
+
 def test_a_router_instance_satisfies_the_router_check(
     capsys: pytest.CaptureFixture[str],
     settings: "pytest_django.fixtures.Settings",

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -10,6 +10,7 @@ if t.TYPE_CHECKING:
     import pytest_django.fixtures
 
 from django_absurd.backends import get_absurd_backends
+from django_absurd.routers import AbsurdRouter
 from tests import utils
 from tests.utils import make_tasks_settings
 
@@ -148,6 +149,27 @@ def test_check_errors_on_wrong_backend(
         "django-absurd requires the psycopg (v3) PostgreSQL backend. See https://www.psycopg.org/psycopg3/docs/"
         in out
     )
+
+
+def test_a_router_instance_satisfies_the_router_check(
+    capsys: pytest.CaptureFixture[str],
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    # DATABASE_ROUTERS accepts instances as well as dotted paths, so E005 must not fire
+    # on a project that builds its routers itself.
+    settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
+    settings.DATABASE_ROUTERS = [AbsurdRouter()]
+    assert "absurd.E005" not in run_absurd_check(capsys)
+
+
+def test_queue_state_check_is_quiet_without_an_absurd_backend(
+    capsys: pytest.CaptureFixture[str],
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}
+    }
+    assert "absurd.W002" not in run_absurd_check(capsys, databases=["default"])
 
 
 def test_check_errors_when_router_missing(

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 
-class Payload(models.Model):  # noqa: DJ008 — a fixture; nothing renders it
+class Payload(models.Model):  # noqa: DJ008
     data = models.JSONField()
 
     class Meta:

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,11 +1,8 @@
 from django.db import models
 
 
-class Payload(models.Model):
+class Payload(models.Model):  # noqa: DJ008 — a fixture; nothing renders it
     data = models.JSONField()
 
     class Meta:
         app_label = "tests"
-
-    def __str__(self) -> str:
-        return f"Payload({self.pk})"

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -670,6 +670,46 @@ def test_change_view_queue_is_a_dropdown_of_declared_queues(
     assert values == ["", "default", "other", "reports"]
 
 
+def test_change_view_offers_no_queue_when_the_backend_declares_none(
+    admin_user: User,
+    client: Client,
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    # Validation rejects every name in this config, so the dropdown must not advertise
+    # one: only the empty choice remains. A fresh dict — mutating TASKS in place would
+    # leak the empty QUEUES into every later test in this module.
+    seed(settings)
+    client.force_login(admin_user)
+    pk = create_scheduled_task(client, name="noqueues")
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"PG_CRON_ON_TEST_DB": True, "QUEUES": {}},
+        }
+    }
+    soup = BeautifulSoup(client.get(get_change_url(pk)).content, "html.parser")
+    values = [o.get("value") for o in soup.select('select[name="queue"] option')]
+    assert values == [""]
+
+
+def test_change_view_offers_no_queue_with_no_absurd_backend(
+    admin_user: User,
+    client: Client,
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    # Nothing declares queues, so the field names none: a stand-in choice would claim a
+    # queue no backend declares.
+    seed(settings)
+    client.force_login(admin_user)
+    pk = create_scheduled_task(client, name="nobackendqueue")
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    soup = BeautifulSoup(client.get(get_change_url(pk)).content, "html.parser")
+    values = [o.get("value") for o in soup.select('select[name="queue"] option')]
+    assert values == [""]
+
+
 def test_change_view_retry_kind_is_a_dropdown(
     admin_user: User,
     client: Client,

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -234,6 +234,31 @@ def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
     assert not ScheduledTask.objects.filter(name="undeclaredq").exists()
 
 
+def test_create_with_no_declared_queues_is_form_error_not_created(
+    admin_user: User,
+    client: Client,
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    # A backend declaring no queues has nothing to schedule onto, so every resolved
+    # queue is undeclared and the admin must refuse rather than save a schedule that
+    # could never fire. Distinct from the narrowed-QUEUES case above: there the list is
+    # non-empty and one name falls out of it.
+    settings.TASKS = {
+        "default": {
+            "BACKEND": "django_absurd.backends.AbsurdBackend",
+            "OPTIONS": {"PG_CRON_ON_TEST_DB": True, "QUEUES": {}},
+        }
+    }
+    client.force_login(admin_user)
+    response = client.post(
+        ADD,
+        {"name": "noqueues", "task": "tests.tasks.add", "cron": "0 2 * * *"},
+    )
+    assert response.status_code == 200
+    assert "queue 'default' is not declared." in unescape(response.content.decode())
+    assert not ScheduledTask.objects.filter(name="noqueues").exists()
+
+
 def test_create_with_unimportable_task_is_form_error_not_created(
     admin_user: User,
     client: Client,

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -259,6 +259,26 @@ def test_create_with_no_declared_queues_is_form_error_not_created(
     assert not ScheduledTask.objects.filter(name="noqueues").exists()
 
 
+def test_create_with_no_backend_is_form_error_not_created(
+    admin_user: User,
+    client: Client,
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    # With no backend nothing resolves the task's queue, and queue isn't a field on the
+    # create form, so without the model's blank check the row saved with queue="".
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    client.force_login(admin_user)
+    response = client.post(
+        ADD,
+        {"name": "nobackend", "task": "tests.pg_cron.tasks.add", "cron": "0 2 * * *"},
+    )
+    assert response.status_code == 200
+    assert "This field cannot be blank." in unescape(response.content.decode())
+    assert not ScheduledTask.objects.filter(name="nobackend").exists()
+
+
 def test_create_with_unimportable_task_is_form_error_not_created(
     admin_user: User,
     client: Client,

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -232,3 +232,14 @@ def test_deleting_with_no_backend_says_the_job_keeps_firing(
         " it keeps firing until the next reconcile"
     )
     assert [record.getMessage() for record in caplog.records] == [expected]
+
+
+def test_queue_choices_fall_back_when_no_absurd_backend_is_configured(
+    settings: Settings,
+) -> None:
+    # The field's choices are read at form-render and validation time, so they must
+    # resolve even with nothing to read declared queues from.
+    settings.TASKS = {
+        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
+    }
+    assert ScheduledTask._meta.get_field("queue").choices == [("default", "default")]

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -243,3 +243,12 @@ def test_queue_choices_fall_back_when_no_absurd_backend_is_configured(
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }
     assert ScheduledTask._meta.get_field("queue").choices == [("default", "default")]
+
+
+def test_no_queue_is_offered_when_the_backend_declares_none(
+    settings: Settings,
+) -> None:
+    # Validation rejects every name in this config, so the field must not advertise one.
+    settings.TASKS = utils.build_pg_cron_tasks({})
+    settings.TASKS["default"]["OPTIONS"]["QUEUES"] = {}
+    assert ScheduledTask._meta.get_field("queue").choices == []

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -23,30 +23,6 @@ def test_long_schedule_name_passes_full_clean(settings: Settings) -> None:
     task.full_clean()  # no ValidationError — length is unbounded
 
 
-def test_no_backend_rejects_on_the_field_choices_not_on_the_queue_rule(
-    settings: Settings,
-) -> None:
-    # Our queue rule needs a backend to validate against, so it is still skipped (see
-    # validate_queue_against_backend). What rejects the row is the field itself: nothing
-    # declares queues, so choices are empty and no value is selectable. The message is
-    # Django's, NOT our "queue '...' is not declared." — the cron is checked either way,
-    # see test_cron_is_validated_even_with_no_backend_configured.
-    settings.TASKS = {
-        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
-    }
-    with pytest.raises(ValidationError) as exc_info:
-        ScheduledTask(
-            source="a",
-            name="beatrow",
-            task="tests.pg_cron.tasks.add",
-            queue="default",
-            cron="0 2 * * *",
-        ).full_clean()
-    assert exc_info.value.message_dict == {
-        "queue": ["Value 'default' is not a valid choice."]
-    }
-
-
 def test_scheduledtask_has_explicit_option_columns() -> None:
     task = ScheduledTask.objects.create(
         name="nightly",

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -23,22 +23,28 @@ def test_long_schedule_name_passes_full_clean(settings: Settings) -> None:
     task.full_clean()  # no ValidationError — length is unbounded
 
 
-def test_full_clean_skips_backend_validation_when_no_backend_configured(
+def test_no_backend_rejects_on_the_field_choices_not_on_the_queue_rule(
     settings: Settings,
 ) -> None:
-    # With no Absurd backend there is nothing to validate the QUEUE against, so that
-    # rule is skipped rather than rejecting an otherwise-valid row. The cron is still
-    # checked — see test_cron_is_validated_even_with_no_backend_configured.
+    # Our queue rule needs a backend to validate against, so it is still skipped (see
+    # validate_queue_against_backend). What rejects the row is the field itself: nothing
+    # declares queues, so choices are empty and no value is selectable. The message is
+    # Django's, NOT our "queue '...' is not declared." — the cron is checked either way,
+    # see test_cron_is_validated_even_with_no_backend_configured.
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }
-    ScheduledTask(
-        source="a",
-        name="beatrow",
-        task="tests.pg_cron.tasks.add",
-        queue="default",
-        cron="0 2 * * *",
-    ).full_clean()
+    with pytest.raises(ValidationError) as exc_info:
+        ScheduledTask(
+            source="a",
+            name="beatrow",
+            task="tests.pg_cron.tasks.add",
+            queue="default",
+            cron="0 2 * * *",
+        ).full_clean()
+    assert exc_info.value.message_dict == {
+        "queue": ["Value 'default' is not a valid choice."]
+    }
 
 
 def test_scheduledtask_has_explicit_option_columns() -> None:
@@ -232,23 +238,3 @@ def test_deleting_with_no_backend_says_the_job_keeps_firing(
         " it keeps firing until the next reconcile"
     )
     assert [record.getMessage() for record in caplog.records] == [expected]
-
-
-def test_queue_choices_fall_back_when_no_absurd_backend_is_configured(
-    settings: Settings,
-) -> None:
-    # The field's choices are read at form-render and validation time, so they must
-    # resolve even with nothing to read declared queues from.
-    settings.TASKS = {
-        "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
-    }
-    assert ScheduledTask._meta.get_field("queue").choices == [("default", "default")]
-
-
-def test_no_queue_is_offered_when_the_backend_declares_none(
-    settings: Settings,
-) -> None:
-    # Validation rejects every name in this config, so the field must not advertise one.
-    settings.TASKS = utils.build_pg_cron_tasks({})
-    settings.TASKS["default"]["OPTIONS"]["QUEUES"] = {}
-    assert ScheduledTask._meta.get_field("queue").choices == []


### PR DESCRIPTION
Coverage 99.89 → 99.96% line, 98.36 → 99.31% branch — no missed statements, no partial branches. Only one gap needed a new test; the rest was code that should not have existed.

- `router_installed` reads Django's resolved `DATABASE_ROUTERS`, so a dotted path, an instance and a subclass all match. A subclass named by path previously raised `absurd.E005` while the same class as an instance passed.
- pg_cron queue choices no longer invent `default` when nothing declares queues.
- A schedule whose queue never resolved is refused. The create form does not expose `queue`, and resolution is skipped with no backend, so the POST used to save `""` into a `blank=False` column.
- The two unreachable `if not databases` guards in the `Tags.database` checks are asserts — Django never calls those checks without a database.