### PR TITLE
refactor(tests): import Settings from pytest_django root

### DIFF
--- a/tests/core/test_absurd_fixture.py
+++ b/tests/core/test_absurd_fixture.py
@@ -5,7 +5,7 @@ import psycopg.errors
 import pytest
 from django.db import connections, transaction
 from django.db.utils import ProgrammingError
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.exceptions import (
     BackendNotConfiguredError,

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -8,7 +8,7 @@ from django.core.management import call_command
 from django.db import connections
 from django.test import Client
 from django.urls import reverse, reverse_lazy
-from pytest_django import Settings
+from pytest_django import DjangoDbBlocker, Settings
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.queues import get_absurd_client
@@ -24,7 +24,6 @@ from tests.core.test_admin.utils import (
 
 if t.TYPE_CHECKING:
     from bs4 import ResultSet, Tag
-    from pytest_django.plugin import DjangoDbBlocker
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -164,7 +163,7 @@ def test_changelist_no_warning_when_all_queues_indexed(
 def test_changelist_survives_staleness_detection_failure(
     admin_user: User,
     client: Client,
-    django_db_blocker: "DjangoDbBlocker",
+    django_db_blocker: DjangoDbBlocker,
 ) -> None:
     client.force_login(admin_user)
     with utils.hide_absurd_schema():

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -8,7 +8,7 @@ from django.core.management import call_command
 from django.db import connections
 from django.test import Client
 from django.urls import reverse, reverse_lazy
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.queues import get_absurd_client

--- a/tests/core/test_admin_backend_resolve.py
+++ b/tests/core/test_admin_backend_resolve.py
@@ -1,4 +1,4 @@
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.backends import AbsurdBackend
 from django_absurd.queues import get_absurd_backend

--- a/tests/core/test_admin_checks.py
+++ b/tests/core/test_admin_checks.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 BACKEND = "django_absurd.backends.AbsurdBackend"
 IMMEDIATE = "django.tasks.backends.immediate.ImmediateBackend"

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -1,7 +1,7 @@
 import typing as t
 
 from django.tasks import task_backends
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.backends import (
     AbsurdBackend,

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -5,9 +5,7 @@ from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.db import connections
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.routers import AbsurdRouter
@@ -41,7 +39,7 @@ def run_absurd_check(
 
 def test_in_sync_no_warning(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -53,7 +51,7 @@ def test_in_sync_no_warning(
 
 def test_db_unreachable_is_silent(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
     real_name = settings.DATABASES["default"]["NAME"]
@@ -81,7 +79,7 @@ def test_db_unreachable_is_silent(
 )
 def test_self_healing_drift_no_longer_warns(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
     after: dict[str, CreateQueueOptions],
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
@@ -93,7 +91,7 @@ def test_self_healing_drift_no_longer_warns(
 
 def test_storage_mode_drift_warns(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
     call_command("absurd_sync_queues")  # 'q' created unpartitioned
@@ -106,7 +104,7 @@ def test_storage_mode_drift_warns(
 
 def test_invalid_policy_modes_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # Deliberately invalid values, to exercise the check's own rejection at
     # runtime — CreateQueueOptions' Literal fields don't allow this statically.
@@ -128,7 +126,7 @@ def test_invalid_policy_modes_error(
 
 def test_schema_absent_check_is_silent(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
     with utils.hide_absurd_schema():
@@ -140,7 +138,7 @@ def test_schema_absent_check_is_silent(
 @pytest.mark.django_db(databases=["default", "sqlite"])
 def test_check_errors_on_wrong_backend(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
     out = run_absurd_check(capsys)
@@ -157,7 +155,7 @@ class RouterSubclassedByAProject(AbsurdRouter):
 
 def test_a_router_subclass_by_path_satisfies_the_router_check(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
     settings.DATABASE_ROUTERS = ["tests.core.test_checks.RouterSubclassedByAProject"]
@@ -166,7 +164,7 @@ def test_a_router_subclass_by_path_satisfies_the_router_check(
 
 def test_a_router_instance_satisfies_the_router_check(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # DATABASE_ROUTERS accepts instances as well as dotted paths, so E005 must not fire
     # on a project that builds its routers itself.
@@ -177,7 +175,7 @@ def test_a_router_instance_satisfies_the_router_check(
 
 def test_queue_state_check_is_quiet_without_an_absurd_backend(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}
@@ -187,7 +185,7 @@ def test_queue_state_check_is_quiet_without_an_absurd_backend(
 
 def test_check_errors_when_router_missing(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
     settings.DATABASE_ROUTERS = []
@@ -201,7 +199,7 @@ def test_check_errors_when_router_missing(
 
 def test_both_queue_forms_set_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -220,7 +218,7 @@ def test_both_queue_forms_set_errors(
 
 def test_pure_options_queues_no_e002(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": {"a": {}}}}}
     out = run_absurd_check(capsys)
@@ -229,7 +227,7 @@ def test_pure_options_queues_no_e002(
 
 def test_invalid_policy_key_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -245,7 +243,7 @@ def test_invalid_policy_key_errors(
 
 def test_invalid_storage_mode_literal_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -260,7 +258,7 @@ def test_invalid_storage_mode_literal_errors(
 
 def test_queues_option_as_a_list_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -282,7 +280,7 @@ def test_queues_option_as_a_list_errors(
 
 def test_queues_option_with_a_non_mapping_policy_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -304,7 +302,7 @@ def test_queues_option_with_a_non_mapping_policy_errors(
 
 def test_single_absurd_backend_no_e004(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
     assert "more than one Absurd backend" not in run_absurd_check(
@@ -314,7 +312,7 @@ def test_single_absurd_backend_no_e004(
 
 def test_two_absurd_backends_distinct_db_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -337,7 +335,7 @@ def test_two_absurd_backends_distinct_db_error(
 
 def test_two_absurd_backends_same_db_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # https://github.com/lincolnloop/django-absurd/issues/63
     settings.TASKS = {
@@ -355,7 +353,7 @@ def test_two_absurd_backends_same_db_error(
 
 def test_plain_check_skips_db_state(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -366,7 +364,7 @@ def test_plain_check_skips_db_state(
 
 def test_check_with_database_runs_db_state(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -381,7 +379,7 @@ E009_MSG = "django-absurd: OPTIONS['DEFAULT_MAX_ATTEMPTS'] must be an integer >=
 @pytest.mark.parametrize("value", [-1, 0, 1.5, "3", True])
 def test_default_max_attempts_invalid_is_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
     value: float | str | bool,
 ) -> None:
     # A DEFAULT_MAX_ATTEMPTS < 1 (or a non-int) would feed 0/garbage into every
@@ -400,7 +398,7 @@ def test_default_max_attempts_invalid_is_error(
 
 def test_default_max_attempts_valid_no_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -431,7 +429,7 @@ E010_HINT = (
 )
 def test_invalid_cleanup_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
     cleanup: str | dict[str, t.Any],
 ) -> None:
     settings.TASKS = {
@@ -450,7 +448,7 @@ def test_invalid_cleanup_errors(
 
 
 def test_scheduler_defaults_to_beat(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": {"default": {}}}}
@@ -460,7 +458,7 @@ def test_scheduler_defaults_to_beat(
 
 def test_valid_cleanup_no_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -7,7 +7,7 @@ from django.core.management.base import SystemCheckError
 from django.db import connections
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.routers import AbsurdRouter
@@ -41,7 +41,7 @@ def run_absurd_check(
 
 def test_in_sync_no_warning(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -53,7 +53,7 @@ def test_in_sync_no_warning(
 
 def test_db_unreachable_is_silent(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
     real_name = settings.DATABASES["default"]["NAME"]
@@ -81,7 +81,7 @@ def test_db_unreachable_is_silent(
 )
 def test_self_healing_drift_no_longer_warns(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
     after: dict[str, CreateQueueOptions],
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
@@ -93,7 +93,7 @@ def test_self_healing_drift_no_longer_warns(
 
 def test_storage_mode_drift_warns(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
     call_command("absurd_sync_queues")  # 'q' created unpartitioned
@@ -106,7 +106,7 @@ def test_storage_mode_drift_warns(
 
 def test_invalid_policy_modes_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # Deliberately invalid values, to exercise the check's own rejection at
     # runtime — CreateQueueOptions' Literal fields don't allow this statically.
@@ -128,7 +128,7 @@ def test_invalid_policy_modes_error(
 
 def test_schema_absent_check_is_silent(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"a": {}})
     with utils.hide_absurd_schema():
@@ -140,7 +140,7 @@ def test_schema_absent_check_is_silent(
 @pytest.mark.django_db(databases=["default", "sqlite"])
 def test_check_errors_on_wrong_backend(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
     out = run_absurd_check(capsys)
@@ -157,7 +157,7 @@ class RouterSubclassedByAProject(AbsurdRouter):
 
 def test_a_router_subclass_by_path_satisfies_the_router_check(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
     settings.DATABASE_ROUTERS = ["tests.core.test_checks.RouterSubclassedByAProject"]
@@ -166,7 +166,7 @@ def test_a_router_subclass_by_path_satisfies_the_router_check(
 
 def test_a_router_instance_satisfies_the_router_check(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # DATABASE_ROUTERS accepts instances as well as dotted paths, so E005 must not fire
     # on a project that builds its routers itself.
@@ -177,7 +177,7 @@ def test_a_router_instance_satisfies_the_router_check(
 
 def test_queue_state_check_is_quiet_without_an_absurd_backend(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.immediate.ImmediateBackend"}
@@ -187,7 +187,7 @@ def test_queue_state_check_is_quiet_without_an_absurd_backend(
 
 def test_check_errors_when_router_missing(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
     settings.DATABASE_ROUTERS = []
@@ -201,7 +201,7 @@ def test_check_errors_when_router_missing(
 
 def test_both_queue_forms_set_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -220,7 +220,7 @@ def test_both_queue_forms_set_errors(
 
 def test_pure_options_queues_no_e002(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {"default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": {"a": {}}}}}
     out = run_absurd_check(capsys)
@@ -229,7 +229,7 @@ def test_pure_options_queues_no_e002(
 
 def test_invalid_policy_key_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -245,7 +245,7 @@ def test_invalid_policy_key_errors(
 
 def test_invalid_storage_mode_literal_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -260,7 +260,7 @@ def test_invalid_storage_mode_literal_errors(
 
 def test_queues_option_as_a_list_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -282,7 +282,7 @@ def test_queues_option_as_a_list_errors(
 
 def test_queues_option_with_a_non_mapping_policy_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -304,7 +304,7 @@ def test_queues_option_with_a_non_mapping_policy_errors(
 
 def test_single_absurd_backend_no_e004(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
     assert "more than one Absurd backend" not in run_absurd_check(
@@ -314,7 +314,7 @@ def test_single_absurd_backend_no_e004(
 
 def test_two_absurd_backends_distinct_db_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -337,7 +337,7 @@ def test_two_absurd_backends_distinct_db_error(
 
 def test_two_absurd_backends_same_db_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # https://github.com/lincolnloop/django-absurd/issues/63
     settings.TASKS = {
@@ -355,7 +355,7 @@ def test_two_absurd_backends_same_db_error(
 
 def test_plain_check_skips_db_state(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -366,7 +366,7 @@ def test_plain_check_skips_db_state(
 
 def test_check_with_database_runs_db_state(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = build_tasks_setting({"synced": {}})
     call_command("absurd_sync_queues")
@@ -381,7 +381,7 @@ E009_MSG = "django-absurd: OPTIONS['DEFAULT_MAX_ATTEMPTS'] must be an integer >=
 @pytest.mark.parametrize("value", [-1, 0, 1.5, "3", True])
 def test_default_max_attempts_invalid_is_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
     value: float | str | bool,
 ) -> None:
     # A DEFAULT_MAX_ATTEMPTS < 1 (or a non-int) would feed 0/garbage into every
@@ -400,7 +400,7 @@ def test_default_max_attempts_invalid_is_error(
 
 def test_default_max_attempts_valid_no_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -431,7 +431,7 @@ E010_HINT = (
 )
 def test_invalid_cleanup_errors(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
     cleanup: str | dict[str, t.Any],
 ) -> None:
     settings.TASKS = {
@@ -450,7 +450,7 @@ def test_invalid_cleanup_errors(
 
 
 def test_scheduler_defaults_to_beat(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": {"default": {}}}}
@@ -460,7 +460,7 @@ def test_scheduler_defaults_to_beat(
 
 def test_valid_cleanup_no_error(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -24,7 +24,7 @@ from django_absurd.test import AbsurdTestRuntime, FrozenTime
 from tests import tasks, utils
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
     import django_absurd.backends
 
@@ -40,7 +40,7 @@ BEAT_EPOCH = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
 
 
 def sync_queue(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
     cleanup_ttl: str = "0 seconds",
     cleanup_limit: int = 1000,
     names: tuple[str, ...] = ("default",),
@@ -107,7 +107,7 @@ def answer(text: str) -> collections.abc.Iterator[None]:
 def test_cleanup_deletes_aged_terminal_tasks(
     caplog: pytest.LogCaptureFixture,
     cleanup: "CleanupCallable",
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings)
     tasks.add.enqueue(2, 3)
@@ -124,7 +124,7 @@ def test_cleanup_deletes_aged_terminal_tasks(
 
 def test_cleanup_skips_non_terminal_tasks(
     cleanup: "CleanupCallable",
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings)
     tasks.add.enqueue(2, 3)  # pending — worker not run, so not terminal
@@ -139,7 +139,7 @@ def test_cleanup_skips_non_terminal_tasks(
 
 def test_cleanup_respects_batch_limit(
     cleanup: "CleanupCallable",
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, cleanup_limit=2)
     for _ in range(3):
@@ -158,7 +158,7 @@ def test_cleanup_respects_batch_limit(
 
 def test_cleanup_targets_specific_queue(
     cleanup: "CleanupCallable",
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     tasks.add.enqueue(2, 3)  # default
@@ -176,7 +176,7 @@ def test_cleanup_targets_specific_queue(
 
 def test_cleanup_command_reports_per_queue_counts(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings)
     tasks.add.enqueue(2, 3)
@@ -187,7 +187,7 @@ def test_cleanup_command_reports_per_queue_counts(
 
 
 def test_cleanup_does_not_relabel_an_unrelated_missing_relation(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """A missing relation inside ``absurd.cleanup_all_queues`` that is not the
     schema-absent shape (``InvalidSchemaName``/``UndefinedFunction``) surfaces as
@@ -217,7 +217,7 @@ def test_cleanup_does_not_relabel_an_unrelated_missing_relation(
 
 def test_cleanup_command_reports_no_backends(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {}
     call_command("absurd_cleanup")
@@ -226,7 +226,7 @@ def test_cleanup_command_reports_no_backends(
 
 def test_flush_reports_no_backends(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {}
     call_command("absurd_flush")
@@ -240,7 +240,7 @@ def test_flush_reports_no_queues(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_flush_noinput_drops_all_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -251,7 +251,7 @@ def test_flush_noinput_drops_all_queues(
 
 def test_flush_interactive_yes_drops_all_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -267,7 +267,7 @@ def test_flush_interactive_yes_drops_all_queues(
 
 def test_flush_interactive_no_keeps_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -283,7 +283,7 @@ def test_flush_interactive_no_keeps_queues(
 
 def test_flush_non_interactive_eof_keeps_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -313,7 +313,7 @@ def test_beat_fires_cleanup_on_cadence(
     caplog: pytest.LogCaptureFixture,
     cleanup: "CleanupCallable",
     dj_absurd: AbsurdTestRuntime,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
@@ -341,7 +341,7 @@ def test_beat_fires_cleanup_on_cadence(
 def test_beat_isolates_failing_cleanup(
     caplog: pytest.LogCaptureFixture,
     dj_absurd: AbsurdTestRuntime,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
@@ -359,7 +359,7 @@ def test_beat_isolates_failing_cleanup(
 
 def test_beat_fires_cleanup_and_task_same_slot(
     dj_absurd: AbsurdTestRuntime,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # A scheduled task and CLEANUP sharing a cron slot both fire in the one tick:
     # the task enqueues (pending → survives cleanup) and cleanup deletes the aged row.

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -14,6 +14,7 @@ from django.core.management import call_command
 from django.db import connection
 from django.db.utils import ProgrammingError
 from django.utils import timezone
+from pytest_django import Settings
 
 from django_absurd import worker
 from django_absurd.backends import get_absurd_backends
@@ -24,8 +25,6 @@ from django_absurd.test import AbsurdTestRuntime, FrozenTime
 from tests import tasks, utils
 
 if t.TYPE_CHECKING:
-    from pytest_django import Settings
-
     import django_absurd.backends
 
     CleanupCallable = t.Callable[..., list[QueueCleanup]]
@@ -40,7 +39,7 @@ BEAT_EPOCH = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
 
 
 def sync_queue(
-    settings: "Settings",
+    settings: Settings,
     cleanup_ttl: str = "0 seconds",
     cleanup_limit: int = 1000,
     names: tuple[str, ...] = ("default",),
@@ -107,7 +106,7 @@ def answer(text: str) -> collections.abc.Iterator[None]:
 def test_cleanup_deletes_aged_terminal_tasks(
     caplog: pytest.LogCaptureFixture,
     cleanup: "CleanupCallable",
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings)
     tasks.add.enqueue(2, 3)
@@ -124,7 +123,7 @@ def test_cleanup_deletes_aged_terminal_tasks(
 
 def test_cleanup_skips_non_terminal_tasks(
     cleanup: "CleanupCallable",
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings)
     tasks.add.enqueue(2, 3)  # pending — worker not run, so not terminal
@@ -139,7 +138,7 @@ def test_cleanup_skips_non_terminal_tasks(
 
 def test_cleanup_respects_batch_limit(
     cleanup: "CleanupCallable",
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, cleanup_limit=2)
     for _ in range(3):
@@ -158,7 +157,7 @@ def test_cleanup_respects_batch_limit(
 
 def test_cleanup_targets_specific_queue(
     cleanup: "CleanupCallable",
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     tasks.add.enqueue(2, 3)  # default
@@ -176,7 +175,7 @@ def test_cleanup_targets_specific_queue(
 
 def test_cleanup_command_reports_per_queue_counts(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings)
     tasks.add.enqueue(2, 3)
@@ -187,7 +186,7 @@ def test_cleanup_command_reports_per_queue_counts(
 
 
 def test_cleanup_does_not_relabel_an_unrelated_missing_relation(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """A missing relation inside ``absurd.cleanup_all_queues`` that is not the
     schema-absent shape (``InvalidSchemaName``/``UndefinedFunction``) surfaces as
@@ -217,7 +216,7 @@ def test_cleanup_does_not_relabel_an_unrelated_missing_relation(
 
 def test_cleanup_command_reports_no_backends(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {}
     call_command("absurd_cleanup")
@@ -226,7 +225,7 @@ def test_cleanup_command_reports_no_backends(
 
 def test_flush_reports_no_backends(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {}
     call_command("absurd_flush")
@@ -240,7 +239,7 @@ def test_flush_reports_no_queues(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_flush_noinput_drops_all_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -251,7 +250,7 @@ def test_flush_noinput_drops_all_queues(
 
 def test_flush_interactive_yes_drops_all_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -267,7 +266,7 @@ def test_flush_interactive_yes_drops_all_queues(
 
 def test_flush_interactive_no_keeps_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -283,7 +282,7 @@ def test_flush_interactive_no_keeps_queues(
 
 def test_flush_non_interactive_eof_keeps_queues(
     capsys: pytest.CaptureFixture[str],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
@@ -313,7 +312,7 @@ def test_beat_fires_cleanup_on_cadence(
     caplog: pytest.LogCaptureFixture,
     cleanup: "CleanupCallable",
     dj_absurd: AbsurdTestRuntime,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
@@ -341,7 +340,7 @@ def test_beat_fires_cleanup_on_cadence(
 def test_beat_isolates_failing_cleanup(
     caplog: pytest.LogCaptureFixture,
     dj_absurd: AbsurdTestRuntime,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     sync_queue(settings, cleanup={"schedule": "* * * * *"})
     backend = get_absurd_backends()["default"]
@@ -359,7 +358,7 @@ def test_beat_isolates_failing_cleanup(
 
 def test_beat_fires_cleanup_and_task_same_slot(
     dj_absurd: AbsurdTestRuntime,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # A scheduled task and CLEANUP sharing a cron slot both fire in the one tick:
     # the task enqueues (pending → survives cleanup) and cleanup deletes the aged row.

--- a/tests/core/test_command_errors.py
+++ b/tests/core/test_command_errors.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.exceptions import (
     BackendNotConfiguredError,

--- a/tests/core/test_command_output.py
+++ b/tests/core/test_command_output.py
@@ -2,7 +2,7 @@ import io
 
 import pytest
 from django.core.management import call_command
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.test import AbsurdTestRuntime
 from tests import utils

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -7,7 +7,7 @@ from django.core.management import call_command
 from django.db import connections, transaction
 from django.tasks import TaskResultStatus, task
 from django.tasks.exceptions import InvalidTask
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd import absurd_params
 from django_absurd.connection import register_jsonb_loader

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -2,7 +2,7 @@ import psycopg.errors
 import pytest
 from django.core.management import call_command
 from django.db import connection
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd import emit_event
 from django_absurd.exceptions import (

--- a/tests/core/test_logging/test_handler.py
+++ b/tests/core/test_logging/test_handler.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 
 import pytest
-import pytest_django.fixtures
+from pytest_django import Settings
 
 from django_absurd import hooks
 from django_absurd import logging as absurd_logging
@@ -51,7 +51,7 @@ def test_running_the_worker_gives_the_package_a_console_handler() -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_the_worker_defers_to_a_project_that_configured_this_package(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.LOGGING = CONSOLE_LOGGING
     logger = logging.getLogger("django_absurd")
@@ -61,7 +61,7 @@ def test_the_worker_defers_to_a_project_that_configured_this_package(
 
 
 def test_a_configured_child_logger_is_left_alone(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Configuring django_absurd.worker says what you want from the worker; a handler
     on the parent would print those lines twice.
@@ -84,7 +84,7 @@ def test_a_configured_child_logger_is_left_alone(
     ],
 )
 def test_a_logging_config_that_names_someone_else_still_gets_the_default(
-    config: object, settings: pytest_django.fixtures.Settings
+    config: object, settings: Settings
 ) -> None:
     settings.LOGGING = config
     absurd_logging.attach_console_handler()
@@ -93,7 +93,7 @@ def test_a_logging_config_that_names_someone_else_still_gets_the_default(
 
 @pytest.mark.django_db(transaction=True)
 def test_attaching_twice_does_not_duplicate_the_handler(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.make_tasks_settings()
     absurd_logging.attach_console_handler()
@@ -114,7 +114,7 @@ def test_the_sync_client_gets_only_the_hook_it_can_run() -> None:
 
 
 def test_the_worker_defers_the_handler_to_a_root_only_logging_config(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Root catches our records by propagation, so attaching underneath it would
     print every line twice — once bare, once through the project's handler.
@@ -133,7 +133,7 @@ def test_the_worker_defers_the_handler_to_a_root_only_logging_config(
 
 
 def test_a_root_entry_spelled_under_loggers_counts_too(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.LOGGING = {
         **DICTCONFIG_HEADER,

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -5,6 +5,7 @@ import pytest
 from django.apps import apps
 from django.core.management import call_command
 from django.db import connections, models
+from pytest_django import DjangoDbBlocker
 
 from django_absurd import admin_views
 from django_absurd.admin_views import (
@@ -21,7 +22,6 @@ from tests import tasks, utils
 
 if t.TYPE_CHECKING:
     from django.apps.config import AppConfig
-    from pytest_django.plugin import DjangoDbBlocker
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -53,7 +53,7 @@ def test_read_path_does_no_ddl() -> None:
 
 @pytest.mark.django_db(transaction=True)
 def test_migrate_provisions_declared_queues_and_views(
-    django_db_blocker: "DjangoDbBlocker",
+    django_db_blocker: DjangoDbBlocker,
 ) -> None:
     # `migrate` fires post_migrate → sync_queues: declared queues created + views
     # built, reported on stdout in Django's migrate style.
@@ -75,7 +75,7 @@ def test_migrate_provisions_declared_queues_and_views(
 
 @pytest.mark.django_db(transaction=True)
 def test_provision_skips_when_schema_absent(
-    django_db_blocker: "DjangoDbBlocker",
+    django_db_blocker: DjangoDbBlocker,
 ) -> None:
     # post_migrate: best-effort; missing schema swallowed, not raised
     with utils.hide_absurd_schema():

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -6,9 +6,7 @@ import pytest
 from django.core.management import call_command
 from django.db import connections
 from django.test import TransactionTestCase
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
+from pytest_django import Settings
 
 from django_absurd import absurd_params, pytest_plugin
 from django_absurd.flush import flush_absurd_state
@@ -53,7 +51,7 @@ def test_flush_absurd_state_truncates_rows_by_default() -> None:
 
 
 def test_flush_absurd_state_truncates_a_partitioned_queues_idempotency_table(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # `i_<queue>` only exists for a `partitioned` queue — exercise that branch of
     # truncate_queue_tables (the unpartitioned "default" queue used elsewhere in this
@@ -83,7 +81,7 @@ def test_flush_absurd_state_drops_schema_when_requested() -> None:
 
 
 def test_flush_absurd_state_is_a_noop_on_an_unmigrated_schema(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # Mirrors tests/core/test_checks.py::test_db_unreachable_is_silent's real
     # unreachable-DB technique: mutating settings.DATABASES alone is not enough — the
@@ -165,7 +163,7 @@ def test_post_teardown_hook_skips_undeclared_absurd_alias() -> None:
 
 
 def test_post_teardown_hook_skips_without_an_absurd_backend(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # Seed under the real Absurd backend, then swap TASKS to a non-Absurd backend so
     # the hook's unconfigured-backend guard (no AbsurdBackend) fires and skips flushing.

--- a/tests/core/test_pytest_plugin.py
+++ b/tests/core/test_pytest_plugin.py
@@ -8,7 +8,7 @@ from django.db import connections
 from django.test import TransactionTestCase
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
 from django_absurd import absurd_params, pytest_plugin
 from django_absurd.flush import flush_absurd_state
@@ -53,7 +53,7 @@ def test_flush_absurd_state_truncates_rows_by_default() -> None:
 
 
 def test_flush_absurd_state_truncates_a_partitioned_queues_idempotency_table(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # `i_<queue>` only exists for a `partitioned` queue — exercise that branch of
     # truncate_queue_tables (the unpartitioned "default" queue used elsewhere in this
@@ -83,7 +83,7 @@ def test_flush_absurd_state_drops_schema_when_requested() -> None:
 
 
 def test_flush_absurd_state_is_a_noop_on_an_unmigrated_schema(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # Mirrors tests/core/test_checks.py::test_db_unreachable_is_silent's real
     # unreachable-DB technique: mutating settings.DATABASES alone is not enough — the
@@ -165,7 +165,7 @@ def test_post_teardown_hook_skips_undeclared_absurd_alias() -> None:
 
 
 def test_post_teardown_hook_skips_without_an_absurd_backend(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # Seed under the real Absurd backend, then swap TASKS to a non-Absurd backend so
     # the hook's unconfigured-backend guard (no AbsurdBackend) fires and skips flushing.

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -13,7 +13,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.db import connection, connections
 from django.db.utils import OperationalError, ProgrammingError
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.models import Queue
 from django_absurd.queues import (

--- a/tests/core/test_run_after.py
+++ b/tests/core/test_run_after.py
@@ -4,7 +4,7 @@ import pytest
 from django.db import connections
 from django.tasks import TaskResultStatus, task_backends
 from django.utils import timezone
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd import absurd_params
 from django_absurd.connection import register_jsonb_loader

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -8,13 +8,13 @@ import typing as t
 import zoneinfo
 
 import pytest
-import pytest_django.fixtures
 import time_machine
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.tasks import TaskResultStatus
 from django.utils import timezone
+from pytest_django import Settings
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.scheduler import (
@@ -46,7 +46,7 @@ def make_tasks_setting(
 
 
 def test_settings_provider_reads_entries(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -73,7 +73,7 @@ def test_settings_provider_reads_entries(
 
 
 def test_settings_provider_defaults_and_empty(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {"ping": {"task": "tests.tasks.add", "cron": "*/5 * * * *"}}
@@ -86,7 +86,7 @@ def test_settings_provider_defaults_and_empty(
 
 
 def test_settings_provider_no_schedule_key(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -111,7 +111,7 @@ def test_get_next_datetime_rolls_forward(dj_absurd: AbsurdTestRuntime) -> None:
 
 
 def test_get_next_datetime_uses_django_timezone(
-    dj_absurd: AbsurdTestRuntime, settings: pytest_django.fixtures.Settings
+    dj_absurd: AbsurdTestRuntime, settings: Settings
 ) -> None:
     # 06:00 in Chicago (UTC-6)
     with dj_absurd.freeze_time(dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)):
@@ -171,7 +171,7 @@ def run_beat_until(
 
 def test_beat_fires_each_due_slot(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -195,7 +195,7 @@ def test_beat_fires_each_due_slot(
 
 def test_beat_fires_multiple_schedules_due_same_slot(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Two distinct schedules sharing a cron slot both fire in the one tick pass.
     settings.TASKS = make_tasks_setting(
@@ -224,7 +224,7 @@ def test_beat_fires_multiple_schedules_due_same_slot(
 
 def test_beat_no_schedules_returns(
     caplog: pytest.LogCaptureFixture,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting({})
     backend = get_absurd_backends()["default"]
@@ -237,7 +237,7 @@ def test_beat_no_schedules_returns(
 
 def test_beat_started_logs_schedule_count_and_cleanup(
     caplog: pytest.LogCaptureFixture,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}},
@@ -257,7 +257,7 @@ def test_beat_started_logs_schedule_count_and_cleanup(
 def test_beat_isolates_failing_schedule(
     caplog: pytest.LogCaptureFixture,
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -296,7 +296,7 @@ def test_beat_isolates_failing_schedule(
 
 def test_beat_spawns_task_with_args(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -319,7 +319,7 @@ def test_beat_spawns_task_with_args(
 
 def test_beat_spawns_task_with_kwargs(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -342,7 +342,7 @@ def test_beat_spawns_task_with_kwargs(
 
 def test_beat_empty_queue_string_falls_back_to_task_queue(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """queue: "" normalises to the task's own queue (parity with pg_cron's
     fallback), not a literal "" queue that enqueue would reject."""
@@ -368,7 +368,7 @@ def test_beat_empty_queue_string_falls_back_to_task_queue(
 
 def test_beat_routes_task_to_queue(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -394,7 +394,7 @@ def test_beat_routes_task_to_queue(
 
 def test_beat_routes_task_to_queue_non_default_alias(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "second": {
@@ -426,7 +426,7 @@ def test_beat_routes_task_to_queue_non_default_alias(
 
 def test_get_result_rebinds_queue_and_backend_together(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # tasks.make_group's own decorator names the "default" alias, and these settings
     # deliberately omit it: only "second" is configured, so a queue-only rebind of the
@@ -496,7 +496,7 @@ def test_derive_idempotency_key_differs_across_backends() -> None:
 
 
 def test_settings_provider_sets_backend_alias(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "second": {
@@ -521,7 +521,7 @@ def test_settings_provider_sets_backend_alias(
 
 def test_idempotency_key_dedups_same_slot(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # The command/loop never re-fires a single slot; this tests spawn_scheduled
     # directly to prove our key + Absurd's real dedup together collapse repeated
@@ -547,7 +547,7 @@ def test_idempotency_key_dedups_same_slot(
 
 
 def test_absurd_beat_empty_schedule_runs_handle(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Covers absurd_beat handle body (single-backend path via base.py:16-17).
     # Empty SCHEDULE → run_beat returns immediately (no blocking), no threads needed.
@@ -563,7 +563,7 @@ def test_absurd_beat_empty_schedule_runs_handle(
 
 
 def test_absurd_beat_valid_and_signal_handler(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Covers base.py:15 (valid alias → backend = backends[alias]) and
     # absurd_beat.py:27 (handle_signal body: stop.set()).
@@ -604,7 +604,7 @@ def test_absurd_beat_valid_and_signal_handler(
 
 def test_absurd_beat_startup_reports_cleanup(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Covers absurd_beat.py:38-39 (cleanup appended to the startup message). Empty
     # SCHEDULE + a CLEANUP makes run_beat loop, so a handler-gated SIGINT stops it; the
@@ -640,7 +640,7 @@ def test_absurd_beat_startup_reports_cleanup(
 
 
 def test_absurd_beat_rejects_alias_flag(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting({})
     with pytest.raises(CommandError):
@@ -648,7 +648,7 @@ def test_absurd_beat_rejects_alias_flag(
 
 
 def test_beat_stop_interrupts_long_sleep(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Real threading.Event.wait — stop.set() must wake the beat promptly.
     settings.TASKS = make_tasks_setting(
@@ -679,7 +679,7 @@ def test_beat_stop_interrupts_long_sleep(
 
 
 def test_worker_with_beat_runs_scheduled_task(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_setting(
         {
@@ -708,7 +708,7 @@ def test_worker_with_beat_runs_scheduled_task(
 
 
 def test_beat_already_stopped_on_entry_skips_loop(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Covers scheduler.py 92->exit: while-False branch when stop is pre-set.
     # Beat has at least one schedule so it passes the early-return guard, reaches
@@ -734,7 +734,7 @@ def test_beat_already_stopped_on_entry_skips_loop(
 
 def test_beat_skips_not_yet_due_schedule(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Covers scheduler.py 99->98: if due <= current False branch.
     # Two schedules: one every minute (due), one at 02:00 (far future, not due).
@@ -770,7 +770,7 @@ def test_beat_skips_not_yet_due_schedule(
 
 def test_plain_worker_runs_blocking_worker(
     caplog: pytest.LogCaptureFixture,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Covers arun_worker's else branch: a worker started without --beat.
     settings.TASKS = make_tasks_setting(

--- a/tests/core/test_scheduler_checks.py
+++ b/tests/core/test_scheduler_checks.py
@@ -3,7 +3,7 @@ import typing as t
 import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -14,7 +14,7 @@ from django.core.management import call_command, load_command_class
 from django.core.management.base import CommandError
 from django.db import connection
 from django.tasks import task
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.exceptions import (

--- a/tests/multidb/test_check.py
+++ b/tests/multidb/test_check.py
@@ -1,6 +1,6 @@
 import pytest
 from django.core.management import call_command
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(databases=["default", "absurd"])
 

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -6,7 +6,7 @@ from django.db import connections
 from django.tasks import task
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
 from django_absurd.models import Queue
 from django_absurd.routers import AbsurdRouter
@@ -58,7 +58,7 @@ def test_db_for_read_write_route_django_absurd() -> None:
 
 
 def test_sync_command_honors_alias(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -1,12 +1,8 @@
-import typing as t
-
 import pytest
 from django.core.management import call_command
 from django.db import connections
 from django.tasks import task
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
+from pytest_django import Settings
 
 from django_absurd.models import Queue
 from django_absurd.routers import AbsurdRouter
@@ -58,7 +54,7 @@ def test_db_for_read_write_route_django_absurd() -> None:
 
 
 def test_sync_command_honors_alias(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {

--- a/tests/pg_cron/test_absurd_sync_crons_command.py
+++ b/tests/pg_cron/test_absurd_sync_crons_command.py
@@ -2,9 +2,9 @@ import io
 import sys
 
 import pytest
-import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron import catalog
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("kwargs", [{}, {"no_input": True, "teardown": True}])
 def test_command_errors_when_inert(
     kwargs: dict[str, bool],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Both sync and --teardown refuse to run when pg_cron scheduling is inert
     (a test DB / active test run without PG_CRON_ON_TEST_DB)."""
@@ -34,7 +34,7 @@ def test_command_errors_when_inert(
 
 
 def test_sync_crons_command_malformed_schedule_raises_commanderror(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """A SCHEDULE entry missing task/cron must surface as a clean CommandError,
     not a raw KeyError traceback."""
@@ -44,7 +44,7 @@ def test_sync_crons_command_malformed_schedule_raises_commanderror(
 
 
 def test_sync_crons_command_no_backend_errors(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
@@ -59,7 +59,7 @@ def test_sync_crons_command_no_backend_errors(
 
 def test_sync_crons_command_creates_cron_jobs(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {
@@ -81,7 +81,7 @@ def test_sync_crons_command_creates_cron_jobs(
 
 def test_sync_crons_command_writes_summary_to_stdout(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -94,7 +94,7 @@ def test_sync_crons_command_writes_summary_to_stdout(
 
 def test_sync_crons_command_is_idempotent(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -107,7 +107,7 @@ def test_sync_crons_command_is_idempotent(
 
 def test_teardown_removes_owned_cron_jobs(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {
@@ -132,7 +132,7 @@ def test_teardown_removes_owned_cron_jobs(
 
 
 def test_teardown_command_deletes_admin_job_and_row_after_confirmation(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     ScheduledTask.objects.create(
@@ -165,7 +165,7 @@ def test_teardown_command_deletes_admin_job_and_row_after_confirmation(
 
 
 def test_teardown_admin_schedule_does_not_resurrect_on_next_sync(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """--teardown deletes the admin rows, so the next reconcile (which re-emits admin
     rows) has nothing to resurrect — the destructive teardown is terminal."""
@@ -193,7 +193,7 @@ def test_teardown_admin_schedule_does_not_resurrect_on_next_sync(
 @pytest.mark.parametrize("stdin_text", ["", "no\n"])
 def test_teardown_command_aborts_without_confirmation(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
     stdin_text: str,
 ) -> None:
     # "no\n" declines; "" is a non-interactive EOF (CI / docker exec -T) — both abort

--- a/tests/pg_cron/test_admin/test_registration.py
+++ b/tests/pg_cron/test_admin/test_registration.py
@@ -16,7 +16,7 @@ from django_absurd.pg_cron.models import ScheduledTask
 from tests.admin import custom_site, gated_site, other_site
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -46,7 +46,7 @@ def test_staff_user_with_view_permission_sees_scheduledtask_in_index(
 
 
 def test_custom_admin_site_registration(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -59,7 +59,7 @@ def test_custom_admin_site_registration(
 
 
 def test_autoregister_skips_when_enable_admin_false(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     gated_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {
@@ -76,7 +76,7 @@ def test_autoregister_skips_when_enable_admin_false(
 
 
 def test_register_is_idempotent(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     other_site._registry.pop(ScheduledTask, None)
     register_scheduled_task_admin([other_site])
@@ -87,7 +87,7 @@ def test_register_is_idempotent(
 
 
 def test_autoregister_skips_when_no_absurd_backend(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     gated_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {}
@@ -96,7 +96,7 @@ def test_autoregister_skips_when_no_absurd_backend(
 
 
 def test_autoregister_registers_when_enable_admin_true(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     other_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {

--- a/tests/pg_cron/test_admin/test_registration.py
+++ b/tests/pg_cron/test_admin/test_registration.py
@@ -1,11 +1,10 @@
-import typing as t
-
 import pytest
 from bs4 import BeautifulSoup
 from django.contrib import admin as djadmin
 from django.contrib.auth.models import Permission, User
 from django.test import Client
 from django.urls import reverse_lazy
+from pytest_django import Settings
 
 from django_absurd.admin import resolve_admin_sites
 from django_absurd.pg_cron.admin import (
@@ -14,9 +13,6 @@ from django_absurd.pg_cron.admin import (
 )
 from django_absurd.pg_cron.models import ScheduledTask
 from tests.admin import custom_site, gated_site, other_site
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -46,7 +42,7 @@ def test_staff_user_with_view_permission_sees_scheduledtask_in_index(
 
 
 def test_custom_admin_site_registration(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -59,7 +55,7 @@ def test_custom_admin_site_registration(
 
 
 def test_autoregister_skips_when_enable_admin_false(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     gated_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {
@@ -76,7 +72,7 @@ def test_autoregister_skips_when_enable_admin_false(
 
 
 def test_register_is_idempotent(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     other_site._registry.pop(ScheduledTask, None)
     register_scheduled_task_admin([other_site])
@@ -87,7 +83,7 @@ def test_register_is_idempotent(
 
 
 def test_autoregister_skips_when_no_absurd_backend(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     gated_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {}
@@ -96,7 +92,7 @@ def test_autoregister_skips_when_no_absurd_backend(
 
 
 def test_autoregister_registers_when_enable_admin_true(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     other_site._registry.pop(ScheduledTask, None)
     settings.TASKS = {

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -9,8 +9,8 @@ from django.test import Client
 from django.urls import reverse, reverse_lazy
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
     from bs4.element import ResultSet
+    from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron import catalog
@@ -63,7 +63,7 @@ CHANGE_PAYLOAD = {
 }
 
 
-def seed(settings: "pytest_django.fixtures.Settings") -> None:
+def seed(settings: "Settings") -> None:
     settings.TASKS = TASKS
     call_command("absurd_sync_queues")
     sync_crons(get_absurd_backends()["default"])
@@ -81,7 +81,7 @@ def get_change_url(pk: int) -> str:
 def test_changelist_renders_one_row_per_schedule(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -91,7 +91,7 @@ def test_changelist_renders_one_row_per_schedule(
 def test_changelist_shows_expected_columns(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -104,7 +104,7 @@ def test_changelist_shows_expected_columns(
 def test_queue_filter_renders_and_narrows(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -118,7 +118,7 @@ def test_queue_filter_renders_and_narrows(
 def test_search_by_name_narrows(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -128,7 +128,7 @@ def test_search_by_name_narrows(
 def test_create_resolves_all_spawn_options_and_is_disabled(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -156,7 +156,7 @@ def test_create_resolves_all_spawn_options_and_is_disabled(
 def test_create_with_save_and_add_another_returns_to_the_add_view(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # "Save and add another" must NOT force the review-on-change redirect — it lands
     # back on the add view like Django's default.
@@ -178,7 +178,7 @@ def test_create_with_save_and_add_another_returns_to_the_add_view(
 def test_add_view_renders_only_the_minimal_fields(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -191,7 +191,7 @@ def test_add_view_renders_only_the_minimal_fields(
 
 
 def narrow_to_default_queue_only(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """Re-declare the backend with only "default" queue.
 
@@ -211,7 +211,7 @@ def narrow_to_default_queue_only(
 def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # on_reports' own queue ("reports") resolves fine, but the backend no longer
     # declares it, so the model rejects the resolved queue. queue isn't a field on the
@@ -237,7 +237,7 @@ def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
 def test_create_with_no_declared_queues_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # A backend declaring no queues has nothing to schedule onto, so every resolved
     # queue is undeclared and the admin must refuse rather than save a schedule that
@@ -262,7 +262,7 @@ def test_create_with_no_declared_queues_is_form_error_not_created(
 def test_create_with_no_backend_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # With no backend nothing resolves the task's queue, and queue isn't a field on the
     # create form, so without the model's blank check the row saved with queue="".
@@ -282,7 +282,7 @@ def test_create_with_no_backend_is_form_error_not_created(
 def test_create_with_unimportable_task_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # An unimportable task path is rejected on the task field before any spawn-option
     # resolution runs (so build_scheduled_fields never sees a bad path), and nothing is
@@ -307,7 +307,7 @@ def test_create_with_unimportable_task_is_form_error_not_created(
 def test_create_with_non_task_target_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # A path that imports but isn't a Django task is rejected on the task field (so
     # resolution, which reads task-only attributes, is never reached).
@@ -329,7 +329,7 @@ def test_create_with_non_task_target_is_form_error_not_created(
 def test_create_with_blank_task_skips_resolution_and_is_required_error(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # A blank task never reaches cleaned_data, so spawn-option resolution is skipped
     # entirely; the form reports the field as required and creates nothing.
@@ -347,7 +347,7 @@ def test_create_with_blank_task_skips_resolution_and_is_required_error(
 def test_create_with_bad_cron_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -366,7 +366,7 @@ def test_create_with_bad_cron_is_form_error_not_created(
 def test_create_and_sync_produce_identical_spawn_columns(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # parity: admin-creating a task resolves the same spawn columns as running
     # sync_crons over a settings SCHEDULE of that same task (the two write lanes).
@@ -416,7 +416,7 @@ def test_create_and_sync_produce_identical_spawn_columns(
 def test_add_link_present_and_add_view_renders(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -431,7 +431,7 @@ def test_add_link_present_and_add_view_renders(
 def test_add_view_cron_help_renders_pg_cron_link_as_html(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # the cron field's help text embeds an <a> to the pg_cron docs; Django form
     # help_text is not auto-escaped, so it must reach the page as a real anchor (an
@@ -461,7 +461,7 @@ def create_scheduled_task(
 def test_change_view_shows_resolved_default_max_attempts(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # The create form resolves max_attempts from the task/backend (here the backend
     # default, 5); the change form then renders that resolved value editable.
@@ -477,7 +477,7 @@ def test_change_view_shows_resolved_default_max_attempts(
 def test_posting_add_creates_admin_schedule_and_schedules_job(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -497,7 +497,7 @@ def test_posting_add_creates_admin_schedule_and_schedules_job(
 def test_posting_add_with_tampered_source_is_forced_to_admin(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # source is a hidden, pinned field: a crafted POST setting source="s" (settings)
     # must not create a settings-owned row via the writable admin.
@@ -511,7 +511,7 @@ def test_posting_add_with_tampered_source_is_forced_to_admin(
 def test_editing_blank_args_kwargs_falls_back_to_defaults(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # queue="reports" (declared) so the edit exercises the "stored queue is still a
     # valid choice" path (no injection) alongside the blank args/kwargs fallback.
@@ -532,7 +532,7 @@ def test_editing_blank_args_kwargs_falls_back_to_defaults(
 def test_posting_duplicate_admin_name_is_form_error_not_500(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -549,7 +549,7 @@ def test_posting_duplicate_admin_name_is_form_error_not_500(
 def test_posting_add_with_invalid_cron_shows_pg_crons_message(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -564,7 +564,7 @@ def test_posting_add_with_invalid_cron_shows_pg_crons_message(
 def test_settings_schedule_detail_is_readonly(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     pk = ScheduledTask.objects.get(name="hourly").pk  # a settings row
@@ -579,7 +579,7 @@ def test_settings_schedule_detail_is_readonly(
 def test_admin_schedule_edit_form_cron_editable_name_immutable(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -597,7 +597,7 @@ def test_admin_schedule_edit_form_cron_editable_name_immutable(
 def test_posting_edit_reschedules_the_job_with_the_new_cron(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -618,7 +618,7 @@ def test_posting_edit_reschedules_the_job_with_the_new_cron(
 def test_deleting_admin_schedule_via_admin_unschedules_the_job(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -646,7 +646,7 @@ def test_deleting_admin_schedule_via_admin_unschedules_the_job(
 def test_deleting_settings_schedule_via_admin_is_forbidden(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     pk = ScheduledTask.objects.get(name="hourly").pk  # a settings row
@@ -659,7 +659,7 @@ def test_deleting_settings_schedule_via_admin_is_forbidden(
 def test_change_form_rejects_a_blank_queue(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -680,7 +680,7 @@ def test_change_form_rejects_a_blank_queue(
 def test_change_view_queue_is_a_dropdown_of_declared_queues(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)  # QUEUES: default, other, reports
     client.force_login(admin_user)
@@ -693,7 +693,7 @@ def test_change_view_queue_is_a_dropdown_of_declared_queues(
 def test_change_view_offers_no_queue_when_the_backend_declares_none(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # Validation rejects every name in this config, so the dropdown must not advertise
     # one: only the empty choice remains. A fresh dict — mutating TASKS in place would
@@ -715,7 +715,7 @@ def test_change_view_offers_no_queue_when_the_backend_declares_none(
 def test_change_view_offers_no_queue_with_no_absurd_backend(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     # Nothing declares queues, so the field names none: a stand-in choice would claim a
     # queue no backend declares.
@@ -733,7 +733,7 @@ def test_change_view_offers_no_queue_with_no_absurd_backend(
 def test_change_view_retry_kind_is_a_dropdown(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -746,7 +746,7 @@ def test_change_view_retry_kind_is_a_dropdown(
 def test_change_view_cancellation_fields_are_number_inputs(
     admin_user: User,
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -758,7 +758,7 @@ def test_change_view_cancellation_fields_are_number_inputs(
 
 def test_add_forbidden_for_staff_without_permission(
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
     staff_user: User,
 ) -> None:
     seed(settings)
@@ -768,7 +768,7 @@ def test_add_forbidden_for_staff_without_permission(
 
 def test_add_allowed_for_staff_with_permission(
     client: Client,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
     staff_user: User,
 ) -> None:
     staff_user.user_permissions.add(

--- a/tests/pg_cron/test_admin/test_scheduledtask.py
+++ b/tests/pg_cron/test_admin/test_scheduledtask.py
@@ -7,10 +7,10 @@ from django.contrib.auth.models import Permission, User
 from django.core.management import call_command
 from django.test import Client
 from django.urls import reverse, reverse_lazy
+from pytest_django import Settings
 
 if t.TYPE_CHECKING:
     from bs4.element import ResultSet
-    from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron import catalog
@@ -63,7 +63,7 @@ CHANGE_PAYLOAD = {
 }
 
 
-def seed(settings: "Settings") -> None:
+def seed(settings: Settings) -> None:
     settings.TASKS = TASKS
     call_command("absurd_sync_queues")
     sync_crons(get_absurd_backends()["default"])
@@ -81,7 +81,7 @@ def get_change_url(pk: int) -> str:
 def test_changelist_renders_one_row_per_schedule(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -91,7 +91,7 @@ def test_changelist_renders_one_row_per_schedule(
 def test_changelist_shows_expected_columns(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -104,7 +104,7 @@ def test_changelist_shows_expected_columns(
 def test_queue_filter_renders_and_narrows(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -118,7 +118,7 @@ def test_queue_filter_renders_and_narrows(
 def test_search_by_name_narrows(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -128,7 +128,7 @@ def test_search_by_name_narrows(
 def test_create_resolves_all_spawn_options_and_is_disabled(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -156,7 +156,7 @@ def test_create_resolves_all_spawn_options_and_is_disabled(
 def test_create_with_save_and_add_another_returns_to_the_add_view(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # "Save and add another" must NOT force the review-on-change redirect — it lands
     # back on the add view like Django's default.
@@ -178,7 +178,7 @@ def test_create_with_save_and_add_another_returns_to_the_add_view(
 def test_add_view_renders_only_the_minimal_fields(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -191,7 +191,7 @@ def test_add_view_renders_only_the_minimal_fields(
 
 
 def narrow_to_default_queue_only(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """Re-declare the backend with only "default" queue.
 
@@ -211,7 +211,7 @@ def narrow_to_default_queue_only(
 def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # on_reports' own queue ("reports") resolves fine, but the backend no longer
     # declares it, so the model rejects the resolved queue. queue isn't a field on the
@@ -237,7 +237,7 @@ def test_create_with_undeclared_resolved_queue_is_form_error_not_created(
 def test_create_with_no_declared_queues_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # A backend declaring no queues has nothing to schedule onto, so every resolved
     # queue is undeclared and the admin must refuse rather than save a schedule that
@@ -262,7 +262,7 @@ def test_create_with_no_declared_queues_is_form_error_not_created(
 def test_create_with_no_backend_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # With no backend nothing resolves the task's queue, and queue isn't a field on the
     # create form, so without the model's blank check the row saved with queue="".
@@ -282,7 +282,7 @@ def test_create_with_no_backend_is_form_error_not_created(
 def test_create_with_unimportable_task_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # An unimportable task path is rejected on the task field before any spawn-option
     # resolution runs (so build_scheduled_fields never sees a bad path), and nothing is
@@ -307,7 +307,7 @@ def test_create_with_unimportable_task_is_form_error_not_created(
 def test_create_with_non_task_target_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # A path that imports but isn't a Django task is rejected on the task field (so
     # resolution, which reads task-only attributes, is never reached).
@@ -329,7 +329,7 @@ def test_create_with_non_task_target_is_form_error_not_created(
 def test_create_with_blank_task_skips_resolution_and_is_required_error(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # A blank task never reaches cleaned_data, so spawn-option resolution is skipped
     # entirely; the form reports the field as required and creates nothing.
@@ -347,7 +347,7 @@ def test_create_with_blank_task_skips_resolution_and_is_required_error(
 def test_create_with_bad_cron_is_form_error_not_created(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -366,7 +366,7 @@ def test_create_with_bad_cron_is_form_error_not_created(
 def test_create_and_sync_produce_identical_spawn_columns(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # parity: admin-creating a task resolves the same spawn columns as running
     # sync_crons over a settings SCHEDULE of that same task (the two write lanes).
@@ -416,7 +416,7 @@ def test_create_and_sync_produce_identical_spawn_columns(
 def test_add_link_present_and_add_view_renders(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -431,7 +431,7 @@ def test_add_link_present_and_add_view_renders(
 def test_add_view_cron_help_renders_pg_cron_link_as_html(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # the cron field's help text embeds an <a> to the pg_cron docs; Django form
     # help_text is not auto-escaped, so it must reach the page as a real anchor (an
@@ -461,7 +461,7 @@ def create_scheduled_task(
 def test_change_view_shows_resolved_default_max_attempts(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # The create form resolves max_attempts from the task/backend (here the backend
     # default, 5); the change form then renders that resolved value editable.
@@ -477,7 +477,7 @@ def test_change_view_shows_resolved_default_max_attempts(
 def test_posting_add_creates_admin_schedule_and_schedules_job(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -497,7 +497,7 @@ def test_posting_add_creates_admin_schedule_and_schedules_job(
 def test_posting_add_with_tampered_source_is_forced_to_admin(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # source is a hidden, pinned field: a crafted POST setting source="s" (settings)
     # must not create a settings-owned row via the writable admin.
@@ -511,7 +511,7 @@ def test_posting_add_with_tampered_source_is_forced_to_admin(
 def test_editing_blank_args_kwargs_falls_back_to_defaults(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # queue="reports" (declared) so the edit exercises the "stored queue is still a
     # valid choice" path (no injection) alongside the blank args/kwargs fallback.
@@ -532,7 +532,7 @@ def test_editing_blank_args_kwargs_falls_back_to_defaults(
 def test_posting_duplicate_admin_name_is_form_error_not_500(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -549,7 +549,7 @@ def test_posting_duplicate_admin_name_is_form_error_not_500(
 def test_posting_add_with_invalid_cron_shows_pg_crons_message(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -564,7 +564,7 @@ def test_posting_add_with_invalid_cron_shows_pg_crons_message(
 def test_settings_schedule_detail_is_readonly(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     pk = ScheduledTask.objects.get(name="hourly").pk  # a settings row
@@ -579,7 +579,7 @@ def test_settings_schedule_detail_is_readonly(
 def test_admin_schedule_edit_form_cron_editable_name_immutable(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -597,7 +597,7 @@ def test_admin_schedule_edit_form_cron_editable_name_immutable(
 def test_posting_edit_reschedules_the_job_with_the_new_cron(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -618,7 +618,7 @@ def test_posting_edit_reschedules_the_job_with_the_new_cron(
 def test_deleting_admin_schedule_via_admin_unschedules_the_job(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -646,7 +646,7 @@ def test_deleting_admin_schedule_via_admin_unschedules_the_job(
 def test_deleting_settings_schedule_via_admin_is_forbidden(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     pk = ScheduledTask.objects.get(name="hourly").pk  # a settings row
@@ -659,7 +659,7 @@ def test_deleting_settings_schedule_via_admin_is_forbidden(
 def test_change_form_rejects_a_blank_queue(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -680,7 +680,7 @@ def test_change_form_rejects_a_blank_queue(
 def test_change_view_queue_is_a_dropdown_of_declared_queues(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)  # QUEUES: default, other, reports
     client.force_login(admin_user)
@@ -693,7 +693,7 @@ def test_change_view_queue_is_a_dropdown_of_declared_queues(
 def test_change_view_offers_no_queue_when_the_backend_declares_none(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # Validation rejects every name in this config, so the dropdown must not advertise
     # one: only the empty choice remains. A fresh dict — mutating TASKS in place would
@@ -715,7 +715,7 @@ def test_change_view_offers_no_queue_when_the_backend_declares_none(
 def test_change_view_offers_no_queue_with_no_absurd_backend(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     # Nothing declares queues, so the field names none: a stand-in choice would claim a
     # queue no backend declares.
@@ -733,7 +733,7 @@ def test_change_view_offers_no_queue_with_no_absurd_backend(
 def test_change_view_retry_kind_is_a_dropdown(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -746,7 +746,7 @@ def test_change_view_retry_kind_is_a_dropdown(
 def test_change_view_cancellation_fields_are_number_inputs(
     admin_user: User,
     client: Client,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     seed(settings)
     client.force_login(admin_user)
@@ -758,7 +758,7 @@ def test_change_view_cancellation_fields_are_number_inputs(
 
 def test_add_forbidden_for_staff_without_permission(
     client: Client,
-    settings: "Settings",
+    settings: Settings,
     staff_user: User,
 ) -> None:
     seed(settings)
@@ -768,7 +768,7 @@ def test_add_forbidden_for_staff_without_permission(
 
 def test_add_allowed_for_staff_with_permission(
     client: Client,
-    settings: "Settings",
+    settings: Settings,
     staff_user: User,
 ) -> None:
     staff_user.user_permissions.add(

--- a/tests/pg_cron/test_catalog.py
+++ b/tests/pg_cron/test_catalog.py
@@ -1,6 +1,6 @@
 import psycopg
 import pytest
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.connection import open_central_connection
 from django_absurd.pg_cron import catalog

--- a/tests/pg_cron/test_central_checks.py
+++ b/tests/pg_cron/test_central_checks.py
@@ -1,11 +1,11 @@
 """absurd.E011 (test-DB composition) / absurd.E012 (central-extension fail-safe)."""
 
 import pytest
-import pytest_django.fixtures
 from django.core.checks import Tags
 from django.core.checks.registry import registry
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
+from pytest_django import Settings
 
 from django_absurd.pg_cron import checks
 from tests.pg_cron import utils
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_composition_check_rejects_sync_on_test_db_without_opt_in(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=False)
     settings.TASKS["default"]["OPTIONS"]["SYNC_SCHEDULES_ON_TEST_DB"] = True
@@ -29,7 +29,7 @@ def test_composition_check_rejects_sync_on_test_db_without_opt_in(
 
 
 def test_composition_check_passes_with_both_opted_in(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=True)
     settings.TASKS["default"]["OPTIONS"]["SYNC_SCHEDULES_ON_TEST_DB"] = True
@@ -37,7 +37,7 @@ def test_composition_check_passes_with_both_opted_in(
 
 
 def test_composition_check_passes_with_sync_off(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=False)
     settings.TASKS["default"]["OPTIONS"]["SYNC_SCHEDULES_ON_TEST_DB"] = False
@@ -50,7 +50,7 @@ def test_central_extension_check_registered_under_database_tag() -> None:
 
 
 def test_central_extension_check_skips_under_test_environment(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """The check body is gated to skip while the test env is active — call_command
     passes --database, so the check runs, but the test-env skip means no error."""
@@ -59,7 +59,7 @@ def test_central_extension_check_skips_under_test_environment(
 
 
 def test_central_extension_check_skips_beat_scheduler_backend(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """When pg_cron is uninstalled process-wide, backend.scheduler resolves to
     'beat'; the central-extension check must not fire for it."""
@@ -71,7 +71,7 @@ def test_central_extension_check_skips_beat_scheduler_backend(
 
 
 def test_central_extension_check_skips_backend_on_other_database(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """The backend's DATABASE is "default"; checking a different alias ("replica")
     must not touch it, exercising the databases-filter branch."""

--- a/tests/pg_cron/test_central_connection.py
+++ b/tests/pg_cron/test_central_connection.py
@@ -2,8 +2,8 @@ import typing as t
 
 import psycopg
 import pytest
-import pytest_django.fixtures
 from django.db import ProgrammingError
+from pytest_django import Settings
 
 from django_absurd import connection
 from tests.pg_cron import utils
@@ -11,7 +11,7 @@ from tests.pg_cron import utils
 
 @pytest.mark.django_db(transaction=True)
 def test_open_central_connection_reaches_central_db(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     with connection.open_central_connection("default") as cur:
@@ -22,7 +22,7 @@ def test_open_central_connection_reaches_central_db(
 
 @pytest.mark.django_db(transaction=True)
 def test_open_central_connection_translates_psycopg_errors(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     with (

--- a/tests/pg_cron/test_cleanup_schedule.py
+++ b/tests/pg_cron/test_cleanup_schedule.py
@@ -1,8 +1,8 @@
 import typing as t
 
 import pytest
-import pytest_django.fixtures
 from django.core.management import call_command
+from pytest_django import Settings
 
 from django_absurd.pg_cron import catalog
 from django_absurd.pg_cron.choices import Source
@@ -33,7 +33,7 @@ def build_cleanup_jobname() -> str:
 
 
 def test_sync_schedules_cleanup_job(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
 
@@ -45,7 +45,7 @@ def test_sync_schedules_cleanup_job(
 
 
 def test_cleanup_job_is_isolated_to_its_own_lane(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
 
@@ -60,7 +60,7 @@ def test_cleanup_job_is_isolated_to_its_own_lane(
 
 
 def test_sync_unschedules_cleanup_job_when_cleanup_dropped(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
     call_command("absurd_sync_crons")
@@ -73,7 +73,7 @@ def test_sync_unschedules_cleanup_job_when_cleanup_dropped(
 
 
 def test_cleanup_job_survives_absurd_flush_command(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
 
@@ -89,7 +89,7 @@ def test_cleanup_job_survives_absurd_flush_command(
 
 
 def test_teardown_removes_cleanup_job(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
     call_command("absurd_sync_crons")

--- a/tests/pg_cron/test_cross_source_coexistence.py
+++ b/tests/pg_cron/test_cross_source_coexistence.py
@@ -1,5 +1,5 @@
 import pytest
-import pytest_django.fixtures
+from pytest_django import Settings
 
 from django_absurd.pg_cron import catalog
 from django_absurd.pg_cron.choices import Source
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_settings_and_admin_schedule_may_share_a_name(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Namespaced by source, a settings and an admin schedule with the same
     name coexist as two distinct pg_cron jobs — no clash, no double-fire."""
@@ -39,7 +39,7 @@ def test_settings_and_admin_schedule_may_share_a_name(
 
 
 def test_revalidating_a_saved_admin_schedule_does_not_self_clash(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """full_clean's uniqueness check excludes the row's own pk, so re-validating an
     existing admin schedule (e.g. after editing a field) does not clash with itself."""

--- a/tests/pg_cron/test_detection.py
+++ b/tests/pg_cron/test_detection.py
@@ -2,7 +2,7 @@ import typing as t
 
 import pytest
 from django.db import connections
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.pg_cron import detection
 from tests.pg_cron import utils

--- a/tests/pg_cron/test_flush_scoped.py
+++ b/tests/pg_cron/test_flush_scoped.py
@@ -1,6 +1,6 @@
 import pytest
 from django.db import connections
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.flush import flush_absurd_state
 from django_absurd.pg_cron import catalog

--- a/tests/pg_cron/test_isolation_regression.py
+++ b/tests/pg_cron/test_isolation_regression.py
@@ -3,15 +3,15 @@
 # (poll cron.job_run_details until the producer fires into its own DB) rather than a
 # blind sleep; xdist-safe because the producer targets a per-worker-unique DB.
 import pytest
-import pytest_django.fixtures
 from django.db import connections
+from pytest_django import Settings
 
 from tests.pg_cron import utils
 
 
 @pytest.mark.django_db(transaction=True)
 def test_producing_schedule_never_fires_into_this_test_db(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=True)
     test_db = str(connections["default"].settings_dict["NAME"])

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -3,9 +3,9 @@
 import typing as t
 
 import pytest
-import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
+from pytest_django import Settings
 
 from tests.utils import ABSURD_BACKEND, make_tasks_settings
 from tests.utils import DECLARED_QUEUES as BASE_QUEUES
@@ -16,7 +16,7 @@ E007_MSG = "django-absurd: invalid SCHEDULE entry."
 
 
 def run_pg_cron_check(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
     capsys: pytest.CaptureFixture[str],
     options: dict[str, t.Any],
 ) -> str:
@@ -37,7 +37,7 @@ def run_pg_cron_check(
 
 
 def run_pg_cron_cleanup_check(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
     capsys: pytest.CaptureFixture[str],
     cleanup: dict[str, str],
 ) -> str:
@@ -55,7 +55,7 @@ def run_pg_cron_cleanup_check(
 def test_pg_cron_cleanup_accepts_pg_cron_grammar(
     capsys: pytest.CaptureFixture[str],
     schedule: str,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_pg_cron_cleanup_check(settings, capsys, {"schedule": schedule})
     assert "absurd.E010" not in out
@@ -63,7 +63,7 @@ def test_pg_cron_cleanup_accepts_pg_cron_grammar(
 
 def test_pg_cron_cleanup_rejects_a_non_cron_schedule(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_pg_cron_cleanup_check(settings, capsys, {"schedule": "not a cron"})
     assert "absurd.E010" in out
@@ -71,7 +71,7 @@ def test_pg_cron_cleanup_rejects_a_non_cron_schedule(
 
 def test_pg_cron_cleanup_rejects_empty_schedule(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_pg_cron_cleanup_check(settings, capsys, {"schedule": ""})
     assert "absurd.E010" in out
@@ -79,7 +79,7 @@ def test_pg_cron_cleanup_rejects_empty_schedule(
 
 def test_pg_cron_task_import_raise_reports_e007_not_crash(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """A scheduled task whose module raises non-ImportError on import.
 
@@ -105,7 +105,7 @@ def test_pg_cron_task_import_raise_reports_e007_not_crash(
 @pytest.mark.parametrize("cron", ["30 seconds", "@daily", "0 2 * * *"])
 def test_pg_cron_cron_grammar_accepted_at_check_time(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
     cron: str,
 ) -> None:
     out = run_pg_cron_check(
@@ -121,7 +121,7 @@ def test_pg_cron_cron_grammar_accepted_at_check_time(
 
 def test_pg_cron_rejects_beats_six_field_cron_at_check_time(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # The beat scheduler's leading-seconds form is not pg_cron syntax. pg_cron would
     # accept it and silently drop the sixth field — its parser reads five fields and
@@ -140,7 +140,7 @@ def test_pg_cron_rejects_beats_six_field_cron_at_check_time(
 
 def test_pg_cron_bad_name_charset_rejected(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Schedule name with spaces/special chars rejected under pg_cron."""
     out = run_pg_cron_check(
@@ -162,7 +162,7 @@ def test_pg_cron_bad_name_charset_rejected(
 
 def test_pg_cron_undeclared_task_queue_rejected(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Task with queue_name='reports' not in declared queues rejected."""
     # tests.tasks.on_reports has @task(queue_name="reports"); exclude from
@@ -188,7 +188,7 @@ def test_pg_cron_undeclared_task_queue_rejected(
 
 def test_pg_cron_undeclared_explicit_queue_single_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Undeclared explicit queue override yields exactly ONE E007 (core's)."""
     out = run_pg_cron_check(
@@ -211,7 +211,7 @@ def test_pg_cron_undeclared_explicit_queue_single_error(
 
 def test_pg_cron_non_mapping_schedule_single_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Non-mapping SCHEDULE under pg_cron yields only core's mapping E007."""
     out = run_pg_cron_check(
@@ -227,7 +227,7 @@ def test_pg_cron_non_mapping_schedule_single_error(
 
 def test_pg_cron_non_mapping_entry_single_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Non-mapping schedule entry under pg_cron yields only core's E007."""
     out = run_pg_cron_check(
@@ -243,7 +243,7 @@ def test_pg_cron_non_mapping_entry_single_error(
 
 def test_pg_cron_missing_task_no_queue_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Missing task under pg_cron yields core's import E007 only."""
     out = run_pg_cron_check(
@@ -260,7 +260,7 @@ def test_pg_cron_missing_task_no_queue_error(
 
 def test_pg_cron_unimportable_task_no_queue_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Unimportable task under pg_cron yields core's import E007."""
     out = run_pg_cron_check(
@@ -277,7 +277,7 @@ def test_pg_cron_unimportable_task_no_queue_error(
 
 def test_pg_cron_non_task_no_queue_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Non-task path under pg_cron yields core's not-a-task E007."""
     out = run_pg_cron_check(
@@ -297,7 +297,7 @@ def test_pg_cron_non_task_no_queue_error(
 @pytest.mark.parametrize("cron", ["", 300])
 def test_pg_cron_structurally_absent_cron_rejected(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
     cron: t.Any,
 ) -> None:
     """A missing or non-string cron is core's report, not the grammar check's — the
@@ -316,7 +316,7 @@ def test_pg_cron_structurally_absent_cron_rejected(
 
 def test_pg_cron_trailing_newline_name_rejected(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Schedule name with trailing newline rejected (fullmatch, not match)."""
     out = run_pg_cron_check(
@@ -338,7 +338,7 @@ def test_pg_cron_trailing_newline_name_rejected(
 
 def test_pg_cron_empty_string_queue_resolves_via_effective_queue(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """queue: "" is falsy — pg_cron resolves via task queue_name.
 
@@ -365,7 +365,7 @@ def test_pg_cron_empty_string_queue_resolves_via_effective_queue(
 
 def test_pg_cron_valid_five_field_cron_no_error(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Valid 5-field cron under pg_cron passes without absurd.E007."""
     out = run_pg_cron_check(
@@ -386,7 +386,7 @@ def test_pg_cron_valid_five_field_cron_no_error(
 
 def test_pg_cron_non_string_name_yields_e007_not_typeerror(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """SCHEDULE key that is integer yields E007, not TypeError."""
     out = run_pg_cron_check(
@@ -403,7 +403,7 @@ def test_pg_cron_non_string_name_yields_e007_not_typeerror(
 
 def test_pg_cron_cleanup_cron_grammar_is_checked(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # CLEANUP's cron is pg_cron's own grammar too, so it earns the same check as a
     # SCHEDULE entry: beat's 6-field form would otherwise reach sync, where pg_cron
@@ -417,7 +417,7 @@ def test_pg_cron_cleanup_cron_grammar_is_checked(
 def test_pg_cron_cleanup_defers_a_non_grammar_problem_to_core(
     capsys: pytest.CaptureFixture[str],
     cleanup: dict[str, t.Any],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Core already reports shape/emptiness as absurd.E010; reporting it again from the
     # grammar check would show one field's problem twice.
@@ -427,7 +427,7 @@ def test_pg_cron_cleanup_defers_a_non_grammar_problem_to_core(
 
 def test_pg_cron_schedule_defers_an_empty_cron_to_core(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_pg_cron_check(
         settings,
@@ -441,7 +441,7 @@ def test_pg_cron_schedule_defers_an_empty_cron_to_core(
 
 
 def test_queues_option_as_a_list_errors_without_crashing_the_schedule_check(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = {
         "default": {

--- a/tests/pg_cron/test_pg_cron_e2e.py
+++ b/tests/pg_cron/test_pg_cron_e2e.py
@@ -3,9 +3,9 @@ drain the queue, and assert the task result is persisted.
 """
 
 import pytest
-import pytest_django.fixtures
 from django.core.management import call_command
 from django.db import connection
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.reconcile import sync_crons
@@ -35,7 +35,7 @@ TASKS_PG_CRON = {
 
 def test_e2e_sync_fire_worker_assert_payload(
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Sync schedule into pg_cron, fire wrapper directly, drain queue, assert row."""
     settings.TASKS = TASKS_PG_CRON

--- a/tests/pg_cron/test_pg_cron_options.py
+++ b/tests/pg_cron/test_pg_cron_options.py
@@ -1,5 +1,5 @@
 import pytest
-import pytest_django.fixtures
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.reconcile import resolve_spawn_options
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_max_attempts_from_decorator(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings()
     be = get_absurd_backends()["default"]
@@ -20,7 +20,7 @@ def test_max_attempts_from_decorator(
 
 
 def test_max_attempts_falls_back_to_backend_default(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(default_max_attempts=7)
     be = get_absurd_backends()["default"]

--- a/tests/pg_cron/test_pg_cron_post_migrate.py
+++ b/tests/pg_cron/test_pg_cron_post_migrate.py
@@ -16,7 +16,7 @@ from django_absurd.queues import get_absurd_client
 from tests.pg_cron import utils
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -49,7 +49,7 @@ def run_cron_sync(
 
 def test_reconcile_creates_owned_cron_jobs_under_pg_cron(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {
@@ -69,7 +69,7 @@ def test_reconcile_creates_owned_cron_jobs_under_pg_cron(
 
 def test_reconcile_emits_jobs_for_admin_rows_created_without_signal(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """A source="a" row created without firing post_save (a data migration's
     historical model, or bulk_create) has no pg_cron job; the reconcile re-emits it so
@@ -104,7 +104,7 @@ def test_reconcile_emits_jobs_for_admin_rows_created_without_signal(
 
 def test_reconcile_admin_rows_is_idempotent(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """Re-running the reconcile re-emits admin jobs harmlessly (cron.schedule is an
     upsert) — one row still maps to exactly one job, unchanged."""
@@ -134,7 +134,7 @@ def test_reconcile_admin_rows_is_idempotent(
 
 def test_reconcile_prunes_owned_settings_job_whose_row_vanished(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """A settings job with no backing row — its row was removed out-of-band (a
     signal-less delete), so no post_delete unscheduled it — is orphaned; reconcile
@@ -170,7 +170,7 @@ def test_reconcile_prunes_owned_settings_job_whose_row_vanished(
 
 def test_reconcile_prunes_admin_job_whose_row_vanished(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """An admin job with no backing row is orphaned; the reconcile prunes it (symmetric
     with the settings lane). Set up by scheduling from an unsaved instance."""
@@ -199,7 +199,7 @@ def test_reconcile_prunes_admin_job_whose_row_vanished(
 
 
 def test_reconcile_is_noop_without_absurd_backend(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """The pg_cron app is installed but no Absurd backend is configured: reconcile
     returns early, touching no pg_cron jobs — migrate must not break just because the
@@ -215,7 +215,7 @@ def test_reconcile_is_noop_without_absurd_backend(
 
 
 def test_reconcile_missing_row_fires_clean_noop(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -231,7 +231,7 @@ def test_reconcile_missing_row_fires_clean_noop(
 
 def test_reconcile_survives_missing_scheduledtask_table(
     caplog: pytest.LogCaptureFixture,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -257,7 +257,7 @@ def test_reconcile_survives_missing_scheduledtask_table(
 
 
 def test_reconcile_skips_on_malformed_schedule_spec(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({"broken": {}})  # no task/cron keys
 
@@ -269,7 +269,7 @@ def test_reconcile_skips_on_malformed_schedule_spec(
 
 
 def test_reconcile_skips_on_bad_dotted_path(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.does_not_exist", "cron": "0 2 * * *"}}
@@ -290,7 +290,7 @@ def test_pg_cron_app_registered_after_core() -> None:
 
 
 def test_migrate_provisions_queues_and_reconciles_crons(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -307,7 +307,7 @@ def test_migrate_provisions_queues_and_reconciles_crons(
 
 
 def test_reconcile_emits_migrate_stdout_on_sync(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -322,7 +322,7 @@ def test_reconcile_emits_migrate_stdout_on_sync(
 
 
 def test_reconcile_is_quiet_on_noop_migrate(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     """A second migrate with an unchanged SCHEDULE creates and prunes nothing,
     so it must emit no reconcile output (parity with queue provisioning)."""
@@ -340,7 +340,7 @@ def test_reconcile_is_quiet_on_noop_migrate(
 
 
 def test_reconcile_emits_prune_line_on_sync(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -358,7 +358,7 @@ def test_reconcile_emits_prune_line_on_sync(
 
 def test_reconcile_warns_on_none_task_path(
     caplog: pytest.LogCaptureFixture,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"x": {"task": None, "cron": "0 2 * * *"}}
@@ -374,7 +374,7 @@ def test_reconcile_warns_on_none_task_path(
 
 def test_reconcile_warns_on_string_kwargs(
     caplog: pytest.LogCaptureFixture,
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "kwargs": "abc"}}

--- a/tests/pg_cron/test_pg_cron_post_migrate.py
+++ b/tests/pg_cron/test_pg_cron_post_migrate.py
@@ -1,12 +1,12 @@
 import collections.abc
 import logging
-import typing as t
 from io import StringIO
 
 import pytest
 from django.apps import apps
 from django.core.management import call_command
 from django.db import connection
+from pytest_django import Settings
 
 from django_absurd.pg_cron import catalog
 from django_absurd.pg_cron.apps import reconcile_crons_after_migrate
@@ -14,9 +14,6 @@ from django_absurd.pg_cron.choices import Source
 from django_absurd.pg_cron.models import ScheduledTask
 from django_absurd.queues import get_absurd_client
 from tests.pg_cron import utils
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -49,7 +46,7 @@ def run_cron_sync(
 
 def test_reconcile_creates_owned_cron_jobs_under_pg_cron(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {
@@ -69,7 +66,7 @@ def test_reconcile_creates_owned_cron_jobs_under_pg_cron(
 
 def test_reconcile_emits_jobs_for_admin_rows_created_without_signal(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """A source="a" row created without firing post_save (a data migration's
     historical model, or bulk_create) has no pg_cron job; the reconcile re-emits it so
@@ -104,7 +101,7 @@ def test_reconcile_emits_jobs_for_admin_rows_created_without_signal(
 
 def test_reconcile_admin_rows_is_idempotent(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """Re-running the reconcile re-emits admin jobs harmlessly (cron.schedule is an
     upsert) — one row still maps to exactly one job, unchanged."""
@@ -134,7 +131,7 @@ def test_reconcile_admin_rows_is_idempotent(
 
 def test_reconcile_prunes_owned_settings_job_whose_row_vanished(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """A settings job with no backing row — its row was removed out-of-band (a
     signal-less delete), so no post_delete unscheduled it — is orphaned; reconcile
@@ -170,7 +167,7 @@ def test_reconcile_prunes_owned_settings_job_whose_row_vanished(
 
 def test_reconcile_prunes_admin_job_whose_row_vanished(
     run_cron_sync: collections.abc.Callable[[], None],
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """An admin job with no backing row is orphaned; the reconcile prunes it (symmetric
     with the settings lane). Set up by scheduling from an unsaved instance."""
@@ -199,7 +196,7 @@ def test_reconcile_prunes_admin_job_whose_row_vanished(
 
 
 def test_reconcile_is_noop_without_absurd_backend(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """The pg_cron app is installed but no Absurd backend is configured: reconcile
     returns early, touching no pg_cron jobs — migrate must not break just because the
@@ -215,7 +212,7 @@ def test_reconcile_is_noop_without_absurd_backend(
 
 
 def test_reconcile_missing_row_fires_clean_noop(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -231,7 +228,7 @@ def test_reconcile_missing_row_fires_clean_noop(
 
 def test_reconcile_survives_missing_scheduledtask_table(
     caplog: pytest.LogCaptureFixture,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -257,7 +254,7 @@ def test_reconcile_survives_missing_scheduledtask_table(
 
 
 def test_reconcile_skips_on_malformed_schedule_spec(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({"broken": {}})  # no task/cron keys
 
@@ -269,7 +266,7 @@ def test_reconcile_skips_on_malformed_schedule_spec(
 
 
 def test_reconcile_skips_on_bad_dotted_path(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.does_not_exist", "cron": "0 2 * * *"}}
@@ -290,7 +287,7 @@ def test_pg_cron_app_registered_after_core() -> None:
 
 
 def test_migrate_provisions_queues_and_reconciles_crons(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -307,7 +304,7 @@ def test_migrate_provisions_queues_and_reconciles_crons(
 
 
 def test_reconcile_emits_migrate_stdout_on_sync(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -322,7 +319,7 @@ def test_reconcile_emits_migrate_stdout_on_sync(
 
 
 def test_reconcile_is_quiet_on_noop_migrate(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     """A second migrate with an unchanged SCHEDULE creates and prunes nothing,
     so it must emit no reconcile output (parity with queue provisioning)."""
@@ -340,7 +337,7 @@ def test_reconcile_is_quiet_on_noop_migrate(
 
 
 def test_reconcile_emits_prune_line_on_sync(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -358,7 +355,7 @@ def test_reconcile_emits_prune_line_on_sync(
 
 def test_reconcile_warns_on_none_task_path(
     caplog: pytest.LogCaptureFixture,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"x": {"task": None, "cron": "0 2 * * *"}}
@@ -374,7 +371,7 @@ def test_reconcile_warns_on_none_task_path(
 
 def test_reconcile_warns_on_string_kwargs(
     caplog: pytest.LogCaptureFixture,
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "kwargs": "abc"}}

--- a/tests/pg_cron/test_pg_cron_sync_jobs.py
+++ b/tests/pg_cron/test_pg_cron_sync_jobs.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.management import call_command
 from django.db import connection
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.connection import open_central_connection

--- a/tests/pg_cron/test_pg_cron_sync_rows.py
+++ b/tests/pg_cron/test_pg_cron_sync_rows.py
@@ -1,5 +1,5 @@
 import pytest
-import pytest_django.fixtures
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_upsert_and_prune_settings_rows(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(
         schedule={
@@ -29,7 +29,7 @@ def test_upsert_and_prune_settings_rows(
 
 
 def test_admin_rows_untouched(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     ScheduledTask.objects.create(
         name="a",
@@ -43,7 +43,7 @@ def test_admin_rows_untouched(
 
 
 def test_sync_writes_named_option_columns(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(
         schedule={
@@ -64,7 +64,7 @@ def test_sync_writes_named_option_columns(
 
 
 def test_reconcile_splits_cancellation_into_columns(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(
         schedule={"c": {"task": "tests.tasks.cancellable", "cron": "0 2 * * *"}}
@@ -77,7 +77,7 @@ def test_reconcile_splits_cancellation_into_columns(
 
 
 def test_reconcile_splits_retry_strategy_into_columns(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(
         schedule={"r": {"task": "tests.tasks.retrying", "cron": "0 2 * * *"}}
@@ -90,7 +90,7 @@ def test_reconcile_splits_retry_strategy_into_columns(
 
 
 def test_sync_materializes_decorator_derived_columns(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(
         schedule={"full": {"task": "tests.tasks.fully_specced", "cron": "0 2 * * *"}}

--- a/tests/pg_cron/test_pg_cron_teardown.py
+++ b/tests/pg_cron/test_pg_cron_teardown.py
@@ -3,7 +3,7 @@ import typing as t
 import pytest
 
 if t.TYPE_CHECKING:
-    from pytest_django.fixtures import Settings
+    from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask

--- a/tests/pg_cron/test_pg_cron_teardown.py
+++ b/tests/pg_cron/test_pg_cron_teardown.py
@@ -1,9 +1,5 @@
-import typing as t
-
 import pytest
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.pg_cron.models import ScheduledTask
@@ -14,7 +10,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_teardown_removes_all_owned_cron_jobs_and_settings_rows(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {
@@ -35,7 +31,7 @@ def test_teardown_removes_all_owned_cron_jobs_and_settings_rows(
 
 
 def test_teardown_leaves_admin_rows_intact(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     ScheduledTask.objects.create(
         name="admin-job",
@@ -54,7 +50,7 @@ def test_teardown_leaves_admin_rows_intact(
     assert ScheduledTask.objects.filter(source="a", name="admin-job").exists()
 
 
-def test_teardown_is_idempotent(settings: "Settings") -> None:
+def test_teardown_is_idempotent(settings: Settings) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"a": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
     )

--- a/tests/pg_cron/test_pytest_plugin.py
+++ b/tests/pg_cron/test_pytest_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 from django.core.management import call_command
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.connection import open_central_connection
 from django_absurd.flush import flush_absurd_state

--- a/tests/pg_cron/test_schedule_emission.py
+++ b/tests/pg_cron/test_schedule_emission.py
@@ -2,9 +2,9 @@ import logging
 from pathlib import Path
 
 import pytest
-import pytest_django.fixtures
 from django.core.management import call_command
 from django.db import transaction
+from pytest_django import Settings
 
 from django_absurd.pg_cron import catalog
 from django_absurd.pg_cron.choices import Source
@@ -19,7 +19,7 @@ LOADED_SCHEDULE_FIXTURE = str(
 
 
 def test_save_emits_job_only_after_commit(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Emission rides the row's transaction.on_commit, never synchronously in post_save:
     inside an open transaction the central job is still absent; it appears only once the
@@ -39,7 +39,7 @@ def test_save_emits_job_only_after_commit(
 
 def test_central_failure_after_commit_is_swallowed_and_logged(
     caplog: pytest.LogCaptureFixture,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """A central-connection failure that lands AFTER the row committed (here pg_cron
     rejecting an invalid cron) is swallowed-and-logged, never propagated as a 500 — the
@@ -66,7 +66,7 @@ def test_central_failure_after_commit_is_swallowed_and_logged(
 
 
 def test_saving_admin_schedule_schedules_the_job(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     ScheduledTask.objects.create(
@@ -84,7 +84,7 @@ def test_saving_admin_schedule_schedules_the_job(
 
 
 def test_saving_disabled_admin_schedule_is_inactive(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     ScheduledTask.objects.create(
@@ -102,7 +102,7 @@ def test_saving_disabled_admin_schedule_is_inactive(
 
 
 def test_saving_settings_schedule_also_schedules_the_job(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Unified path: a settings row emits through the same signal (reconcile upserts
     rows; the signal schedules the jobs)."""
@@ -124,7 +124,7 @@ def test_saving_settings_schedule_also_schedules_the_job(
 
 
 def test_deleting_admin_schedule_unschedules_the_job(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     scheduled_task = ScheduledTask.objects.create(
@@ -140,7 +140,7 @@ def test_deleting_admin_schedule_unschedules_the_job(
 
 
 def test_saving_schedule_without_absurd_backend_is_a_noop(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """No Absurd backend configured at all: (un)schedule are clean no-ops — the
     only surviving no-op condition once the scheduler-specific guard collapses."""
@@ -166,7 +166,7 @@ def test_saving_schedule_without_absurd_backend_is_a_noop(
 
 @pytest.mark.django_db(transaction=True, databases=["default", "replica"])
 def test_cross_database_write_is_rejected(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """A ScheduledTask forced onto a non-absurd database (here via .using on a second
     alias) is rejected before the row is inserted — schedules live only on the absurd
@@ -190,7 +190,7 @@ def test_cross_database_write_is_rejected(
 
 @pytest.mark.django_db(transaction=True, databases=["default", "replica"])
 def test_cross_database_row_stays_deletable(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """A stray row created out-of-band on a foreign DB (bulk_create bypasses
     the pre_save guard) must stay deletable — the delete receiver skips it
@@ -211,7 +211,7 @@ def test_cross_database_row_stays_deletable(
 
 
 def test_loaddata_schedules_the_job(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """loaddata is a real write, so the row's job materializes — the row is the source
     of truth, so a loaded/restored schedule is a live schedule."""

--- a/tests/pg_cron/test_scheduledtask_model.py
+++ b/tests/pg_cron/test_scheduledtask_model.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.pg_cron.choices import Source
 from django_absurd.pg_cron.models import ScheduledTask

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -4,9 +4,9 @@ suite."""
 import typing as t
 
 import pytest
-import pytest_django.fixtures
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
+from pytest_django import Settings
 
 from tests.utils import make_tasks_settings
 
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 def run_check(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
     installed_apps: t.Sequence[str] | None = None,
     schedule: dict[str, dict[str, object]] | None = None,
 ) -> str:
@@ -32,7 +32,7 @@ def run_check(
 
 
 def build_apps_with_pg_cron_first(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> list[str]:
     apps_without = [
         app for app in settings.INSTALLED_APPS if app != "django_absurd.pg_cron"
@@ -42,7 +42,7 @@ def build_apps_with_pg_cron_first(
 
 def test_pg_cron_app_before_core_warns(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_check(capsys, settings, build_apps_with_pg_cron_first(settings))
     assert "absurd.W003" in out
@@ -58,7 +58,7 @@ def test_pg_cron_app_before_core_warns(
 
 def test_pg_cron_app_after_core_clean(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_check(capsys, settings)
     assert "absurd.W003" not in out
@@ -66,7 +66,7 @@ def test_pg_cron_app_after_core_clean(
 
 def test_pg_cron_schedule_error_reported(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     out = run_check(
         capsys,
@@ -85,7 +85,7 @@ def test_pg_cron_schedule_error_reported(
 
 def test_pg_cron_app_config_path_before_core_warns(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     """Dotted AppConfig path for pg_cron listed before core must still trigger W003."""
     apps_with_config_path_first = [
@@ -110,7 +110,7 @@ def test_pg_cron_app_config_path_before_core_warns(
 
 
 def test_pg_cron_installed_without_an_absurd_backend_is_reported(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # A TASKS pointing somewhere other than an AbsurdBackend leaves the scheduler app
     # installed with nothing to schedule for. Every ScheduledTask then saves normally
@@ -132,6 +132,6 @@ def test_pg_cron_installed_without_an_absurd_backend_is_reported(
 
 def test_pg_cron_installed_with_a_backend_is_not_reported(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     assert "absurd.E013" not in run_check(capsys, settings)

--- a/tests/pg_cron/test_scheduler_selector.py
+++ b/tests/pg_cron/test_scheduler_selector.py
@@ -1,10 +1,10 @@
 import re
 
 import pytest
-import pytest_django.fixtures
 from absurd_sdk import CreateQueueOptions
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from pytest_django import Settings
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.management.base import BEAT_DISABLED_UNDER_PG_CRON
@@ -17,14 +17,14 @@ SINGLE_QUEUE: dict[str, CreateQueueOptions] = {"default": {}}
 
 
 def test_scheduler_is_pg_cron_when_app_installed(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(queues=SINGLE_QUEUE)
     assert get_absurd_backends()["default"].scheduler == "pg_cron"
 
 
 def test_beat_command_refuses_under_pg_cron(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(queues=SINGLE_QUEUE)
     with pytest.raises(CommandError, match=re.escape(BEAT_DISABLED_UNDER_PG_CRON)):
@@ -32,7 +32,7 @@ def test_beat_command_refuses_under_pg_cron(
 
 
 def test_worker_beat_flag_refuses_under_pg_cron(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     settings.TASKS = make_tasks_settings(queues=SINGLE_QUEUE)
     with pytest.raises(CommandError, match=re.escape(BEAT_DISABLED_UNDER_PG_CRON)):

--- a/tests/pg_cron/test_sync_schedules_on_migrate.py
+++ b/tests/pg_cron/test_sync_schedules_on_migrate.py
@@ -12,14 +12,12 @@ from pathlib import Path
 import pytest
 from django.core.management import call_command
 from django.db import connections
+from pytest_django import Settings
 
 from django_absurd.pg_cron import catalog
 from django_absurd.pg_cron.choices import Source
 from django_absurd.pg_cron.models import ScheduledTask
 from tests.pg_cron import utils
-
-if t.TYPE_CHECKING:
-    from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -103,7 +101,7 @@ def test_migrate_skips_sync_on_a_real_database_when_explicitly_disabled(
 
 
 def test_migrate_skips_sync_by_default_on_a_test_database(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -120,7 +118,7 @@ def test_migrate_skips_sync_by_default_on_a_test_database(
 
 
 def test_migrate_syncs_on_a_test_database_when_explicitly_enabled(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -136,7 +134,7 @@ def test_migrate_syncs_on_a_test_database_when_explicitly_enabled(
 
 
 def test_scheduled_task_create_and_delete_are_unaffected_by_either_setting(
-    settings: "Settings",
+    settings: Settings,
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     settings.TASKS["default"]["OPTIONS"]["SYNC_SCHEDULES_ON_TEST_DB"] = False

--- a/tests/pg_cron/test_sync_schedules_on_migrate.py
+++ b/tests/pg_cron/test_sync_schedules_on_migrate.py
@@ -19,7 +19,7 @@ from django_absurd.pg_cron.models import ScheduledTask
 from tests.pg_cron import utils
 
 if t.TYPE_CHECKING:
-    import pytest_django.fixtures
+    from pytest_django import Settings
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -103,7 +103,7 @@ def test_migrate_skips_sync_on_a_real_database_when_explicitly_disabled(
 
 
 def test_migrate_skips_sync_by_default_on_a_test_database(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -120,7 +120,7 @@ def test_migrate_skips_sync_by_default_on_a_test_database(
 
 
 def test_migrate_syncs_on_a_test_database_when_explicitly_enabled(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks(
         {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
@@ -136,7 +136,7 @@ def test_migrate_syncs_on_a_test_database_when_explicitly_enabled(
 
 
 def test_scheduled_task_create_and_delete_are_unaffected_by_either_setting(
-    settings: "pytest_django.fixtures.Settings",
+    settings: "Settings",
 ) -> None:
     settings.TASKS = utils.build_pg_cron_tasks({})
     settings.TASKS["default"]["OPTIONS"]["SYNC_SCHEDULES_ON_TEST_DB"] = False

--- a/tests/pg_cron/validators/conftest.py
+++ b/tests/pg_cron/validators/conftest.py
@@ -1,7 +1,7 @@
 import pytest
-import pytest_django.fixtures
 from django.contrib.auth.models import User
 from django.test import Client
+from pytest_django import Settings
 
 from tests.pg_cron.validators.utils import (
     ValidateSubject,
@@ -17,7 +17,7 @@ def validate(
     capsys: pytest.CaptureFixture[str],
     client: Client,
     request: pytest.FixtureRequest,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> ValidateSubject:
     """Parametrized subject: run a case through each real enforcing entrypoint —
     the system check, the admin change-form POST, and ScheduledTask.full_clean()."""
@@ -34,7 +34,7 @@ def validate(
 def validate_check_and_model(
     capsys: pytest.CaptureFixture[str],
     request: pytest.FixtureRequest,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> ValidateSubject:
     """Subjects for rules the admin form cannot express (e.g. a non-JSON Python
     object for args/kwargs is not a form text input): the system check + full_clean."""

--- a/tests/pg_cron/validators/test_args_kwargs_shape.py
+++ b/tests/pg_cron/validators/test_args_kwargs_shape.py
@@ -1,7 +1,7 @@
 import typing as t
 
 import pytest
-import pytest_django.fixtures
+from pytest_django import Settings
 
 from tests.pg_cron.validators.utils import ValidateSubject, validate_from_model
 
@@ -30,7 +30,7 @@ def test_wrong_shape_rejected(
 # headers is model/admin-only (not a SCHEDULE key), so the check subject can't express
 # it — validate it through full_clean. null is allowed; any other non-object is not.
 def test_headers_wrong_shape_rejected_by_model(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     result = validate_from_model(settings, headers=[1, 2])
     assert result
@@ -38,6 +38,6 @@ def test_headers_wrong_shape_rejected_by_model(
 
 
 def test_headers_object_accepted_by_model(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     assert validate_from_model(settings, headers={"x": "y"}) is None

--- a/tests/pg_cron/validators/test_cancellation.py
+++ b/tests/pg_cron/validators/test_cancellation.py
@@ -1,4 +1,4 @@
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from tests.pg_cron.validators.utils import validate_from_model
 

--- a/tests/pg_cron/validators/test_declared_queue.py
+++ b/tests/pg_cron/validators/test_declared_queue.py
@@ -1,5 +1,5 @@
 import pytest
-import pytest_django.fixtures
+from pytest_django import Settings
 
 from tests.pg_cron.validators.utils import (
     ValidateSubject,
@@ -10,7 +10,7 @@ from tests.pg_cron.validators.utils import (
 
 def test_undeclared_queue_override_rejected_by_check(
     capsys: pytest.CaptureFixture[str],
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # The core check validates explicit queue overrides via validate_schedule, which
     # calls validate_declared_queue with the override value and emits the custom
@@ -21,7 +21,7 @@ def test_undeclared_queue_override_rejected_by_check(
 
 
 def test_undeclared_queue_override_rejected_by_model(
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
     # Model full_clean: the queue field's callable choices enforce membership at the
     # field level (Django emits its own message) before clean() runs.

--- a/tests/pg_cron/validators/test_max_attempts.py
+++ b/tests/pg_cron/validators/test_max_attempts.py
@@ -1,4 +1,4 @@
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from tests.pg_cron.validators.utils import validate_from_model
 

--- a/tests/pg_cron/validators/test_retry_strategy.py
+++ b/tests/pg_cron/validators/test_retry_strategy.py
@@ -1,4 +1,4 @@
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from tests.pg_cron.validators.utils import validate_from_model
 

--- a/tests/pg_cron/validators/utils.py
+++ b/tests/pg_cron/validators/utils.py
@@ -12,7 +12,7 @@ from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import Client
 from django.urls import reverse
-from pytest_django.fixtures import Settings
+from pytest_django import Settings
 
 from django_absurd.pg_cron.models import ScheduledTask
 


### PR DESCRIPTION
Mechanical: tests import `Settings` / `DjangoDbBlocker` from the `pytest_django` package root instead of `pytest_django.fixtures` / `pytest_django.plugin`, and at runtime instead of under `TYPE_CHECKING` (so the annotations lose their quotes).