### PR TITLE
fix: serialize provisioning with an advisory lock

### DIFF
--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -203,6 +203,11 @@ def lock_provisioning(using: str) -> t.Iterator[None]:
     lives exactly as long as its transaction, so taken under autocommit it would release
     before the work it guards. Scoping it here also means a crashed provisioner releases
     it, with no stuck-lock cleanup path to own.
+
+    Called inside a caller's own atomic this degrades to a savepoint, so the lock is
+    held until THEIR commit — still correct, just longer. No caller here provisions
+    inside a transaction: both commands and the post_migrate receiver run outside one,
+    and ``AbsurdTestRuntime.sync_queues`` refuses if one is open.
     """
     with transaction.atomic(using=using):
         with connections[using].cursor() as cur:

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime as dt
 import logging
 import re
@@ -182,17 +183,31 @@ def provision_backend(backend: backends.AbsurdBackend) -> SyncResult:
     # The single integral provisioning step (used by post_migrate, the sync command,
     # and worker start): reconcile every declared queue, then rebuild all admin views
     # so they reflect the full catalog — not just the queue a worker happens to serve.
-    #
-    # Serialized: an absent object gets created by name under no lock (CREATE TABLE IF
-    # NOT EXISTS, CREATE VIEW after a no-op DROP), so provisioners racing a first boot
-    # collide on a catalog unique index. Held to commit, released on a crash.
     validate_backend(backend.database)  # the lock below is Postgres-only SQL
-    with transaction.atomic(using=backend.database):
-        with connections[backend.database].cursor() as cur:
-            cur.execute("SELECT pg_advisory_xact_lock(%s)", [PROVISION_LOCK_KEY])
+    with lock_provisioning(backend.database):
         result = sync_queues(backend)
         rebuild_views(backend.database)
     return result
+
+
+@contextlib.contextmanager
+def lock_provisioning(using: str) -> t.Iterator[None]:
+    """Serialize concurrent provisioners, which a deploy runs by the handful.
+
+    Both halves of provisioning create objects by name with no lock held while the name
+    is absent — ``CREATE TABLE IF NOT EXISTS`` inside ``absurd.create_queue``, and
+    ``CREATE VIEW`` after a ``DROP VIEW IF EXISTS`` that matched nothing — so racing a
+    database's first boot collides on a catalog unique index.
+
+    The transaction belongs to the lock, not to the caller: ``pg_advisory_xact_lock``
+    lives exactly as long as its transaction, so taken under autocommit it would release
+    before the work it guards. Scoping it here also means a crashed provisioner releases
+    it, with no stuck-lock cleanup path to own.
+    """
+    with transaction.atomic(using=using):
+        with connections[using].cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", [PROVISION_LOCK_KEY])
+        yield
 
 
 def parse_interval(using: str, interval_str: str) -> dt.timedelta:

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -2,11 +2,12 @@ import datetime as dt
 import logging
 import re
 import typing as t
+import zlib
 from dataclasses import dataclass, field
 
 import psycopg.errors
 from absurd_sdk import Absurd, QueuePolicyOptions
-from django.db import connections
+from django.db import connections, transaction
 from django.db.utils import ProgrammingError
 
 from django_absurd import backends
@@ -36,6 +37,11 @@ MUTABLE_OPTION_KEYS = (
 INTERVAL_OPTION_KEYS = frozenset(
     ("partition_lookahead", "partition_lookback", "cleanup_ttl", "detach_min_age")
 )
+
+# Advisory-lock key for provision_backend. Derived from a name rather than written as a
+# literal so it reads as ours; concurrent sessions only have to agree with each other,
+# never across servers or versions.
+PROVISION_LOCK_KEY = zlib.crc32(b"django_absurd.provision")
 
 
 @dataclass
@@ -176,8 +182,16 @@ def provision_backend(backend: backends.AbsurdBackend) -> SyncResult:
     # The single integral provisioning step (used by post_migrate, the sync command,
     # and worker start): reconcile every declared queue, then rebuild all admin views
     # so they reflect the full catalog — not just the queue a worker happens to serve.
-    result = sync_queues(backend)
-    rebuild_views(backend.database)
+    #
+    # Serialized: an absent object gets created by name under no lock (CREATE TABLE IF
+    # NOT EXISTS, CREATE VIEW after a no-op DROP), so provisioners racing a first boot
+    # collide on a catalog unique index. Held to commit, released on a crash.
+    validate_backend(backend.database)  # the lock below is Postgres-only SQL
+    with transaction.atomic(using=backend.database):
+        with connections[backend.database].cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", [PROVISION_LOCK_KEY])
+        result = sync_queues(backend)
+        rebuild_views(backend.database)
     return result
 
 

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -243,20 +243,7 @@ def test_concurrent_sync_survives_the_admin_views_being_absent() -> None:
     # takes no lock on a view that isn't there, so unserialized provisioners reach
     # CREATE VIEW together and the losers collide on the catalog's unique index.
     provisioners = 4
-    rounds = 3
-    # Absurd's own install SQL creates no views, so these five are the whole population
-    # of the schema — the counts below fail loudly if that stops holding.
-    drop_admin_views = (
-        "DROP VIEW IF EXISTS absurd.tasks_view, absurd.runs_view, "
-        "absurd.checkpoints_view, absurd.waits_view, absurd.events_view CASCADE"
-    )
     barrier = threading.Barrier(provisioners)
-
-    def count_absurd_views() -> int:
-        with connection.cursor() as cur:
-            cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
-            row = t.cast("tuple[int]", cur.fetchone())
-            return row[0]
 
     def sync_queues_concurrently() -> None:
         try:
@@ -265,16 +252,25 @@ def test_concurrent_sync_survives_the_admin_views_being_absent() -> None:
         finally:
             connections.close_all()  # this thread's own connection
 
-    for _ in range(rounds):
-        with connection.cursor() as cur:
-            cur.execute(drop_admin_views)
-        assert count_absurd_views() == 0
-        with futures.ThreadPoolExecutor(provisioners) as pool:
-            # .result() re-raises in this thread: an exception inside a bare Thread
-            # target only prints, leaving the test green.
-            for future in [
-                pool.submit(sync_queues_concurrently) for _ in range(provisioners)
-            ]:
-                future.result()
+    with connection.cursor() as cur:
+        # Absurd's own install SQL creates no views, so django-absurd's five admin
+        # views are the whole population of the schema — the count assertions fail
+        # loudly if a rename ever makes this statement drop less than all of them.
+        cur.execute(
+            "DROP VIEW IF EXISTS absurd.tasks_view, absurd.runs_view, "
+            "absurd.checkpoints_view, absurd.waits_view, absurd.events_view CASCADE"
+        )
+        cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
+        assert cur.fetchone() == (0,)
 
-    assert count_absurd_views() == 5
+    with futures.ThreadPoolExecutor(provisioners) as pool:
+        # .result() re-raises in this thread: an exception inside a bare Thread
+        # target only prints, leaving the test green.
+        for future in [
+            pool.submit(sync_queues_concurrently) for _ in range(provisioners)
+        ]:
+            future.result()
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
+        assert cur.fetchone() == (5,)

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -1,6 +1,9 @@
 import datetime as dt
+import io
 import logging
+import threading
 import typing as t
+from concurrent import futures
 
 import psycopg
 import pytest
@@ -8,12 +11,16 @@ from absurd_sdk import CreateQueueOptions
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.db import connection
-from django.db.utils import ProgrammingError
+from django.db import connection, connections
+from django.db.utils import OperationalError, ProgrammingError
 from pytest_django.fixtures import Settings
 
 from django_absurd.models import Queue
-from django_absurd.queues import get_absurd_client, resolve_absurd_database
+from django_absurd.queues import (
+    PROVISION_LOCK_KEY,
+    get_absurd_client,
+    resolve_absurd_database,
+)
 from tests import utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -208,3 +215,71 @@ def test_sync_command_reports_nothing_when_no_absurd_backend(
     }
     call_command("absurd_sync_queues")
     assert "No Absurd task backends configured." in capsys.readouterr().out
+
+
+PROVISIONERS = 4
+CONCURRENT_ROUNDS = 3
+
+# Absurd's own install SQL creates no views, so django-absurd's five admin views are
+# the whole population of the schema — count_absurd_views() below fails loudly if a
+# rename or an addition ever makes this statement drop less than all of them.
+DROP_ADMIN_VIEWS = (
+    "DROP VIEW IF EXISTS absurd.tasks_view, absurd.runs_view, "
+    "absurd.checkpoints_view, absurd.waits_view, absurd.events_view CASCADE"
+)
+
+
+def count_absurd_views() -> int:
+    with connection.cursor() as cur:
+        cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
+        row = t.cast("tuple[int]", cur.fetchone())
+        return row[0]
+
+
+def test_sync_command_waits_for_a_concurrent_provisioner(settings: Settings) -> None:
+    # The lock is taken before any provisioning work, not just around the view
+    # rebuild: the command dies waiting for it with its queue still uncreated.
+    settings.TASKS = build_tasks_setting({"locked": {}})
+    holder = psycopg.connect(**utils.get_absurd_connection_params(), autocommit=True)
+    try:
+        holder.execute("SELECT pg_advisory_lock(%s)", [PROVISION_LOCK_KEY])
+        with connection.cursor() as cur:
+            cur.execute("SET lock_timeout = '250ms'")
+        try:
+            with pytest.raises(OperationalError) as excinfo:
+                call_command("absurd_sync_queues", stdout=io.StringIO())
+        finally:
+            with connection.cursor() as cur:
+                cur.execute("RESET lock_timeout")
+    finally:
+        holder.close()
+    assert str(excinfo.value) == "canceling statement due to lock timeout"
+    assert not Queue.objects.filter(queue_name="locked").exists()
+
+
+def test_concurrent_sync_survives_the_admin_views_being_absent() -> None:
+    # https://github.com/lincolnloop/django-absurd/issues/195 — DROP VIEW IF EXISTS
+    # takes no lock on a view that isn't there, so unserialized provisioners reach
+    # CREATE VIEW together and the losers collide on the catalog's unique index.
+    barrier = threading.Barrier(PROVISIONERS)
+
+    def sync_queues_concurrently() -> None:
+        try:
+            barrier.wait()
+            call_command("absurd_sync_queues", stdout=io.StringIO())
+        finally:
+            connections.close_all()  # this thread's own connection
+
+    for _ in range(CONCURRENT_ROUNDS):
+        with connection.cursor() as cur:
+            cur.execute(DROP_ADMIN_VIEWS)
+        assert count_absurd_views() == 0
+        with futures.ThreadPoolExecutor(PROVISIONERS) as pool:
+            # .result() re-raises in this thread: an exception inside a bare Thread
+            # target only prints, leaving the test green.
+            for future in [
+                pool.submit(sync_queues_concurrently) for _ in range(PROVISIONERS)
+            ]:
+                future.result()
+
+    assert count_absurd_views() == 5

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -217,25 +217,6 @@ def test_sync_command_reports_nothing_when_no_absurd_backend(
     assert "No Absurd task backends configured." in capsys.readouterr().out
 
 
-PROVISIONERS = 4
-CONCURRENT_ROUNDS = 3
-
-# Absurd's own install SQL creates no views, so django-absurd's five admin views are
-# the whole population of the schema — count_absurd_views() below fails loudly if a
-# rename or an addition ever makes this statement drop less than all of them.
-DROP_ADMIN_VIEWS = (
-    "DROP VIEW IF EXISTS absurd.tasks_view, absurd.runs_view, "
-    "absurd.checkpoints_view, absurd.waits_view, absurd.events_view CASCADE"
-)
-
-
-def count_absurd_views() -> int:
-    with connection.cursor() as cur:
-        cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
-        row = t.cast("tuple[int]", cur.fetchone())
-        return row[0]
-
-
 def test_sync_command_waits_for_a_concurrent_provisioner(settings: Settings) -> None:
     # The lock is taken before any provisioning work, not just around the view
     # rebuild: the command dies waiting for it with its queue still uncreated.
@@ -261,7 +242,21 @@ def test_concurrent_sync_survives_the_admin_views_being_absent() -> None:
     # https://github.com/lincolnloop/django-absurd/issues/195 — DROP VIEW IF EXISTS
     # takes no lock on a view that isn't there, so unserialized provisioners reach
     # CREATE VIEW together and the losers collide on the catalog's unique index.
-    barrier = threading.Barrier(PROVISIONERS)
+    provisioners = 4
+    rounds = 3
+    # Absurd's own install SQL creates no views, so these five are the whole population
+    # of the schema — the counts below fail loudly if that stops holding.
+    drop_admin_views = (
+        "DROP VIEW IF EXISTS absurd.tasks_view, absurd.runs_view, "
+        "absurd.checkpoints_view, absurd.waits_view, absurd.events_view CASCADE"
+    )
+    barrier = threading.Barrier(provisioners)
+
+    def count_absurd_views() -> int:
+        with connection.cursor() as cur:
+            cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
+            row = t.cast("tuple[int]", cur.fetchone())
+            return row[0]
 
     def sync_queues_concurrently() -> None:
         try:
@@ -270,15 +265,15 @@ def test_concurrent_sync_survives_the_admin_views_being_absent() -> None:
         finally:
             connections.close_all()  # this thread's own connection
 
-    for _ in range(CONCURRENT_ROUNDS):
+    for _ in range(rounds):
         with connection.cursor() as cur:
-            cur.execute(DROP_ADMIN_VIEWS)
+            cur.execute(drop_admin_views)
         assert count_absurd_views() == 0
-        with futures.ThreadPoolExecutor(PROVISIONERS) as pool:
+        with futures.ThreadPoolExecutor(provisioners) as pool:
             # .result() re-raises in this thread: an exception inside a bare Thread
             # target only prints, leaving the test green.
             for future in [
-                pool.submit(sync_queues_concurrently) for _ in range(PROVISIONERS)
+                pool.submit(sync_queues_concurrently) for _ in range(provisioners)
             ]:
                 future.result()
 


### PR DESCRIPTION
Closes #195.

`provision_backend` runs from `post_migrate`, `absurd_worker` start and `absurd_sync_queues`, so a deploy runs several concurrently. On a freshly installed schema both halves create objects by name under no lock — `DROP VIEW IF EXISTS` takes none on an absent view, and `absurd.create_queue` uses `CREATE TABLE IF NOT EXISTS` — so the losers collide on `pg_type_typname_nsp_index`. The `IntegrityError` escapes both the `post_migrate` receiver's except tuple and `CONFIGURATION_ERRORS`, failing `migrate` and the deploy with it.

Wraps both halves in a transaction-scoped advisory lock. The reporter's suggestion guarded only the view rebuild, which leaves the queue-table window open. `validate_backend` moves ahead of the lock, which is Postgres-only SQL.

Not included: an `IntegrityError` catch at the call sites, also suggested in the issue. With the lock, one from provisioning is a bug that should surface.
