### PR TITLE
feat: log durations as bare numbers, without the s suffix

### DIFF
--- a/django_absurd/context.py
+++ b/django_absurd/context.py
@@ -267,12 +267,12 @@ def describe_step_replayed(checkpoint_name: str, task_id: str) -> str:
 def describe_step_completed(checkpoint_name: str, task_id: str, duration: float) -> str:
     return (
         f'step completed: name="{checkpoint_name}" task_id="{task_id}"'
-        f" duration={duration:.3f}s"
+        f" duration={duration:.3f}"
     )
 
 
 def describe_sleep_for_suspended(step_name: str, task_id: str, duration: float) -> str:
-    return f'sleep suspended: step="{step_name}" task_id="{task_id}" for={duration}s'
+    return f'sleep suspended: step="{step_name}" task_id="{task_id}" for={duration}'
 
 
 def describe_sleep_until_suspended(

--- a/django_absurd/hooks.py
+++ b/django_absurd/hooks.py
@@ -120,7 +120,7 @@ def report_run_event(
             f" attempt={claimed['attempt']} max_attempts={claimed['max_attempts']}"
         )
         if started is not None:
-            detail += f" duration={time.monotonic() - started:.3f}s"
+            detail += f" duration={time.monotonic() - started:.3f}"
         logger.log(level, "%s: %s", event, detail, exc_info=exc_info)
     except Exception:
         # Last resort: reporting the fault is itself what failed, and raising from here

--- a/tests/core/test_durable.py
+++ b/tests/core/test_durable.py
@@ -158,7 +158,7 @@ def test_suspend_logged_as_lifecycle_not_failure(
     assert len(suspended) == 1
     assert re.fullmatch(
         rf"task suspended: name=\"{re.escape(atasks.asleep_for_once.module_path)}\""
-        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration=\d+\.\d{{3}}s",
+        rf" task_id=\"{task_id}\" attempt=1 max_attempts=5 duration=\d+\.\d{{3}}",
         suspended[0],
     )
     assert not [m for m in messages if m.startswith("task failed")]

--- a/tests/core/test_logging/test_durable.py
+++ b/tests/core/test_logging/test_durable.py
@@ -10,7 +10,7 @@ from tests import atasks, tasks
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
-DURATION = r"\d+\.\d{3}s"
+DURATION = r"\d+\.\d{3}"
 
 
 def read_context_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
@@ -117,7 +117,7 @@ def test_an_async_sleep_logs_suspended_then_resumed(
     messages = read_context_messages(caplog)
     assert (
         messages.count(
-            f'sleep suspended: step="nap" task_id="{task_id}" for={tasks.WEEK_SECONDS}s'
+            f'sleep suspended: step="nap" task_id="{task_id}" for={tasks.WEEK_SECONDS}'
         )
         == 1
     )
@@ -140,7 +140,7 @@ def test_a_sync_sleep_logs_suspended_then_resumed(
     messages = read_context_messages(caplog)
     assert (
         messages.count(
-            f'sleep suspended: step="nap" task_id="{task_id}" for={tasks.WEEK_SECONDS}s'
+            f'sleep suspended: step="nap" task_id="{task_id}" for={tasks.WEEK_SECONDS}'
         )
         == 1
     )

--- a/tests/core/test_logging/test_lifecycle.py
+++ b/tests/core/test_logging/test_lifecycle.py
@@ -52,7 +52,7 @@ def read_hook_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
     return [r.getMessage() for r in caplog.records if r.name == "django_absurd.hooks"]
 
 
-DURATION = r"\d+\.\d{3}s"
+DURATION = r"\d+\.\d{3}"
 
 
 def test_a_successful_run_logs_started_then_completed(


### PR DESCRIPTION
Drops the `s` from `duration=2.234s` → `duration=2.234` so the value parses as a float. Same for `for=604800s` on `sleep suspended` — same unit-in-value pattern.

Fields touched: `task started/completed/failed/suspended`, `step completed`, `sleep suspended`.