### PR TITLE
feat!: provisioning is a deploy step, not a runtime seam

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Run the suite in its Docker stack
         run: |
-          docker compose up -d --build db
-          until docker compose exec -T db pg_isready -U postgres; do sleep 1; done
+          docker compose up -d --build --wait db
           docker compose run --rm --build app sh -c "cd /app && pytest"
       - name: Rewrite container coverage paths to repo-relative
         if: ${{ success() || failure() }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -32,7 +32,7 @@ body = """
 {% if breaking | length > 0 %}
 ### Breaking changes
 {% for commit in breaking %}
-- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}{% if commit.breaking_description != commit.message %} — {{ commit.breaking_description | replace(from="\n", to=" ") }}{% endif %}
 {%- endfor %}
 {% endif -%}
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     ports:
       - "${PGPORT:-5432}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -31,7 +31,7 @@ services:
     ports:
       - "${PGPORT_PGCRON:-5434}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -91,6 +91,8 @@ module: tasks resolve by import path, so no `tasks.py` is required. Tasks may be
 (`def`) or async (`async def`); one worker runs both.
 
 - `async def` enqueues with `await send_report.aenqueue(42)`.
+- The queue must already exist — enqueuing never creates one. See
+  [what `migrate` installs](#what-migrate-installs).
 - Enqueuing rides the surrounding transaction, so an `atomic()` rollback drops the task.
 - Delivery is **at-least-once** — keep handlers idempotent. See
   [runs and retries](#runs-and-retries).
@@ -710,10 +712,10 @@ python manage.py absurd_worker --queue reports --concurrency 4
 ```
 
 A single worker runs **both** sync and async tasks: `async def` on an event loop (true
-concurrency for I/O-bound work), sync `def` in a thread pool. On start it reconciles
-every declared queue — creating missing ones, applying declared policy changes — and
-rebuilds the admin views to reflect the whole catalog, not just the served queue,
-reporting to stdout. Then it polls until `SIGINT`/`SIGTERM`.
+concurrency for I/O-bound work), sync `def` in a thread pool. It provisions nothing: a
+`--queue` that [`migrate`](#what-migrate-installs) has not created is refused before the
+first poll, naming `absurd_sync_queues`. Otherwise it announces itself on stdout and
+polls until `SIGINT`/`SIGTERM`.
 
 | Flag              | Default         | What it does                                          |
 | ----------------- | --------------- | ----------------------------------------------------- |
@@ -755,8 +757,11 @@ python manage.py migrate
 ```
 
 Absurd's schema ships as a Django migration, and `post_migrate` provisions the declared
-queues and rebuilds the admin views. Declared queues are additionally created on worker
-start, by `absurd_sync_queues`, and on first enqueue; only declared queues are ever
+queues and rebuilds the admin views on every `migrate`, applied migrations or not.
+`manage.py absurd_sync_queues` does the same on demand — and repairs a queue whose
+catalog row outlived its tables. Those two, plus
+[`dj_absurd.sync_queues()`](#fixture-api) in tests, are the only things that provision:
+enqueuing and starting a worker never create a queue. Only declared queues are ever
 created, and an undeclared name is rejected. The SQL comes from the pinned Absurd
 version and is never fetched at migrate time.
 
@@ -839,8 +844,7 @@ python manage.py absurd_flush --noinput  # drops without prompting
 **Destructive: this deletes all task history.** It removes every queue — its per-queue
 tables and registry entry — along with all tasks, runs, and events in them. It does not
 uninstall Absurd: the schema, migrations, and functions stay, so you never re-`migrate`,
-only re-provision the queues with `migrate`, `absurd_sync_queues`, or by starting a
-worker.
+only re-provision the queues with `migrate` or `absurd_sync_queues`.
 
 - Scheduled jobs survive the flush and **error on each fire** until the queues exist
   again, so re-provision promptly. The `OPTIONS["CLEANUP"]` job is the exception: it
@@ -903,10 +907,9 @@ synthesized `queue` column. `Queue` is the queue catalog, keyed by `queue_name`.
 - **Filter by `queue=` whenever you can.** The views carry no cross-queue index, so
   `queue=` prunes to a single per-queue table while an unfiltered query — ordering by
   `enqueue_at`, or filtering only on `state` — scans every queue's table.
-- They are backed by Postgres views rebuilt by `migrate`, worker start, and
-  `absurd_sync_queues`. A queue that appears only afterwards — declared late and reached
-  by an enqueue before the next provisioning step — is absent from results until then.
-  Dropping a queue removes its view.
+- They are backed by Postgres views rebuilt by `migrate` and `absurd_sync_queues`. A
+  queue declared since the later of those is absent from results until the next one
+  runs. Dropping a queue removes its view.
 
 ### The admin
 
@@ -914,8 +917,8 @@ With `django.contrib.admin` installed, django-absurd registers read-only pages f
 models above. No configuration. Turn them off with [`ENABLE_ADMIN`](#backend-options),
 or register elsewhere with `ADMIN_SITE`.
 
-- A queue created only by an enqueue, with no worker started and no sync run, is not yet
-  in the views, so its tasks do not appear — run `absurd_sync_queues`.
+- A queue declared since the last `migrate` is not yet in the views, so its tasks do not
+  appear — run `absurd_sync_queues`.
 - **Non-default `DATABASE`:** the synthesized models read from the Absurd database, but
   Django's own `LogEntry`, session, and `ContentType` tables must still exist in
   `"default"` — run `migrate` on it too.
@@ -1019,10 +1022,10 @@ entry). Its `FrozenTime` handle carries the only two movers, `move_to(datetime)`
 
 **`drain()`** runs every currently-claimable task on `queue` to completion in-process —
 no worker subprocess, no polling loop — one at a time, returning one `RunSnapshot` per
-run executed, in claim order. It **provisions nothing**, unlike the CLI: `migrate`
-leaves a test database ready, but a queue a single test declares by overriding `TASKS`
-has no table, so call `sync_queues()` first or `drain()` raises
-`QueueNotProvisionedError`. An undeclared queue raises `QueueNotDeclaredError`.
+run executed, in claim order. It **provisions nothing**: `migrate` leaves a test
+database ready, but a queue a single test declares by overriding `TASKS` has no table,
+so call `sync_queues()` first or `drain()` raises `QueueNotProvisionedError`. An
+undeclared queue raises `QueueNotDeclaredError`.
 
 ```python
 (run,) = dj_absurd.drain()  # one RunSnapshot per run, in claim order
@@ -1073,8 +1076,8 @@ snapshot.failure  # None except on a terminal failure
   task's own status.
 
 **`sync_queues()`** is the runtime counterpart of `manage.py absurd_sync_queues`. Rarely
-needed, since `migrate` already provisions the declared catalog — reach for it only when
-the test itself changed queue topology.
+needed, since `migrate` already provisions the declared catalog — but nothing else
+re-provisions, so a test that changes queue topology has to call it.
 
 ### Cleanup is automatic
 
@@ -1253,6 +1256,8 @@ except DjangoAbsurdError:
 - `enqueue` raises `QueueNotDeclaredError` only when the backend's `QUEUES` is empty or
   unset; with `QUEUES` configured, a typo'd name is rejected earlier as Django's own
   `InvalidTask`.
+- `QueueNotProvisionedError` reaches every entry point alike — `enqueue`, `emit_event`,
+  `absurd_worker` at start, `dj_absurd.drain` — because none of them provision.
 - Every `absurd_*` management command inherits `AbsurdCommand` (or its
   `AbsurdReportCommand` subclass), which turns a fixed set of configuration failures —
   `ImproperlyConfigured`, `BackendNotConfiguredError`, `SchemaNotInstalledError`,

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -759,7 +759,7 @@ python manage.py migrate
 Absurd's schema ships as a Django migration, and `post_migrate` provisions the declared
 queues and rebuilds the admin views on every `migrate`, applied migrations or not.
 `manage.py absurd_sync_queues` does the same on demand — and repairs a queue whose
-catalog row outlived its tables. Those two, plus
+catalog row outlived its tables, reporting `Repaired: <queue>`. Those two, plus
 [`dj_absurd.sync_queues()`](#fixture-api) in tests, are the only things that provision:
 enqueuing and starting a worker never create a queue. Only declared queues are ever
 created, and an undeclared name is rejected. The SQL comes from the pinned Absurd
@@ -908,8 +908,8 @@ synthesized `queue` column. `Queue` is the queue catalog, keyed by `queue_name`.
   `queue=` prunes to a single per-queue table while an unfiltered query — ordering by
   `enqueue_at`, or filtering only on `state` — scans every queue's table.
 - They are backed by Postgres views rebuilt by `migrate` and `absurd_sync_queues`. A
-  queue declared since the later of those is absent from results until the next one
-  runs. Dropping a queue removes its view.
+  queue created outside django-absurd — `absurdctl`, a direct SDK call — is absent from
+  results until the next of those runs. Dropping a queue removes its view.
 
 ### The admin
 
@@ -917,8 +917,9 @@ With `django.contrib.admin` installed, django-absurd registers read-only pages f
 models above. No configuration. Turn them off with [`ENABLE_ADMIN`](#backend-options),
 or register elsewhere with `ADMIN_SITE`.
 
-- A queue declared since the last `migrate` is not yet in the views, so its tasks do not
-  appear — run `absurd_sync_queues`.
+- A queue created outside django-absurd — `absurdctl`, a direct SDK call — is not in the
+  views, so its tasks do not appear. The changelist says so and names the queues;
+  `absurd_sync_queues` indexes them.
 - **Non-default `DATABASE`:** the synthesized models read from the Absurd database, but
   Django's own `LogEntry`, session, and `ContentType` tables must still exist in
   `"default"` — run `migrate` on it too.
@@ -1257,7 +1258,8 @@ except DjangoAbsurdError:
   unset; with `QUEUES` configured, a typo'd name is rejected earlier as Django's own
   `InvalidTask`.
 - `QueueNotProvisionedError` reaches every entry point alike — `enqueue`, `emit_event`,
-  `absurd_worker` at start, `dj_absurd.drain` — because none of them provision.
+  `absurd_worker` at start, `dj_absurd.drain`, `dj_absurd.get_result` — because none of
+  them provision.
 - Every `absurd_*` management command inherits `AbsurdCommand`, which turns a fixed set
   of configuration failures — `ImproperlyConfigured`, `BackendNotConfiguredError`,
   `SchemaNotInstalledError`, `QueueNotDeclaredError`, `QueueNotProvisionedError` — into

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1258,13 +1258,12 @@ except DjangoAbsurdError:
   `InvalidTask`.
 - `QueueNotProvisionedError` reaches every entry point alike — `enqueue`, `emit_event`,
   `absurd_worker` at start, `dj_absurd.drain` — because none of them provision.
-- Every `absurd_*` management command inherits `AbsurdCommand` (or its
-  `AbsurdReportCommand` subclass), which turns a fixed set of configuration failures —
-  `ImproperlyConfigured`, `BackendNotConfiguredError`, `SchemaNotInstalledError`,
-  `QueueNotDeclaredError`, `QueueNotProvisionedError` — into a clean `CommandError`;
-  `--traceback` still shows the original chain. Every other error, including any other
-  `DjangoAbsurdError` subclass, keeps its own type and full traceback — it signals a
-  bug, not a configuration mistake.
+- Every `absurd_*` management command inherits `AbsurdCommand`, which turns a fixed set
+  of configuration failures — `ImproperlyConfigured`, `BackendNotConfiguredError`,
+  `SchemaNotInstalledError`, `QueueNotDeclaredError`, `QueueNotProvisionedError` — into
+  a clean `CommandError`; `--traceback` still shows the original chain. Every other
+  error, including any other `DjangoAbsurdError` subclass, keeps its own type and full
+  traceback — it signals a bug, not a configuration mistake.
 - The hierarchy is not total. Catch `DjangoAbsurdError` for django-absurd's own typed
   errors; other failures — config validation, clock misuse — still raise plain
   `ImproperlyConfigured` / `RuntimeError` / `TypeError`.

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -767,6 +767,18 @@ enqueuing and starting a worker never create a queue. Only declared queues are e
 created, and an undeclared name is rejected. The SQL comes from the pinned Absurd
 version and is never fetched at migrate time.
 
+```bash
+python manage.py absurd_sync_queues --check   # asserts; writes nothing
+```
+
+- `--check` reports what `absurd_sync_queues` would create, repair or reconcile and
+  exits non-zero if anything would, for a release step that asserts rather than acts.
+- `post_migrate` is per-database: `migrate --database=<alias>` is the run that
+  provisions that alias, and a `migrate` on another one leaves it untouched.
+- `migrate` fails when provisioning fails. The one exception is an absent schema, which
+  it reports and exits 0 on — a partial `migrate <app>`, or a `--fake`, reaches it
+  having installed nothing.
+
 → [Absurd: database setup](https://earendil-works.github.io/absurd/database/).
 
 ## Cleanup
@@ -1245,16 +1257,17 @@ except DjangoAbsurdError:
     ...
 ```
 
-| Type                        | Raised when                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------- |
-| `SchemaNotInstalledError`   | The Absurd Postgres schema itself isn't installed — run `manage.py migrate`                         |
-| `QueueNotDeclaredError`     | A queue name matches no queue declared for the backend                                              |
-| `QueueNotProvisionedError`  | A queue is declared but its Absurd table isn't provisioned yet — run `manage.py absurd_sync_queues` |
-| `BackendNotConfiguredError` | No `AbsurdBackend`, or more than one, is configured in `TASKS`                                      |
-| `QueueReadOnlyError`        | `.save()`/`.delete()` on one of the [read-only models](#query-queue-state)                          |
-| `ViewNotProvisionedError`   | One of those views hits a missing relation because a queue was never provisioned                    |
-| `TaskIdQueueMismatchError`  | `dj_absurd.get_result` got a `"queue:uuid"` id and a `queue=` naming different queues               |
-| `TaskNotFoundError`         | `dj_absurd.get_result` found no task by that id on that queue                                       |
+| Type                              | Raised when                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `SchemaNotInstalledError`         | The Absurd Postgres schema itself isn't installed — run `manage.py migrate`                         |
+| `QueueNotDeclaredError`           | A queue name matches no queue declared for the backend                                              |
+| `QueueNotProvisionedError`        | A queue is declared but its Absurd table isn't provisioned yet — run `manage.py absurd_sync_queues` |
+| `BackendNotConfiguredError`       | No `AbsurdBackend` is configured in `TASKS`                                                         |
+| `MultipleBackendsConfiguredError` | More than one `AbsurdBackend` is configured; the package supports exactly one                       |
+| `QueueReadOnlyError`              | `.save()`/`.delete()` on one of the [read-only models](#query-queue-state)                          |
+| `ViewNotProvisionedError`         | One of those views hits a missing relation because a queue was never provisioned                    |
+| `TaskIdQueueMismatchError`        | `dj_absurd.get_result` got a `"queue:uuid"` id and a `queue=` naming different queues               |
+| `TaskNotFoundError`               | `dj_absurd.get_result` found no task by that id on that queue                                       |
 
 - `enqueue` raises `QueueNotDeclaredError` only when the backend's `QUEUES` is empty or
   unset; with `QUEUES` configured, a typo'd name is rejected earlier as Django's own
@@ -1264,10 +1277,11 @@ except DjangoAbsurdError:
   them provision.
 - Every `absurd_*` management command inherits `AbsurdCommand`, which turns a fixed set
   of configuration failures — `ImproperlyConfigured`, `BackendNotConfiguredError`,
-  `SchemaNotInstalledError`, `QueueNotDeclaredError`, `QueueNotProvisionedError` — into
-  a clean `CommandError`; `--traceback` still shows the original chain. Every other
-  error, including any other `DjangoAbsurdError` subclass, keeps its own type and full
-  traceback — it signals a bug, not a configuration mistake.
+  `MultipleBackendsConfiguredError`, `SchemaNotInstalledError`, `QueueNotDeclaredError`,
+  `QueueNotProvisionedError` — into a clean `CommandError`; `--traceback` still shows
+  the original chain. Every other error, including any other `DjangoAbsurdError`
+  subclass, keeps its own type and full traceback — it signals a bug, not a
+  configuration mistake.
 - The hierarchy is not total. Catch `DjangoAbsurdError` for django-absurd's own typed
   errors; other failures — config validation, clock misuse — still raise plain
   `ImproperlyConfigured` / `RuntimeError` / `TypeError`.

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -516,6 +516,8 @@ Beat evaluates cron in-process and enqueues each task when its slot comes due; a
   fires at most once. It does not replace single-instance supervision.
 - **Never backfills.** A slot that passes while beat is down is skipped; the next one
   proceeds on schedule.
+- **A failed enqueue is not retried either.** Beat logs the error and advances, so an
+  unprovisioned target queue costs every slot until someone provisions it.
 - Grammar is [croniter](https://pypi.org/project/croniter/): standard 5-field
   `min hour dom mon dow`, or 6-field with a leading seconds column for sub-minute
   cadence (`"*/30 * * * * *"` is every 30s). Each slot enqueues a task, so size the

--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -145,8 +145,7 @@ class ReadOnlyAbsurdAdmin(ReadOnlyAdminBase):
                 messages.warning(
                     request,
                     f"Queue(s) {names} exist but aren't indexed in the admin views "
-                    "yet — run 'manage.py absurd_sync_queues' (or start a worker on "
-                    "them) to include their tasks.",
+                    "yet — run 'manage.py absurd_sync_queues' to include their tasks.",
                 )
         return super().changelist_view(request, extra_context)
 

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -1,11 +1,9 @@
 import typing as t
 
 from django.apps import AppConfig
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models.signals import post_migrate
-from django.db.utils import OperationalError, ProgrammingError
 
 from django_absurd.admin_views import PRIVATE_ADMIN_APPS
 from django_absurd.backends import get_absurd_backends
@@ -51,16 +49,14 @@ def provision_queues_after_migrate(
             continue
         try:
             result = provision_backend(backend)
-        except (
-            ImproperlyConfigured,
-            OperationalError,
-            ProgrammingError,
-            SchemaNotInstalledError,
-        ) as exc:
-            # Swallowed so a faked or adopted migration still completes, but said
-            # out loud: nothing at runtime provisions a queue any more. A signal
-            # receiver never runs through the command base, so this tuple is
-            # permanent, not a stopgap.
+        except SchemaNotInstalledError as exc:
+            # The one forgiven failure, and the reason the escape hatch exists:
+            # `migrate --fake django_absurd` against a schema installed out of band
+            # has nothing to provision into yet. Said out loud all the same, because
+            # nothing at runtime provisions a queue any more. Every OTHER failure
+            # propagates and fails the migrate — a deploy that provisioned nothing
+            # must not report success, and re-running migrate retries provisioning
+            # once the cause is fixed.
             lines = [style.WARNING(f"  Not provisioned: {exc}")]
         else:
             lines = [f"  Created {name!r}" for name in result.created]

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -50,18 +50,10 @@ def provision_queues_after_migrate(
         try:
             result = provision_backend(backend)
         except SchemaNotInstalledError:
-            # The one forgiven failure, and the reason the escape hatch exists:
-            # `migrate --fake django_absurd` against a schema installed out of band
-            # has nothing to provision into yet. Said out loud all the same, because
-            # nothing at runtime provisions a queue any more. Every OTHER failure
-            # propagates and fails the migrate — a deploy that provisioned nothing
-            # must not report success, and re-running migrate retries provisioning
-            # once the cause is fixed.
-            #
+            # Forgiven because post_migrate fires for every app config: a partial
+            # `migrate auth` on a fresh database lands here before ours has run.
             # Worded here rather than printed off the exception, whose own "Run:
-            # manage.py migrate" is right at every other door and circular at this one:
-            # `migrate` is what is printing it, and after a `--fake` the migration is
-            # recorded, so re-running installs nothing however often it is run.
+            # manage.py migrate" is circular when migrate is what prints it.
             lines = [
                 style.WARNING(
                     "  Not provisioned: the Absurd schema is absent; this migrate did"

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -3,6 +3,7 @@ import typing as t
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
+from django.db import DEFAULT_DB_ALIAS
 from django.db.models.signals import post_migrate
 from django.db.utils import OperationalError, ProgrammingError
 
@@ -35,12 +36,19 @@ class AbsurdConfig(AppConfig):
 def provision_queues_after_migrate(
     sender: AppConfig,
     *,
+    using: str = DEFAULT_DB_ALIAS,
     verbosity: int = 1,
     stdout: t.IO[str] | None = None,
     **kwargs: object,
 ) -> None:
     style = color_style()
     for alias, backend in get_absurd_backends().items():
+        # post_migrate is per-database. Provisioning a backend whose database was
+        # not the one migrated is work the operator did not ask for, and it makes
+        # every pass-through migrate swallow a failure that was never a problem.
+        # Django's own receivers gate the same way, on ``using``.
+        if backend.database != using:
+            continue
         try:
             result = provision_backend(backend)
         except (
@@ -48,15 +56,17 @@ def provision_queues_after_migrate(
             OperationalError,
             ProgrammingError,
             SchemaNotInstalledError,
-        ):
-            # Best-effort: skip when the schema isn't installed on the target DB
-            # (e.g. a faked/adopted migration, or a non-Absurd database). This is
-            # a signal receiver, not a command — it never runs through the
-            # command base, so this except tuple is permanent, not a stopgap.
-            continue
-        lines = [f"  Created {name!r}" for name in result.created]
-        lines += [f"  Reconciled {name!r}" for name in result.reconciled]
-        lines += [style.WARNING(f"  {w}") for w in result.storage_warnings]
+        ) as exc:
+            # Swallowed so a faked or adopted migration still completes, but said
+            # out loud: nothing at runtime provisions a queue any more. A signal
+            # receiver never runs through the command base, so this tuple is
+            # permanent, not a stopgap.
+            lines = [style.WARNING(f"  Not provisioned: {exc}")]
+        else:
+            lines = [f"  Created {name!r}" for name in result.created]
+            lines += [f"  Reconciled {name!r}" for name in result.reconciled]
+            lines += [f"  Repaired {name!r}" for name in result.repaired]
+            lines += [style.WARNING(f"  {w}") for w in result.storage_warnings]
         if lines and verbosity >= 1 and stdout is not None:
             heading = f"Provisioning Absurd queues ({alias}):"
             stdout.write(style.MIGRATE_HEADING(heading))

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -51,7 +51,8 @@ def provision_queues_after_migrate(
             result = provision_backend(backend)
         except SchemaNotInstalledError:
             # Forgiven because post_migrate fires for every app config: a partial
-            # `migrate auth` on a fresh database lands here before ours has run.
+            # `migrate auth` on a fresh database lands here before ours has run, and
+            # `migrate --fake` lands here having deliberately run no DDL at all.
             # Worded here rather than printed off the exception, whose own "Run:
             # manage.py migrate" is circular when migrate is what prints it.
             lines = [

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -51,10 +51,9 @@ def provision_queues_after_migrate(
             result = provision_backend(backend)
         except SchemaNotInstalledError:
             # Forgiven because post_migrate fires for every app config: a partial
-            # `migrate auth` on a fresh database lands here before ours has run, and
-            # `migrate --fake` lands here having deliberately run no DDL at all.
-            # Worded here rather than printed off the exception, whose own "Run:
-            # manage.py migrate" is circular when migrate is what prints it.
+            # `migrate auth`, or a `--fake`, reaches here having installed nothing.
+            # Worded here, not printed off the exception: its "Run: manage.py migrate"
+            # is circular when migrate is what prints it.
             lines = [
                 style.WARNING(
                     "  Not provisioned: the Absurd schema is absent; this migrate did"

--- a/django_absurd/apps.py
+++ b/django_absurd/apps.py
@@ -49,7 +49,7 @@ def provision_queues_after_migrate(
             continue
         try:
             result = provision_backend(backend)
-        except SchemaNotInstalledError as exc:
+        except SchemaNotInstalledError:
             # The one forgiven failure, and the reason the escape hatch exists:
             # `migrate --fake django_absurd` against a schema installed out of band
             # has nothing to provision into yet. Said out loud all the same, because
@@ -57,7 +57,17 @@ def provision_queues_after_migrate(
             # propagates and fails the migrate — a deploy that provisioned nothing
             # must not report success, and re-running migrate retries provisioning
             # once the cause is fixed.
-            lines = [style.WARNING(f"  Not provisioned: {exc}")]
+            #
+            # Worded here rather than printed off the exception, whose own "Run:
+            # manage.py migrate" is right at every other door and circular at this one:
+            # `migrate` is what is printing it, and after a `--fake` the migration is
+            # recorded, so re-running installs nothing however often it is run.
+            lines = [
+                style.WARNING(
+                    "  Not provisioned: the Absurd schema is absent; this migrate did"
+                    " not install it."
+                )
+            ]
         else:
             lines = [f"  Created {name!r}" for name in result.created]
             lines += [f"  Reconciled {name!r}" for name in result.reconciled]

--- a/django_absurd/backends.py
+++ b/django_absurd/backends.py
@@ -17,11 +17,15 @@ from django.tasks.signals import task_enqueued
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
-from django_absurd import dispatch
+from django_absurd import dispatch, queues
 from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_queue_table_model
 from django_absurd.connection import build_absurd_client
 from django_absurd.deferred import DEFER_NAME_SUFFIX
-from django_absurd.exceptions import QueueNotDeclaredError, SchemaNotInstalledError
+from django_absurd.exceptions import (
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+    SchemaNotInstalledError,
+)
 from django_absurd.tasks import AbsurdTask, SpawnKwargs, build_merged_spawn_options
 
 if t.TYPE_CHECKING:
@@ -183,28 +187,18 @@ class AbsurdBackend(BaseTaskBackend):
             psycopg.errors.UndefinedFunction,
             psycopg.errors.InvalidSchemaName,
         ) as exc:
-            declared = get_declared_queues(self)
             # validate_task() rejects an undeclared queue (InvalidTask) when the
-            # backend declares queues. This guards the empty-QUEUES config (where
-            # that check is skipped) and the declared[...] access below from KeyError.
-            if task.queue_name not in declared:
+            # backend declares queues. This guards the empty-QUEUES config, where
+            # that check is skipped.
+            if task.queue_name not in get_declared_queues(self):
                 raise QueueNotDeclaredError(
                     task.queue_name, self.alias, self.queues
                 ) from exc
-            try:
-                client.create_queue(task.queue_name, **declared[task.queue_name])
-            except (
-                psycopg.errors.UndefinedFunction,
-                psycopg.errors.InvalidSchemaName,
-            ) as exc:
+            if not isinstance(exc, psycopg.errors.UndefinedTable):
                 raise SchemaNotInstalledError from exc
-            with transaction.atomic(using=self.database, savepoint=True):
-                spawn_result = client.spawn(
-                    spawn_name,
-                    spawn_params,
-                    queue=task.queue_name,
-                    **merged,
-                )
+            if queues.names_a_queue_table(exc, task.queue_name):
+                raise QueueNotProvisionedError(task.queue_name) from exc
+            raise
         result: TaskResult[t.Any, t.Any] = TaskResult(
             task=task,
             id=f"{task.queue_name}:{spawn_result['task_id']}",

--- a/django_absurd/events.py
+++ b/django_absurd/events.py
@@ -25,7 +25,7 @@ def emit_event(
 ) -> None:
     backend = get_absurd_backend()
     if backend is None:
-        raise BackendNotConfiguredError(0)
+        raise BackendNotConfiguredError
     if queue not in backend.queues:
         raise QueueNotDeclaredError(queue, backend.alias, backend.queues)
     client = get_absurd_client()

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -122,20 +122,22 @@ class SchemaNotInstalledError(DjangoAbsurdError):
 
 
 class BackendNotConfiguredError(DjangoAbsurdError):
-    """No single Absurd backend could be resolved — zero or several configured. One
-    type for both counts: the package supports exactly one Absurd backend per
-    project, so either way there is no single backend to act on.
-    """
+    """No Absurd backend is configured at all."""
 
-    def __init__(self, backend_count: int) -> None:
-        if backend_count == 0:
-            msg = (
-                "No Absurd backend configured. Add a "
-                "django_absurd.backends.AbsurdBackend entry to TASKS."
-            )
-        else:
-            msg = (
-                "django-absurd supports one Absurd backend per project; "
-                "configure exactly one AbsurdBackend in TASKS."
-            )
+    def __init__(self) -> None:
+        msg = (
+            "No Absurd backend configured. Add a "
+            "django_absurd.backends.AbsurdBackend entry to TASKS."
+        )
+        super().__init__(msg)
+
+
+class MultipleBackendsConfiguredError(DjangoAbsurdError):
+    """Several Absurd backends are configured, and the package supports exactly one."""
+
+    def __init__(self) -> None:
+        msg = (
+            "django-absurd supports one Absurd backend per project; "
+            "configure exactly one AbsurdBackend in TASKS."
+        )
         super().__init__(msg)

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -58,9 +58,10 @@ class QueueNotProvisionedError(DjangoAbsurdError):
     Raised by ``AbsurdBackend.enqueue``, ``worker.drain_queue``, ``worker.run_worker``,
     ``events.emit_event`` and ``AbsurdTestRuntime.get_result`` when a statement hits a
     missing relation that names one of the queue's own Absurd tables. ``aworker_client``
-    also raises it up front, from the queue's absence from ``list_queues()`` — a catalog
-    check, so a queue whose row outlived its tables passes that one and reaches this
-    error through ``run_worker``'s translation instead, once a claim runs.
+    also raises it up front, from two boot checks — the queue's absence from
+    ``list_queues()``, and any of its own tables being absent — so no worker announces
+    a start it cannot honour. ``run_worker``'s translation then covers the rest of the
+    run, a queue dropped while the worker holds it included.
     """
 
     def __init__(self, queue: str) -> None:

--- a/django_absurd/exceptions.py
+++ b/django_absurd/exceptions.py
@@ -55,8 +55,12 @@ class QueueNotDeclaredError(DjangoAbsurdError):
 class QueueNotProvisionedError(DjangoAbsurdError):
     """A queue is declared but its Absurd table has not been provisioned.
 
-    Raised by ``worker.drain_queue`` and ``events.emit_event`` when a claim/emit hits
-    a missing relation that names one of the queue's own Absurd tables.
+    Raised by ``AbsurdBackend.enqueue``, ``worker.drain_queue``, ``worker.run_worker``,
+    ``events.emit_event`` and ``AbsurdTestRuntime.get_result`` when a statement hits a
+    missing relation that names one of the queue's own Absurd tables. ``aworker_client``
+    also raises it up front, from the queue's absence from ``list_queues()`` — a catalog
+    check, so a queue whose row outlived its tables passes that one and reaches this
+    error through ``run_worker``'s translation instead, once a claim runs.
     """
 
     def __init__(self, queue: str) -> None:

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -6,12 +6,13 @@ from django.core.management.base import BaseCommand, CommandError
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.exceptions import (
     BackendNotConfiguredError,
+    MultipleBackendsConfiguredError,
     QueueNotDeclaredError,
     QueueNotProvisionedError,
     SchemaNotInstalledError,
 )
 
-# Each of these five owns a message that already names the fix (an add/run/configure
+# Each of these six owns a message that already names the fix (an add/run/configure
 # instruction), so translating it into an untyped CommandError with no traceback loses
 # nothing an operator needs. Any other DjangoAbsurdError subclass — and anything
 # unforeseen — signals a bug, not a configuration mistake, and keeps its own type and
@@ -19,6 +20,7 @@ from django_absurd.exceptions import (
 CONFIGURATION_ERRORS: tuple[type[Exception], ...] = (
     ImproperlyConfigured,
     BackendNotConfiguredError,
+    MultipleBackendsConfiguredError,
     SchemaNotInstalledError,
     QueueNotDeclaredError,
     QueueNotProvisionedError,
@@ -34,9 +36,11 @@ BEAT_DISABLED_UNDER_PG_CRON = (
 
 def resolve_backend() -> AbsurdBackend:
     backends = get_absurd_backends()
-    if len(backends) == 1:
-        return next(iter(backends.values()))
-    raise BackendNotConfiguredError(len(backends))
+    if not backends:
+        raise BackendNotConfiguredError
+    if len(backends) > 1:
+        raise MultipleBackendsConfiguredError
+    return next(iter(backends.values()))
 
 
 class AbsurdCommand(BaseCommand):

--- a/django_absurd/management/base.py
+++ b/django_absurd/management/base.py
@@ -10,7 +10,6 @@ from django_absurd.exceptions import (
     QueueNotProvisionedError,
     SchemaNotInstalledError,
 )
-from django_absurd.queues import SyncResult
 
 # Each of these five owns a message that already names the fix (an add/run/configure
 # instruction), so translating it into an untyped CommandError with no traceback loses
@@ -55,25 +54,3 @@ class AbsurdCommand(BaseCommand):
             return super().execute(*args, **options)
         except CONFIGURATION_ERRORS as exc:
             raise CommandError(str(exc)) from exc
-
-
-class AbsurdReportCommand(AbsurdCommand):
-    """Base for commands that report a queue SyncResult to stdout/stderr."""
-
-    def report_sync_result(
-        self,
-        result: SyncResult,
-        stdout_prefix: str = "",
-        stderr_prefix: str = "",
-        empty_message: str | None = None,
-    ) -> None:
-        if result.created:
-            self.stdout.write(f"{stdout_prefix}Created: {', '.join(result.created)}")
-        if result.reconciled:
-            self.stdout.write(
-                f"{stdout_prefix}Reconciled: {', '.join(result.reconciled)}"
-            )
-        if empty_message and not result.created and not result.reconciled:
-            self.stdout.write(f"{stdout_prefix}{empty_message}")
-        for warning in result.storage_warnings:
-            self.stderr.write(self.style.WARNING(f"{stderr_prefix}{warning}"))

--- a/django_absurd/management/commands/absurd_cleanup.py
+++ b/django_absurd/management/commands/absurd_cleanup.py
@@ -20,7 +20,7 @@ class Command(AbsurdCommand):
 
     def handle(self, *args: object, **options: object) -> None:
         if not get_absurd_backends():
-            raise BackendNotConfiguredError(0)
+            raise BackendNotConfiguredError
         queues = t.cast("list[str]", options["queues"]) or None
         for row in cleanup_queues(queues):
             self.stdout.write(

--- a/django_absurd/management/commands/absurd_cleanup.py
+++ b/django_absurd/management/commands/absurd_cleanup.py
@@ -4,6 +4,7 @@ from django.core.management.base import CommandParser
 
 from django_absurd.backends import get_absurd_backends
 from django_absurd.cleanup import cleanup_queues
+from django_absurd.exceptions import BackendNotConfiguredError
 from django_absurd.management.base import AbsurdCommand
 
 
@@ -19,8 +20,7 @@ class Command(AbsurdCommand):
 
     def handle(self, *args: object, **options: object) -> None:
         if not get_absurd_backends():
-            self.stdout.write("No Absurd task backends configured.")
-            return
+            raise BackendNotConfiguredError(0)
         queues = t.cast("list[str]", options["queues"]) or None
         for row in cleanup_queues(queues):
             self.stdout.write(

--- a/django_absurd/management/commands/absurd_flush.py
+++ b/django_absurd/management/commands/absurd_flush.py
@@ -24,7 +24,7 @@ class Command(AbsurdCommand):
 
     def handle(self, *args: object, **options: object) -> None:
         if not get_absurd_backends():
-            raise BackendNotConfiguredError(0)
+            raise BackendNotConfiguredError
         queues = list_provisioned_queues()
         if not queues:
             self.stdout.write("No queues to flush.")

--- a/django_absurd/management/commands/absurd_flush.py
+++ b/django_absurd/management/commands/absurd_flush.py
@@ -1,6 +1,7 @@
 from django.core.management.base import CommandParser
 
 from django_absurd.backends import get_absurd_backends
+from django_absurd.exceptions import BackendNotConfiguredError
 from django_absurd.flush import clear_queues
 from django_absurd.management.base import AbsurdCommand
 from django_absurd.queues import list_provisioned_queues
@@ -23,8 +24,7 @@ class Command(AbsurdCommand):
 
     def handle(self, *args: object, **options: object) -> None:
         if not get_absurd_backends():
-            self.stdout.write("No Absurd task backends configured.")
-            return
+            raise BackendNotConfiguredError(0)
         queues = list_provisioned_queues()
         if not queues:
             self.stdout.write("No queues to flush.")

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -1,27 +1,55 @@
+import typing as t
+
+from django.core.management.base import CommandError
+
 from django_absurd import console
 from django_absurd.backends import get_absurd_backends
 from django_absurd.management.base import AbsurdCommand
-from django_absurd.queues import SyncResult, provision_backend
+from django_absurd.queues import SyncResult, plan_queue_sync, provision_backend
+
+if t.TYPE_CHECKING:
+    from django.core.management.base import CommandParser
+
+NOT_IN_SYNC = "Queues are not in sync. Run: manage.py absurd_sync_queues"
 
 
 class Command(AbsurdCommand):
     help = "Create and reconcile queues declared on each Absurd task backend."
 
-    def handle(self, *args: object, **options: object) -> None:
+    def add_arguments(self, parser: "CommandParser") -> None:
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help=(
+                "Report what would change and exit non-zero if anything would, "
+                "without writing. For a release step that asserts rather than acts."
+            ),
+        )
+
+    def handle(self, *args: t.Any, **options: t.Any) -> None:
         backends = get_absurd_backends()
         if not backends:
             self.stdout.write("No Absurd task backends configured.")
             return
+        dry_run = options["check"]
         crate_out = console.build_glyph_prefix(self.stdout, "🗃️")
         crate_err = console.build_glyph_prefix(self.stderr, "🗃️")
+        pending = False
         for alias, backend in backends.items():
             alias_label = f"[{alias}] " if len(backends) > 1 else ""
+            result = plan_queue_sync(backend) if dry_run else provision_backend(backend)
+            pending = pending or bool(
+                result.created or result.reconciled or result.repaired
+            )
             self.report_sync_result(
-                provision_backend(backend),
+                result,
                 stdout_prefix=f"{crate_out}{alias_label}",
                 stderr_prefix=f"{crate_err}{alias_label}",
                 empty_message="No queues to sync.",
+                dry_run=dry_run,
             )
+        if dry_run and pending:
+            raise CommandError(NOT_IN_SYNC)
 
     def report_sync_result(
         self,
@@ -30,15 +58,23 @@ class Command(AbsurdCommand):
         stdout_prefix: str,
         stderr_prefix: str,
         empty_message: str,
+        dry_run: bool = False,
     ) -> None:
+        created, reconciled, repaired = (
+            ("Would create", "Would reconcile", "Would repair")
+            if dry_run
+            else ("Created", "Reconciled", "Repaired")
+        )
         if result.created:
-            self.stdout.write(f"{stdout_prefix}Created: {', '.join(result.created)}")
+            self.stdout.write(f"{stdout_prefix}{created}: {', '.join(result.created)}")
         if result.reconciled:
             self.stdout.write(
-                f"{stdout_prefix}Reconciled: {', '.join(result.reconciled)}"
+                f"{stdout_prefix}{reconciled}: {', '.join(result.reconciled)}"
             )
         if result.repaired:
-            self.stdout.write(f"{stdout_prefix}Repaired: {', '.join(result.repaired)}")
+            self.stdout.write(
+                f"{stdout_prefix}{repaired}: {', '.join(result.repaired)}"
+            )
         if not result.created and not result.reconciled and not result.repaired:
             self.stdout.write(f"{stdout_prefix}{empty_message}")
         for warning in result.storage_warnings:

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -1,10 +1,10 @@
 from django_absurd import console
 from django_absurd.backends import get_absurd_backends
-from django_absurd.management.base import AbsurdReportCommand
-from django_absurd.queues import provision_backend
+from django_absurd.management.base import AbsurdCommand
+from django_absurd.queues import SyncResult, provision_backend
 
 
-class Command(AbsurdReportCommand):
+class Command(AbsurdCommand):
     help = "Create and reconcile queues declared on each Absurd task backend."
 
     def handle(self, *args: object, **options: object) -> None:
@@ -22,3 +22,22 @@ class Command(AbsurdReportCommand):
                 stderr_prefix=f"{crate_err}{alias_label}",
                 empty_message="No queues to sync.",
             )
+
+    def report_sync_result(
+        self,
+        result: SyncResult,
+        *,
+        stdout_prefix: str,
+        stderr_prefix: str,
+        empty_message: str,
+    ) -> None:
+        if result.created:
+            self.stdout.write(f"{stdout_prefix}Created: {', '.join(result.created)}")
+        if result.reconciled:
+            self.stdout.write(
+                f"{stdout_prefix}Reconciled: {', '.join(result.reconciled)}"
+            )
+        if not result.created and not result.reconciled:
+            self.stdout.write(f"{stdout_prefix}{empty_message}")
+        for warning in result.storage_warnings:
+            self.stderr.write(self.style.WARNING(f"{stderr_prefix}{warning}"))

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -4,6 +4,7 @@ from django.core.management.base import CommandError
 
 from django_absurd import console
 from django_absurd.backends import get_absurd_backends
+from django_absurd.exceptions import BackendNotConfiguredError
 from django_absurd.management.base import AbsurdCommand
 from django_absurd.queues import SyncResult, plan_queue_sync, provision_backend
 
@@ -29,8 +30,7 @@ class Command(AbsurdCommand):
     def handle(self, *args: t.Any, **options: t.Any) -> None:
         backends = get_absurd_backends()
         if not backends:
-            self.stdout.write("No Absurd task backends configured.")
-            return
+            raise BackendNotConfiguredError(0)
         dry_run = options["check"]
         crate_out = console.build_glyph_prefix(self.stdout, "🗃️")
         crate_err = console.build_glyph_prefix(self.stderr, "🗃️")

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -37,7 +37,9 @@ class Command(AbsurdCommand):
             self.stdout.write(
                 f"{stdout_prefix}Reconciled: {', '.join(result.reconciled)}"
             )
-        if not result.created and not result.reconciled:
+        if result.repaired:
+            self.stdout.write(f"{stdout_prefix}Repaired: {', '.join(result.repaired)}")
+        if not result.created and not result.reconciled and not result.repaired:
             self.stdout.write(f"{stdout_prefix}{empty_message}")
         for warning in result.storage_warnings:
             self.stderr.write(self.style.WARNING(f"{stderr_prefix}{warning}"))

--- a/django_absurd/management/commands/absurd_sync_queues.py
+++ b/django_absurd/management/commands/absurd_sync_queues.py
@@ -30,7 +30,7 @@ class Command(AbsurdCommand):
     def handle(self, *args: t.Any, **options: t.Any) -> None:
         backends = get_absurd_backends()
         if not backends:
-            raise BackendNotConfiguredError(0)
+            raise BackendNotConfiguredError
         dry_run = options["check"]
         crate_out = console.build_glyph_prefix(self.stdout, "🗃️")
         crate_err = console.build_glyph_prefix(self.stderr, "🗃️")

--- a/django_absurd/management/commands/absurd_worker.py
+++ b/django_absurd/management/commands/absurd_worker.py
@@ -10,14 +10,13 @@ from django_absurd import logging as absurd_logging
 from django_absurd.exceptions import QueueNotDeclaredError
 from django_absurd.management.base import (
     BEAT_DISABLED_UNDER_PG_CRON,
-    AbsurdReportCommand,
+    AbsurdCommand,
     resolve_backend,
 )
-from django_absurd.queues import provision_backend
 from django_absurd.worker import WorkerOptions, run_worker
 
 
-class Command(AbsurdReportCommand):
+class Command(AbsurdCommand):
     help = "Start the Absurd task worker."
 
     def add_arguments(self, parser: "CommandParser") -> None:
@@ -83,13 +82,10 @@ class Command(AbsurdReportCommand):
         if queue not in backend.queues:
             raise QueueNotDeclaredError(queue, backend.alias, backend.queues)
 
-        # Full provision on start so the admin views reflect every declared queue,
-        # not just the one this worker serves.
-        result = provision_backend(backend)
-        self.report_sync_result(result)
-
         elephant = console.build_glyph_prefix(self.stdout, "🐘")
-        self.stdout.write(f"{elephant}Started worker on queue '{queue}'.")
+
+        def announce_started() -> None:
+            self.stdout.write(f"{elephant}Started worker on queue '{queue}'.")
 
         def announce_stop_requested() -> None:
             self.stdout.write(
@@ -102,6 +98,7 @@ class Command(AbsurdReportCommand):
             queue,
             run_beat=options["beat"],
             options=worker_options,
+            on_started=announce_started,
             on_stop_requested=announce_stop_requested,
         )
         self.stdout.write(f"{elephant}Stopped worker on queue '{queue}'.")

--- a/django_absurd/pytest_plugin.py
+++ b/django_absurd/pytest_plugin.py
@@ -18,7 +18,7 @@ module-level import.
 
 That constraint has ONE choke point, not a rule spread over this file: the only
 model-touching import in the whole graph reachable from here lives inside
-``django_absurd.queues.reconcile_queue``'s function body (see the comment there), which
+``django_absurd.queues.get_queue_object``'s function body (see the comment there), which
 is what keeps ``queues``, ``flush``, ``events`` and ``django_absurd.test`` settings-free
 and so importable at module level here. ``tests/core/test_pytest_plugin.py``'s
 ``test_a_pytest_run_with_no_django_settings_still_collects`` runs a real settings-less

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -49,6 +49,7 @@ PROVISION_LOCK_KEY = zlib.crc32(b"django_absurd.provision")
 class SyncResult:
     created: list[str] = field(default_factory=list)
     reconciled: list[str] = field(default_factory=list)
+    repaired: list[str] = field(default_factory=list)
     storage_warnings: list[str] = field(default_factory=list)
 
 
@@ -139,18 +140,22 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
         client.create_queue(queue_name, **opts)
         result.created.append(queue_name)
     else:
-        # Idempotent by construction (INSERT ... ON CONFLICT DO NOTHING, then
-        # ensure_queue_tables), so this puts back the tables of a queue whose catalog
-        # row outlived them — a manual drop, a partial restore — which is the state
-        # QueueNotProvisionedError sends an operator here to repair. The EXISTING
-        # storage mode, never the declared one: create_queue refuses a mode change
-        # outright, and drift is warned about below rather than applied.
-        client.create_queue(
-            queue_name,
-            # Read back from absurd.queues, whose create_queue only ever writes
-            # these two.
-            storage_mode=t.cast("QueueStorageMode", existing.storage_mode),
-        )
+        # Puts back the tables of a queue whose catalog row outlived them — a manual
+        # drop, a partial restore — the state QueueNotProvisionedError sends an
+        # operator here to repair. Gated on them actually being absent rather than
+        # called unconditionally: create_queue re-runs ensure_partitions, and a
+        # partitioned queue whose default partition has collected rows for a week the
+        # window now covers cannot survive that. The EXISTING storage mode, never the
+        # declared one: create_queue refuses a mode change outright, and drift is
+        # warned about below rather than applied.
+        if find_missing_queue_tables(db, queue_name):
+            client.create_queue(
+                queue_name,
+                # Read back from absurd.queues, whose create_queue only ever writes
+                # these two.
+                storage_mode=t.cast("QueueStorageMode", existing.storage_mode),
+            )
+            result.repaired.append(queue_name)
         # MUTABLE_OPTION_KEYS mirrors QueuePolicyOptions's fields exactly; the cast is
         # safe by construction.
         mutable_opts = t.cast(
@@ -169,25 +174,45 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
     return result
 
 
+def find_missing_queue_tables(using: str, queue_name: str) -> list[str]:
+    """Which of ``queue_name``'s own Absurd tables are absent, catalog row aside.
+
+    ``to_regclass`` rather than a ``pg_class`` join: it takes the qualified name and
+    answers NULL instead of raising, which is the whole question being asked. A
+    partitioned queue also owns ``i_<queue>``, deliberately not probed — it exists only
+    when an idempotency key is used, so its absence is not what a half-provisioned
+    queue looks like.
+    """
+    with connections[using].cursor() as cursor:
+        cursor.execute(
+            "select name from unnest(%s::text[]) as name "
+            "where to_regclass('absurd.' || quote_ident(name)) is null",
+            [[f"{prefix}_{queue_name}" for prefix in QUEUE_TABLE_PREFIXES]],
+        )
+        return [str(row[0]) for row in cursor.fetchall()]
+
+
 def sync_queues(backend: backends.AbsurdBackend) -> SyncResult:
     result = SyncResult()
     for name in backends.get_declared_queues(backend):
         r = reconcile_queue(backend, name)
         result.created.extend(r.created)
         result.reconciled.extend(r.reconciled)
+        result.repaired.extend(r.repaired)
         result.storage_warnings.extend(r.storage_warnings)
     log_sync_result(result)
     return result
 
 
 def log_sync_result(result: SyncResult) -> None:
-    if not result.created and not result.reconciled:
+    if not result.created and not result.reconciled and not result.repaired:
         logger.info("queues provisioned: no changes")
         return
     logger.info(
-        'queues provisioned: created="%s" reconciled="%s"',
+        'queues provisioned: created="%s" reconciled="%s" repaired="%s"',
         ", ".join(result.created),
         ", ".join(result.reconciled),
+        ", ".join(result.repaired),
     )
 
 

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -116,31 +116,12 @@ def names_a_queue_table(exc: psycopg.errors.UndefinedTable, queue: str) -> bool:
 
 
 def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncResult:
-    # The ONE import that would make this module settings-dependent at load time:
-    # ``django_absurd.models`` defines model classes (``build_admin_model``), so
-    # importing it reads INSTALLED_APPS. Keeping it in here is what lets
-    # ``django_absurd.pytest_plugin``/``.test``/``.flush`` import this module at their
-    # own top level during pytest's bootstrap, in any venv, before Django is configured.
-    # Move it to the top of this module and every pytest run in a non-Django project
-    # dies with INTERNALERROR (see tests/core/test_pytest_plugin.py's
-    # test_a_pytest_run_with_no_django_settings_still_collects).
-    from django_absurd.models import Queue  # noqa: PLC0415
-
     db = backend.database
     validate_backend(db)
     opts = backends.get_declared_queues(backend)[queue_name]
     result = SyncResult()
     client = build_absurd_client(db)
-    try:
-        existing = Queue.objects.using(db).filter(queue_name=queue_name).first()
-    except ProgrammingError as exc:
-        cause = exc.__cause__
-        if not isinstance(
-            cause,
-            (psycopg.errors.InvalidSchemaName, psycopg.errors.UndefinedTable),
-        ):
-            raise
-        raise SchemaNotInstalledError from exc
+    existing = get_queue_object(db, queue_name)
     if existing is None:
         client.create_queue(queue_name, **opts)
         result.created.append(queue_name)
@@ -186,13 +167,11 @@ def plan_queue_sync(backend: backends.AbsurdBackend) -> SyncResult:
     policy drift — so the two cannot disagree about a queue without one of those
     changing. Nothing here writes, so a role with no DDL rights can still ask.
     """
-    from django_absurd.models import Queue  # noqa: PLC0415
-
     db = backend.database
     validate_backend(db)
     result = SyncResult()
     for queue_name, opts in backends.get_declared_queues(backend).items():
-        existing = Queue.objects.using(db).filter(queue_name=queue_name).first()
+        existing = get_queue_object(db, queue_name)
         if existing is None:
             result.created.append(queue_name)
             continue
@@ -211,6 +190,32 @@ def plan_queue_sync(backend: backends.AbsurdBackend) -> SyncResult:
                 f"declared: {opts['storage_mode']!r}); skipping."
             )
     return result
+
+
+def get_queue_object(using: str, queue_name: str) -> "Queue | None":
+    """``queue_name``'s ``Queue``, or None — with schema-absence classified.
+
+    Shared by the write path and the dry run so only one of them can be wrong about what
+    a missing schema looks like. A ``ProgrammingError`` that is NOT about the schema
+    surfaces as itself: relabelling it would send the reader to the wrong door.
+    """
+    # The ONE import that would make this module settings-dependent at load time —
+    # ``django_absurd.models`` reads INSTALLED_APPS — and our pytest plugin is an
+    # entry point, so it loads in ANY venv's pytest run, Django project or not. See
+    # tests/core/test_pytest_plugin.py's
+    # test_a_pytest_run_with_no_django_settings_still_collects.
+    from django_absurd.models import Queue  # noqa: PLC0415
+
+    try:
+        return Queue.objects.using(using).filter(queue_name=queue_name).first()
+    except ProgrammingError as exc:
+        cause = exc.__cause__
+        if not isinstance(
+            cause,
+            (psycopg.errors.InvalidSchemaName, psycopg.errors.UndefinedTable),
+        ):
+            raise
+        raise SchemaNotInstalledError from exc
 
 
 def find_missing_queue_tables(using: str, queue_name: str) -> list[str]:

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -7,7 +7,7 @@ import zlib
 from dataclasses import dataclass, field
 
 import psycopg.errors
-from absurd_sdk import Absurd, QueuePolicyOptions
+from absurd_sdk import Absurd, QueuePolicyOptions, QueueStorageMode
 from django.db import connections, transaction
 from django.db.utils import ProgrammingError
 
@@ -139,6 +139,18 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
         client.create_queue(queue_name, **opts)
         result.created.append(queue_name)
     else:
+        # Idempotent by construction (INSERT ... ON CONFLICT DO NOTHING, then
+        # ensure_queue_tables), so this puts back the tables of a queue whose catalog
+        # row outlived them — a manual drop, a partial restore — which is the state
+        # QueueNotProvisionedError sends an operator here to repair. The EXISTING
+        # storage mode, never the declared one: create_queue refuses a mode change
+        # outright, and drift is warned about below rather than applied.
+        client.create_queue(
+            queue_name,
+            # Read back from absurd.queues, whose create_queue only ever writes
+            # these two.
+            storage_mode=t.cast("QueueStorageMode", existing.storage_mode),
+        )
         # MUTABLE_OPTION_KEYS mirrors QueuePolicyOptions's fields exactly; the cast is
         # safe by construction.
         mutable_opts = t.cast(

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -21,10 +21,15 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Per-queue table prefixes, as absurd.create_queue names them: tasks, runs, checkpoints,
-# events, waiters. (``i_<queue>`` exists for a partitioned queue too, but only spawn and
-# cleanup touch it — nothing a drain runs can miss it.)
+# Per-queue table prefixes absurd.create_queue names for EVERY queue: tasks, runs,
+# checkpoints, events, waiters. What truncate and the missing-table probe iterate, so it
+# omits the conditional ``i_<queue>`` — both would be wrong about a queue that has none.
 QUEUE_TABLE_PREFIXES = ("t", "r", "c", "e", "w")
+
+# Plus ``i_<queue>``, which a PARTITIONED queue owns as well: spawn_task reserves an
+# idempotency key there before it touches ``t_<queue>``, so it is the first relation a
+# half-provisioned partitioned queue reports missing.
+QUEUE_OWNED_TABLE_PREFIXES = (*QUEUE_TABLE_PREFIXES, "i")
 
 MUTABLE_OPTION_KEYS = (
     "partition_lookahead",
@@ -106,7 +111,7 @@ def names_a_queue_table(exc: psycopg.errors.UndefinedTable, queue: str) -> bool:
     message = exc.diag.message_primary or ""
     return any(
         re.search(rf"\b{re.escape(prefix)}_{re.escape(queue)}\b", message)
-        for prefix in QUEUE_TABLE_PREFIXES
+        for prefix in QUEUE_OWNED_TABLE_PREFIXES
     )
 
 
@@ -178,10 +183,10 @@ def find_missing_queue_tables(using: str, queue_name: str) -> list[str]:
     """Which of ``queue_name``'s own Absurd tables are absent, catalog row aside.
 
     ``to_regclass`` rather than a ``pg_class`` join: it takes the qualified name and
-    answers NULL instead of raising, which is the whole question being asked. A
-    partitioned queue also owns ``i_<queue>``, deliberately not probed — it exists only
-    when an idempotency key is used, so its absence is not what a half-provisioned
-    queue looks like.
+    answers NULL instead of raising, which is the whole question being asked. Probes
+    the five every queue owns, never a partitioned queue's ``i_<queue>``: one list then
+    works whatever the storage mode, and ``create_queue`` makes them all together, so a
+    missing ``i_<queue>`` never travels alone.
     """
     with connections[using].cursor() as cursor:
         cursor.execute(
@@ -240,8 +245,8 @@ def lock_provisioning(using: str) -> t.Iterator[None]:
 
     Called inside a caller's own atomic this degrades to a savepoint, so the lock is
     held until THEIR commit — still correct, just longer. No caller here provisions
-    inside a transaction: both commands and the post_migrate receiver run outside one,
-    and ``AbsurdTestRuntime.sync_queues`` refuses if one is open.
+    inside a transaction: ``absurd_sync_queues`` and the post_migrate receiver run
+    outside one, and ``AbsurdTestRuntime.sync_queues`` refuses if one is open.
     """
     with transaction.atomic(using=using):
         with connections[using].cursor() as cur:

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -7,7 +7,12 @@ import zlib
 from dataclasses import dataclass, field
 
 import psycopg.errors
-from absurd_sdk import Absurd, QueuePolicyOptions, QueueStorageMode
+from absurd_sdk import (
+    Absurd,
+    CreateQueueOptions,
+    QueuePolicyOptions,
+    QueueStorageMode,
+)
 from django.db import connections, transaction
 
 from django_absurd import backends
@@ -55,6 +60,19 @@ class SyncResult:
     reconciled: list[str] = field(default_factory=list)
     repaired: list[str] = field(default_factory=list)
     storage_warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class QueuePlan:
+    """What one declared queue needs — carrying the arguments that would satisfy it, not
+    just flags, so the write path applies a decision it never re-derives.
+    """
+
+    queue_name: str
+    create_options: CreateQueueOptions | None = None
+    repair_storage_mode: QueueStorageMode | None = None
+    policy_options: QueuePolicyOptions | None = None
+    storage_warning: str | None = None
 
 
 def get_absurd_database(backend: backends.AbsurdBackend) -> str:
@@ -117,82 +135,84 @@ def names_a_queue_table(exc: psycopg.errors.UndefinedTable, queue: str) -> bool:
 def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncResult:
     db = backend.database
     validate_backend(db)
-    opts = backends.get_declared_queues(backend)[queue_name]
-    result = SyncResult()
-    client = build_absurd_client(db)
-    existing = get_queue_object(db, queue_name)
-    if existing is None:
-        client.create_queue(queue_name, **opts)
-        result.created.append(queue_name)
-    else:
-        # Puts back the tables of a queue whose catalog row outlived them — a manual
-        # drop, a partial restore — the state QueueNotProvisionedError sends an
-        # operator here to repair. Gated on them actually being absent rather than
-        # called unconditionally: create_queue re-runs ensure_partitions, and a
-        # partitioned queue whose default partition has collected rows for a week the
-        # window now covers cannot survive that. The EXISTING storage mode, never the
-        # declared one: create_queue refuses a mode change outright, and drift is
-        # warned about below rather than applied.
-        if find_missing_queue_tables(
-            db, queue_name, storage_mode=existing.storage_mode
-        ):
-            client.create_queue(
-                queue_name,
-                # Read back from absurd.queues, whose create_queue only ever writes
-                # these two.
-                storage_mode=t.cast("QueueStorageMode", existing.storage_mode),
-            )
-            result.repaired.append(queue_name)
-        # MUTABLE_OPTION_KEYS mirrors QueuePolicyOptions's fields exactly; the cast is
-        # safe by construction.
-        mutable_opts = t.cast(
-            "QueuePolicyOptions",
-            {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS},
-        )
-        if mutable_opts and check_mutable_options_drifted(db, mutable_opts, existing):
-            client.set_queue_policy(queue_name, **mutable_opts)
-            result.reconciled.append(queue_name)
-        if "storage_mode" in opts and opts["storage_mode"] != existing.storage_mode:
-            result.storage_warnings.append(
-                f"Queue '{queue_name}': storage_mode cannot be changed "
-                f"(existing: {existing.storage_mode!r}, "
-                f"declared: {opts['storage_mode']!r}); skipping."
-            )
-    return result
+    plan = plan_queue(db, queue_name, backends.get_declared_queues(backend)[queue_name])
+    apply_queue_plan(build_absurd_client(db), plan)
+    return summarize_queue_plans([plan])
 
 
 def plan_queue_sync(backend: backends.AbsurdBackend) -> SyncResult:
     """What ``provision_backend`` would do, without doing any of it.
 
-    Reads the same three predicates the write path branches on — catalog row, tables,
-    policy drift — so the two cannot disagree about a queue without one of those
-    changing. Nothing here writes, so a role with no DDL rights can still ask.
+    Shares ``plan_queue`` with the write path, so the two cannot classify a queue
+    differently or word the storage warning two ways. Nothing here writes, so a role
+    with no DDL rights can still ask, and the provisioning lock keeps covering the
+    writes alone.
     """
     db = backend.database
     validate_backend(db)
     require_installed_schema(db)
-    result = SyncResult()
-    for queue_name, opts in backends.get_declared_queues(backend).items():
-        existing = get_queue_object(db, queue_name)
-        if existing is None:
-            result.created.append(queue_name)
-            continue
-        if find_missing_queue_tables(
-            db, queue_name, storage_mode=existing.storage_mode
-        ):
-            result.repaired.append(queue_name)
-        mutable_opts = t.cast(
-            "QueuePolicyOptions",
-            {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS},
+    return summarize_queue_plans(
+        plan_queue(db, queue_name, opts)
+        for queue_name, opts in backends.get_declared_queues(backend).items()
+    )
+
+
+def plan_queue(using: str, queue_name: str, opts: CreateQueueOptions) -> QueuePlan:
+    """What ``queue_name`` needs to match ``opts``, decided by reading only.
+
+    The one decision point for both the dry run and the write path: a second copy of
+    this branching drifts silently, since a reworded warning moves no exit code.
+    """
+    existing = get_queue_object(using, queue_name)
+    if existing is None:
+        return QueuePlan(queue_name, create_options=opts)
+    plan = QueuePlan(queue_name)
+    # Puts back the tables of a queue whose catalog row outlived them — a manual drop, a
+    # partial restore — the state QueueNotProvisionedError sends an operator here to
+    # repair. Gated on them actually being absent rather than repaired unconditionally:
+    # create_queue re-runs ensure_partitions, and a partitioned queue whose default
+    # partition has collected rows for a week the window now covers cannot survive that.
+    if find_missing_queue_tables(using, queue_name, storage_mode=existing.storage_mode):
+        # The EXISTING mode, read back from absurd.queues: create_queue refuses a mode
+        # change outright, so declared drift is warned about below, never applied here.
+        plan.repair_storage_mode = t.cast("QueueStorageMode", existing.storage_mode)
+    # MUTABLE_OPTION_KEYS mirrors QueuePolicyOptions's fields exactly; the cast is safe
+    # by construction.
+    mutable_opts = t.cast(
+        "QueuePolicyOptions",
+        {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS},
+    )
+    if mutable_opts and check_mutable_options_drifted(using, mutable_opts, existing):
+        plan.policy_options = mutable_opts
+    if "storage_mode" in opts and opts["storage_mode"] != existing.storage_mode:
+        plan.storage_warning = (
+            f"Queue '{queue_name}': storage_mode cannot be changed "
+            f"(existing: {existing.storage_mode!r}, "
+            f"declared: {opts['storage_mode']!r}); skipping."
         )
-        if mutable_opts and check_mutable_options_drifted(db, mutable_opts, existing):
-            result.reconciled.append(queue_name)
-        if "storage_mode" in opts and opts["storage_mode"] != existing.storage_mode:
-            result.storage_warnings.append(
-                f"Queue '{queue_name}': storage_mode cannot be changed "
-                f"(existing: {existing.storage_mode!r}, "
-                f"declared: {opts['storage_mode']!r}); skipping."
-            )
+    return plan
+
+
+def apply_queue_plan(client: Absurd, plan: QueuePlan) -> None:
+    if plan.create_options is not None:
+        client.create_queue(plan.queue_name, **plan.create_options)
+    if plan.repair_storage_mode is not None:
+        client.create_queue(plan.queue_name, storage_mode=plan.repair_storage_mode)
+    if plan.policy_options is not None:
+        client.set_queue_policy(plan.queue_name, **plan.policy_options)
+
+
+def summarize_queue_plans(plans: t.Iterable[QueuePlan]) -> SyncResult:
+    result = SyncResult()
+    for plan in plans:
+        if plan.create_options is not None:
+            result.created.append(plan.queue_name)
+        if plan.repair_storage_mode is not None:
+            result.repaired.append(plan.queue_name)
+        if plan.policy_options is not None:
+            result.reconciled.append(plan.queue_name)
+        if plan.storage_warning is not None:
+            result.storage_warnings.append(plan.storage_warning)
     return result
 
 

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -192,9 +192,6 @@ def log_sync_result(result: SyncResult) -> None:
 
 
 def provision_backend(backend: backends.AbsurdBackend) -> SyncResult:
-    # The single integral provisioning step (used by post_migrate, the sync command,
-    # and worker start): reconcile every declared queue, then rebuild all admin views
-    # so they reflect the full catalog — not just the queue a worker happens to serve.
     validate_backend(backend.database)  # the lock below is Postgres-only SQL
     with lock_provisioning(backend.database):
         result = sync_queues(backend)

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -179,6 +179,40 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
     return result
 
 
+def plan_queue_sync(backend: backends.AbsurdBackend) -> SyncResult:
+    """What ``provision_backend`` would do, without doing any of it.
+
+    Reads the same three predicates the write path branches on — catalog row, tables,
+    policy drift — so the two cannot disagree about a queue without one of those
+    changing. Nothing here writes, so a role with no DDL rights can still ask.
+    """
+    from django_absurd.models import Queue  # noqa: PLC0415
+
+    db = backend.database
+    validate_backend(db)
+    result = SyncResult()
+    for queue_name, opts in backends.get_declared_queues(backend).items():
+        existing = Queue.objects.using(db).filter(queue_name=queue_name).first()
+        if existing is None:
+            result.created.append(queue_name)
+            continue
+        if find_missing_queue_tables(db, queue_name):
+            result.repaired.append(queue_name)
+        mutable_opts = t.cast(
+            "QueuePolicyOptions",
+            {k: v for k, v in opts.items() if k in MUTABLE_OPTION_KEYS},
+        )
+        if mutable_opts and check_mutable_options_drifted(db, mutable_opts, existing):
+            result.reconciled.append(queue_name)
+        if "storage_mode" in opts and opts["storage_mode"] != existing.storage_mode:
+            result.storage_warnings.append(
+                f"Queue '{queue_name}': storage_mode cannot be changed "
+                f"(existing: {existing.storage_mode!r}, "
+                f"declared: {opts['storage_mode']!r}); skipping."
+            )
+    return result
+
+
 def find_missing_queue_tables(using: str, queue_name: str) -> list[str]:
     """Which of ``queue_name``'s own Absurd tables are absent, catalog row aside.
 

--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 import psycopg.errors
 from absurd_sdk import Absurd, QueuePolicyOptions, QueueStorageMode
 from django.db import connections, transaction
-from django.db.utils import ProgrammingError
 
 from django_absurd import backends
 from django_absurd.admin_views import rebuild_views
@@ -22,8 +21,8 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Per-queue table prefixes absurd.create_queue names for EVERY queue: tasks, runs,
-# checkpoints, events, waiters. What truncate and the missing-table probe iterate, so it
-# omits the conditional ``i_<queue>`` — both would be wrong about a queue that has none.
+# checkpoints, events, waiters. Truncate and the missing-table probe both start here and
+# add ``i_<queue>`` for a partitioned queue only, the one kind that owns one.
 QUEUE_TABLE_PREFIXES = ("t", "r", "c", "e", "w")
 
 # Plus ``i_<queue>``, which a PARTITIONED queue owns as well: spawn_task reserves an
@@ -134,7 +133,9 @@ def reconcile_queue(backend: backends.AbsurdBackend, queue_name: str) -> SyncRes
         # window now covers cannot survive that. The EXISTING storage mode, never the
         # declared one: create_queue refuses a mode change outright, and drift is
         # warned about below rather than applied.
-        if find_missing_queue_tables(db, queue_name):
+        if find_missing_queue_tables(
+            db, queue_name, storage_mode=existing.storage_mode
+        ):
             client.create_queue(
                 queue_name,
                 # Read back from absurd.queues, whose create_queue only ever writes
@@ -169,13 +170,16 @@ def plan_queue_sync(backend: backends.AbsurdBackend) -> SyncResult:
     """
     db = backend.database
     validate_backend(db)
+    require_installed_schema(db)
     result = SyncResult()
     for queue_name, opts in backends.get_declared_queues(backend).items():
         existing = get_queue_object(db, queue_name)
         if existing is None:
             result.created.append(queue_name)
             continue
-        if find_missing_queue_tables(db, queue_name):
+        if find_missing_queue_tables(
+            db, queue_name, storage_mode=existing.storage_mode
+        ):
             result.repaired.append(queue_name)
         mutable_opts = t.cast(
             "QueuePolicyOptions",
@@ -193,11 +197,11 @@ def plan_queue_sync(backend: backends.AbsurdBackend) -> SyncResult:
 
 
 def get_queue_object(using: str, queue_name: str) -> "Queue | None":
-    """``queue_name``'s ``Queue``, or None — with schema-absence classified.
+    """``queue_name``'s ``Queue``, or None.
 
-    Shared by the write path and the dry run so only one of them can be wrong about what
-    a missing schema looks like. A ``ProgrammingError`` that is NOT about the schema
-    surfaces as itself: relabelling it would send the reader to the wrong door.
+    Schema absence is classified by the probe below, ahead of the read; the read's own
+    ``ProgrammingError`` surfaces as itself, since relabelling it would send the reader
+    to the wrong door.
     """
     # The ONE import that would make this module settings-dependent at load time —
     # ``django_absurd.models`` reads INSTALLED_APPS — and our pytest plugin is an
@@ -206,34 +210,85 @@ def get_queue_object(using: str, queue_name: str) -> "Queue | None":
     # test_a_pytest_run_with_no_django_settings_still_collects.
     from django_absurd.models import Queue  # noqa: PLC0415
 
-    try:
-        return Queue.objects.using(using).filter(queue_name=queue_name).first()
-    except ProgrammingError as exc:
-        cause = exc.__cause__
-        if not isinstance(
-            cause,
-            (psycopg.errors.InvalidSchemaName, psycopg.errors.UndefinedTable),
-        ):
-            raise
-        raise SchemaNotInstalledError from exc
+    require_installed_schema(using)
+    return Queue.objects.using(using).filter(queue_name=queue_name).first()
 
 
-def find_missing_queue_tables(using: str, queue_name: str) -> list[str]:
+def require_installed_schema(using: str) -> None:
+    """Raise ``SchemaNotInstalledError`` when ``using`` has no Absurd schema.
+
+    Asked of the whole operation up front, never read off a failed statement. An absent
+    schema and a dropped ``absurd.queues`` raise the identical ``UndefinedTable`` while
+    only the first is something ``migrate`` can fix, and the statement that hit it has
+    already aborted its transaction, so nothing can be asked after the fact. A backend
+    declaring no queues reads no queue at all and still rebuilds views off that table.
+    """
+    with connections[using].cursor() as cursor:
+        cursor.execute("select to_regnamespace('absurd') is null")
+        if cursor.fetchone()[0]:
+            raise SchemaNotInstalledError
+
+
+def find_missing_queue_tables(
+    using: str, queue_name: str, *, storage_mode: str
+) -> list[str]:
     """Which of ``queue_name``'s own Absurd tables are absent, catalog row aside.
 
     ``to_regclass`` rather than a ``pg_class`` join: it takes the qualified name and
-    answers NULL instead of raising, which is the whole question being asked. Probes
-    the five every queue owns, never a partitioned queue's ``i_<queue>``: one list then
-    works whatever the storage mode, and ``create_queue`` makes them all together, so a
-    missing ``i_<queue>`` never travels alone.
+    answers NULL instead of raising, which is the whole question being asked. Which
+    tables to expect follows ``storage_mode`` — the EXISTING one, since that is what
+    the queue was built with — so a partitioned queue's ``i_<queue>`` counts too: a
+    keyed enqueue reserves that relation before any other, and a probe blind to it
+    calls a queue healthy that refuses every keyed enqueue.
     """
+    prefixes = (
+        QUEUE_OWNED_TABLE_PREFIXES
+        if storage_mode == "partitioned"
+        else QUEUE_TABLE_PREFIXES
+    )
     with connections[using].cursor() as cursor:
         cursor.execute(
             "select name from unnest(%s::text[]) as name "
             "where to_regclass('absurd.' || quote_ident(name)) is null",
-            [[f"{prefix}_{queue_name}" for prefix in QUEUE_TABLE_PREFIXES]],
+            [[f"{prefix}_{queue_name}" for prefix in prefixes]],
         )
         return [str(row[0]) for row in cursor.fetchall()]
+
+
+async def afind_missing_queue_tables(
+    conn: "psycopg.AsyncConnection[t.Any]", queue_name: str
+) -> list[str]:
+    """``find_missing_queue_tables``, asked on a worker's own async connection.
+
+    A twin body, not a shared one: a worker holds a raw async connection, and a Django
+    cursor inside its loop raises ``SynchronousOnlyOperation``. The two must answer the
+    same question, so the ``to_regclass`` test, the prefix sets and the ``partitioned``
+    reading are kept identical — change one and change the other.
+
+    ``storage_mode`` is read here rather than passed in: one round trip, and a queue
+    with no catalog row (which every caller refuses before this) then reports nothing
+    missing instead of needing a branch that no input can reach.
+    """
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            "select name from absurd.queues q "
+            "cross join lateral unnest("
+            "case when q.storage_mode = 'partitioned' then %(partitioned)s::text[] "
+            "else %(unpartitioned)s::text[] end"
+            ") as name "
+            "where q.queue_name = %(queue)s "
+            "and to_regclass('absurd.' || quote_ident(name)) is null",
+            {
+                "partitioned": [
+                    f"{prefix}_{queue_name}" for prefix in QUEUE_OWNED_TABLE_PREFIXES
+                ],
+                "queue": queue_name,
+                "unpartitioned": [
+                    f"{prefix}_{queue_name}" for prefix in QUEUE_TABLE_PREFIXES
+                ],
+            },
+        )
+        return [str(row[0]) for row in await cursor.fetchall()]
 
 
 def sync_queues(backend: backends.AbsurdBackend) -> SyncResult:
@@ -262,6 +317,7 @@ def log_sync_result(result: SyncResult) -> None:
 
 def provision_backend(backend: backends.AbsurdBackend) -> SyncResult:
     validate_backend(backend.database)  # the lock below is Postgres-only SQL
+    require_installed_schema(backend.database)
     with lock_provisioning(backend.database):
         result = sync_queues(backend)
         rebuild_views(backend.database)

--- a/django_absurd/scheduler.py
+++ b/django_absurd/scheduler.py
@@ -56,15 +56,15 @@ def get_settings_schedules(backend: AbsurdBackend) -> list[Schedule]:
     ]
 
 
-def derive_idempotency_key(schedule: Schedule, slot: dt.datetime) -> str:
+def derive_idempotency_key(schedule: Schedule, due: dt.datetime) -> str:
     # Dedup key, anchored on the schedule name (not task/cron) so args/queue-varying
     # entries don't collide. https://earendil-works.github.io/absurd/patterns/cron/
-    utc_slot = slot.astimezone(dt.UTC).isoformat(timespec="seconds")
-    raw = f"{schedule.backend}|{schedule.name}|{schedule.cron}|{utc_slot}"
+    utc_due = due.astimezone(dt.UTC).isoformat(timespec="seconds")
+    raw = f"{schedule.backend}|{schedule.name}|{schedule.cron}|{utc_due}"
     return "cron:" + hashlib.sha256(raw.encode()).hexdigest()[:24]
 
 
-def spawn_scheduled(schedule: Schedule, slot: dt.datetime) -> None:
+def spawn_scheduled(schedule: Schedule, due: dt.datetime) -> None:
     close_old_connections()
     try:
         task = import_string(schedule.task)
@@ -72,7 +72,7 @@ def spawn_scheduled(schedule: Schedule, slot: dt.datetime) -> None:
         if schedule.queue is not None:
             overrides["queue_name"] = schedule.queue
         task = task.using(**overrides)
-        key = derive_idempotency_key(schedule, slot)
+        key = derive_idempotency_key(schedule, due)
         absurd_params(idempotency_key=key).bind(task).enqueue(
             *schedule.args, **schedule.kwargs
         )
@@ -124,7 +124,7 @@ def run_beat(
 class BeatEntry:
     """One thing the beat loop fires on a cron cadence — a task schedule or cleanup.
 
-    Both kinds share one loop: ``fire`` is the callback for a due slot, ``next_at`` is
+    Both kinds share one loop: ``fire`` is the callback for a due time, ``next_at`` is
     advanced after each firing.
     """
 
@@ -158,7 +158,7 @@ def build_beat_entries(
     return entries
 
 
-def fire_cleanup(backend: AbsurdBackend, slot: dt.datetime) -> None:
+def fire_cleanup(backend: AbsurdBackend, due: dt.datetime) -> None:
     close_old_connections()
     try:
         cleanup_queues()
@@ -166,21 +166,25 @@ def fire_cleanup(backend: AbsurdBackend, slot: dt.datetime) -> None:
         logger.exception("cleanup failed")
     else:
         logger.info(
-            'cleanup ran: slot="%s"',
-            slot.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'cleanup ran: due="%s"',
+            due.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         )
     finally:
         close_old_connections()
 
 
-def fire_schedule(schedule: Schedule, slot: dt.datetime) -> None:
+def fire_schedule(schedule: Schedule, due: dt.datetime) -> None:
+    due_utc = due.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     try:
-        spawn_scheduled(schedule, slot)
+        spawn_scheduled(schedule, due)
     except Exception:
-        logger.exception('schedule failed: name="%s"', schedule.name)
-    else:
-        logger.info(
-            'schedule enqueued: name="%s" slot="%s"',
+        # The loop advances past this firing and never comes back, so this is an
+        # operator's only notice of it. Our own errors name their fix in the message,
+        # which lands on the traceback's last line.
+        logger.exception(
+            'schedule enqueue failed: name="%s" due="%s"',
             schedule.name,
-            slot.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            due_utc,
         )
+    else:
+        logger.info('schedule enqueued: name="%s" due="%s"', schedule.name, due_utc)

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -20,7 +20,7 @@ underscore-prefixed methods are internal, and its dataclass fields are plain sta
 run in any venv with django-absurd installed, so its top level must stay settings-free
 — never add a module-level import reaching ``django_absurd.models``/``.checks``/
 ``.admin``. Full constraint and the one sanctioned choke point:
-``django_absurd.pytest_plugin``'s module docstring and ``queues.reconcile_queue``.
+``django_absurd.pytest_plugin``'s module docstring and ``queues.get_queue_object``.
 """
 
 import asyncio

--- a/django_absurd/test.py
+++ b/django_absurd/test.py
@@ -257,7 +257,7 @@ class AbsurdTestRuntime:
         guard_against_open_transaction(self.alias, "sync_queues")
         backend = queues.get_absurd_backend()
         if backend is None:
-            raise BackendNotConfiguredError(0)
+            raise BackendNotConfiguredError
         run_off_event_loop(functools.partial(queues.provision_backend, backend))
 
     def get_result(

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -174,6 +174,7 @@ def run_worker(
     *,
     run_beat: bool = False,
     options: WorkerOptions | None = None,
+    on_started: t.Callable[[], None] | None = None,
     on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
     options = options or WorkerOptions()
@@ -184,6 +185,7 @@ def run_worker(
             queue,
             run_beat=run_beat,
             options=options,
+            on_started=on_started,
             on_stop_requested=on_stop_requested,
         )
     )
@@ -195,9 +197,15 @@ async def arun_worker(
     *,
     run_beat: bool = False,
     options: WorkerOptions,
+    on_started: t.Callable[[], None] | None = None,
     on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
     async with open_worker_runtime(backend, queue, options) as client:
+        # Announce only once the runtime is up: the startup guards live inside the
+        # context manager, so a banner written before it would advertise a worker
+        # that then refuses.
+        if on_started is not None:
+            on_started()
         if run_beat:
             await run_worker_with_beat(
                 client, options, backend, on_stop_requested=on_stop_requested
@@ -287,13 +295,19 @@ async def aworker_client(
         client._registry = LazyTaskRegistry(queue, backend)  # noqa: SLF001 -- SDK has no public fallback-resolver hook; install lazy import_string resolution
         try:
             # Probes for the schema-absent guard; raises if Absurd is not migrated.
-            await client.list_queues()
+            provisioned = await client.list_queues()
         except (
             psycopg.errors.InvalidSchemaName,
             psycopg.errors.UndefinedTable,
             psycopg.errors.UndefinedFunction,
         ) as err:
             raise SchemaNotInstalledError from err
+        # Nothing provisions at boot any more, so refuse here rather than let the
+        # claim loop raise a raw UndefinedTable. Free: list_queues() is already
+        # awaited above. Residual: a catalog row whose tables were dropped still
+        # reads as provisioned — absurd_sync_queues is what repairs that.
+        if queue not in provisioned:
+            raise QueueNotProvisionedError(queue)
         yield client
     finally:
         await conn.close()

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -177,18 +177,31 @@ def run_worker(
     on_started: t.Callable[[], None] | None = None,
     on_stop_requested: t.Callable[[], None] | None = None,
 ) -> None:
+    """Run the blocking worker to a stop signal — what ``absurd_worker`` calls.
+
+    The missing-relation translation wraps the whole run rather than the boot probe,
+    because ``aworker_client``'s guard reads the catalog: a queue whose row outlived its
+    tables passes it and only fails once ``claim_tasks`` runs — which a ``--beat`` run
+    reaches through here too. As in ``drain_queue``, only a relation of THIS queue's own
+    earns the translation; anything else re-raises as itself, chained.
+    """
     options = options or WorkerOptions()
     validate_backend(backend.database)
-    asyncio.run(
-        arun_worker(
-            backend,
-            queue,
-            run_beat=run_beat,
-            options=options,
-            on_started=on_started,
-            on_stop_requested=on_stop_requested,
+    try:
+        asyncio.run(
+            arun_worker(
+                backend,
+                queue,
+                run_beat=run_beat,
+                options=options,
+                on_started=on_started,
+                on_stop_requested=on_stop_requested,
+            )
         )
-    )
+    except psycopg.errors.UndefinedTable as exc:
+        if not names_a_queue_table(exc, queue):
+            raise
+        raise QueueNotProvisionedError(queue) from exc
 
 
 async def arun_worker(
@@ -302,10 +315,8 @@ async def aworker_client(
             psycopg.errors.UndefinedFunction,
         ) as err:
             raise SchemaNotInstalledError from err
-        # Nothing provisions at boot any more, so refuse here rather than let the
-        # claim loop raise a raw UndefinedTable. Free: list_queues() is already
-        # awaited above. Residual: a catalog row whose tables were dropped still
-        # reads as provisioned — absurd_sync_queues is what repairs that.
+        # Refuse before the banner, for free: list_queues() is already awaited above.
+        # A catalog row outliving its tables passes this — run_worker catches that one.
         if queue not in provisioned:
             raise QueueNotProvisionedError(queue)
         yield client

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -50,7 +50,7 @@ from django_absurd.hooks import (
     read_sdk_claimed_task,
 )
 from django_absurd.management.base import resolve_backend
-from django_absurd.queues import names_a_queue_table
+from django_absurd.queues import afind_missing_queue_tables, names_a_queue_table
 from django_absurd.scheduler import run_beat
 
 logger = logging.getLogger(__name__)
@@ -179,11 +179,12 @@ def run_worker(
 ) -> None:
     """Run the blocking worker to a stop signal — what ``absurd_worker`` calls.
 
-    The missing-relation translation wraps the whole run rather than the boot probe,
-    because ``aworker_client``'s guard reads the catalog: a queue whose row outlived its
-    tables passes it and only fails once ``claim_tasks`` runs — which a ``--beat`` run
-    reaches through here too. As in ``drain_queue``, only a relation of THIS queue's own
-    earns the translation; anything else re-raises as itself, chained.
+    The missing-relation translation wraps the whole run rather than the boot probe:
+    ``aworker_client`` refuses a queue whose tables are already gone, so what is left
+    for this one to catch is a queue dropped mid-flight, from any claim the run makes —
+    which a ``--beat`` run reaches through here too. As in ``drain_queue``, only a
+    relation of THIS queue's own earns the translation; anything else re-raises as
+    itself, chained.
     """
     options = options or WorkerOptions()
     validate_backend(backend.database)
@@ -315,9 +316,13 @@ async def aworker_client(
             psycopg.errors.UndefinedFunction,
         ) as err:
             raise SchemaNotInstalledError from err
-        # Refuse before the banner, for free: list_queues() is already awaited above.
-        # A catalog row outliving its tables passes this — run_worker catches that one.
+        # Both refusals belong before the banner: this is where "may this worker start"
+        # is decided, and open_worker_runtime logs `worker started` one frame out.
         if queue not in provisioned:
+            raise QueueNotProvisionedError(queue)
+        # The catalog row alone proves nothing — it outlives its tables after a manual
+        # drop or a partial restore, and only a claim would find out.
+        if await afind_missing_queue_tables(conn, queue):
             raise QueueNotProvisionedError(queue)
         yield client
     finally:

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -53,6 +53,55 @@ replaced upstream by a function that falls back to what Postgres has built in, w
 what makes the package installable by an ordinary application role on a locked-down
 deployment.
 
+### Queue provisioning: `migrate` or the command, never a runtime seam
+
+Provisioning per-queue tables from the declared queue list has been redesigned three
+times, and none of the three left a record — the reasoning below had to be reconstructed
+from commit history, which is precisely why it is written here. The founding design was
+explicit-only: all mutation through a management command, `migrate` only migrates, and a
+system check to tell you when the command was due.
+
+The second design added runtime self-heal at two seams — an enqueue created a missing
+declared queue, and the worker provisioned at boot — to take a mandatory command out of
+the workflow. It also retired the founding check: the missing-queue warning was narrowed
+to storage-mode drift because auto-create now healed that case, and the schema-absent
+warning was dropped separately as a runtime error rather than a deploy-time one. Being
+always-on with no opt-out rested on a claim that concurrent creators race harmlessly.
+That claim was false. The create is an if-not-exists, which Postgres documents as not
+race-free: two sessions creating the same table for the first time collide on a catalog
+unique index.
+
+The third design, two days later, moved provisioning onto `post_migrate`, which fires on
+every `migrate` invocation whether or not any migration was applied. That delivered
+exactly the ergonomics the runtime seams had been bought for, without a runtime seam —
+which made the two self-heal paths redundant with it rather than complementary. Nobody
+noticed at the time, so they stayed, and the same change quietly widened the worker seam
+past what had been agreed: reconcile the served queue only became reconcile the whole
+catalog and rebuild the admin views.
+
+The fourth design removes both seams, and the reasons stack in this order. The race is
+real and was measured — 74 of 100 concurrent provisioning calls failed at four
+processes, 39 of 80 at two — and the enqueue half was the same race, never guarded,
+surfacing an integrity error out of a web request. Self-heal also wanted DDL rights in a
+web request: creating a queue needs create privilege on the engine's namespace at
+request time, and production web roles are commonly DML-only — the same anti-correlation
+between who has the privilege and who benefits that already ruled out read-path
+self-heal in the admin, here on the write path. The engine itself self-heals nothing:
+spawning and claiming build dynamic SQL against a per-queue table name and raise on a
+missing one, and creating a queue is a separate explicit call the SDK never makes
+implicitly, so auto-create was entirely this layer's invention. And `post_migrate`
+already carries the ergonomics.
+
+The founding design's queue-state check was deliberately not restored with it. A
+database-dependent check runs _before_ the command that would fix the condition it
+reports — `migrate` injects its target database into the check kwargs, and the command
+base runs checks ahead of its own handler — so "a declared queue is not provisioned"
+would fire on every `migrate` that follows declaring a queue, moments before
+`post_migrate` provisions it. An error would block that `migrate`; a warning would cry
+wolf, get silenced project-wide, and then be dead in the one case it exists for. That is
+half of why the original warning was retired as noisy. The founding requirement was
+written when nothing provisioned automatically; `post_migrate` carries that load now.
+
 ## Tasks, enqueue & the worker
 
 Enqueuing runs on Django's connection inside the caller's transaction, so a task spawned
@@ -587,10 +636,10 @@ corrupt its bookkeeping. So the models refuse `save`/`delete` and the admin gran
 add/change/delete. Each entity (tasks, runs, checkpoints, events, waits) spans every
 queue through a single `UNION ALL` view carrying a synthesized queue column, so one
 changelist or queryset covers all queues instead of one per queue; the cost is no
-cross-queue index, so filtering by queue is the fast path. The views are (re)built at
-migrate / worker-start / sync, so a queue reached only by a bare enqueue before the next
-sync is briefly absent from them — the admin surfaces that gap rather than pretending
-the list is complete.
+cross-queue index, so filtering by queue is the fast path. The views are (re)built
+wherever the declared catalog is provisioned — `migrate` or the sync command — so a
+queue declared but not yet provisioned is absent from them; the admin surfaces that gap
+rather than pretending the list is complete.
 
 ## Routing & multiple databases
 

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -102,6 +102,37 @@ wolf, get silenced project-wide, and then be dead in the one case it exists for 
 trap the schema-absent warning fell into. The founding requirement was written when
 nothing provisioned automatically; `post_migrate` carries that load now.
 
+Four rules fell out of reviewing and running that fourth design, each one a decision
+someone could otherwise get wrong later.
+
+**Exactly one failure is forgiven at migrate time, and only one can be.** The
+migrate-time hook fires for every installed app, not only the ones being migrated, so
+migrating a single unrelated app on a fresh database reaches it before the engine's
+schema exists. That state has to pass quietly, or the command breaks for a reason the
+operator did not cause. Everything else fails the migrate, because a deploy that
+provisioned nothing must not report success. Narrowing the forgiven case to "unless the
+operator faked the migration" is not available: the framework consumes that flag before
+the hook runs, and a faked run is indistinguishable from a real one once the schema
+exists.
+
+**"Provisioned" gets exactly one definition** — the catalog row plus every table the
+queue owns, which depends on its storage mode. Two doors once disagreed about that, one
+counting five tables and the other six: the queue refused every request that touched the
+sixth, while the repair command reported nothing to do and the release gate reported
+healthy. Any new door deciding whether a queue is usable must ask that same question; a
+second definition is a defect even while the two copies happen to agree.
+
+**A gate has to be satisfiable.** The assert-only mode fails when provisioning would
+change anything — except a declared storage-mode change, which is warned about and
+skipped. That one cannot fail the gate, because the mode of an existing queue cannot be
+changed and no shipped command clears the condition, so failing would wedge a pipeline
+with no way through. A gate that cannot be satisfied is worse than one that stays quiet.
+
+**Nothing announces a start it cannot honour.** A worker that logs itself started and
+then dies on its first claim poisons the one line an operator alerts on, and under a
+restart policy it repeats forever. Every check deciding whether a worker may run happens
+before the banner, not after.
+
 ## Tasks, enqueue & the worker
 
 Enqueuing runs on Django's connection inside the caller's transaction, so a task spawned
@@ -767,6 +798,26 @@ Honest limit: catching the base is not universal. Several configuration, connect
 test-guard paths still raise plain framework or stdlib errors, so the docs must not
 promise otherwise.
 
+One type per condition, not one type per area. A single type once covered both "none
+configured" and "more than one configured", which forced it to take a count and branch
+on it — so every raise site passed a literal number naming a condition the reader then
+had to look up, and five of the six sites could only ever mean one of them. The count
+never reached either message.
+
+Only configuration failures are translated. The management-command base turns a fixed,
+deliberately narrow set of them into a clean error without a traceback; everything else,
+including the package's other own types, keeps its type and full traceback. Broadening
+that set to the whole family reads tidier and is worse: a command that swallowed every
+error this package raises would present bugs as configuration mistakes, and the
+traceback is the only thing that distinguishes them.
+
+No command reports success for work it did not do. A command asked to act on the engine
+when none is configured exits non-zero rather than printing a note and exiting zero. The
+tempting exception is a maintenance command whose no-op is harmless — but a missing
+backend is a misconfiguration rather than an intended no-op, and the quiet version means
+a settings regression passes a release gate and stops recurring maintenance without ever
+failing.
+
 ## Release notes are generated from commit titles
 
 The changelog is rendered from commit subjects, and the newest section is also the
@@ -796,6 +847,12 @@ notes without a second step.
 
 Task **priority** is unsupported because Absurd has no notion of it — we won't fake it
 behind a flag that implies otherwise.
+
+**Partitioned queues** can be declared, but their support is unsettled and the scope
+decision is tracked separately. One known edge has no in-band exit: repairing a
+partitioned queue re-runs partition creation, and Postgres refuses to create a partition
+whose range overlaps rows already sitting in the default partition, which no shipped
+command clears.
 
 A **natively** async enqueue is a deliberate non-goal, and that is narrower than it
 sounds: async task bodies run on the worker, and the async enqueue call exists and works

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -98,9 +98,9 @@ reports — `migrate` injects its target database into the check kwargs, and the
 base runs checks ahead of its own handler — so "a declared queue is not provisioned"
 would fire on every `migrate` that follows declaring a queue, moments before
 `post_migrate` provisions it. An error would block that `migrate`; a warning would cry
-wolf, get silenced project-wide, and then be dead in the one case it exists for. That is
-half of why the original warning was retired as noisy. The founding requirement was
-written when nothing provisioned automatically; `post_migrate` carries that load now.
+wolf, get silenced project-wide, and then be dead in the one case it exists for — the
+trap the schema-absent warning fell into. The founding requirement was written when
+nothing provisioned automatically; `post_migrate` carries that load now.
 
 ## Tasks, enqueue & the worker
 

--- a/docs/plans/2026-08-17-explicit-provisioning.md
+++ b/docs/plans/2026-08-17-explicit-provisioning.md
@@ -1,0 +1,53 @@
+# Explicit provisioning — plan
+
+Design:
+[`docs/specs/2026-08-17-explicit-provisioning-design.md`](../specs/2026-08-17-explicit-provisioning-design.md).
+
+One PR. An earlier version of this plan split it in two on the premise that the suites
+self-heal broadly and that ~95 tests would need repairing. Measured: they do not. The
+suites reach a provisioned queue because they run `migrate`, not because anything heals
+at runtime. Disabling both self-heal seams fails exactly eight tests in `tests/core` and
+none in `tests/multidb` or `tests/pg_cron` — and every one of the eight asserts the
+behaviour being deleted. There is no signal to untangle, so there is no split.
+
+## Prerequisite, already done
+
+Three tests inside `_isolate_queues` files enqueue or start a worker after the fixture
+dropped the catalog, and are repaired today by accident. Each takes an explicit
+`dj_absurd.sync_queues()` at its call site (`tests/core/test_worker.py`
+`::test_queue_defaults_to_default` and
+`::test_worker_uses_single_backend_at_nondefault_alias`,
+`tests/multidb/test_router.py::test_roundtrip_drains_on_the_non_default_alias`). A no-op
+against today's code; it just stops the three depending on a path that is going away.
+
+No fixture change. Re-provisioning on `_isolate_queues` teardown was built and then
+measured to change nothing — same eight failures with or without it.
+
+## Sequence
+
+RED first, per the design's Testing section.
+
+1. Enqueue refuses. Tests: declared-but-unprovisioned raises `QueueNotProvisionedError`
+   with the queue still absent afterwards; schema-absent still raises
+   `SchemaNotInstalledError` (now read off the spawn exception, not a failed retry);
+   undeclared still raises `QueueNotDeclaredError`; an unrelated `UndefinedTable` from
+   inside `spawn_task` propagates as itself; an outer `atomic` survives the refusal.
+   Then delete the create-and-retry branch.
+2. Worker refuses at startup. Tests: `absurd_worker` on an unprovisioned declared queue
+   exits `CommandError` with the typed message BEFORE any "Started worker" line, and
+   creates neither queue nor views. Then restore `aworker_client`'s provisioned-queue
+   guard as `QueueNotProvisionedError`, and drop `provision_backend` +
+   `report_sync_result` from the command.
+3. Sync heals the row-present/tables-absent state. Test: drop a provisioned queue's
+   tables leaving its catalog row, run `absurd_sync_queues`, tables are back and the
+   command still reports no change. Then make `reconcile_queue` call `create_queue`
+   unconditionally.
+4. Retire the eight, per the design's inventory — delete the five that only exist for
+   self-heal, rewrite the three whose assertion survives.
+5. Docs + `admin.py`'s changelist message (source, with its message-asserting test), per
+   the design's Docs section. `docs/WHY.md` gets the durable record: explicit-only →
+   self-heal → `post_migrate` → back to explicit-only, none of which was ever captured.
+6. Examples: real `docker compose up` on all three, watching the worker converge rather
+   than reading the compose file.
+
+`feat!` — a breaking change, with the upgrade note from the design.

--- a/docs/specs/2026-08-17-explicit-provisioning-design.md
+++ b/docs/specs/2026-08-17-explicit-provisioning-design.md
@@ -290,3 +290,49 @@ Three ways to be affected anyway, all worth naming in the release notes:
   — or a migrate role without `CREATE` on the `absurd` schema — provisions nothing and
   reports nothing. Worker boot and first enqueue are today's fallbacks for that, and
   both are being removed.
+
+## Shipped beyond this design
+
+Adversarial review and live testing against a fresh project moved five things after the
+sections above were written. Each supersedes what it names.
+
+- **Missing-table probe follows storage mode.** `find_missing_queue_tables` probed the
+  five tables every queue owns; the enqueue-time classifier matched six. A partitioned
+  queue missing only `i_<queue>` therefore refused every keyed enqueue while sync
+  reported nothing to repair and `--check` exited 0 — unrepairable by any shipped
+  command, and fatal to a whole schedule, since `spawn_scheduled` always carries an
+  idempotency key. The probe now takes the existing `storage_mode`. `aworker_client`
+  asks the same question on its own async connection
+  (`queues.afind_missing_queue_tables`) — a twin body, because a Django cursor inside
+  the worker's loop raises `SynchronousOnlyOperation`.
+- **Schema absence classified per operation, not per queue.** Classification lived in
+  the per-queue loop, so a backend declaring no queues reached `rebuild_views` and
+  raised a raw `ProgrammingError` — breaking the `migrate --fake` path the swallow
+  exists for, and diverging from `--check`, which exited 0 in the same state.
+  `require_installed_schema` asks up front, in both the write path and the dry run.
+- **The swallow narrowed to genuine absence** — supersedes _Out of scope_'s
+  "`post_migrate`'s silent swallow … Separate decision", and the third upgrade bullet
+  below it. An absent schema and a dropped `absurd.queues` raise the identical
+  `UndefinedTable`, and only the first is something `migrate` can fix; the second made
+  `migrate` print `Not provisioned: … Run: manage.py migrate` and exit 0 forever, advice
+  that loops because the migration is already applied. Only a live probe separates them,
+  and it has to run before the failing statement, which has already aborted its
+  transaction.
+- **The worker refuses before it announces a start.** The catalog check passed a queue
+  whose row outlived its tables, so `worker started:` and the `🐘 Started worker` banner
+  both printed for a worker that died on its first claim — repeating under
+  `restart: on-failure`, on the one line an operator would alert on. `drain_queue`
+  logged it too. The boot guard in `aworker_client` covers both entry points;
+  `run_worker`'s translation is left holding a queue dropped mid-flight.
+- **No Absurd backend configured is an error for every `absurd_*` command**,
+  `absurd_cleanup` and `absurd_flush` included — reverses the exit-code split left
+  standing in `2026-08-15-command-error-translation-design.md`'s _Out of scope_. Exiting
+  0 is defensible only where doing nothing is the intended outcome, and a missing
+  backend is a misconfiguration: a nightly `absurd_cleanup` otherwise stops cleaning
+  silently and reports success.
+
+Two additions the _Docs_ section above does not list: `docs/web/deploying.md` (the
+deploy script, the `--database` asymmetry, `--check`, and the `migrate --check` trap),
+and examples gating `app` and `worker` on a one-shot `migrate` service via
+`service_completed_successfully` — which replaces the `restart: on-failure` convergence
+that section describes.

--- a/docs/specs/2026-08-17-explicit-provisioning-design.md
+++ b/docs/specs/2026-08-17-explicit-provisioning-design.md
@@ -1,0 +1,292 @@
+# Explicit provisioning — design
+
+Follows [#195](https://github.com/lincolnloop/django-absurd/issues/195).
+
+## Problem
+
+Five code paths create queue topology today:
+
+| path                                        | creates                             | runs in           |
+| ------------------------------------------- | ----------------------------------- | ----------------- |
+| `post_migrate` → `provision_backend`        | declared queues + all 5 admin views | `migrate`         |
+| `absurd_sync_queues` → `provision_backend`  | declared queues + all 5 admin views | operator command  |
+| `AbsurdTestRuntime.sync_queues` (`test.py`) | declared queues + all 5 admin views | a test, on demand |
+| `absurd_worker` start → `provision_backend` | declared queues + all 5 admin views | worker boot       |
+| `enqueue` (`backends.py:181-207`)           | one declared queue, retries spawn   | **a web request** |
+
+Last two are self-heal, from [#13](https://github.com/lincolnloop/django-absurd/pull/13)
+(2026-06-24). That design locked "both seams auto-create, always on, no opt-out" on a
+stated constraint:
+
+> `absurd.create_queue` already idempotent … Calling on existing queue = no-op.
+> Concurrent creators race harmlessly.
+
+Second sentence false. `ensure_queue_tables` is `CREATE TABLE IF NOT EXISTS`, which
+Postgres documents as not race-free — concurrent FIRST creation collides on a catalog
+unique index. #195 proved it in the view half: 74 failures of 100 concurrent calls at 4
+processes, 39 of 80 at 2. Enqueue half is the same race, still unguarded (`create_queue`
+at `backends.py:195` sits outside `lock_provisioning`): N web containers enqueueing to a
+declared-but-unprovisioned queue collide, and the `IntegrityError` surfaces out of a
+request.
+
+Three further facts, all verified:
+
+- **Upstream does not self-heal.** `spawn_task` and `claim_task` build dynamic SQL
+  against `'t_' || p_queue_name` and raise
+  `UndefinedTable: relation "absurd.t_<queue>" does not exist` on a missing queue
+  (probed live; pinned SQL corroborates). `create_queue` is a separate explicit call the
+  SDK never invokes implicitly. Auto-create is entirely a django-absurd layer.
+- **Self-heal wants DDL rights in a web request.** Enqueue's `create_queue` needs
+  `CREATE` on the `absurd` schema at request time. Prod web roles are commonly DML-only
+  — the same anti-correlation that got admin read-path self-heal dropped. Here it is the
+  write path.
+- **`post_migrate` already delivers what #13 wanted.** #13 existed to remove a mandatory
+  command; `post_migrate` provisioning landed two days later in
+  [#17](https://github.com/lincolnloop/django-absurd/pull/17) and provisions the full
+  declared set on every `migrate`, applied or not. The two seams are redundant with it,
+  not complementary. The project's founding position
+  (`docs/superpowers/specs/2026-06-18-queue-models-design.md`, initial commit) was
+  explicit-only: "All mutation happens through an explicit management command — NO
+  `migrate`/`post_migrate`/`ready()` magic. `migrate` only migrates. A system check
+  tells you when to run the command." #13 overrode it and removed that check — W002
+  narrowed to storage_mode drift because auto-create healed the missing-queue case, and
+  W001 dropped on the separate ground that schema-absence is a runtime error rather than
+  a deploy warning.
+
+## Ship
+
+Provisioning is a deploy step. Runtime paths classify and refuse.
+
+### Enqueue stops creating
+
+`AbsurdBackend.enqueue`'s
+`except (UndefinedTable, UndefinedFunction, InvalidSchemaName)` branch keeps
+classifying, drops the create-and-retry:
+
+- undeclared queue → `QueueNotDeclaredError` (unchanged)
+- `InvalidSchemaName`/`UndefinedFunction` → `SchemaNotInstalledError`
+- `UndefinedTable` naming one of this queue's own tables → `QueueNotProvisionedError`
+- anything else → re-raise untouched
+
+Schema-absence classification MOVES. Today it is detected by the create-and-retry
+failing (`backends.py:194-200`); with the create gone it must read off the ORIGINAL
+spawn exception. Same outcomes, new mechanism, so its tests change too.
+
+`UndefinedTable` case reuses `names_a_queue_table`, the discipline `drain_queue` and
+`events.emit_event` already follow. `QueueNotProvisionedError`'s message already names
+the fix (`Run: manage.py absurd_sync_queues`).
+
+Savepoint stays: `spawn` still runs inside `transaction.atomic(savepoint=True)` so a
+failed enqueue leaves an enclosing atomic usable. The retry spawn goes with the create.
+
+### Worker start stops provisioning, and regains a startup guard
+
+`absurd_worker.handle` drops `provision_backend` + `report_sync_result`.
+
+That alone is NOT enough, and the naive version regresses the operator experience. The
+live worker path (`run_worker` → `arun_worker` → `run_blocking_worker`) carries no
+`UndefinedTable` handling: the `QueueNotProvisionedError` translation at `worker.py:168`
+belongs to `drain_queue`, the in-process test-tooling entry point, not to the CLI. The
+only guard on the live path is `aworker_client`'s schema probe (`worker.py:289-296`),
+and its `list_queues()` succeeds whenever the schema exists — including when the served
+queue's tables do not. A raw `psycopg.errors.UndefinedTable` is not in
+`CONFIGURATION_ERRORS`, so without new work the operator gets an untranslated traceback
+out of the claim loop.
+
+So restore the guard #13 deleted, retyped. #13's spec says outright: "`aworker_client`:
+DELETE the `if queue not in provisioned: raise ImproperlyConfigured` block. Queue
+guaranteed to exist by the time the async client runs (command reconciled first)." That
+premise dies with worker provisioning, so the block comes back beside the existing
+schema probe, raising `QueueNotProvisionedError` instead of `ImproperlyConfigured`. It
+costs no extra query — `list_queues()` is already awaited there — and it fires before
+the worker announces itself, so the command base turns it into one clean `CommandError`.
+
+Residual, accepted: `list_queues` reads catalog rows, so a row-present/tables-absent
+queue still reaches the claim loop and raises raw `UndefinedTable`. See the reconcile
+fix below, which is what makes that state recoverable at all.
+
+Losing the view rebuild on worker boot is fine: views are admin-only (`get_result` reads
+the raw per-queue tables, not the union views), and both command-side provisioners
+rebuild the full catalog.
+
+Note the worker seam had already drifted past what #13 authorized — spec said reconcile
+the SERVED queue only; #17 widened it to the whole catalog plus views.
+
+### Sync heals what the error promises it heals
+
+`reconcile_queue` calls `create_queue` only when the `Queue` catalog row is absent
+(`queues.py:129-157`); with the row present it reconciles policy and nothing else. So a
+row-present/tables-absent queue — manual drop, partial restore — is healed today ONLY by
+enqueue's unconditional `create_queue`, and after this change by nothing:
+`QueueNotProvisionedError` would send an operator to a command that reports "no
+changes".
+
+Call `create_queue` unconditionally instead. It is idempotent by construction
+(`INSERT … ON CONFLICT DO NOTHING` then `perform ensure_queue_tables`), so it recreates
+missing tables for an existing row and no-ops otherwise. `created` accounting still keys
+off the pre-existing row check, so command output is unchanged. Cost is a handful of
+`IF NOT EXISTS` statements per declared queue, at deploy time only.
+
+### No queue-state check
+
+The founding spec paired explicit-only provisioning with "a system check tells you when
+to run the command", and #13 removed it. Not restoring it, deliberately:
+
+- DB-dependent checks run BEFORE the command that would fix the condition. Verified:
+  `migrate` injects `databases=[options["database"]]` into its check kwargs
+  (`migrate.py:95`) and `BaseCommand.execute` runs `self.check()` ahead of `handle()`.
+  So a "declared queue not provisioned" check fires on every `migrate` that follows
+  declaring a queue — moments before `post_migrate` provisions it. An Error would block
+  that `migrate`; a Warning cries wolf. This is half of why W001 was retired as noisy.
+- A warning that routinely fires when nothing is wrong gets added to
+  `SILENCED_SYSTEM_CHECKS`, and is then dead in the case it exists for.
+- The condition is already reported at runtime with a message naming the command.
+- The founding spec wrote that requirement when NOTHING provisioned automatically —
+  `post_migrate` did not exist. It carries the ergonomic load now, so the gap the check
+  covered is far narrower than it was.
+
+`query_queue_state` therefore keeps reporting W002 storage-mode drift only, unchanged.
+
+### Test tooling needs no fixture change
+
+`post_migrate` provisions the test database at creation (`tests/settings.py:61-65`) and
+per-test `flush_absurd_state` only TRUNCATEs, so the declared catalog is standing for
+the whole session. The suites do not depend on self-heal to reach a provisioned queue;
+they reach one because they ran `migrate`.
+
+The exception is `_isolate_queues` (`tests/conftest.py`), which hard-drops all topology
+before AND after its test. Three tests inside those files then enqueue or start a worker
+with nothing of their own, and today the hole is repaired by accident. Those three take
+an explicit `dj_absurd.sync_queues()` at the call site — the util that already exists
+for exactly this, already used by `test_task_outside_tasks_py_runs`:
+
+- `tests/core/test_worker.py::test_queue_defaults_to_default`
+- `tests/core/test_worker.py::test_worker_uses_single_backend_at_nondefault_alias`
+- `tests/multidb/test_router.py::test_roundtrip_drains_on_the_non_default_alias`
+
+`_isolate_queues` keeps its current contract (drop before and after). Re-provisioning on
+teardown was tried and MEASURED to change nothing: with the three call-site fixes in
+place the control run fails the same eight tests either way, so the fixture change was
+dead weight and is not shipping.
+
+Same exposure downstream, and it needs documenting rather than fixing: a project using
+the pytest tooling that drops topology and relies on first-enqueue recreation must call
+`dj_absurd.sync_queues()`; a `--reuse-db` run that declares a NEW queue gets no
+`post_migrate` on later runs, so it needs `--create-db` or that same call.
+`AbsurdTestRuntime.sync_queues`'s docstring ("rarely needed") stays true — it is still
+rare, just no longer optional in a topology-dropping test.
+
+### Unchanged
+
+`post_migrate` and `absurd_sync_queues` keep `provision_backend`, and with it
+`lock_provisioning`. Best-effort swallow in the `post_migrate` receiver stays as is.
+
+## Consequences elsewhere, accepted
+
+- **Beat.** `spawn_scheduled` (`scheduler.py:76`) enqueues, and `fire_schedule`
+  (`:176-180`) catches every exception into `logger.exception`. A schedule pointed at an
+  unprovisioned queue currently auto-creates; afterwards it logs the typed error every
+  slot and never runs, while the worker stays up. Loud in the log, invisible in the
+  queue — and the beat loop must keep going for the other schedules, so the swallow
+  stays.
+- **Deferred enqueue.** The `run_after` wrapper's inner enqueue happens inside a worker
+  at due time. An unprovisioned target now burns the wrapper's `max_attempts` and lands
+  FAILED instead of auto-creating. Visible in the admin, which is the right place.
+
+## Out of scope
+
+- Skipping the view rebuild when nothing changed (deploy-stall hedge). Measured on this
+  branch with a temporary timing test: `rebuild_views` is 4.9ms at one queue and 24.2ms
+  at 25 (min of 5 runs, local Postgres), so the only argument was lock exposure, and
+  that is dominated by the admin ORDER BY work.
+- `post_migrate`'s silent swallow — see the upgrade note, which it makes worse. Separate
+  decision.
+- Anything about admin views' shape or the pg_cron provisioning path (pg_cron is
+  unaffected: its SQL wrapper spawns directly and never had auto-create).
+
+## Testing
+
+RED first, through real entrypoints.
+
+- Enqueue to a declared, unprovisioned queue raises `QueueNotProvisionedError`; assert
+  the complete message. Assert the queue is still absent afterwards — the point is that
+  nothing was created.
+- Enqueue to an undeclared queue still raises `QueueNotDeclaredError`; enqueue against a
+  hidden schema still raises `SchemaNotInstalledError` (now classified off the spawn
+  exception, so this test is exercising new code).
+- An unrelated `UndefinedTable` raised from inside `spawn_task` propagates as itself,
+  not relabelled.
+- Enqueue inside an outer `transaction.atomic` leaves that block usable after the
+  refusal (replaces the existing auto-create-under-atomic test).
+- `absurd_worker` against an unprovisioned declared queue exits with `CommandError`
+  carrying the typed message, before any "Started worker" output, and creates neither
+  the queue nor the views.
+- `absurd_sync_queues` recreates the tables of a queue whose catalog row survived but
+  whose tables were dropped, and still reports it as no change.
+- Existing `post_migrate` / `absurd_sync_queues` and system-check tests keep passing
+  untouched — no check changes ship here.
+
+Tests asserting the removed behaviour, to delete or rewrite. MEASURED, not predicted:
+with the three call-site fixes above already applied, disabling both self-heal seams
+fails exactly these eight in `tests/core` and nothing at all in `tests/multidb` or
+`tests/pg_cron`.
+
+- `tests/core/test_enqueue.py::test_enqueue_auto_creates_declared_queue_and_runs`,
+  `::test_enqueue_auto_create_survives_outer_atomic` — delete; replaced by the refusal
+  tests above.
+- `tests/core/test_enqueue.py::test_enqueue_with_absent_schema_raises_clear_error` —
+  keep the assertion, rewrite: schema-absence is classified off the spawn exception now.
+- `tests/core/test_worker.py::test_worker_start_provisions_all_declared_queues` —
+  delete; the worker no longer provisions.
+- `tests/core/test_worker.py::test_worker_command_reconciles_changed_mutable_option`,
+  `::test_worker_command_reconciles_changed_interval_option`,
+  `::test_worker_command_warns_on_storage_mode_drift` — the reconcile-on-boot half goes;
+  each already syncs by command first, so what survives is a startup-output assertion.
+  Their reconcile coverage belongs to `absurd_sync_queues`' own tests.
+- `tests/core/test_orm_views.py::test_worker_start_rebuilds_when_it_created_queue` —
+  delete; boot no longer rebuilds views.
+
+`::test_worker_command_no_reconcile_when_unchanged` passes unchanged (it asserts the
+ABSENCE of provisioning output), as does
+`test_orm_views.py::test_sync_command_rebuilds_views_with_new_queue` — though the latter
+never calls the command its name claims and passes on in-file ordering, worth fixing
+while in there.
+
+## Docs
+
+- `django_absurd/AGENTS.md:757-761` states the removed behaviour outright ("on worker
+  start, by `absurd_sync_queues`, and on first enqueue") — rewrite, plus `:906-909` and
+  `:917-918`. `README.md` already promises migrate-provisioning only.
+- `docs/web/workers.md:16` — "On start it provisions every declared queue and rebuilds
+  the admin views" is exactly what stops being true.
+- `docs/web/configuration.md:120-122` — the `QueueNotProvisionedError` raiser list gains
+  enqueue and the worker. `docs/web/testing.md:118` and its `--reuse-db` guidance per
+  the test-tooling section above.
+- `django_absurd/admin.py:146-149` is SOURCE, not docs: the changelist warning offers
+  "(or start a worker on them)", which becomes false. Its message-asserting test changes
+  with it.
+- `django_absurd/queues.py:183-184`'s comment names worker start as a caller.
+- `examples/`: worker services converge via `restart: on-failure` once the app service's
+  `migrate` lands; confirm with a real `docker compose up` on all three rather than by
+  reading. No example doc promises auto-create.
+- `docs/WHY.md`: the durable record. Three decisions have passed through here
+  (explicit-only → self-heal → post_migrate) and none was ever captured, which is why
+  this had to be reconstructed from git.
+
+## Upgrade note
+
+Breaking; `feat!`. A deploy that runs `manage.py migrate` to completion is unaffected —
+`post_migrate` provisions the declared set every time, applied migrations or not.
+
+Three ways to be affected anyway, all worth naming in the release notes:
+
+- Declaring a queue and deploying without `migrate`. Add `absurd_sync_queues` to the
+  release step.
+- Pipelines gated on `migrate --check`: it exits before `post_migrate` fires, and a
+  queue-only change touches no migrations, so the provisioning step is skipped by a
+  pipeline that believes it runs migrate.
+- The `post_migrate` receiver swallows `ImproperlyConfigured`, `OperationalError`,
+  `ProgrammingError` and `SchemaNotInstalledError` silently, so an unreachable database
+  — or a migrate role without `CREATE` on the `absurd` schema — provisions nothing and
+  reports nothing. Worker boot and first enqueue are today's fallbacks for that, and
+  both are being removed.

--- a/docs/specs/2026-08-17-explicit-provisioning-design.md
+++ b/docs/specs/2026-08-17-explicit-provisioning-design.md
@@ -331,6 +331,10 @@ sections above were written. Each supersedes what it names.
   backend is a misconfiguration: a nightly `absurd_cleanup` otherwise stops cleaning
   silently and reports success.
 
+The repair reports itself. _Testing_'s "recreates the tables … and still reports it as
+no change" describes a shape that was never shipped: `SyncResult` gained a `repaired`
+list, so sync prints `Repaired: <queue>` and `--check` prints `Would repair: <queue>`.
+
 Two additions the _Docs_ section above does not list: `docs/web/deploying.md` (the
 deploy script, the `--database` asymmetry, `--check`, and the `migrate --check` trap),
 and examples gating `app` and `worker` on a one-shot `migrate` service via

--- a/docs/web/admin.md
+++ b/docs/web/admin.md
@@ -12,9 +12,9 @@ filterable by queue and state. Runs, Checkpoints, Events, Waits, and the Queues 
 get their own alongside it.
 
 - Read-only. There is no retry or cancel — the admin reports, it does not drive.
-- A queue created only by an enqueue is not in the views yet, so its tasks do not
-  appear. The changelist says so and names the queues — run
-  `manage.py absurd_sync_queues` or start a worker on them.
+- A queue created outside django-absurd — `absurdctl`, a direct SDK call — is not in the
+  views, so its tasks do not appear. The changelist says so and names the queues;
+  `manage.py absurd_sync_queues` indexes them.
 - Toggle with `ENABLE_ADMIN`, or register on your own site with `ADMIN_SITE`
   ([Configuration](configuration.md#backend-options)).
 

--- a/docs/web/cleanup.md
+++ b/docs/web/cleanup.md
@@ -86,8 +86,7 @@ only re-provision the queues, never re-`migrate`.
 !!! warning "Destructive"
 
     This permanently deletes all task history across every queue. Re-provision your
-    declared queues afterward with `migrate`, `absurd_sync_queues`, or by starting a
-    worker.
+    declared queues afterward with `migrate` or `absurd_sync_queues`.
 
     Scheduled jobs survive the flush and **error on each fire** until the queues exist
     again — re-provision promptly. The `OPTIONS["CLEANUP"]` job is the exception: it

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -41,8 +41,9 @@ Use this to set [retention](https://earendil-works.github.io/absurd/storage/)
 }}
 ```
 
-Declared queues are provisioned at `migrate` and again when a [worker](workers.md)
-starts.
+Declared queues are provisioned at `migrate` and by `manage.py absurd_sync_queues` —
+nothing else creates one. `enqueue` and a starting [worker](workers.md) both refuse an
+unprovisioned queue.
 
 - Setting both forms is a configuration error (`absurd.E002`). Undeclared queue names
   are rejected, never silently created.
@@ -119,9 +120,10 @@ except DjangoAbsurdError:
 
 Typed errors under `DjangoAbsurdError`: `QueueNotDeclaredError` (never declared) and
 `QueueNotProvisionedError` (declared, no table yet — run
-`manage.py absurd_sync_queues`), raised by [`emit_event`](workflows.md#emit-from-a-view)
-and the test fixture's [`drain()`](testing.md#drain); and `SchemaNotInstalledError` (the
-Absurd schema itself isn't installed — run `manage.py migrate`).
+`manage.py absurd_sync_queues`), raised by `enqueue`, by a starting
+[worker](workers.md), by [`emit_event`](workflows.md#emit-from-a-view) and by the test
+fixture's [`drain()`](testing.md#drain); and `SchemaNotInstalledError` (the Absurd
+schema itself isn't installed — run `manage.py migrate`).
 
 - `enqueue` raises `QueueNotDeclaredError` only when `QUEUES` is empty or unset. With
   `QUEUES` configured, a typo is rejected earlier as Django's own `InvalidTask`.

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -41,9 +41,9 @@ Use this to set [retention](https://earendil-works.github.io/absurd/storage/)
 }}
 ```
 
-Declared queues are provisioned at `migrate` and by `manage.py absurd_sync_queues` —
-nothing else creates one. `enqueue` and a starting [worker](workers.md) both refuse an
-unprovisioned queue.
+Declared queues are provisioned at `migrate`, by `manage.py absurd_sync_queues`, and by
+[`dj_absurd.sync_queues()`](testing.md#sync-queues) in tests — nothing else creates one.
+`enqueue` and a starting [worker](workers.md) both refuse an unprovisioned queue.
 
 - Setting both forms is a configuration error (`absurd.E002`). Undeclared queue names
   are rejected, never silently created.
@@ -122,8 +122,9 @@ Typed errors under `DjangoAbsurdError`: `QueueNotDeclaredError` (never declared)
 `QueueNotProvisionedError` (declared, no table yet — run
 `manage.py absurd_sync_queues`), raised by `enqueue`, by a starting
 [worker](workers.md), by [`emit_event`](workflows.md#emit-from-a-view) and by the test
-fixture's [`drain()`](testing.md#drain); and `SchemaNotInstalledError` (the Absurd
-schema itself isn't installed — run `manage.py migrate`).
+fixture's [`drain()`](testing.md#drain) and [`get_result()`](testing.md#get-result); and
+`SchemaNotInstalledError` (the Absurd schema itself isn't installed — run
+`manage.py migrate`).
 
 - `enqueue` raises `QueueNotDeclaredError` only when `QUEUES` is empty or unset. With
   `QUEUES` configured, a typo is rejected earlier as Django's own `InvalidTask`.

--- a/docs/web/configuration.md
+++ b/docs/web/configuration.md
@@ -129,9 +129,10 @@ fixture's [`drain()`](testing.md#drain) and [`get_result()`](testing.md#get-resu
 - `enqueue` raises `QueueNotDeclaredError` only when `QUEUES` is empty or unset. With
   `QUEUES` configured, a typo is rejected earlier as Django's own `InvalidTask`.
 - Every `absurd_*` management command turns a fixed set of configuration failures —
-  `ImproperlyConfigured`, `BackendNotConfiguredError`, `SchemaNotInstalledError`,
-  `QueueNotDeclaredError`, `QueueNotProvisionedError` — into a `CommandError`;
-  `--traceback` still shows the original. Every other error, including any other
-  `DjangoAbsurdError` subclass, keeps its own type and full traceback.
+  `ImproperlyConfigured`, `BackendNotConfiguredError`,
+  `MultipleBackendsConfiguredError`, `SchemaNotInstalledError`, `QueueNotDeclaredError`,
+  `QueueNotProvisionedError` — into a `CommandError`; `--traceback` still shows the
+  original. Every other error, including any other `DjangoAbsurdError` subclass, keeps
+  its own type and full traceback.
 - The hierarchy isn't total — other failures still raise plain `ImproperlyConfigured` /
   `RuntimeError` / `TypeError`.

--- a/docs/web/cron-jobs.md
+++ b/docs/web/cron-jobs.md
@@ -55,6 +55,9 @@ like any other.
 
 - **Run exactly one.** No leader election — concurrent beats each fire every slot.
 - **Never backfills.** A slot missed while down is skipped.
+- **A failed enqueue is not retried either.** Beat logs the error and moves to the next
+  slot, so an [unprovisioned](deploying.md) target queue costs you every slot until
+  someone provisions it.
 - Grammar is [croniter](https://pypi.org/project/croniter/): 5-field, or 6-field with a
   leading seconds column (`"*/30 * * * * *"`).
 - Expressions use Django's

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -19,14 +19,6 @@ enqueuing to a declared but unprovisioned queue raises
 Those two lines are the whole deploy for most projects. Everything below is for a
 release step that departs from them.
 
-## Updating queues explicitly
-
-```bash
-python manage.py absurd_sync_queues
-```
-
-`migrate` already does this on every run; this command does only that part.
-
 ## What `migrate` needs
 
 Absurd's schema ships as a Django
@@ -69,15 +61,17 @@ python manage.py migrate                     # Django's own tables
 - A non-default alias needs `django_absurd.routers.AbsurdRouter` in `DATABASE_ROUTERS`
   (`absurd.E005`) — see [Non-default database](configuration.md#non-default-database).
 
-## Assert instead of act
+## Updating queues explicitly
 
 ```bash
-python manage.py absurd_sync_queues --check
+python manage.py absurd_sync_queues
+python manage.py absurd_sync_queues --check   # report only, write nothing
 ```
 
-Read-only: reports what would change and exits non-zero if anything would. It answers
-about queues; the admin views are rebuilt by every real run, so a dropped view is not
-something it reports.
+`migrate` already does this on every run; this command does only that part. `--check`
+reports what would change and exits non-zero if anything would. It answers about queues;
+the admin views are rebuilt by every real run, so a dropped view is not something it
+reports.
 
 ```
 🗃️ Would create: pending

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -16,20 +16,21 @@ enqueuing to a declared but unprovisioned queue raises
 [`QueueNotProvisionedError`](configuration.md#exceptions), and
 [`absurd_worker`](workers.md#run-a-worker) refuses to start on one.
 
-Those two lines are the whole deploy for most projects — queue changes are rare, and
-`migrate` covers them when they happen.
+Those two lines are the whole deploy for most projects. Everything below is for a
+release step that departs from them.
+
+## Provisioning without `migrate`
 
 ```bash
 python manage.py absurd_sync_queues
 ```
 
-Provisions the declared queues on its own, without a `migrate` — for a release step that
-doesn't run one, or to pick up a queue change between deploys.
+Provisions the declared queues on its own — for a release step that doesn't run
+`migrate`, or to pick up a queue change between deploys.
 
 - `check --deploy` does not run the checks tagged `database` — `absurd.W002`, and
-  pg_cron's `absurd.E012`. `migrate` runs them for the database it migrates, so the two
-  lines above cover them; a release step without `migrate` needs
-  `check --database=<alias>` to get them.
+  pg_cron's `absurd.E012`. `migrate` runs them for the database it migrates, so a deploy
+  that skips `migrate` needs `check --database=<alias>` to get them.
 
 ## What `migrate` needs
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -25,8 +25,7 @@ release step that departs from them.
 python manage.py absurd_sync_queues
 ```
 
-`migrate` already does this on every run; this command does only that part — for a
-release step that doesn't run `migrate`, or to pick up a queue change between deploys.
+`migrate` already does this on every run; this command does only that part.
 
 ## What `migrate` needs
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -17,8 +17,19 @@ enqueuing to a declared but unprovisioned queue raises
 [`absurd_worker`](workers.md#run-a-worker) refuses to start on one.
 
 Those two lines are the whole deploy for most projects — queue changes are rare, and
-`migrate` covers them when they happen. Add `python manage.py absurd_sync_queues` only
-when your release step doesn't run `migrate` at all.
+`migrate` covers them when they happen.
+
+```bash
+python manage.py absurd_sync_queues
+```
+
+Provisions the declared queues on its own, without a `migrate` — for a release step that
+doesn't run one, or to pick up a queue change between deploys.
+
+- `check --deploy` does not run the checks tagged `database` — `absurd.W002`, and
+  pg_cron's `absurd.E012`. `migrate` runs them for the database it migrates, so the two
+  lines above cover them; a release step without `migrate` needs
+  `check --database=<alias>` to get them.
 
 ## What `migrate` needs
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -28,10 +28,6 @@ python manage.py absurd_sync_queues
 Provisions the declared queues on its own — for a release step that doesn't run
 `migrate`, or to pick up a queue change between deploys.
 
-- `check --deploy` does not run the checks tagged `database` — `absurd.W002`, and
-  pg_cron's `absurd.E012`. `migrate` runs them for the database it migrates, so a deploy
-  that skips `migrate` needs `check --database=<alias>` to get them.
-
 ## What `migrate` needs
 
 Absurd's schema ships as a Django

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -19,14 +19,14 @@ enqueuing to a declared but unprovisioned queue raises
 Those two lines are the whole deploy for most projects. Everything below is for a
 release step that departs from them.
 
-## Provisioning without `migrate`
+## Updating queues explicitly
 
 ```bash
 python manage.py absurd_sync_queues
 ```
 
-Provisions the declared queues on its own — for a release step that doesn't run
-`migrate`, or to pick up a queue change between deploys.
+`migrate` already does this on every run; this command does only that part — for a
+release step that doesn't run `migrate`, or to pick up a queue change between deploys.
 
 ## What `migrate` needs
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -75,9 +75,14 @@ CommandError: Queues are not in sync. Run: manage.py absurd_sync_queues
 row outlived its tables. In sync, it prints `🗃️ No queues to sync.` and exits 0.
 
 Reach for it in a release step that asserts rather than acts, or to ask a production
-database whether it is in sync without needing DDL rights. It is also the way to gate a
-pipeline on the answer: `migrate` prints `Not provisioned:` and the reason when it can't
-provision, but it still exits 0, so only this reports the condition as a status code.
+database whether it is in sync without needing DDL rights. It is not a second line of
+defence behind `migrate`, which fails on a provisioning error itself — it answers the
+question a release step that never runs `migrate`, or runs it against another database,
+would otherwise leave unasked.
+
+The one condition `migrate` reports without failing is an absent schema: it prints
+`Not provisioned: Absurd schema is not installed.` and exits 0, because there is nothing
+to provision into yet. That is the state `migrate --fake` leaves behind.
 
 ## `migrate --check` doesn't see queues
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -20,6 +20,24 @@ Those two lines are the whole deploy for most projects — queue changes are rar
 `migrate` covers them when they happen. Add `python manage.py absurd_sync_queues` only
 when your release step doesn't run `migrate` at all.
 
+## What `migrate` needs
+
+Absurd's schema ships as a Django
+[migration](https://docs.djangoproject.com/en/6.0/topics/migrations/). The SQL comes
+from the pinned Absurd version and is never fetched at migrate time.
+
+- **Privileges:** `migrate` needs `GRANT CREATE ON DATABASE <db>` and nothing more — no
+  extension, so no superuser and no managed-Postgres allow-list entry.
+  `CREATE SCHEMA IF NOT EXISTS` checks that privilege _before_ the schema's existence,
+  so pre-creating `absurd` yourself doesn't avoid the grant. The schema name is fixed.
+- **Already running Absurd?** `python manage.py migrate --fake django_absurd` records
+  the migration as applied without re-running the DDL. Only do this when the existing
+  schema matches `django_absurd.ABSURD_SCHEMA_VERSION` exactly — faking doesn't check,
+  and a mismatch fails at runtime in ways Django can't detect. Faking skips the DDL but
+  still fires `post_migrate`, so the declared queues are provisioned either way.
+
+→ [Absurd: database setup](https://earendil-works.github.io/absurd/database/).
+
 ## Non-default database
 
 ```bash
@@ -57,9 +75,9 @@ CommandError: Queues are not in sync. Run: manage.py absurd_sync_queues
 row outlived its tables. In sync, it prints `🗃️ No queues to sync.` and exits 0.
 
 Reach for it in a release step that asserts rather than acts, or to ask a production
-database whether it is in sync without needing DDL rights. It is also the way to make
-provisioning failure loud: the `post_migrate` receiver reports nothing when it can't
-provision, so a `migrate` that provisioned no queue still exits 0.
+database whether it is in sync without needing DDL rights. It is also the way to gate a
+pipeline on the answer: `migrate` prints `Not provisioned:` and the reason when it can't
+provision, but it still exits 0, so only this reports the condition as a status code.
 
 ## `migrate --check` doesn't see queues
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -26,15 +26,19 @@ Absurd's schema ships as a Django
 [migration](https://docs.djangoproject.com/en/6.0/topics/migrations/). The SQL comes
 from the pinned Absurd version and is never fetched at migrate time.
 
-- **Privileges:** `migrate` needs `GRANT CREATE ON DATABASE <db>` and nothing more — no
-  extension, so no superuser and no managed-Postgres allow-list entry.
-  `CREATE SCHEMA IF NOT EXISTS` checks that privilege _before_ the schema's existence,
-  so pre-creating `absurd` yourself doesn't avoid the grant. The schema name is fixed.
+- **Privileges:** `migrate` needs `GRANT CREATE ON DATABASE <db>` — no extension, so no
+  superuser and no managed-Postgres allow-list entry. `CREATE SCHEMA IF NOT EXISTS`
+  checks that privilege _before_ the schema's existence, so pre-creating `absurd`
+  yourself doesn't avoid the grant. The schema name is fixed. Provisioning then creates
+  tables _inside_ `absurd`, so the role needs `CREATE` on the schema as well — implicit
+  when `migrate` created it, and not when someone else did.
 - **Already running Absurd?** `python manage.py migrate --fake django_absurd` records
   the migration as applied without re-running the DDL. Only do this when the existing
   schema matches `django_absurd.ABSURD_SCHEMA_VERSION` exactly — faking doesn't check,
   and a mismatch fails at runtime in ways Django can't detect. Faking skips the DDL but
-  still fires `post_migrate`, so the declared queues are provisioned either way.
+  still fires `post_migrate`, so the declared queues are provisioned either way — which
+  needs `CREATE` on the schema the other role created. Without it `migrate` fails, where
+  earlier releases provisioned nothing and left the first worker or enqueue to heal it.
 
 → [Absurd: database setup](https://earendil-works.github.io/absurd/database/).
 
@@ -64,7 +68,9 @@ python manage.py migrate                     # Django's own tables
 python manage.py absurd_sync_queues --check
 ```
 
-Read-only: reports what would change and exits non-zero if anything would.
+Read-only: reports what would change and exits non-zero if anything would. It answers
+about queues; the admin views are rebuilt by every real run, so a dropped view is not
+something it reports.
 
 ```
 🗃️ Would create: pending
@@ -81,8 +87,9 @@ question a release step that never runs `migrate`, or runs it against another da
 would otherwise leave unasked.
 
 The one condition `migrate` reports without failing is an absent schema: it prints
-`Not provisioned: Absurd schema is not installed.` and exits 0, because there is nothing
-to provision into yet. That is the state `migrate --fake` leaves behind.
+`Not provisioned: the Absurd schema is absent; this migrate did not install it.` and
+exits 0, because there is nothing to provision into yet. That is the state
+`migrate --fake` leaves behind.
 
 ## `migrate --check` doesn't see queues
 

--- a/docs/web/deploying.md
+++ b/docs/web/deploying.md
@@ -1,0 +1,75 @@
+---
+icon: lucide/ship
+---
+
+# Deploying
+
+```bash
+python manage.py check --deploy
+python manage.py migrate
+```
+
+`migrate` installs Absurd's schema and provisions the
+[declared queues](configuration.md#declaring-queues) through `post_migrate` — on every
+run, whether or not a migration was applied. Nothing at runtime creates a queue:
+enqueuing to a declared but unprovisioned queue raises
+[`QueueNotProvisionedError`](configuration.md#exceptions), and
+[`absurd_worker`](workers.md#run-a-worker) refuses to start on one.
+
+Those two lines are the whole deploy for most projects — queue changes are rare, and
+`migrate` covers them when they happen. Add `python manage.py absurd_sync_queues` only
+when your release step doesn't run `migrate` at all.
+
+## Non-default database
+
+```bash
+python manage.py migrate --database=absurd   # Absurd's schema + queues
+python manage.py migrate                     # Django's own tables
+```
+
+| Command                      | How it picks a database                                                                                                                                   |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `migrate --database=<alias>` | Django's [`--database`](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-migrate-database) flag — this is what installs Absurd's schema. |
+| `migrate`                    | The `default` alias, where Django's own `LogEntry`, session, and `ContentType` tables live. The [admin](admin.md) needs them.                             |
+| `absurd_sync_queues`         | No flag — resolves the Absurd alias from `TASKS`.                                                                                                         |
+| `absurd_worker`              | No flag — same.                                                                                                                                           |
+
+- `post_migrate` is per-database, so `migrate --database=absurd` is the run that
+  provisions — a `migrate` on `default` leaves the Absurd alias untouched. Which alias
+  that is comes from [`OPTIONS["DATABASE"]`](configuration.md#backend-options).
+- A non-default alias needs `django_absurd.routers.AbsurdRouter` in `DATABASE_ROUTERS`
+  (`absurd.E005`) — see [Non-default database](configuration.md#non-default-database).
+
+## Assert instead of act
+
+```bash
+python manage.py absurd_sync_queues --check
+```
+
+Read-only: reports what would change and exits non-zero if anything would.
+
+```
+🗃️ Would create: pending
+CommandError: Queues are not in sync. Run: manage.py absurd_sync_queues
+```
+
+`Would reconcile:` and `Would repair:` cover drifted policy and a queue whose catalog
+row outlived its tables. In sync, it prints `🗃️ No queues to sync.` and exits 0.
+
+Reach for it in a release step that asserts rather than acts, or to ask a production
+database whether it is in sync without needing DDL rights. It is also the way to make
+provisioning failure loud: the `post_migrate` receiver reports nothing when it can't
+provision, so a `migrate` that provisioned no queue still exits 0.
+
+## `migrate --check` doesn't see queues
+
+[`migrate --check`](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-migrate-check)
+exits before `post_migrate` fires — it is a predicate about unapplied migrations, not a
+migration. Declaring a queue touches no migration file, so it exits 0:
+
+```bash
+python manage.py migrate --check || python manage.py migrate
+```
+
+That pipeline skips the only step that would have provisioned a newly declared queue,
+and reports success. Run `absurd_sync_queues --check` for the queue half.

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -115,10 +115,13 @@ one `RunSnapshot` per run executed, in claim order.
 | `failed`    | raised, and out of retries                                                                                                        |
 | `cancelled` | cancelled before or during execution                                                                                              |
 
-- **`drain` provisions nothing**, unlike the CLI. `migrate` leaves a test database
-  ready, but a queue declared by overriding `TASKS` in one test has no table — call
-  `sync_queues()` first or `drain()` raises `QueueNotProvisionedError`. Undeclared
-  raises `QueueNotDeclaredError`; see [exceptions](configuration.md#exceptions).
+- **`drain` provisions nothing.** Building the test database runs `migrate`, which
+  provisions the queues declared at that moment. A queue declared after that — by
+  overriding `TASKS` in one test, or by adding it to settings on a
+  [`--reuse-db`](https://pytest-django.readthedocs.io/en/latest/database.html#reuse-db-reuse-the-testing-database-between-test-runs)
+  run — has no table: call [`sync_queues()`](#sync-queues) first, or re-run with
+  `--create-db`, or `drain()` raises `QueueNotProvisionedError`. Undeclared raises
+  `QueueNotDeclaredError`; see [exceptions](configuration.md#exceptions).
 
 ### `dj_absurd.emit(name, payload=None, queue="default")` { #emit data-toc-label="emit()" }
 
@@ -165,8 +168,9 @@ including `sleeping`, which `TaskResult.status` can't show.
 ### `dj_absurd.sync_queues()` { #sync-queues data-toc-label="sync_queues()" }
 
 Provisions every declared queue — the runtime counterpart of
-`manage.py absurd_sync_queues`. Only needed when a test changes queue topology, such as
-a `settings` override declaring a queue the migration never saw.
+`manage.py absurd_sync_queues`. Only needed when a test declares a queue the test
+database was never built with — a `settings` override, or a new queue in settings under
+`--reuse-db`.
 
 ### `dj_absurd.now` { #now data-toc-label="now" }
 

--- a/docs/web/testing.md
+++ b/docs/web/testing.md
@@ -156,7 +156,8 @@ including `sleeping`, which `TaskResult.status` can't show.
 | `failure`          | `None` except on a terminal failure (see below)   |
 
 - `task_id` takes a bare uuid or a prefixed `"queue:uuid"`. The prefix wins over
-  `queue`'s default; a `queue=` that disagrees raises `TaskIdQueueMismatchError`.
+  `queue`'s default; a `queue=` that disagrees raises `TaskIdQueueMismatchError`. An
+  unprovisioned queue raises `QueueNotProvisionedError`, same as `drain()`.
 - **This view can't express an in-flight [retry](tasks.md#retries-spawn-options):**
   `attempts` reads `2` before the second attempt runs, `state="sleeping"` covers a
   backoff as well as a durable sleep, and `failure` is `None` mid-backoff. Use

--- a/docs/web/workers.md
+++ b/docs/web/workers.md
@@ -13,10 +13,12 @@ python manage.py absurd_worker --queue reports --concurrency 4
 ```
 
 One worker runs both sync and `async def` tasks — async on an event loop, sync in a
-thread pool. On start it checks that `--queue` is declared and provisioned, then polls
-for work. It provisions nothing: an unprovisioned queue exits with
-`QueueNotProvisionedError` before the worker prints anything — run `migrate` or
-[`manage.py absurd_sync_queues`](configuration.md#declaring-queues) first.
+thread pool. On start it checks that `--queue` is declared and present in the queue
+catalog, then polls for work. It provisions nothing: a queue that isn't there exits with
+a `CommandError` before the worker prints anything — run `migrate` or
+[`manage.py absurd_sync_queues`](configuration.md#declaring-queues) first. A queue whose
+catalog row outlived its tables passes that check and exits the same way on the first
+claim, after the banner.
 
 | Flag              | Default        | What it does                                                       |
 | ----------------- | -------------- | ------------------------------------------------------------------ |

--- a/docs/web/workers.md
+++ b/docs/web/workers.md
@@ -48,24 +48,9 @@ retries never redo completed work.
 →
 [Absurd: Concepts — Retries](https://earendil-works.github.io/absurd/concepts/#retries).
 
-## Schema & migrations
+## Before a worker starts
 
-```bash
-python manage.py migrate
-```
-
-Absurd's schema ships as a Django
-[migration](https://docs.djangoproject.com/en/6.0/topics/migrations/) and installs the
-declared queues with it. The SQL comes from the pinned Absurd version and is never
-fetched at migrate time.
-
-- **Privileges:** `migrate` needs `GRANT CREATE ON DATABASE <db>` and nothing more — no
-  extension, so no superuser and no managed-Postgres allow-list entry.
-  `CREATE SCHEMA IF NOT EXISTS` checks that privilege _before_ the schema's existence,
-  so pre-creating `absurd` yourself doesn't avoid the grant. The schema name is fixed.
-- **Already running Absurd?** `python manage.py migrate --fake django_absurd` records
-  the migration as applied without re-running the DDL. Only do this when the existing
-  schema matches `django_absurd.ABSURD_SCHEMA_VERSION` exactly — faking doesn't check,
-  and a mismatch fails at runtime in ways Django can't detect.
-
-→ [Absurd: database setup](https://earendil-works.github.io/absurd/database/).
+`migrate` has to have run: it installs Absurd's schema and provisions the declared
+queues, and a worker refuses to start on a queue that isn't provisioned. See
+[Deploying](deploying.md) for the release step, the privileges `migrate` needs, and
+adopting a database that already runs Absurd.

--- a/docs/web/workers.md
+++ b/docs/web/workers.md
@@ -13,8 +13,10 @@ python manage.py absurd_worker --queue reports --concurrency 4
 ```
 
 One worker runs both sync and `async def` tasks — async on an event loop, sync in a
-thread pool. On start it provisions every declared queue and rebuilds the admin views,
-then polls for work.
+thread pool. On start it checks that `--queue` is declared and provisioned, then polls
+for work. It provisions nothing: an unprovisioned queue exits with
+`QueueNotProvisionedError` before the worker prints anything — run `migrate` or
+[`manage.py absurd_sync_queues`](configuration.md#declaring-queues) first.
 
 | Flag              | Default        | What it does                                                       |
 | ----------------- | -------------- | ------------------------------------------------------------------ |

--- a/docs/web/workers.md
+++ b/docs/web/workers.md
@@ -14,11 +14,11 @@ python manage.py absurd_worker --queue reports --concurrency 4
 
 One worker runs both sync and `async def` tasks — async on an event loop, sync in a
 thread pool. On start it checks that `--queue` is declared and present in the queue
-catalog, then polls for work. It provisions nothing: a queue that isn't there exits with
-a `CommandError` before the worker prints anything — run `migrate` or
-[`manage.py absurd_sync_queues`](configuration.md#declaring-queues) first. A queue whose
-catalog row outlived its tables passes that check and exits the same way on the first
-claim, after the banner.
+catalog, then polls for work. It provisions nothing: a queue that isn't there — no
+catalog row, or a row whose tables are gone — exits with a `CommandError` before the
+worker prints anything, so nothing announces a start it can't honour. Run `migrate` or
+[`manage.py absurd_sync_queues`](configuration.md#declaring-queues) first. A queue
+dropped from under a running worker fails on its next claim, with the same message.
 
 | Flag              | Default        | What it does                                                       |
 | ----------------- | -------------- | ------------------------------------------------------------------ |

--- a/examples/beat/compose.yaml
+++ b/examples/beat/compose.yaml
@@ -6,16 +6,23 @@ services:
       - POSTGRES_PASSWORD=postgres
     volumes:
       - beat_pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
 
-  app:
+  # Provisioning is a deploy step: nothing at runtime creates a queue any more, so
+  # the worker refuses to start until this has run. One-shot, and both long-running
+  # services gate on it completing.
+  migrate:
     build:
       context: ../..
       dockerfile: examples/beat/Dockerfile
+    command: nanodjango manage app.py migrate
     depends_on:
-      - db
-    restart: on-failure
-    ports:
-      - "${APP_PORT:-8000}:8000"
+      db:
+        condition: service_healthy
     environment: &env
       - PGHOST=db
       - PGPORT=5432
@@ -26,13 +33,27 @@ services:
       - ./:/app
       - ../../django_absurd:/src/django_absurd
 
+  app:
+    build:
+      context: ../..
+      dockerfile: examples/beat/Dockerfile
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    restart: on-failure
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    environment: *env
+    volumes: *mounts
+
   worker:
     build:
       context: ../..
       dockerfile: examples/beat/Dockerfile
     command: nanodjango manage app.py absurd_worker --beat
     depends_on:
-      - app
+      migrate:
+        condition: service_completed_successfully
     restart: on-failure
     environment: *env
     volumes: *mounts

--- a/examples/beat/compose.yaml
+++ b/examples/beat/compose.yaml
@@ -12,9 +12,9 @@ services:
       timeout: 5s
       retries: 30
 
-  # Provisioning is a deploy step: nothing at runtime creates a queue any more, so
-  # the worker refuses to start until this has run. One-shot, and both long-running
-  # services gate on it completing.
+  # Provisioning is a deploy step: migrate is what creates the queues, and the worker
+  # refuses to start until this has run. One-shot, and both long-running services gate
+  # on it completing.
   migrate:
     build:
       context: ../..

--- a/examples/beat/compose.yaml
+++ b/examples/beat/compose.yaml
@@ -7,7 +7,7 @@ services:
     volumes:
       - beat_pgdata:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 1s
       timeout: 5s
       retries: 30

--- a/examples/pg_cron/compose.yaml
+++ b/examples/pg_cron/compose.yaml
@@ -20,16 +20,23 @@ services:
       - POSTGRES_DB=demo
     volumes:
       - pg_cron_pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
 
-  app:
+  # Provisioning is a deploy step: nothing at runtime creates a queue any more, so
+  # the worker refuses to start until this has run. One-shot, and both long-running
+  # services gate on it completing.
+  migrate:
     build:
       context: ../..
       dockerfile: examples/pg_cron/Dockerfile
+    command: nanodjango manage app.py migrate
     depends_on:
-      - db
-    restart: on-failure
-    ports:
-      - "${APP_PORT:-8000}:8000"
+      db:
+        condition: service_healthy
     environment: &env
       - PGHOST=db
       - PGPORT=5432
@@ -40,13 +47,27 @@ services:
       - ./:/app
       - ../../django_absurd:/src/django_absurd
 
+  app:
+    build:
+      context: ../..
+      dockerfile: examples/pg_cron/Dockerfile
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    restart: on-failure
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    environment: *env
+    volumes: *mounts
+
   worker:
     build:
       context: ../..
       dockerfile: examples/pg_cron/Dockerfile
     command: nanodjango manage app.py absurd_worker
     depends_on:
-      - app
+      migrate:
+        condition: service_completed_successfully
     restart: on-failure
     environment: *env
     volumes: *mounts

--- a/examples/pg_cron/compose.yaml
+++ b/examples/pg_cron/compose.yaml
@@ -26,9 +26,9 @@ services:
       timeout: 5s
       retries: 30
 
-  # Provisioning is a deploy step: nothing at runtime creates a queue any more, so
-  # the worker refuses to start until this has run. One-shot, and both long-running
-  # services gate on it completing.
+  # Provisioning is a deploy step: migrate is what creates the queues, and the worker
+  # refuses to start until this has run. One-shot, and both long-running services gate
+  # on it completing.
   migrate:
     build:
       context: ../..

--- a/examples/pg_cron/compose.yaml
+++ b/examples/pg_cron/compose.yaml
@@ -21,7 +21,7 @@ services:
     volumes:
       - pg_cron_pgdata:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 1s
       timeout: 5s
       retries: 30

--- a/examples/web/compose.yaml
+++ b/examples/web/compose.yaml
@@ -6,16 +6,23 @@ services:
       - POSTGRES_PASSWORD=postgres
     volumes:
       - web_pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
 
-  app:
+  # Provisioning is a deploy step: nothing at runtime creates a queue any more, so
+  # the worker refuses to start until this has run. One-shot, and both long-running
+  # services gate on it completing.
+  migrate:
     build:
       context: ../..
       dockerfile: examples/web/Dockerfile
+    command: nanodjango manage app.py migrate
     depends_on:
-      - db
-    restart: on-failure
-    ports:
-      - "${APP_PORT:-8000}:8000"
+      db:
+        condition: service_healthy
     environment: &env
       - PGHOST=db
       - PGPORT=5432
@@ -26,13 +33,27 @@ services:
       - ./:/app
       - ../../django_absurd:/src/django_absurd
 
+  app:
+    build:
+      context: ../..
+      dockerfile: examples/web/Dockerfile
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    restart: on-failure
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    environment: *env
+    volumes: *mounts
+
   worker:
     build:
       context: ../..
       dockerfile: examples/web/Dockerfile
     command: nanodjango manage app.py absurd_worker
     depends_on:
-      - app
+      migrate:
+        condition: service_completed_successfully
     restart: on-failure
     environment: *env
     volumes: *mounts

--- a/examples/web/compose.yaml
+++ b/examples/web/compose.yaml
@@ -7,7 +7,7 @@ services:
     volumes:
       - web_pgdata:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 1s
       timeout: 5s
       retries: 30

--- a/examples/web/compose.yaml
+++ b/examples/web/compose.yaml
@@ -12,9 +12,9 @@ services:
       timeout: 5s
       retries: 30
 
-  # Provisioning is a deploy step: nothing at runtime creates a queue any more, so
-  # the worker refuses to start until this has run. One-shot, and both long-running
-  # services gate on it completing.
+  # Provisioning is a deploy step: migrate is what creates the queues, and the worker
+  # refuses to start until this has run. One-shot, and both long-running services gate
+  # on it completing.
   migrate:
     build:
       context: ../..

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -14,6 +14,11 @@ pre-commit gates), see [`../CLAUDE.md`](../CLAUDE.md).
 - **`from pytest_django import Settings`**, always, and annotate bare:
   `settings: Settings`. Never `pytest_django.fixtures.Settings`, quoted or otherwise — a
   quoted one passes the test run and fails mypy, so it survives until the slow gate.
+- **Assert a boolean by identity: `is True` / `is False`**, never `assert x` or
+  `assert not x`. Applies to every `.exists()` — `assert qs.exists() is False`, not
+  `assert not qs.exists()`. Truthiness passes for the wrong object too: drop the
+  `.exists()` call in a refactor and `assert qs` still passes on a non-empty queryset,
+  while `is True` fails. Same for any predicate helper returning `bool`.
 - **Shared fixtures live in the parent `tests/conftest.py`**, inherited by all three
   suites via `--confcutdir=..` in each suite's `pytest.toml` (each suite's rootdir is
   its own dir, so without `confcutdir` a parent conftest isn't discovered). Do NOT

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -11,6 +11,9 @@ pre-commit gates), see [`../CLAUDE.md`](../CLAUDE.md).
   `from tests import atasks`, then `tasks.add`, `tasks.routed`, `atasks.aecho`. Never
   `from tests.tasks import routed` — a bare adjective at the call site says nothing
   about what runs, and it forces rename-aliases like `make_group as make_group_task`.
+- **`from pytest_django import Settings`**, always, and annotate bare:
+  `settings: Settings`. Never `pytest_django.fixtures.Settings`, quoted or otherwise — a
+  quoted one passes the test run and fails mypy, so it survives until the slow gate.
 - **Shared fixtures live in the parent `tests/conftest.py`**, inherited by all three
   suites via `--confcutdir=..` in each suite's `pytest.toml` (each suite's rootdir is
   its own dir, so without `confcutdir` a parent conftest isn't discovered). Do NOT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import pytest
 from django.contrib.auth.models import User
 
 from django_absurd.flush import flush_absurd_state
-from tests import utils
 
 
 @pytest.fixture(autouse=True)
@@ -32,22 +31,14 @@ def _restore_absurd_logger() -> t.Iterator[None]:
 
 @pytest.fixture
 def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
-    """Hard-drop all Absurd queue topology before a test, restore the declared set
-    after it.
+    """Hard-drop all Absurd queue topology around a test (before AND after).
 
     The auto cleanup installed by the pytest plugin only TRUNCATEs after each DB
     test — it removes rows, not queues. Topology-varying files create/vary queues
     whose per-queue tables (DDL) and ``managed=False`` registry rows survive a
     truncate and leak across ``--reuse-db`` runs. Apply this (via a module-level
-    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files, so each such
-    test starts from nothing.
-
-    Teardown drops and then RE-PROVISIONS, because ``migrate`` provisions the test
-    database once at creation and nothing re-runs it per test. Dropping on both sides
-    left the next test to enqueue on a queue that no longer existed, repaired only by
-    a runtime path that recreated it — a dependency invisible at the failing test's
-    call site, and one django-absurd is removing. A test that wants the unprovisioned
-    state drops the queue itself, where a reader can see it.
+    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files to drop the
+    schema on both sides so each such test is hermetic.
 
     Naming: ``_``-prefixed but non-autouse. Outside the LETTER of CLAUDE.md's
     autouse-only underscore exception, but within its spirit — never called
@@ -56,7 +47,6 @@ def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
     flush_absurd_state(drop_schema=True)
     yield
     flush_absurd_state(drop_schema=True)
-    utils.provision_declared_queues()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth.models import User
 
 from django_absurd.flush import flush_absurd_state
+from tests import utils
 
 
 @pytest.fixture(autouse=True)
@@ -31,14 +32,22 @@ def _restore_absurd_logger() -> t.Iterator[None]:
 
 @pytest.fixture
 def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
-    """Hard-drop all Absurd queue topology around a test (before AND after).
+    """Hard-drop all Absurd queue topology before a test, restore the declared set
+    after it.
 
     The auto cleanup installed by the pytest plugin only TRUNCATEs after each DB
     test — it removes rows, not queues. Topology-varying files create/vary queues
     whose per-queue tables (DDL) and ``managed=False`` registry rows survive a
     truncate and leak across ``--reuse-db`` runs. Apply this (via a module-level
-    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files to drop the
-    schema on both sides so each such test is hermetic.
+    ``pytest.mark.usefixtures("_isolate_queues")``) only to those files, so each such
+    test starts from nothing.
+
+    Teardown drops and then RE-PROVISIONS, because ``migrate`` provisions the test
+    database once at creation and nothing re-runs it per test. Dropping on both sides
+    left the next test to enqueue on a queue that no longer existed, repaired only by
+    a runtime path that recreated it — a dependency invisible at the failing test's
+    call site, and one django-absurd is removing. A test that wants the unprovisioned
+    state drops the queue itself, where a reader can see it.
 
     Naming: ``_``-prefixed but non-autouse. Outside the LETTER of CLAUDE.md's
     autouse-only underscore exception, but within its spirit — never called
@@ -47,6 +56,7 @@ def _isolate_queues(_enable_db: None) -> t.Iterator[None]:
     flush_absurd_state(drop_schema=True)
     yield
     flush_absurd_state(drop_schema=True)
+    utils.provision_declared_queues()
 
 
 @pytest.fixture

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -133,21 +133,25 @@ def test_changelist_shows_dates_ordered_by_recent_activity(
     assert enqueue_elem.get_text(strip=True) != ""
 
 
+@pytest.mark.usefixtures("_isolate_queues")
 def test_changelist_warns_about_unindexed_queue(
-    admin_user: User, client: Client
+    admin_user: User, client: Client, dj_absurd: AbsurdTestRuntime
 ) -> None:
     # build the views over the declared queues, then create a queue directly
     # (config drift): it lands in the catalog but no view arm references it →
-    # unindexed.
+    # unindexed. _isolate_queues so 'drift' cannot outlive the run and leave the
+    # next --reuse-db pass with nothing to warn about.
+    dj_absurd.sync_queues()
     get_absurd_client().create_queue("drift")
     client.force_login(admin_user)
     resp = client.get(CHANGELIST)
     soup = parse_html(resp)
     warning = soup.select_one("ul.messagelist li.warning")
     assert warning is not None
-    text = warning.get_text()
-    assert "drift" in text
-    assert "absurd_sync_queues" in text
+    assert warning.get_text(strip=True) == (
+        "Queue(s) 'drift' exist but aren't indexed in the admin views yet — "
+        "run 'manage.py absurd_sync_queues' to include their tasks."
+    )
 
 
 def test_changelist_no_warning_when_all_queues_indexed(

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -334,7 +334,7 @@ def test_beat_fires_cleanup_on_cadence(
         for r in caplog.records
         if r.name == "django_absurd.scheduler" and r.getMessage().startswith("cleanup")
     ]
-    assert ran == ['cleanup ran: slot="2026-01-01T00:01:00Z"']
+    assert ran == ['cleanup ran: due="2026-01-01T00:01:00Z"']
 
 
 def test_beat_isolates_failing_cleanup(

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -11,6 +11,7 @@ import psycopg.errors
 import pytest
 from django.contrib.auth.models import Group
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db import connection
 from django.db.utils import ProgrammingError
 from django.utils import timezone
@@ -214,22 +215,26 @@ def test_cleanup_does_not_relabel_an_unrelated_missing_relation(
             cur.execute("alter table absurd.t_default_probe rename to t_default")
 
 
-def test_cleanup_command_reports_no_backends(
-    capsys: pytest.CaptureFixture[str],
-    settings: Settings,
-) -> None:
+def test_cleanup_command_fails_when_no_absurd_backend(settings: Settings) -> None:
+    # A nightly cron is the caller that matters: a settings regression must not stop
+    # every cleanup while the exit code still reports success.
     settings.TASKS = {}
-    call_command("absurd_cleanup")
-    assert capsys.readouterr().out == "No Absurd task backends configured.\n"
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_cleanup")
+    assert str(excinfo.value) == (
+        "No Absurd backend configured. Add a "
+        "django_absurd.backends.AbsurdBackend entry to TASKS."
+    )
 
 
-def test_flush_reports_no_backends(
-    capsys: pytest.CaptureFixture[str],
-    settings: Settings,
-) -> None:
+def test_flush_command_fails_when_no_absurd_backend(settings: Settings) -> None:
     settings.TASKS = {}
-    call_command("absurd_flush")
-    assert capsys.readouterr().out == "No Absurd task backends configured.\n"
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_flush")
+    assert str(excinfo.value) == (
+        "No Absurd backend configured. Add a "
+        "django_absurd.backends.AbsurdBackend entry to TASKS."
+    )
 
 
 def test_flush_reports_no_queues(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -150,6 +150,27 @@ def test_enqueue_to_a_half_provisioned_partitioned_queue_refuses(
     assert Queue.objects.filter(queue_name="parts").exists() is True
 
 
+def test_enqueue_lands_after_a_repaired_idempotency_table(
+    settings: Settings,
+) -> None:
+    # i_<queue> gone on its own is what a partial restore leaves, and the refusal above
+    # sends the operator to absurd_sync_queues — so that command has to repair it.
+    settings.TASKS = utils.make_tasks_settings(
+        queues={**utils.DECLARED_QUEUES, "parts": {"storage_mode": "partitioned"}}
+    )
+    call_command("absurd_sync_queues")
+    with connections["default"].cursor() as cursor:
+        cursor.execute("drop table absurd.i_parts cascade")
+    call_command("absurd_sync_queues")
+    bound = absurd_params(idempotency_key="k").bind(tasks.add).using(queue_name="parts")
+    result = bound.enqueue(1, 2)
+    with connections["default"].cursor() as cursor:
+        cursor.execute("select idempotency_key, task_id from absurd.i_parts")
+        assert [(key, str(task_id)) for key, task_id in cursor.fetchall()] == [
+            ("k", result.id.removeprefix("parts:"))
+        ]
+
+
 def test_enqueue_propagates_an_unrelated_undefined_table() -> None:
     # spawn_task reads absurd.queues when an idempotency key is set, and that relation
     # is nobody's queue table — the classifier must not relabel it as provisioning.

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -125,6 +125,31 @@ def test_enqueue_to_an_unprovisioned_queue_refuses() -> None:
     assert not Queue.objects.filter(queue_name="default").exists()
 
 
+def test_enqueue_to_a_half_provisioned_partitioned_queue_refuses(
+    settings: Settings,
+) -> None:
+    # spawn_task reserves the idempotency key in i_<queue> before it touches
+    # t_<queue>, so a partitioned queue whose catalog row outlived its tables reports
+    # that relation missing first.
+    settings.TASKS = utils.make_tasks_settings(
+        queues={**utils.DECLARED_QUEUES, "parts": {"storage_mode": "partitioned"}}
+    )
+    call_command("absurd_sync_queues")
+    with connections["default"].cursor() as cursor:
+        cursor.execute(
+            "drop table absurd.i_parts, absurd.t_parts, absurd.r_parts, "
+            "absurd.c_parts, absurd.e_parts, absurd.w_parts cascade"
+        )
+    bound = absurd_params(idempotency_key="k").bind(tasks.add).using(queue_name="parts")
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        bound.enqueue(1, 2)
+    assert str(exc.value) == (
+        "Queue 'parts' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+    assert Queue.objects.filter(queue_name="parts").exists()
+
+
 def test_enqueue_propagates_an_unrelated_undefined_table() -> None:
     # spawn_task reads absurd.queues when an idempotency key is set, and that relation
     # is nobody's queue table — the classifier must not relabel it as provisioning.

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -1,6 +1,7 @@
 import asyncio
 import typing as t
 
+import psycopg.errors
 import pytest
 from django.contrib.auth.models import Group
 from django.core.management import call_command
@@ -11,10 +12,14 @@ from pytest_django import Settings
 
 from django_absurd import absurd_params
 from django_absurd.connection import register_jsonb_loader
-from django_absurd.exceptions import QueueNotDeclaredError, SchemaNotInstalledError
+from django_absurd.exceptions import (
+    QueueNotDeclaredError,
+    QueueNotProvisionedError,
+    SchemaNotInstalledError,
+)
+from django_absurd.models import Queue
 from django_absurd.queues import get_absurd_client
 from django_absurd.tasks import AbsurdTask
-from django_absurd.test import AbsurdTestRuntime
 from tests import tasks, utils
 
 if t.TYPE_CHECKING:
@@ -108,14 +113,31 @@ def test_aenqueue_lands() -> None:
     assert len(get_absurd_client().claim_tasks(batch_size=1)) == 1
 
 
-def test_enqueue_auto_creates_declared_queue_and_runs(
-    dj_absurd: AbsurdTestRuntime,
-) -> None:
-    # 'default' declared but unprovisioned (no absurd_sync_queues). Enqueue auto-creates
-    # it; the worker then runs the task end-to-end.
-    tasks.make_group.enqueue("auto")
-    dj_absurd.drain()
-    assert Group.objects.filter(name="auto").exists()
+def test_enqueue_to_an_unprovisioned_queue_refuses() -> None:
+    # 'default' declared, but _isolate_queues dropped its tables and nothing at runtime
+    # puts them back.
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        tasks.add.enqueue(1, 2)
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+    assert not Queue.objects.filter(queue_name="default").exists()
+
+
+def test_enqueue_propagates_an_unrelated_undefined_table() -> None:
+    # spawn_task reads absurd.queues when an idempotency key is set, and that relation
+    # is nobody's queue table — the classifier must not relabel it as provisioning.
+    call_command("absurd_sync_queues")
+    with connections["default"].cursor() as cursor:
+        cursor.execute("alter table absurd.queues rename to queues_hidden")
+    try:
+        with pytest.raises(psycopg.errors.UndefinedTable) as exc:
+            absurd_params(idempotency_key="k").bind(tasks.add).enqueue(1, 2)
+    finally:
+        with connections["default"].cursor() as cursor:
+            cursor.execute("alter table absurd.queues_hidden rename to queues")
+    assert exc.value.diag.message_primary == 'relation "absurd.queues" does not exist'
 
 
 def test_enqueue_to_undeclared_queue_raises() -> None:
@@ -143,14 +165,14 @@ def test_enqueue_with_empty_queues_reports_undeclared(
     )
 
 
-def test_enqueue_auto_create_survives_outer_atomic(
-    dj_absurd: AbsurdTestRuntime,
-) -> None:
+def test_enqueue_refusal_leaves_an_outer_atomic_usable() -> None:
+    # The savepoint around spawn is what buys this: the refusal rolls back only the
+    # spawn, so the enclosing block can still commit its own writes.
     with transaction.atomic():
-        tasks.make_group.enqueue("inatomic")
-        assert Group.objects.count() == 0  # nothing committed yet
-    dj_absurd.drain()
-    assert Group.objects.filter(name="inatomic").exists()
+        with pytest.raises(QueueNotProvisionedError):
+            tasks.make_group.enqueue("refused")
+        Group.objects.create(name="after-refusal")
+    assert Group.objects.filter(name="after-refusal").exists()
 
 
 def test_enqueue_with_absent_schema_raises_clear_error() -> None:

--- a/tests/core/test_enqueue.py
+++ b/tests/core/test_enqueue.py
@@ -122,7 +122,7 @@ def test_enqueue_to_an_unprovisioned_queue_refuses() -> None:
         "Queue 'default' is declared but its Absurd table is not provisioned. "
         "Run: manage.py absurd_sync_queues"
     )
-    assert not Queue.objects.filter(queue_name="default").exists()
+    assert Queue.objects.filter(queue_name="default").exists() is False
 
 
 def test_enqueue_to_a_half_provisioned_partitioned_queue_refuses(
@@ -147,7 +147,7 @@ def test_enqueue_to_a_half_provisioned_partitioned_queue_refuses(
         "Queue 'parts' is declared but its Absurd table is not provisioned. "
         "Run: manage.py absurd_sync_queues"
     )
-    assert Queue.objects.filter(queue_name="parts").exists()
+    assert Queue.objects.filter(queue_name="parts").exists() is True
 
 
 def test_enqueue_propagates_an_unrelated_undefined_table() -> None:
@@ -197,7 +197,7 @@ def test_enqueue_refusal_leaves_an_outer_atomic_usable() -> None:
         with pytest.raises(QueueNotProvisionedError):
             tasks.make_group.enqueue("refused")
         Group.objects.create(name="after-refusal")
-    assert Group.objects.filter(name="after-refusal").exists()
+    assert Group.objects.filter(name="after-refusal").exists() is True
 
 
 def test_enqueue_with_absent_schema_raises_clear_error() -> None:

--- a/tests/core/test_orm_views.py
+++ b/tests/core/test_orm_views.py
@@ -17,7 +17,6 @@ from django_absurd.apps import provision_queues_after_migrate
 from django_absurd.exceptions import ViewNotProvisionedError
 from django_absurd.flush import flush_absurd_state
 from django_absurd.models import Queue
-from django_absurd.queues import get_absurd_client
 from tests import tasks, utils
 
 if t.TYPE_CHECKING:
@@ -98,19 +97,6 @@ def test_sync_command_rebuilds_views_with_new_queue() -> None:
 def test_self_heal_removed() -> None:
     assert not hasattr(admin_views, "ensure_view_current")
     assert not hasattr(admin_views, "VIEW_BUILD_CACHE")
-
-
-def test_worker_start_rebuilds_when_it_created_queue() -> None:
-    task_model: t.Any = build_admin_model(
-        next(s for s in ADMIN_ENTITY_SPECS if s.name == "tasks")
-    )
-    get_absurd_client().drop_queue("other")
-    utils.start_worker(queue="other")
-    tasks.add.using(queue_name="other").enqueue(7, 8)
-    utils.start_worker_until_done(
-        lambda: task_model.objects.filter(queue="other").exists(), queue="other"
-    )
-    assert task_model.objects.filter(queue="other").count() >= 1
 
 
 def test_dropped_queue_read_raises_typed_error() -> None:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -160,22 +160,6 @@ def test_sync_reports_an_absent_schema_with_no_queues_declared(
     )
 
 
-def test_migrate_tolerates_an_absent_schema_with_no_queues_declared(
-    settings: Settings,
-) -> None:
-    # `migrate --fake django_absurd` is forgiven whatever a project declares, and a
-    # project can legally declare no queues at all.
-    settings.TASKS = build_tasks_setting({})
-    buf = io.StringIO()
-    with utils.hide_absurd_schema():
-        call_command("migrate", "django_absurd", verbosity=1, stdout=buf)
-    assert buf.getvalue().endswith(
-        "Provisioning Absurd queues (default):\n"
-        "  Not provisioned: Absurd schema is not installed. "
-        "Run: manage.py migrate\n"
-    )
-
-
 def test_migrate_fails_when_only_the_catalog_table_is_missing(
     settings: Settings,
 ) -> None:
@@ -218,18 +202,24 @@ def test_migrate_fails_when_provisioning_errors(settings: Settings) -> None:
             )
 
 
-def test_migrate_says_so_when_it_cannot_provision(settings: Settings) -> None:
+@pytest.mark.parametrize("queues", [{}, {"alpha": {}}])
+def test_migrate_says_so_when_it_cannot_provision(
+    queues: dict[str, CreateQueueOptions], settings: Settings
+) -> None:
     # The receiver swallows so a faked or adopted migration still completes, but a
     # silent swallow leaves nothing provisioned and nothing said — and no runtime
-    # path repairs that any more.
-    settings.TASKS = build_tasks_setting({"alpha": {}})
+    # path repairs that any more. It reports the condition in its OWN words rather than
+    # the exception's: `migrate` printing "Run: manage.py migrate" is advice that loops
+    # forever, since the migration is already recorded. Declaring no queues is the same
+    # report — absence is classified for the whole operation, ahead of any queue loop.
+    settings.TASKS = build_tasks_setting(queues)
     buf = io.StringIO()
     with utils.hide_absurd_schema():
         call_command("migrate", "django_absurd", verbosity=1, stdout=buf)
     assert buf.getvalue().endswith(
         "Provisioning Absurd queues (default):\n"
-        "  Not provisioned: Absurd schema is not installed. "
-        "Run: manage.py migrate\n"
+        "  Not provisioned: the Absurd schema is absent; this migrate did not "
+        "install it.\n"
     )
 
 
@@ -488,6 +478,27 @@ def test_sync_prefixes_the_storage_mode_warning(
         "🗃️ Queue 'driftglyph': storage_mode cannot be changed "
         "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
     )
+
+
+def test_sync_check_warns_about_a_storage_mode_change_in_the_same_words(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    # Nothing else pins the warning on the --check side, and a warning never moves the
+    # exit code, so reworded-on-one-side-only is invisible without this.
+    settings.TASKS = build_tasks_setting({"driftcheck": {}})
+    call_command("absurd_sync_queues")  # create 'driftcheck' unpartitioned
+    settings.TASKS = build_tasks_setting(
+        {"driftcheck": {"storage_mode": "partitioned"}}
+    )
+    capsys.readouterr()
+    call_command("absurd_sync_queues", "--check")
+    planned = capsys.readouterr()
+    assert planned.err == (
+        "🗃️ Queue 'driftcheck': storage_mode cannot be changed "
+        "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
+    )
+    call_command("absurd_sync_queues")
+    assert capsys.readouterr().err == planned.err
 
 
 def test_get_absurd_database_resolves_from_backend(settings: Settings) -> None:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -134,6 +134,35 @@ def test_migrate_tolerates_an_absent_schema(settings: Settings) -> None:
         call_command("migrate", "django_absurd", verbosity=0)
 
 
+def test_migrate_says_so_when_it_cannot_provision(settings: Settings) -> None:
+    # The receiver swallows so a faked or adopted migration still completes, but a
+    # silent swallow leaves nothing provisioned and nothing said — and no runtime
+    # path repairs that any more.
+    settings.TASKS = build_tasks_setting({"alpha": {}})
+    buf = io.StringIO()
+    with utils.hide_absurd_schema():
+        call_command("migrate", "django_absurd", verbosity=1, stdout=buf)
+    assert buf.getvalue().endswith(
+        "Provisioning Absurd queues (default):\n"
+        "  Not provisioned: Absurd schema is not installed. "
+        "Run: manage.py migrate\n"
+    )
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_migrate_reports_a_queue_it_repaired(settings: Settings) -> None:
+    settings.TASKS = build_tasks_setting({"mended": {}})
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute(
+            "drop table absurd.t_mended, absurd.r_mended, absurd.c_mended, "
+            "absurd.e_mended, absurd.w_mended cascade"
+        )
+    buf = io.StringIO()
+    call_command("migrate", "django_absurd", verbosity=1, stdout=buf)
+    assert "  Repaired 'mended'" in buf.getvalue()
+
+
 def test_sync_creates_with_options_and_model_maps(settings: Settings) -> None:
     settings.TASKS = build_tasks_setting(
         {"x": {"storage_mode": "partitioned", "cleanup_ttl": "90 days"}}
@@ -261,6 +290,48 @@ def test_sync_leaves_a_provisioned_partitioned_queue_alone(
             )
         call_command("absurd_sync_queues")
     assert Queue.objects.get(queue_name="parts").storage_mode == "partitioned"
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_check_reports_pending_work_and_writes_nothing(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    settings.TASKS = build_tasks_setting({"pending": {}})
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_sync_queues", "--check")
+    assert str(excinfo.value) == (
+        "Queues are not in sync. Run: manage.py absurd_sync_queues"
+    )
+    assert capsys.readouterr().out == "🗃️ Would create: pending\n"
+    assert not Queue.objects.filter(queue_name="pending").exists()
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_check_is_quiet_once_everything_is_provisioned(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    settings.TASKS = build_tasks_setting({"settled": {}})
+    call_command("absurd_sync_queues")
+    capsys.readouterr()
+    call_command("absurd_sync_queues", "--check")
+    assert capsys.readouterr().out == "🗃️ No queues to sync.\n"
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_check_names_what_the_real_run_then_does(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    # The dry run reads the same three predicates the write path does; this is what
+    # keeps the two from drifting apart.
+    settings.TASKS = build_tasks_setting({"agree": {"cleanup_limit": 100}})
+    call_command("absurd_sync_queues")
+    settings.TASKS = build_tasks_setting({"agree": {"cleanup_limit": 250}})
+    capsys.readouterr()
+    with pytest.raises(CommandError):
+        call_command("absurd_sync_queues", "--check")
+    planned = capsys.readouterr().out
+    call_command("absurd_sync_queues")
+    assert planned == capsys.readouterr().out.replace("Reconciled:", "Would reconcile:")
 
 
 def test_non_destructive(settings: Settings) -> None:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -21,6 +21,7 @@ from django_absurd.queues import (
     get_absurd_client,
     resolve_absurd_database,
 )
+from django_absurd.test import AbsurdTestRuntime
 from tests import utils
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -174,7 +175,30 @@ def test_sync_recreates_the_tables_of_a_surviving_catalog_row(
     capsys.readouterr()
     call_command("absurd_sync_queues")
     assert table_exists("t_partial")
-    assert capsys.readouterr().out == "🗃️ No queues to sync.\n"
+    assert capsys.readouterr().out == "🗃️ Repaired: partial\n"
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_leaves_a_provisioned_partitioned_queue_alone(
+    dj_absurd: AbsurdTestRuntime, settings: Settings
+) -> None:
+    # Once the clock passes the pre-created window, rows land in the default partition,
+    # and ensure_partitions can no longer create the weeks they belong to — Postgres
+    # refuses. Provisioning must not reach that DDL for a queue already provisioned.
+    settings.TASKS = build_tasks_setting({"parts": {"storage_mode": "partitioned"}})
+    call_command("absurd_sync_queues")
+    with dj_absurd.freeze_time() as frozen_time:
+        frozen_time.shift(dt.timedelta(days=60))
+        with connection.cursor() as cur:
+            # The partition key is a uuidv7 range over task_id, not enqueue_at.
+            cur.execute(
+                "insert into absurd.t_parts "
+                "(task_id, task_name, params, state, enqueue_at) values "
+                "(absurd.uuidv7_floor(now() + interval '60 days'), 'late', "
+                "'{}'::jsonb, 'pending', now() + interval '60 days')"
+            )
+        call_command("absurd_sync_queues")
+    assert Queue.objects.get(queue_name="parts").storage_mode == "partitioned"
 
 
 def test_non_destructive(settings: Settings) -> None:
@@ -201,7 +225,7 @@ def test_sync_reports_no_queues_when_all_in_sync(
     assert len(records) == 1
     assert (
         records[0].getMessage()
-        == 'queues provisioned: created="freshsync" reconciled=""'
+        == 'queues provisioned: created="freshsync" reconciled="" repaired=""'
     )
     capsys.readouterr()
     call_command("absurd_sync_queues")  # freshsync exists, no drift -> empty result

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -156,6 +156,27 @@ def test_sync_reconciles_changed_option_idempotent(settings: Settings) -> None:
     assert Queue.objects.get(queue_name="q").cleanup_ttl == dt.timedelta(days=60)
 
 
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_recreates_the_tables_of_a_surviving_catalog_row(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    # The state QueueNotProvisionedError sends an operator here to fix: a manual drop
+    # or a partial restore leaves the catalog row behind, so a row-gated reconcile
+    # would report "no changes" and repair nothing.
+    settings.TASKS = build_tasks_setting({"partial": {}})
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute(
+            "drop table absurd.t_partial, absurd.r_partial, absurd.c_partial, "
+            "absurd.e_partial, absurd.w_partial cascade"
+        )
+    assert not table_exists("t_partial")
+    capsys.readouterr()
+    call_command("absurd_sync_queues")
+    assert table_exists("t_partial")
+    assert capsys.readouterr().out == "🗃️ No queues to sync.\n"
+
+
 def test_non_destructive(settings: Settings) -> None:
     settings.TASKS = build_tasks_setting({"keep": {}})
     call_command("absurd_sync_queues")

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -135,13 +135,25 @@ def test_list_shorthand(settings: Settings) -> None:
 
 
 def test_sync_reconciles_changed_option_idempotent(settings: Settings) -> None:
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 100}})
+    # Two mutable opts, so the drift scan is exercised both ways: cleanup_limit
+    # unchanged (loop continues) and cleanup_ttl changed via parse_interval.
+    settings.TASKS = build_tasks_setting(
+        {"q": {"cleanup_limit": 100, "cleanup_ttl": "30 days"}}
+    )
     call_command("absurd_sync_queues")
-    settings.TASKS = build_tasks_setting({"q": {"cleanup_limit": 250}})
+    settings.TASKS = build_tasks_setting(
+        {"q": {"cleanup_limit": 100, "cleanup_ttl": "60 days"}}
+    )
+    call_command("absurd_sync_queues")
+    assert Queue.objects.get(queue_name="q").cleanup_ttl == dt.timedelta(days=60)
+    settings.TASKS = build_tasks_setting(
+        {"q": {"cleanup_limit": 250, "cleanup_ttl": "60 days"}}
+    )
     call_command("absurd_sync_queues")
     assert Queue.objects.get(queue_name="q").cleanup_limit == 250
     call_command("absurd_sync_queues")
     assert Queue.objects.get(queue_name="q").cleanup_limit == 250
+    assert Queue.objects.get(queue_name="q").cleanup_ttl == dt.timedelta(days=60)
 
 
 def test_non_destructive(settings: Settings) -> None:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -338,7 +338,7 @@ def test_sync_check_reports_pending_work_and_writes_nothing(
         "Queues are not in sync. Run: manage.py absurd_sync_queues"
     )
     assert capsys.readouterr().out == "🗃️ Would create: pending\n"
-    assert not Queue.objects.filter(queue_name="pending").exists()
+    assert Queue.objects.filter(queue_name="pending").exists() is False
 
 
 @pytest.mark.usefixtures("_isolate_queues")

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -43,6 +43,22 @@ def table_exists(name: str) -> bool:
         return bool(row[0]) if row else False
 
 
+def list_absent_queue_tables(queue_name: str) -> list[str]:
+    # Spelled out rather than imported from django_absurd.queues: a repair that puts
+    # back only the table the prefix tuple happens to start with has to fail here.
+    return [
+        name
+        for name in (
+            f"t_{queue_name}",
+            f"r_{queue_name}",
+            f"c_{queue_name}",
+            f"e_{queue_name}",
+            f"w_{queue_name}",
+        )
+        if not table_exists(name)
+    ]
+
+
 def test_get_absurd_client_uses_psycopg3_connection() -> None:
     get_absurd_client()
     assert isinstance(connection.connection, psycopg.Connection)
@@ -135,7 +151,9 @@ def test_list_shorthand(settings: Settings) -> None:
     assert Queue.objects.filter(queue_name="alpha").exists()
 
 
-def test_sync_reconciles_changed_option_idempotent(settings: Settings) -> None:
+def test_sync_reconciles_changed_option_idempotent(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
     # Two mutable opts, so the drift scan is exercised both ways: cleanup_limit
     # unchanged (loop continues) and cleanup_ttl changed via parse_interval.
     settings.TASKS = build_tasks_setting(
@@ -145,14 +163,22 @@ def test_sync_reconciles_changed_option_idempotent(settings: Settings) -> None:
     settings.TASKS = build_tasks_setting(
         {"q": {"cleanup_limit": 100, "cleanup_ttl": "60 days"}}
     )
+    capsys.readouterr()
     call_command("absurd_sync_queues")
+    assert capsys.readouterr().out == "🗃️ Reconciled: q\n"
     assert Queue.objects.get(queue_name="q").cleanup_ttl == dt.timedelta(days=60)
     settings.TASKS = build_tasks_setting(
         {"q": {"cleanup_limit": 250, "cleanup_ttl": "60 days"}}
     )
+    capsys.readouterr()
     call_command("absurd_sync_queues")
+    assert capsys.readouterr().out == "🗃️ Reconciled: q\n"
     assert Queue.objects.get(queue_name="q").cleanup_limit == 250
+    capsys.readouterr()
     call_command("absurd_sync_queues")
+    # The report is the only witness of the no-drift direction: set_queue_policy run
+    # unconditionally would leave every column below byte-identical anyway.
+    assert capsys.readouterr().out == "🗃️ No queues to sync.\n"
     assert Queue.objects.get(queue_name="q").cleanup_limit == 250
     assert Queue.objects.get(queue_name="q").cleanup_ttl == dt.timedelta(days=60)
 
@@ -171,11 +197,47 @@ def test_sync_recreates_the_tables_of_a_surviving_catalog_row(
             "drop table absurd.t_partial, absurd.r_partial, absurd.c_partial, "
             "absurd.e_partial, absurd.w_partial cascade"
         )
-    assert not table_exists("t_partial")
+    assert list_absent_queue_tables("partial") == [
+        "t_partial",
+        "r_partial",
+        "c_partial",
+        "e_partial",
+        "w_partial",
+    ]
     capsys.readouterr()
     call_command("absurd_sync_queues")
-    assert table_exists("t_partial")
     assert capsys.readouterr().out == "🗃️ Repaired: partial\n"
+    assert list_absent_queue_tables("partial") == []
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_recreates_the_tables_of_a_surviving_partitioned_catalog_row(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    # Unpartitioned is the one mode where handing create_queue the existing
+    # storage_mode decides nothing, so the repair is only really proven here: dropping
+    # the mode would put t_ back as a plain table and the queue would silently stop
+    # being partitioned.
+    settings.TASKS = build_tasks_setting({"partsurv": {"storage_mode": "partitioned"}})
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute(
+            "drop table absurd.t_partsurv, absurd.r_partsurv, absurd.c_partsurv, "
+            "absurd.e_partsurv, absurd.w_partsurv cascade"
+        )
+    # A partitioned queue's sixth table, which find_missing_queue_tables deliberately
+    # never probes; leaving it keeps the repair driven by the five that are probed.
+    assert table_exists("i_partsurv")
+    capsys.readouterr()
+    call_command("absurd_sync_queues")
+    assert capsys.readouterr().out == "🗃️ Repaired: partsurv\n"
+    assert list_absent_queue_tables("partsurv") == []
+    assert Queue.objects.get(queue_name="partsurv").storage_mode == "partitioned"
+    with connection.cursor() as cur:
+        cur.execute(
+            "select relkind from pg_class where oid = 'absurd.t_partsurv'::regclass"
+        )
+        assert cur.fetchone() == ("p",)
 
 
 @pytest.mark.usefixtures("_isolate_queues")

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -128,10 +128,45 @@ def test_reconcile_does_not_relabel_an_unrelated_missing_column(
 def test_migrate_tolerates_an_absent_schema(settings: Settings) -> None:
     # The migration is already recorded as applied, so `migrate` replays no DDL
     # but still fires `post_migrate` — which must swallow SchemaNotInstalledError
-    # from provisioning rather than blowing up `migrate` itself.
+    # from provisioning rather than blowing up `migrate` itself. This is the
+    # adoption path: `migrate --fake django_absurd` against a schema installed out
+    # of band, and the only failure `migrate` forgives.
     settings.TASKS = build_tasks_setting({"alpha": {}})
     with utils.hide_absurd_schema():
         call_command("migrate", "django_absurd", verbosity=0)
+
+
+def test_sync_check_fails_when_it_cannot_look(settings: Settings) -> None:
+    # --check must never answer "in sync" when it could not read the catalog at all.
+    settings.TASKS = build_tasks_setting({"alpha": {}})
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
+        call_command("absurd_sync_queues", "--check")
+    assert str(excinfo.value) == (
+        "Absurd schema is not installed. Run: manage.py migrate"
+    )
+
+
+def test_migrate_fails_when_provisioning_errors(settings: Settings) -> None:
+    # Anything other than an absent schema means this deploy provisioned nothing and
+    # nothing at runtime will fix it, so `migrate` must not report success. Driven the
+    # way it could happen for real: the catalog's own column altered out from under
+    # the receiver, which classifies as a plain UndefinedColumn rather than as
+    # schema-absent.
+    settings.TASKS = build_tasks_setting({"alpha": {}})
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute(
+            "alter table absurd.queues rename column queue_name to queue_name_gone"
+        )
+    try:
+        with pytest.raises(ProgrammingError) as excinfo:
+            call_command("migrate", "django_absurd", verbosity=0)
+        assert isinstance(excinfo.value.__cause__, psycopg.errors.UndefinedColumn)
+    finally:
+        with connection.cursor() as cur:
+            cur.execute(
+                "alter table absurd.queues rename column queue_name_gone to queue_name"
+            )
 
 
 def test_migrate_says_so_when_it_cannot_provision(settings: Settings) -> None:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -146,6 +146,55 @@ def test_sync_check_fails_when_it_cannot_look(settings: Settings) -> None:
     )
 
 
+@pytest.mark.parametrize("flags", [(), ("--check",)])
+def test_sync_reports_an_absent_schema_with_no_queues_declared(
+    flags: tuple[str, ...], settings: Settings
+) -> None:
+    # An empty QUEUES enters no per-queue loop, so absence has to be classified for the
+    # whole operation — the admin views half reads absurd.queues too.
+    settings.TASKS = build_tasks_setting({})
+    with utils.hide_absurd_schema(), pytest.raises(CommandError) as excinfo:
+        call_command("absurd_sync_queues", *flags)
+    assert str(excinfo.value) == (
+        "Absurd schema is not installed. Run: manage.py migrate"
+    )
+
+
+def test_migrate_tolerates_an_absent_schema_with_no_queues_declared(
+    settings: Settings,
+) -> None:
+    # `migrate --fake django_absurd` is forgiven whatever a project declares, and a
+    # project can legally declare no queues at all.
+    settings.TASKS = build_tasks_setting({})
+    buf = io.StringIO()
+    with utils.hide_absurd_schema():
+        call_command("migrate", "django_absurd", verbosity=1, stdout=buf)
+    assert buf.getvalue().endswith(
+        "Provisioning Absurd queues (default):\n"
+        "  Not provisioned: Absurd schema is not installed. "
+        "Run: manage.py migrate\n"
+    )
+
+
+def test_migrate_fails_when_only_the_catalog_table_is_missing(
+    settings: Settings,
+) -> None:
+    # Damage, not absence: the schema is there, so migrate replays no DDL and advising
+    # it would loop forever — and provisioning nothing must not exit 0.
+    settings.TASKS = build_tasks_setting({"orphan": {}})
+    with connection.cursor() as cur:
+        cur.execute("alter table absurd.queues rename to queues_orphaned")
+    try:
+        with pytest.raises(ProgrammingError) as excinfo:
+            call_command("migrate", "django_absurd", verbosity=0)
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, psycopg.errors.UndefinedTable)
+        assert cause.diag.message_primary == 'relation "absurd.queues" does not exist'
+    finally:
+        with connection.cursor() as cur:
+            cur.execute("alter table absurd.queues_orphaned rename to queues")
+
+
 def test_migrate_fails_when_provisioning_errors(settings: Settings) -> None:
     # Anything other than an absent schema means this deploy provisioned nothing and
     # nothing at runtime will fix it, so `migrate` must not report success. Driven the
@@ -289,9 +338,9 @@ def test_sync_recreates_the_tables_of_a_surviving_partitioned_catalog_row(
             "drop table absurd.t_partsurv, absurd.r_partsurv, absurd.c_partsurv, "
             "absurd.e_partsurv, absurd.w_partsurv cascade"
         )
-    # A partitioned queue's sixth table, which find_missing_queue_tables deliberately
-    # never probes; leaving it keeps the repair driven by the five that are probed.
-    assert table_exists("i_partsurv")
+    # The sixth table a partitioned queue owns survives the drop here, so this repair is
+    # driven by the five; dropping it on its own is the test below.
+    assert table_exists("i_partsurv") is True
     capsys.readouterr()
     call_command("absurd_sync_queues")
     assert capsys.readouterr().out == "🗃️ Repaired: partsurv\n"
@@ -302,6 +351,29 @@ def test_sync_recreates_the_tables_of_a_surviving_partitioned_catalog_row(
             "select relkind from pg_class where oid = 'absurd.t_partsurv'::regclass"
         )
         assert cur.fetchone() == ("p",)
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_sync_repairs_a_partitioned_queues_idempotency_table_on_its_own(
+    capsys: pytest.CaptureFixture[str], settings: Settings
+) -> None:
+    # A keyed enqueue reserves i_<queue> before it touches any other table, so a probe
+    # blind to it leaves this queue refusing every keyed enqueue with nothing to repair.
+    settings.TASKS = build_tasks_setting({"partidem": {"storage_mode": "partitioned"}})
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute("drop table absurd.i_partidem cascade")
+    capsys.readouterr()
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_sync_queues", "--check")
+    assert str(excinfo.value) == (
+        "Queues are not in sync. Run: manage.py absurd_sync_queues"
+    )
+    assert capsys.readouterr().out == "🗃️ Would repair: partidem\n"
+    call_command("absurd_sync_queues")
+    assert capsys.readouterr().out == "🗃️ Repaired: partidem\n"
+    assert table_exists("i_partidem") is True
+    assert Queue.objects.get(queue_name="partidem").storage_mode == "partitioned"
 
 
 @pytest.mark.usefixtures("_isolate_queues")
@@ -431,15 +503,22 @@ def test_sync_command_takes_no_database_flag(settings: Settings) -> None:
         call_command("absurd_sync_queues", database="sqlite")
 
 
-def test_sync_command_reports_nothing_when_no_absurd_backend(
-    capsys: pytest.CaptureFixture[str],
+@pytest.mark.parametrize("flags", [(), ("--check",)])
+def test_sync_command_fails_when_no_absurd_backend(
+    flags: tuple[str, ...],
     settings: Settings,
 ) -> None:
+    # --check is a release gate whose whole job is to assert, so a settings regression
+    # that leaves no Absurd backend at all must not pass as "in sync".
     settings.TASKS = {
         "default": {"BACKEND": "django.tasks.backends.dummy.DummyBackend"}
     }
-    call_command("absurd_sync_queues")
-    assert "No Absurd task backends configured." in capsys.readouterr().out
+    with pytest.raises(CommandError) as excinfo:
+        call_command("absurd_sync_queues", *flags)
+    assert str(excinfo.value) == (
+        "No Absurd backend configured. Add a "
+        "django_absurd.backends.AbsurdBackend entry to TASKS."
+    )
 
 
 def test_sync_command_waits_for_a_concurrent_provisioner(settings: Settings) -> None:

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -257,10 +257,10 @@ def test_beat_started_logs_schedule_count_and_cleanup(
 def test_beat_names_the_fix_when_a_target_queue_is_unprovisioned(
     caplog: pytest.LogCaptureFixture,
     dj_absurd: AbsurdTestRuntime,
-    settings: pytest_django.fixtures.Settings,
+    settings: Settings,
 ) -> None:
-    # Nothing provisions at runtime, and the loop never revisits the slot it just
-    # dropped, so this line is an operator's only notice — it has to say what to run.
+    # Nothing provisions at runtime, and the loop never revisits a firing it could not
+    # enqueue, so this line is an operator's only notice — it has to say what to run.
     settings.TASKS = make_tasks_setting(
         {"reporting": {"task": "tests.tasks.create_payload", "cron": "*/1 * * * *"}},
     )

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -254,6 +254,43 @@ def test_beat_started_logs_schedule_count_and_cleanup(
     assert started[0].getMessage() == 'beat started: schedules=1 cleanup="17 * * * *"'
 
 
+def test_beat_names_the_fix_when_a_target_queue_is_unprovisioned(
+    caplog: pytest.LogCaptureFixture,
+    dj_absurd: AbsurdTestRuntime,
+    settings: pytest_django.fixtures.Settings,
+) -> None:
+    # Nothing provisions at runtime, and the loop never revisits the slot it just
+    # dropped, so this line is an operator's only notice — it has to say what to run.
+    settings.TASKS = make_tasks_setting(
+        {"reporting": {"task": "tests.tasks.create_payload", "cron": "*/1 * * * *"}},
+    )
+    backend = get_absurd_backends()["default"]
+    with (
+        dj_absurd.freeze_time(BEAT_EPOCH) as frozen_time,
+        caplog.at_level(logging.INFO, logger="django_absurd"),
+    ):
+        run_beat_until(
+            frozen_time, backend, dt.datetime(2026, 1, 1, 0, 1, 30, tzinfo=dt.UTC)
+        )
+
+    failed = [
+        r
+        for r in caplog.records
+        if r.name == "django_absurd.scheduler"
+        and r.getMessage().startswith("schedule enqueue failed")
+    ]
+    assert len(failed) == 1
+    assert failed[0].getMessage() == (
+        'schedule enqueue failed: name="reporting" due="2026-01-01T00:01:00Z"'
+    )
+    assert failed[0].exc_text is not None
+    assert failed[0].exc_text.endswith(
+        "django_absurd.exceptions.QueueNotProvisionedError: Queue 'default' is "
+        "declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+
+
 def test_beat_isolates_failing_schedule(
     caplog: pytest.LogCaptureFixture,
     dj_absurd: AbsurdTestRuntime,
@@ -283,14 +320,18 @@ def test_beat_isolates_failing_schedule(
         assert Payload.objects.count() == expected_good
 
     records = [r for r in caplog.records if r.name == "django_absurd.scheduler"]
-    failed = [r for r in records if r.getMessage().startswith("schedule failed")]
+    failed = [
+        r for r in records if r.getMessage().startswith("schedule enqueue failed")
+    ]
     enqueued = [r for r in records if r.getMessage().startswith("schedule enqueued")]
     assert len(failed) == 1
-    assert failed[0].getMessage() == 'schedule failed: name="bad"'
+    assert failed[0].getMessage() == (
+        'schedule enqueue failed: name="bad" due="2026-01-01T00:01:00Z"'
+    )
     assert len(enqueued) == 1
     assert (
         enqueued[0].getMessage()
-        == 'schedule enqueued: name="good" slot="2026-01-01T00:01:00Z"'
+        == 'schedule enqueued: name="good" due="2026-01-01T00:01:00Z"'
     )
 
 

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -18,6 +18,7 @@ from pytest_django import Settings
 from django_absurd.backends import AbsurdBackend, get_absurd_backends
 from django_absurd.exceptions import (
     DjangoAbsurdError,
+    MultipleBackendsConfiguredError,
     QueueNotDeclaredError,
     QueueNotProvisionedError,
     SchemaNotInstalledError,
@@ -245,6 +246,7 @@ def test_worker_multiple_backends_errors(settings: Settings) -> None:
         "django-absurd supports one Absurd backend per project; "
         "configure exactly one AbsurdBackend in TASKS."
     )
+    assert isinstance(exc.value.__cause__, MultipleBackendsConfiguredError)
 
 
 def test_command_parses_all_flags_with_defaults() -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -181,7 +181,8 @@ def test_queue_defaults_to_default(
             "QUEUES": ["default"],
         }
     }
-    tasks.make_group.enqueue("dflt")  # auto-creates the default queue
+    utils.provision_declared_queues()
+    tasks.make_group.enqueue("dflt")
     utils.start_worker_until_done(  # no --queue -> "default"
         lambda: Group.objects.filter(name="dflt").exists()
     )
@@ -217,6 +218,7 @@ def test_worker_uses_single_backend_at_nondefault_alias(
             "QUEUES": ["default"],
         }
     }
+    utils.provision_declared_queues()
     utils.start_worker()
     assert "Started worker on queue 'default'." in capsys.readouterr().out
 

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import datetime as dt
 import logging
 import os
 import signal
@@ -68,16 +67,6 @@ def test_worker_client_rejects_non_psycopg3(settings: Settings) -> None:
     }
     with pytest.raises(CommandError, match="psycopg"):
         call_command("absurd_worker", queue="default")
-
-
-def test_worker_client_opens_without_provisioning_check() -> None:
-    # No absurd_sync_queues; 'default' unprovisioned (schema present).
-    # aworker_client must NOT raise — the provisioned-or-die check is gone.
-    async def _enter() -> list[str]:
-        async with aworker_client(backend(), "default") as client:
-            return await client.list_queues()
-
-    assert "default" not in asyncio.run(_enter())  # unprovisioned, yet no error
 
 
 def test_worker_client_absent_schema_errors() -> None:
@@ -281,150 +270,27 @@ def test_command_runs_task_end_to_end(dj_absurd: AbsurdTestRuntime) -> None:
     assert snap.state == "completed"
 
 
-def test_worker_start_provisions_all_declared_queues(
+def test_worker_refuses_an_unprovisioned_queue(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # full provision on start: every declared queue, not just the served one
-    utils.start_worker(queue="default")
-    created_line, started_line, stop_requested_line, stopped_line = (
-        capsys.readouterr().out.splitlines()
+    # _isolate_queues dropped the catalog and nothing at boot puts it back, so the
+    # worker must refuse before it announces itself rather than reach the claim loop.
+    with connection.cursor() as cur:
+        cur.execute(
+            "drop view if exists absurd.tasks_view, absurd.runs_view, "
+            "absurd.checkpoints_view, absurd.waits_view, absurd.events_view cascade"
+        )
+    with pytest.raises(CommandError) as exc:
+        utils.start_worker(queue="default")
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
     )
-    assert set(created_line.removeprefix("Created: ").split(", ")) == {
-        "default",
-        "other",
-        "reports",
-    }
-    assert started_line == "🐘 Started worker on queue 'default'."
-    assert stop_requested_line == (
-        "🐘 Stop requested on queue 'default'; finishing in-flight tasks."
-    )
-    assert stopped_line == "🐘 Stopped worker on queue 'default'."
-    assert Queue.objects.filter(queue_name="default").exists()
-    assert Queue.objects.filter(queue_name="other").exists()
-
-
-def test_worker_command_reconciles_changed_mutable_option(
-    capsys: pytest.CaptureFixture[str], settings: Settings
-) -> None:
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 100}}},
-        }
-    }
-    call_command("absurd_sync_queues")
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {"QUEUES": {"default": {"cleanup_limit": 250}}},
-        }
-    }
-    capsys.readouterr()  # drop sync output
-    utils.start_worker(queue="default")
-    out = capsys.readouterr().out
-    assert out == (
-        "Reconciled: default\n"
-        "🐘 Started worker on queue 'default'.\n"
-        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
-        "🐘 Stopped worker on queue 'default'.\n"
-    )
-    assert Queue.objects.get(queue_name="default").cleanup_limit == 250  # DB proof
-
-
-def test_worker_command_reconciles_changed_interval_option(
-    capsys: pytest.CaptureFixture[str], settings: Settings
-) -> None:
-    # Two mutable opts: cleanup_limit unchanged (loop continues), cleanup_ttl changed
-    # (interval drift via parse_interval).
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {
-                "QUEUES": {"default": {"cleanup_limit": 100, "cleanup_ttl": "30 days"}}
-            },
-        }
-    }
-    call_command("absurd_sync_queues")
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {
-                "QUEUES": {"default": {"cleanup_limit": 100, "cleanup_ttl": "60 days"}}
-            },
-        }
-    }
-    capsys.readouterr()
-    utils.start_worker(queue="default")
-    out = capsys.readouterr().out
-    assert out == (
-        "Reconciled: default\n"
-        "🐘 Started worker on queue 'default'.\n"
-        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
-        "🐘 Stopped worker on queue 'default'.\n"
-    )
-    assert Queue.objects.get(queue_name="default").cleanup_ttl == dt.timedelta(days=60)
-
-
-def test_worker_command_no_reconcile_when_unchanged(
-    capsys: pytest.CaptureFixture[str], settings: Settings
-) -> None:
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {"QUEUES": {"default": {"cleanup_ttl": "30 days"}}},
-        }
-    }
-    call_command("absurd_sync_queues")
-    before = Queue.objects.get(queue_name="default").cleanup_ttl
-    capsys.readouterr()
-    utils.start_worker(queue="default")
-    out = capsys.readouterr().out
-    # Drift-gated no-op: no Created/Reconciled, no "No queues to sync.", just
-    # the start and stop lines.
-    assert out == (
-        "🐘 Started worker on queue 'default'.\n"
-        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
-        "🐘 Stopped worker on queue 'default'.\n"
-    )
-    assert Queue.objects.get(queue_name="default").cleanup_ttl == before
-
-
-def test_worker_command_warns_on_storage_mode_drift(
-    capsys: pytest.CaptureFixture[str], settings: Settings
-) -> None:
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {"QUEUES": {"default": {}}},
-        }
-    }
-    call_command("absurd_sync_queues")  # create 'default' unpartitioned
-    settings.TASKS = {
-        "default": {
-            "BACKEND": "django_absurd.backends.AbsurdBackend",
-            "OPTIONS": {"QUEUES": {"default": {"storage_mode": "partitioned"}}},
-        }
-    }
-    capsys.readouterr()
-    utils.start_worker(queue="default")
-    cap = capsys.readouterr()
-    assert cap.out == (
-        "🐘 Started worker on queue 'default'.\n"
-        "🐘 Stop requested on queue 'default'; finishing in-flight tasks.\n"
-        "🐘 Stopped worker on queue 'default'.\n"
-    )
-    # The command's own warning shares stderr with the console handler the worker
-    # attaches, whose StreamHandler defaults to stderr as Django's own console
-    # handler does.
-    assert cap.err == (
-        "queues provisioned: no changes\n"
-        "Queue 'default': storage_mode cannot be changed "
-        "(existing: 'unpartitioned', declared: 'partitioned'); skipping.\n"
-        'worker started: alias="default" queue="default" database="default"'
-        " concurrency=1\n"
-        "worker stop requested: finishing in-flight tasks\n"
-        'worker stopped: alias="default" queue="default" database="default"\n'
-    )
+    assert capsys.readouterr().out == ""
+    assert not Queue.objects.filter(queue_name="default").exists()
+    with connection.cursor() as cur:
+        cur.execute("select count(*) from pg_views where schemaname = 'absurd'")
+        assert cur.fetchone() == (0,)
 
 
 def test_worker_command_schema_absent_errors_migrate() -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -293,6 +293,47 @@ def test_worker_refuses_an_unprovisioned_queue(
         assert cur.fetchone() == (0,)
 
 
+@pytest.mark.parametrize(
+    ("entrypoint", "expected_error", "expected_out"),
+    [
+        ("command", CommandError, "🐘 Started worker on queue 'default'.\n"),
+        ("function", QueueNotProvisionedError, ""),
+    ],
+)
+def test_a_half_provisioned_queue_is_refused(
+    capsys: pytest.CaptureFixture[str],
+    entrypoint: str,
+    expected_error: type[Exception],
+    expected_out: str,
+) -> None:
+    # The catalog row outlives its tables, so the boot guard reads the queue as
+    # provisioned and only the claim can tell. The live worker therefore announces
+    # itself first — and then still has to name absurd_sync_queues, not raise a raw
+    # UndefinedTable that restarts it forever under `restart: on-failure`.
+    call_command("absurd_sync_queues")
+    capsys.readouterr()  # drop the sync report; the worker's own output is the subject
+    with connection.cursor() as cur:
+        cur.execute(
+            "drop table absurd.t_default, absurd.r_default, absurd.c_default, "
+            "absurd.e_default, absurd.w_default cascade"
+        )
+
+    def consume_the_queue() -> None:
+        if entrypoint == "command":
+            call_command("absurd_worker", queue="default")
+        else:
+            drain_queue("default")
+
+    with pytest.raises(expected_error) as exc:
+        consume_the_queue()
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+    assert capsys.readouterr().out == expected_out
+    assert Queue.objects.filter(queue_name="default").exists()
+
+
 def test_worker_command_schema_absent_errors_migrate() -> None:
     # The provision_backend error translation errors before ever
     # reaching the blocking worker loop. Driven through the live-worker helper: a
@@ -388,8 +429,7 @@ def test_undeclared_queue_error_is_also_a_django_absurd_error() -> None:
 def test_drain_queue_on_an_unprovisioned_queue_errors_sync_queues() -> None:
     # Declared but never provisioned (no absurd_sync_queues, and _isolate_queues
     # dropped every queue's tables): drain_queue does not provision, so the missing
-    # table surfaces as the curated error naming the command that fixes it. No
-    # enqueue() here — that one auto-creates the queue it writes to.
+    # table surfaces as the curated error naming the command that fixes it.
     with pytest.raises(QueueNotProvisionedError) as exc:
         drain_queue("default")
 
@@ -399,16 +439,25 @@ def test_drain_queue_on_an_unprovisioned_queue_errors_sync_queues() -> None:
     )
 
 
-def test_drain_queue_does_not_relabel_an_unrelated_missing_relation() -> None:
+@pytest.mark.parametrize("entrypoint", ["command", "function"])
+def test_an_unrelated_missing_relation_is_not_relabelled(entrypoint: str) -> None:
     """A missing relation that is NOT one of this queue's own Absurd tables surfaces as
-    itself. Relabeling it "run absurd_sync_queues" would send the reader to the wrong
-    door, and dropping the cause would hide which relation is actually missing.
+    itself, on the live worker and the in-process drain alike. Relabeling it "run
+    absurd_sync_queues" would send the reader to the wrong door, and dropping the cause
+    would hide which relation is actually missing.
 
     Driven the way it happens in production: an audit trigger on a queue table whose
     target relation is gone. A plpgsql body carries no dependency on the tables it
     names, so nothing blocks the drop and the failure lands when the trigger next fires
-    — from inside the claim, i.e. exactly where the curated error used to swallow it.
+    — from inside the claim, which is where both entry points translate.
     """
+
+    def consume_the_queue() -> None:
+        if entrypoint == "command":
+            call_command("absurd_worker", queue="default")
+        else:
+            drain_queue("default")
+
     call_command("absurd_sync_queues")
     tasks.add.enqueue(2, 3)
     try:
@@ -426,7 +475,7 @@ def test_drain_queue_does_not_relabel_an_unrelated_missing_relation() -> None:
             )
 
         with pytest.raises(psycopg.errors.UndefinedTable) as undefined:
-            drain_queue("default")
+            consume_the_queue()
 
         assert (
             undefined.value.diag.message_primary

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -294,22 +294,22 @@ def test_worker_refuses_an_unprovisioned_queue(
 
 
 @pytest.mark.parametrize(
-    ("entrypoint", "expected_error", "expected_out"),
+    ("entrypoint", "expected_error"),
     [
-        ("command", CommandError, "🐘 Started worker on queue 'default'.\n"),
-        ("function", QueueNotProvisionedError, ""),
+        ("command", CommandError),
+        ("function", QueueNotProvisionedError),
     ],
 )
 def test_a_half_provisioned_queue_is_refused(
+    caplog: pytest.LogCaptureFixture,
     capsys: pytest.CaptureFixture[str],
     entrypoint: str,
     expected_error: type[Exception],
-    expected_out: str,
 ) -> None:
-    # The catalog row outlives its tables, so the boot guard reads the queue as
-    # provisioned and only the claim can tell. The live worker therefore announces
-    # itself first — and then still has to name absurd_sync_queues, not raise a raw
-    # UndefinedTable that restarts it forever under `restart: on-failure`.
+    # The catalog row outlives its tables, so the catalog guard reads the queue as
+    # provisioned and the table probe beside it is what refuses. Nothing may announce a
+    # start first: under `restart: on-failure` that line is all an operator sees, and it
+    # would be describing a worker that never claimed anything.
     call_command("absurd_sync_queues")
     capsys.readouterr()  # drop the sync report; the worker's own output is the subject
     with connection.cursor() as cur:
@@ -324,14 +324,90 @@ def test_a_half_provisioned_queue_is_refused(
         else:
             drain_queue("default")
 
-    with pytest.raises(expected_error) as exc:
+    with (
+        caplog.at_level(logging.INFO, logger="django_absurd"),
+        pytest.raises(expected_error) as exc,
+    ):
         consume_the_queue()
     assert str(exc.value) == (
         "Queue 'default' is declared but its Absurd table is not provisioned. "
         "Run: manage.py absurd_sync_queues"
     )
-    assert capsys.readouterr().out == expected_out
+    assert capsys.readouterr().out == ""
+    assert [
+        r.getMessage() for r in caplog.records if r.name == "django_absurd.worker"
+    ] == []
     assert Queue.objects.filter(queue_name="default").exists() is True
+
+
+def test_worker_refuses_a_partitioned_queue_missing_its_idempotency_table(
+    settings: Settings,
+) -> None:
+    # i_<queue> is one of a partitioned queue's own tables, so the boot probe has to
+    # expect it exactly as the repair probe does — a claim alone would never notice.
+    settings.TASKS = utils.make_tasks_settings(
+        queues={**utils.DECLARED_QUEUES, "parts": {"storage_mode": "partitioned"}}
+    )
+    call_command("absurd_sync_queues")
+    with connection.cursor() as cur:
+        cur.execute("drop table absurd.i_parts cascade")
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        drain_queue("parts")
+    assert str(exc.value) == (
+        "Queue 'parts' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+
+
+def test_worker_translates_a_queue_dropped_under_a_running_worker(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # What the boot probe cannot answer, and the only event left for run_worker's own
+    # translation: the tables were there at boot and gone by the next claim. This worker
+    # really did start, so it says so, and the failure still names the repair command.
+    call_command("absurd_sync_queues")
+    capsys.readouterr()  # drop the sync report; the worker's own output is the subject
+
+    def drop_the_queue_tables() -> bool:
+        # IF EXISTS because the predicate is polled: the drop lands once and every later
+        # call has to be a harmless no-op, not an exception on a watcher thread.
+        with connection.cursor() as cur:
+            cur.execute(
+                "drop table if exists absurd.t_default, absurd.r_default, "
+                "absurd.c_default, absurd.e_default, absurd.w_default cascade"
+            )
+        return False
+
+    with pytest.raises(CommandError) as exc:
+        utils.start_worker_until_done(drop_the_queue_tables, queue="default")
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
+    assert capsys.readouterr().out == "🐘 Started worker on queue 'default'.\n"
+
+
+@task(queue_name="default")
+def drop_its_own_queue_tables() -> None:
+    """Take the queue's tables away from under the drain that is running this."""
+    with connection.cursor() as cur:
+        cur.execute(
+            "drop table if exists absurd.t_default, absurd.r_default, "
+            "absurd.c_default, absurd.e_default, absurd.w_default cascade"
+        )
+
+
+def test_drain_translates_a_queue_dropped_under_a_running_drain() -> None:
+    # The drain's half of the same backstop: its claim found the tables and its
+    # bookkeeping no longer does, which no boot probe could have known.
+    call_command("absurd_sync_queues")
+    drop_its_own_queue_tables.enqueue()
+    with pytest.raises(QueueNotProvisionedError) as exc:
+        drain_queue("default")
+    assert str(exc.value) == (
+        "Queue 'default' is declared but its Absurd table is not provisioned. "
+        "Run: manage.py absurd_sync_queues"
+    )
 
 
 def test_worker_command_schema_absent_errors_migrate() -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -287,7 +287,7 @@ def test_worker_refuses_an_unprovisioned_queue(
         "Run: manage.py absurd_sync_queues"
     )
     assert capsys.readouterr().out == ""
-    assert not Queue.objects.filter(queue_name="default").exists()
+    assert Queue.objects.filter(queue_name="default").exists() is False
     with connection.cursor() as cur:
         cur.execute("select count(*) from pg_views where schemaname = 'absurd'")
         assert cur.fetchone() == (0,)
@@ -331,7 +331,7 @@ def test_a_half_provisioned_queue_is_refused(
         "Run: manage.py absurd_sync_queues"
     )
     assert capsys.readouterr().out == expected_out
-    assert Queue.objects.filter(queue_name="default").exists()
+    assert Queue.objects.filter(queue_name="default").exists() is True
 
 
 def test_worker_command_schema_absent_errors_migrate() -> None:

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -173,7 +173,7 @@ def test_task_outside_tasks_py_runs(dj_absurd: AbsurdTestRuntime) -> None:
 
 
 def test_queue_defaults_to_default(
-    capsys: pytest.CaptureFixture[str], settings: Settings
+    capsys: pytest.CaptureFixture[str], dj_absurd: AbsurdTestRuntime, settings: Settings
 ) -> None:
     settings.TASKS = {
         "default": {
@@ -181,7 +181,7 @@ def test_queue_defaults_to_default(
             "QUEUES": ["default"],
         }
     }
-    utils.provision_declared_queues()
+    dj_absurd.sync_queues()  # _isolate_queues dropped the catalog on the way in
     tasks.make_group.enqueue("dflt")
     utils.start_worker_until_done(  # no --queue -> "default"
         lambda: Group.objects.filter(name="dflt").exists()
@@ -210,7 +210,7 @@ def test_worker_rejects_alias_flag(settings: Settings) -> None:
 
 
 def test_worker_uses_single_backend_at_nondefault_alias(
-    capsys: pytest.CaptureFixture[str], settings: Settings
+    capsys: pytest.CaptureFixture[str], dj_absurd: AbsurdTestRuntime, settings: Settings
 ) -> None:
     settings.TASKS = {
         "myabsurd": {
@@ -218,7 +218,7 @@ def test_worker_uses_single_backend_at_nondefault_alias(
             "QUEUES": ["default"],
         }
     }
-    utils.provision_declared_queues()
+    dj_absurd.sync_queues()  # _isolate_queues dropped the catalog on the way in
     utils.start_worker()
     assert "Started worker on queue 'default'." in capsys.readouterr().out
 

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -55,7 +55,7 @@ def test_db_for_read_write_route_django_absurd() -> None:
 
 @pytest.mark.django_db(databases=["absurd", "default"], transaction=True)
 def test_migrate_provisions_only_the_database_it_migrated(
-    settings: "pytest_django.fixtures.Settings",
+    settings: Settings,
 ) -> None:
     # post_migrate is per-database, so migrating "default" must leave the Absurd
     # alias alone; only migrating the alias itself provisions it.

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -53,6 +53,24 @@ def test_db_for_read_write_route_django_absurd() -> None:
     assert router.db_for_write(Queue) == "absurd"
 
 
+@pytest.mark.django_db(databases=["absurd", "default"], transaction=True)
+def test_migrate_provisions_only_the_database_it_migrated(
+    settings: "pytest_django.fixtures.Settings",
+) -> None:
+    # post_migrate is per-database, so migrating "default" must leave the Absurd
+    # alias alone; only migrating the alias itself provisions it.
+    settings.TASKS = {
+        "default": {
+            "BACKEND": ABSURD,
+            "OPTIONS": {"DATABASE": "absurd", "QUEUES": {"scoped": {}}},
+        }
+    }
+    call_command("migrate", "django_absurd", database="default", verbosity=0)
+    assert not Queue.objects.using("absurd").filter(queue_name="scoped").exists()
+    call_command("migrate", "django_absurd", database="absurd", verbosity=0)
+    assert Queue.objects.using("absurd").filter(queue_name="scoped").exists()
+
+
 def test_sync_command_honors_alias(
     settings: Settings,
 ) -> None:

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -66,9 +66,9 @@ def test_migrate_provisions_only_the_database_it_migrated(
         }
     }
     call_command("migrate", "django_absurd", database="default", verbosity=0)
-    assert not Queue.objects.using("absurd").filter(queue_name="scoped").exists()
+    assert Queue.objects.using("absurd").filter(queue_name="scoped").exists() is False
     call_command("migrate", "django_absurd", database="absurd", verbosity=0)
-    assert Queue.objects.using("absurd").filter(queue_name="scoped").exists()
+    assert Queue.objects.using("absurd").filter(queue_name="scoped").exists() is True
 
 
 def test_sync_command_honors_alias(

--- a/tests/multidb/test_router.py
+++ b/tests/multidb/test_router.py
@@ -73,6 +73,7 @@ def test_roundtrip_drains_on_the_non_default_alias(
     # the fixture resolves the Absurd alias itself (resolve_absurd_database), so a
     # drain/get_result here must land on "absurd", never the router's "default"
     assert dj_absurd.alias == "absurd"
+    dj_absurd.sync_queues()  # _isolate_queues dropped the catalog on the way in
     result = sum_numbers.enqueue(1, 2)
     assert [run.result for run in dj_absurd.drain()] == [3]
     snapshot = dj_absurd.get_result(result.id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ from django.core.management import call_command
 from django.db import connections
 from django.dispatch import Signal
 
-from django_absurd import queues, worker
+from django_absurd import worker
 from django_absurd.test import open_test_connection
 
 if t.TYPE_CHECKING:
@@ -326,16 +326,3 @@ def connect_receiver(
         yield
     finally:
         signal.disconnect(receiver, sender=sender)
-
-
-def provision_declared_queues() -> None:
-    """Provision every declared queue, as ``migrate`` and ``absurd_sync_queues`` do.
-
-    For a test that varies topology — ``_isolate_queues`` drops the catalog on the way
-    in, and the pytest plugin never re-runs ``migrate`` — so the queue a later enqueue
-    or worker needs has to be asked for here, at the call site, rather than left to a
-    runtime path that recreates it.
-    """
-    backend = queues.get_absurd_backend()
-    if backend is not None:
-        queues.provision_backend(backend)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ from django.core.management import call_command
 from django.db import connections
 from django.dispatch import Signal
 
-from django_absurd import worker
+from django_absurd import queues, worker
 from django_absurd.test import open_test_connection
 
 if t.TYPE_CHECKING:
@@ -326,3 +326,16 @@ def connect_receiver(
         yield
     finally:
         signal.disconnect(receiver, sender=sender)
+
+
+def provision_declared_queues() -> None:
+    """Provision every declared queue, as ``migrate`` and ``absurd_sync_queues`` do.
+
+    For a test that varies topology — ``_isolate_queues`` drops the catalog on the way
+    in, and the pytest plugin never re-runs ``migrate`` — so the queue a later enqueue
+    or worker needs has to be asked for here, at the call site, rather than left to a
+    runtime path that recreates it.
+    """
+    backend = queues.get_absurd_backend()
+    if backend is not None:
+        queues.provision_backend(backend)

--- a/zensical.toml
+++ b/zensical.toml
@@ -8,6 +8,7 @@ nav = [
   {"Workflows" = "workflows.md"},
   {"Cron Jobs" = "cron-jobs.md"},
   {"Workers" = "workers.md"},
+  {"Deploying" = "deploying.md"},
   {"Cleanup" = "cleanup.md"},
   {"Monitoring" = "monitoring.md"},
   {"Admin" = "admin.md"},


### PR DESCRIPTION
Queues are provisioned by `migrate` alone. Enqueue and the worker refuse an unprovisioned queue instead of creating one, and `absurd_sync_queues --check` asserts without writing.

Docs: [Deploying](docs/web/deploying.md).

BREAKING CHANGE: enqueue and `absurd_worker` raise `QueueNotProvisionedError` instead of creating a missing queue. `post_migrate` provisions only the database being migrated. `migrate` fails when provisioning fails for any reason other than an absent schema. `absurd_sync_queues`, `absurd_cleanup` and `absurd_flush` exit non-zero when no Absurd backend is configured.
