### PR TITLE
test: stop the suites depending on runtime queue self-heal

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import pytest
 from django.contrib.auth.models import User
 
 from django_absurd.flush import flush_absurd_state
-from tests import utils
 
 
 @pytest.fixture(autouse=True)
@@ -32,22 +31,14 @@ def _restore_absurd_logger() -> t.Iterator[None]:
 
 @pytest.fixture
 def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
-    """Hard-drop all Absurd queue topology before a test, restore the declared set
-    after it.
+    """Hard-drop all Absurd queue topology around a test (before AND after).
 
     The auto cleanup installed by the pytest plugin only TRUNCATEs after each DB
     test — it removes rows, not queues. Topology-varying files create/vary queues
     whose per-queue tables (DDL) and ``managed=False`` registry rows survive a
     truncate and leak across ``--reuse-db`` runs. Apply this (via a module-level
-    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files, so each such
-    test starts from nothing.
-
-    Teardown drops and then RE-PROVISIONS, because ``migrate`` provisions the test
-    database once at creation and nothing re-runs it per test. Dropping on both sides
-    left the next test to enqueue on a queue that no longer existed, repaired only by
-    a runtime path that recreated it — a dependency invisible at the failing test's
-    call site, and one django-absurd is removing. A test that wants the unprovisioned
-    state drops the queue itself, where a reader can see it.
+    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files to drop the
+    schema on both sides so each such test is hermetic.
 
     Naming: ``_``-prefixed but non-autouse. Outside the LETTER of CLAUDE.md's
     autouse-only underscore exception, but within its spirit — never called
@@ -56,7 +47,6 @@ def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
     flush_absurd_state(drop_schema=True)
     yield
     flush_absurd_state(drop_schema=True)
-    utils.provision_declared_queues()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth.models import User
 
 from django_absurd.flush import flush_absurd_state
+from tests import utils
 
 
 @pytest.fixture(autouse=True)
@@ -31,14 +32,22 @@ def _restore_absurd_logger() -> t.Iterator[None]:
 
 @pytest.fixture
 def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
-    """Hard-drop all Absurd queue topology around a test (before AND after).
+    """Hard-drop all Absurd queue topology before a test, restore the declared set
+    after it.
 
     The auto cleanup installed by the pytest plugin only TRUNCATEs after each DB
     test — it removes rows, not queues. Topology-varying files create/vary queues
     whose per-queue tables (DDL) and ``managed=False`` registry rows survive a
     truncate and leak across ``--reuse-db`` runs. Apply this (via a module-level
-    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files to drop the
-    schema on both sides so each such test is hermetic.
+    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files, so each such
+    test starts from nothing.
+
+    Teardown drops and then RE-PROVISIONS, because ``migrate`` provisions the test
+    database once at creation and nothing re-runs it per test. Dropping on both sides
+    left the next test to enqueue on a queue that no longer existed, repaired only by
+    a runtime path that recreated it — a dependency invisible at the failing test's
+    call site, and one django-absurd is removing. A test that wants the unprovisioned
+    state drops the queue itself, where a reader can see it.
 
     Naming: ``_``-prefixed but non-autouse. Outside the LETTER of CLAUDE.md's
     autouse-only underscore exception, but within its spirit — never called
@@ -47,6 +56,7 @@ def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
     flush_absurd_state(drop_schema=True)
     yield
     flush_absurd_state(drop_schema=True)
+    utils.provision_declared_queues()
 
 
 @pytest.fixture

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -181,7 +181,8 @@ def test_queue_defaults_to_default(
             "QUEUES": ["default"],
         }
     }
-    tasks.make_group.enqueue("dflt")  # auto-creates the default queue
+    utils.provision_declared_queues()
+    tasks.make_group.enqueue("dflt")
     utils.start_worker_until_done(  # no --queue -> "default"
         lambda: Group.objects.filter(name="dflt").exists()
     )
@@ -217,6 +218,7 @@ def test_worker_uses_single_backend_at_nondefault_alias(
             "QUEUES": ["default"],
         }
     }
+    utils.provision_declared_queues()
     utils.start_worker()
     assert "Started worker on queue 'default'." in capsys.readouterr().out
 

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -77,6 +77,7 @@ def test_roundtrip_drains_on_the_non_default_alias(
     # the fixture resolves the Absurd alias itself (resolve_absurd_database), so a
     # drain/get_result here must land on "absurd", never the router's "default"
     assert dj_absurd.alias == "absurd"
+    dj_absurd.sync_queues()  # _isolate_queues dropped the catalog on the way in
     result = sum_numbers.enqueue(1, 2)
     assert [run.result for run in dj_absurd.drain()] == [3]
     snapshot = dj_absurd.get_result(result.id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ from django.core.management import call_command
 from django.db import connections
 from django.dispatch import Signal
 
-from django_absurd import worker
+from django_absurd import queues, worker
 from django_absurd.test import open_test_connection
 
 if t.TYPE_CHECKING:
@@ -326,3 +326,16 @@ def connect_receiver(
         yield
     finally:
         signal.disconnect(receiver, sender=sender)
+
+
+def provision_declared_queues() -> None:
+    """Provision every declared queue, as ``migrate`` and ``absurd_sync_queues`` do.
+
+    For a test that varies topology — ``_isolate_queues`` drops the catalog on the way
+    in, and the pytest plugin never re-runs ``migrate`` — so the queue a later enqueue
+    or worker needs has to be asked for here, at the call site, rather than left to a
+    runtime path that recreates it.
+    """
+    backend = queues.get_absurd_backend()
+    if backend is not None:
+        queues.provision_backend(backend)


### PR DESCRIPTION
Phase 1 of #203's plan. Tests only — `git diff origin/main...HEAD -- django_absurd/` is empty.

`_isolate_queues` dropped all topology before AND after its test, and nothing re-runs `migrate` per test, so the next test to enqueue landed on a queue that no longer existed and was silently repaired by enqueue's auto-create or by worker-boot provisioning. Teardown now drops and re-provisions; three tests that genuinely varied topology ask for provisioning explicitly.

Verified by temporarily disabling both self-heal paths and running all three suites, serial and under `-n4`: failures drop from 10 to 8 in core and 1 to 0 in multidb, and the remaining 8 are the tests that assert self-heal itself, which the removal will rewrite.
