### PR TITLE
test: assert whole check output by equality across every check test

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+---
+# The 100% target sits on the PROJECT status — the merged view across every
+# uploaded flag — and deliberately not on per-flag statuses. A single flag cannot
+# reach 100%: the central-extension check's `if not databases` guard is only
+# reachable on Django 6.0, because 6.1 skips Tags.database checks when no
+# --database is passed. Each single-version flag is therefore structurally short
+# while their union is exact, so a flag target would be permanently red with no
+# code change able to fix it.
+#
+# Nothing equivalent lives in [tool.coverage.report]: a local `tox -e dev` run is
+# one env, where those per-version gaps are legitimate.
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 0%
+    patch:
+      default:
+        target: 100%

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,4 @@
+# Imported for the decoration: ``@task`` validates ``queue_name`` against the live
+# ``settings.TASKS``, so these must load before a test narrows QUEUES. Per-suite rather
+# than parent — tests/multidb replaces TASKS with a backend declaring no QUEUES at all.
+from tests import atasks, tasks  # noqa: F401

--- a/tests/core/test_admin_checks.py
+++ b/tests/core/test_admin_checks.py
@@ -7,9 +7,6 @@ BACKEND = "django_absurd.backends.AbsurdBackend"
 IMMEDIATE = "django.tasks.backends.immediate.ImmediateBackend"
 
 BAD_PATH = "nonexistent.module.site"
-E006_BAD_PATH_MSG = (
-    f"django-absurd: OPTIONS['ADMIN_SITE'] entry {BAD_PATH!r} could not be imported."
-)
 
 
 def run_check(capsys: pytest.CaptureFixture[str]) -> str:
@@ -33,9 +30,17 @@ def test_bad_admin_site_path_emits_e006(
         }
     }
     out = run_check(capsys)
-    assert "absurd.E006" in out
-    assert E006_BAD_PATH_MSG in out
-    assert "Set ADMIN_SITE to a tuple of dotted paths to AdminSite instances." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E006) django-absurd: OPTIONS['ADMIN_SITE'] entry"
+        " 'nonexistent.module.site' could not be imported.\n"
+        "\tHINT: Set ADMIN_SITE to a tuple of dotted paths to AdminSite"
+        " instances.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_non_bool_enable_admin_emits_e006(
@@ -49,9 +54,16 @@ def test_non_bool_enable_admin_emits_e006(
         }
     }
     out = run_check(capsys)
-    assert "absurd.E006" in out
-    assert "django-absurd: OPTIONS['ENABLE_ADMIN'] must be a bool." in out
-    assert "Set ENABLE_ADMIN to True or False." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E006) django-absurd: OPTIONS['ENABLE_ADMIN'] must be a"
+        " bool.\n"
+        "\tHINT: Set ENABLE_ADMIN to True or False.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_valid_admin_config_no_e006(
@@ -87,11 +99,17 @@ def test_admin_site_not_a_sequence_emits_e006(
         }
     }
     out = run_check(capsys)
-    assert "absurd.E006" in out
-    assert (
-        "django-absurd: OPTIONS['ADMIN_SITE'] must be a tuple or list"
-        " of dotted-path strings."
-    ) in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E006) django-absurd: OPTIONS['ADMIN_SITE'] must be a tuple"
+        " or list of dotted-path strings.\n"
+        "\tHINT: Set ADMIN_SITE to a tuple of dotted paths to AdminSite"
+        " instances.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_admin_site_not_an_adminsite_emits_e006(
@@ -105,5 +123,14 @@ def test_admin_site_not_an_adminsite_emits_e006(
         }
     }
     out = run_check(capsys)
-    assert "absurd.E006" in out
-    assert "is not an AdminSite instance" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E006) django-absurd: OPTIONS['ADMIN_SITE'] entry"
+        " 'decimal.Decimal' is not an AdminSite instance.\n"
+        "\tHINT: Set ADMIN_SITE to a tuple of dotted paths to AdminSite"
+        " instances.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )

--- a/tests/core/test_checks.py
+++ b/tests/core/test_checks.py
@@ -66,9 +66,16 @@ def test_invalid_policy_modes_error(
     )
     settings.TASKS = build_tasks_setting(invalid_queues)
     out = run_absurd_check(capsys)
-    assert (
-        "django-absurd: invalid per-queue policy options. Queue 'q':"
-        " invalid storage_mode 'bogus'." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E003) django-absurd: invalid per-queue policy options."
+        " Queue 'q': invalid storage_mode 'bogus'.\n"
+        "\tHINT: Remove unknown keys; 'unpartitioned' is the only accepted"
+        " storage_mode.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -78,14 +85,17 @@ def test_declaring_partitioned_storage_is_an_error(
 ) -> None:
     settings.TASKS = build_tasks_setting({"q": {"storage_mode": "partitioned"}})
     out = run_absurd_check(capsys)
-    assert "absurd.E015" in out
-    assert (
-        "django-absurd: partitioned queues are not supported."
-        " Queue 'q' declares storage_mode 'partitioned'." in out
-    )
-    assert (
-        "Declare storage_mode 'unpartitioned', or omit it. Track partitioned"
-        " support at https://github.com/lincolnloop/django-absurd/issues/216." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E015) django-absurd: partitioned queues are not supported."
+        " Queue 'q' declares storage_mode 'partitioned'.\n"
+        "\tHINT: Declare storage_mode 'unpartitioned', or omit it. Track"
+        " partitioned support at"
+        " https://github.com/lincolnloop/django-absurd/issues/216.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -108,11 +118,17 @@ def test_declaring_a_partition_only_policy_key_is_an_error(
         t.cast("dict[str, CreateQueueOptions]", {"q": {key: value}})
     )
     out = run_absurd_check(capsys)
-    assert "absurd.E015" in out
-    assert f"Queue 'q' declares '{key}'" in out
-    assert (
-        "Remove this key. Track partitioned support at"
-        " https://github.com/lincolnloop/django-absurd/issues/216." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E015) django-absurd: partitioned-queue-only policy key."
+        f" Queue 'q' declares '{key}', which only applies to a partitioned"
+        " queue.\n"
+        "\tHINT: Remove this key. Track partitioned support at"
+        " https://github.com/lincolnloop/django-absurd/issues/216.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -134,10 +150,14 @@ def test_check_errors_on_wrong_backend(
 ) -> None:
     settings.TASKS = build_tasks_setting({"x": {}}, database="sqlite")
     out = run_absurd_check(capsys)
-    assert "absurd.E001" in out
-    assert (
-        "django-absurd requires the psycopg (v3) PostgreSQL backend. See https://www.psycopg.org/psycopg3/docs/"
-        in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E001) django-absurd requires the psycopg (v3) PostgreSQL"
+        " backend. See https://www.psycopg.org/psycopg3/docs/\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -174,10 +194,16 @@ def test_check_errors_when_router_missing(
     settings.TASKS = build_tasks_setting({"x": {}}, database="absurd")
     settings.DATABASE_ROUTERS = []
     out = run_absurd_check(capsys)
-    assert "absurd.E005" in out
-    assert (
-        "django-absurd: a non-default DATABASE is configured but "
-        "AbsurdRouter is not in DATABASE_ROUTERS." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E005) django-absurd: a non-default DATABASE is configured but"
+        " AbsurdRouter is not in DATABASE_ROUTERS.\n"
+        "\tHINT: Add 'django_absurd.routers.AbsurdRouter' to"
+        " settings.DATABASE_ROUTERS.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -193,10 +219,16 @@ def test_both_queue_forms_set_errors(
         }
     }
     out = run_absurd_check(capsys)
-    assert "absurd.E002" in out
-    assert (
-        "django-absurd: both top-level QUEUES and OPTIONS['QUEUES'] "
-        "are set on the same backend." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E002) django-absurd: both top-level QUEUES and"
+        " OPTIONS['QUEUES'] are set on the same backend.\n"
+        "\tHINT: Remove either the top-level QUEUES key or OPTIONS['QUEUES']"
+        " — not both.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -220,9 +252,17 @@ def test_invalid_policy_key_errors(
         }
     }
     out = run_absurd_check(capsys)
-    assert "absurd.E002" not in out
-    assert "absurd.E003" in out
-    assert "a" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E003) django-absurd: invalid per-queue policy options."
+        " Queue 'a': unknown key 'bogus_key'.\n"
+        "\tHINT: Remove unknown keys; 'unpartitioned' is the only accepted"
+        " storage_mode.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_invalid_storage_mode_literal_errors(
@@ -236,8 +276,17 @@ def test_invalid_storage_mode_literal_errors(
         }
     }
     out = run_absurd_check(capsys)
-    assert "absurd.E002" not in out
-    assert "absurd.E003" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E003) django-absurd: invalid per-queue policy options."
+        " Queue 'a': invalid storage_mode 'nope'.\n"
+        "\tHINT: Remove unknown keys; 'unpartitioned' is the only accepted"
+        " storage_mode.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_queues_option_as_a_list_errors(
@@ -251,14 +300,16 @@ def test_queues_option_as_a_list_errors(
         }
     }
     out = run_absurd_check(capsys)
-    assert "absurd.E014" in out
-    assert (
-        "django-absurd: OPTIONS['QUEUES'] must be a mapping of queue name to"
-        " policy options." in out
-    )
-    assert (
-        "HINT: Write OPTIONS['QUEUES'] = {'a': {}}, or declare names only with the"
-        " top-level QUEUES list." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E014) django-absurd: OPTIONS['QUEUES'] must be a mapping of"
+        " queue name to policy options.\n"
+        "\tHINT: Write OPTIONS['QUEUES'] = {'a': {}}, or declare names only with"
+        " the top-level QUEUES list.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -289,7 +340,9 @@ def test_single_absurd_backend_no_e004(
     settings: Settings,
 ) -> None:
     settings.TASKS = build_tasks_setting({"q": {}})
-    assert "more than one Absurd backend" not in run_absurd_check(capsys)
+    assert (
+        run_absurd_check(capsys) == "System check identified no issues (0 silenced).\n"
+    )
 
 
 def test_two_absurd_backends_distinct_db_error(
@@ -307,11 +360,16 @@ def test_two_absurd_backends_distinct_db_error(
         },
     }
     out = run_absurd_check(capsys)
-    assert "absurd.E004" in out
-    assert "django-absurd: more than one Absurd backend is configured." in out
-    assert (
-        "django-absurd uses a single Absurd backend per project"
-        " — configure exactly one AbsurdBackend in TASKS." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E004) django-absurd: more than one Absurd backend is"
+        " configured.\n"
+        "\tHINT: django-absurd uses a single Absurd backend per project —"
+        " configure exactly one AbsurdBackend in TASKS.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 
@@ -325,15 +383,17 @@ def test_two_absurd_backends_same_db_error(
         "b": {"BACKEND": ABSURD, "OPTIONS": {"QUEUES": {}}},
     }
     out = run_absurd_check(capsys)
-    assert "absurd.E004" in out
-    assert "django-absurd: more than one Absurd backend is configured." in out
-    assert (
-        "django-absurd uses a single Absurd backend per project"
-        " — configure exactly one AbsurdBackend in TASKS." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E004) django-absurd: more than one Absurd backend is"
+        " configured.\n"
+        "\tHINT: django-absurd uses a single Absurd backend per project —"
+        " configure exactly one AbsurdBackend in TASKS.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
-
-
-E009_MSG = "django-absurd: OPTIONS['DEFAULT_MAX_ATTEMPTS'] must be an integer >= 1."
 
 
 @pytest.mark.parametrize("value", [-1, 0, 1.5, "3", True])
@@ -352,8 +412,17 @@ def test_default_max_attempts_invalid_is_error(
         }
     }
     out = run_absurd_check(capsys)
-    assert E009_MSG in out
-    assert "absurd.E009" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E009) django-absurd: OPTIONS['DEFAULT_MAX_ATTEMPTS'] must"
+        " be an integer >= 1.\n"
+        "\tHINT: Set DEFAULT_MAX_ATTEMPTS to a positive integer (Absurd rejects"
+        " < 1).\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_default_max_attempts_valid_no_error(
@@ -368,13 +437,6 @@ def test_default_max_attempts_valid_no_error(
     }
     out = run_absurd_check(capsys)
     assert out == "System check identified no issues (0 silenced).\n"
-
-
-E010_MSG = "django-absurd: invalid CLEANUP option."
-E010_HINT = (
-    "Set CLEANUP to a dict with a single 'schedule' key:"
-    ' OPTIONS["CLEANUP"] = {"schedule": "<cron>"}.'
-)
 
 
 @pytest.mark.parametrize(
@@ -402,9 +464,16 @@ def test_invalid_cleanup_errors(
         }
     }
     out = run_absurd_check(capsys)
-    assert E010_MSG in out
-    assert E010_HINT in out
-    assert "absurd.E010" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E010) django-absurd: invalid CLEANUP option.\n"
+        "\tHINT: Set CLEANUP to a dict with a single 'schedule' key:"
+        ' OPTIONS["CLEANUP"] = {"schedule": "<cron>"}.\n'
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_scheduler_defaults_to_beat(

--- a/tests/core/test_scheduler_checks.py
+++ b/tests/core/test_scheduler_checks.py
@@ -9,8 +9,6 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 ABSURD = "django_absurd.backends.AbsurdBackend"
 
-E007_MSG = "django-absurd: invalid SCHEDULE entry."
-
 
 @pytest.fixture
 def run_check(
@@ -45,57 +43,110 @@ def test_valid_schedule_no_error(run_check: t.Callable[[t.Any], str]) -> None:
 
 def test_unimportable_task(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.nope", "cron": "0 2 * * *"}})
-    assert (
-        f"{E007_MSG} Schedule 'x': task 'tests.tasks.nope' could not be imported"
-    ) in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " task 'tests.tasks.nope' could not be imported: ImportError('Module"
+        ' "tests.tasks" does not define a "nope" attribute/class\')\n'
+        "\tHINT: Ensure the task path is importable and points to a"
+        " @task-decorated function.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_non_import_error_at_task_import(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.raises_on_import.anything", "cron": "0 2 * * *"}}
     )
-    assert (
-        f"{E007_MSG} Schedule 'x': task 'tests.raises_on_import.anything' "
-        "could not be imported"
-    ) in out
-    assert "RuntimeError" in out
-    assert "boom at import" in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " task 'tests.raises_on_import.anything' could not be imported:"
+        " RuntimeError('boom at import')\n"
+        "\tHINT: Ensure the task path is importable and points to a"
+        " @task-decorated function.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_schedule_not_a_mapping(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(["nightly"])
-    assert 'OPTIONS["SCHEDULE"] must be a mapping of name -> spec' in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry."
+        ' OPTIONS["SCHEDULE"] must be a mapping of name -> spec.\n'
+        "\tHINT: Set SCHEDULE to a dict mapping schedule names to spec"
+        " dicts.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_schedule_entry_not_a_mapping(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"nightly": "0 2 * * *"})
-    assert f"{E007_MSG} Schedule 'nightly' must be a mapping." in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly' must be a mapping.\n"
+        "\tHINT: Set the schedule entry to a dict with task, cron, and"
+        " optional queue/args/kwargs.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_not_a_task(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.Payload", "cron": "0 2 * * *"}})
-    assert (
-        f"{E007_MSG} Schedule 'x': 'tests.tasks.Payload' is not a Django task."
-    ) in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " 'tests.tasks.Payload' is not a Django task.\n"
+        "\tHINT: The path must point to a Django @task-decorated callable.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_bad_cron(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "not-cron"}})
-    assert (f"{E007_MSG} Schedule 'x': invalid cron expression 'not-cron'.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " invalid cron expression 'not-cron'.\n"
+        "\tHINT: Provide a valid cron expression (e.g. '0 2 * * *').\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_non_string_cron(run_check: t.Callable[[t.Any], str]) -> None:
     # A non-string cron (e.g. forgot the quotes) must yield a clean E007, not an
     # AttributeError from croniter.is_valid — the check runs at worker/beat boot.
     out = run_check({"x": {"task": "tests.tasks.add", "cron": 300}})
-    assert (f"{E007_MSG} Schedule 'x': invalid cron expression 300.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " invalid cron expression 300.\n"
+        "\tHINT: Provide a valid cron expression (e.g. '0 2 * * *').\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_beat_rejects_pg_cron_interval_syntax(
@@ -103,30 +154,65 @@ def test_beat_rejects_pg_cron_interval_syntax(
 ) -> None:
     # "[1-59] seconds" is pg_cron's grammar; under beat, croniter rejects it.
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "30 seconds"}})
-    assert (f"{E007_MSG} Schedule 'x': invalid cron expression '30 seconds'.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " invalid cron expression '30 seconds'.\n"
+        "\tHINT: Provide a valid cron expression (e.g. '0 2 * * *').\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_unknown_key(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check({"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "bogus": 1}})
-    assert (f"{E007_MSG} Schedule 'x': unknown key 'bogus'.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " unknown key 'bogus'.\n"
+        "\tHINT: Remove unknown keys; valid keys are: task, cron, queue, args,"
+        " kwargs.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_non_serializable_args(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "args": [object()]}}
     )
-    assert (f"{E007_MSG} Schedule 'x': args is not JSON-serializable.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " args is not JSON-serializable.\n"
+        "\tHINT: Ensure args and kwargs contain only JSON-serializable"
+        " values.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_undeclared_queue(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": "ghost"}}
     )
-    assert (f"{E007_MSG} Schedule 'x': queue 'ghost' is not declared.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " queue 'ghost' is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_non_string_queue(run_check: t.Callable[[t.Any], str]) -> None:
@@ -135,5 +221,14 @@ def test_non_string_queue(run_check: t.Callable[[t.Any], str]) -> None:
     out = run_check(
         {"x": {"task": "tests.tasks.add", "cron": "0 2 * * *", "queue": ["bad"]}}
     )
-    assert (f"{E007_MSG} Schedule 'x': queue ['bad'] is not declared.") in out
-    assert "absurd.E007" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 'x':"
+        " queue ['bad'] is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )

--- a/tests/pg_cron/conftest.py
+++ b/tests/pg_cron/conftest.py
@@ -1,0 +1,4 @@
+# Imported for the decoration: ``@task`` validates ``queue_name`` against the live
+# ``settings.TASKS``, so these must load before a test narrows QUEUES. Per-suite rather
+# than parent — tests/multidb replaces TASKS with a backend declaring no QUEUES at all.
+from tests import atasks, tasks  # noqa: F401

--- a/tests/pg_cron/test_central_checks.py
+++ b/tests/pg_cron/test_central_checks.py
@@ -127,6 +127,32 @@ def test_central_extension_check_reports_a_database_without_the_extension(
     )
 
 
+def test_central_extension_check_reports_an_unreachable_database(
+    monkeypatch: pytest.MonkeyPatch,
+    settings: Settings,
+) -> None:
+    """Opted in, central lookup pointed at a database that does not exist, so opening
+    the connection fails — the probe's except arm, where the test above answers with a
+    real query against a database that merely lacks the extension."""
+    settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=True)
+    monkeypatch.setattr(
+        connection, "resolve_cron_database", lambda _alias: "absurd_no_such_database"
+    )
+    with pytest.raises(SystemCheckError) as excinfo:
+        call_command("check", "django_absurd", "--database", "default")
+    assert str(excinfo.value) == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E012) django-absurd: the central pg_cron catalog is unreachable"
+        " or missing the pg_cron extension.\n"
+        "\tHINT: Install pg_cron on the database named by cron.database_name"
+        " (CREATE EXTENSION pg_cron) and ensure it's reachable from this server.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
+
+
 def test_central_extension_check_passes_against_the_real_central_catalog(
     capsys: pytest.CaptureFixture[str],
     settings: Settings,

--- a/tests/pg_cron/test_central_checks.py
+++ b/tests/pg_cron/test_central_checks.py
@@ -21,12 +21,17 @@ def test_composition_check_rejects_sync_on_test_db_without_opt_in(
     settings.TASKS["default"]["OPTIONS"]["SYNC_SCHEDULES_ON_TEST_DB"] = True
     with pytest.raises(SystemCheckError) as excinfo:
         call_command("check", "django_absurd")
-    assert (
-        "?: (absurd.E011) django-absurd: OPTIONS['SYNC_SCHEDULES_ON_TEST_DB'] is True"
-        " without OPTIONS['PG_CRON_ON_TEST_DB'].\n"
-        "\tHINT: Set OPTIONS['PG_CRON_ON_TEST_DB'] = True as well, or turn off"
-        " SYNC_SCHEDULES_ON_TEST_DB."
-    ) in str(excinfo.value)
+    assert str(excinfo.value) == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E011) django-absurd: OPTIONS['SYNC_SCHEDULES_ON_TEST_DB']"
+        " is True without OPTIONS['PG_CRON_ON_TEST_DB'].\n"
+        "\tHINT: Set OPTIONS['PG_CRON_ON_TEST_DB'] = True as well, or turn"
+        " off SYNC_SCHEDULES_ON_TEST_DB.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_composition_check_passes_with_both_opted_in(
@@ -69,6 +74,7 @@ def test_central_extension_check_stays_inert_without_the_test_db_opt_in(
 
 
 def test_central_extension_check_skips_beat_scheduler_backend(
+    capsys: pytest.CaptureFixture[str],
     settings: Settings,
 ) -> None:
     """When pg_cron is uninstalled process-wide, backend.scheduler resolves to
@@ -78,15 +84,22 @@ def test_central_extension_check_skips_beat_scheduler_backend(
     ]
     settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=True)
     call_command("check", "django_absurd", "--database", "default")
+    assert capsys.readouterr().out == (
+        "System check identified no issues (0 silenced).\n"
+    )
 
 
 def test_central_extension_check_skips_backend_on_other_database(
+    capsys: pytest.CaptureFixture[str],
     settings: Settings,
 ) -> None:
     """The backend's DATABASE is "default"; checking a different alias ("replica")
     must not touch it, exercising the databases-filter branch."""
     settings.TASKS = utils.build_pg_cron_tasks({}, pg_cron_on_test_db=True)
     call_command("check", "django_absurd", "--database", "replica")
+    assert capsys.readouterr().out == (
+        "System check identified no issues (0 silenced).\n"
+    )
 
 
 def test_central_extension_check_reports_a_database_without_the_extension(

--- a/tests/pg_cron/test_pg_cron_checks.py
+++ b/tests/pg_cron/test_pg_cron_checks.py
@@ -12,8 +12,6 @@ from tests.utils import DECLARED_QUEUES as BASE_QUEUES
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
-E007_MSG = "django-absurd: invalid SCHEDULE entry."
-
 
 def run_pg_cron_check(
     settings: Settings,
@@ -66,7 +64,20 @@ def test_pg_cron_cleanup_rejects_a_non_cron_schedule(
     settings: Settings,
 ) -> None:
     out = run_pg_cron_cleanup_check(settings, capsys, {"schedule": "not a cron"})
-    assert "absurd.E010" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E010) django-absurd: invalid CLEANUP option. Expected a"
+        " 5-field cron expression; got 3 fields.\n"
+        "\tHINT: Use a 5-field cron expression, an interval such as"
+        " '30 seconds' (1-59), or one of"
+        " @hourly/@daily/@weekly/@monthly/@yearly/@annually/@midnight"
+        " (lowercase). The beat scheduler's 6-field leading-seconds form is"
+        " not pg_cron syntax.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_cleanup_rejects_empty_schedule(
@@ -74,7 +85,16 @@ def test_pg_cron_cleanup_rejects_empty_schedule(
     settings: Settings,
 ) -> None:
     out = run_pg_cron_cleanup_check(settings, capsys, {"schedule": ""})
-    assert "absurd.E010" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E010) django-absurd: invalid CLEANUP option.\n"
+        "\tHINT: Set CLEANUP to a dict with a single 'schedule' key:"
+        ' OPTIONS["CLEANUP"] = {"schedule": "<cron>"}.\n'
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_task_import_raise_reports_e007_not_crash(
@@ -98,8 +118,18 @@ def test_pg_cron_task_import_raise_reports_e007_not_crash(
             },
         },
     )
-    assert E007_MSG in out
-    assert "could not be imported" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'boom': task 'tests.raises_on_import.anything' could not be"
+        " imported: RuntimeError('boom at import')\n"
+        "\tHINT: Ensure the task path is importable and points to a"
+        " @task-decorated function.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 @pytest.mark.parametrize("cron", ["30 seconds", "@daily", "0 2 * * *"])
@@ -134,8 +164,20 @@ def test_pg_cron_rejects_beats_six_field_cron_at_check_time(
             "schedule": {"s": {"task": "tests.tasks.add", "cron": "*/30 * * * * *"}},
         },
     )
-    assert "absurd.E007" in out
-    assert "Expected a 5-field cron expression; got 6 fields." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 's':"
+        " Expected a 5-field cron expression; got 6 fields.\n"
+        "\tHINT: Use a 5-field cron expression, an interval such as"
+        " '30 seconds' (1-59), or one of"
+        " @hourly/@daily/@weekly/@monthly/@yearly/@annually/@midnight"
+        " (lowercase). The beat scheduler's 6-field leading-seconds form is"
+        " not pg_cron syntax.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_bad_name_charset_rejected(
@@ -156,8 +198,18 @@ def test_pg_cron_bad_name_charset_rejected(
             },
         },
     )
-    assert "absurd.E007" in out
-    assert "Schedule name contains characters other than [A-Za-z0-9_-]." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'bad name!': Schedule name contains characters other than"
+        " [A-Za-z0-9_-].\n"
+        "\tHINT: Schedule names must match [A-Za-z0-9_-]+ when using the"
+        " pg_cron scheduler.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_undeclared_task_queue_rejected(
@@ -182,8 +234,17 @@ def test_pg_cron_undeclared_task_queue_rejected(
             },
         },
     )
-    assert "absurd.E007" in out
-    assert "queue 'reports' is not declared" in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'ghostly': queue 'reports' is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_undeclared_explicit_queue_single_error(
@@ -205,8 +266,17 @@ def test_pg_cron_undeclared_explicit_queue_single_error(
             },
         },
     )
-    assert "absurd.E007" in out
-    assert out.count("queue 'ghost' is not declared") == 1
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': queue 'ghost' is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_non_mapping_schedule_single_error(
@@ -222,7 +292,17 @@ def test_pg_cron_non_mapping_schedule_single_error(
             "schedule": ["nightly"],
         },
     )
-    assert out.count('OPTIONS["SCHEDULE"] must be a mapping of name -> spec') == 1
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry."
+        ' OPTIONS["SCHEDULE"] must be a mapping of name -> spec.\n'
+        "\tHINT: Set SCHEDULE to a dict mapping schedule names to spec"
+        " dicts.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_non_mapping_entry_single_error(
@@ -238,7 +318,17 @@ def test_pg_cron_non_mapping_entry_single_error(
             "schedule": {"nightly": "0 2 * * *"},
         },
     )
-    assert out.count("Schedule 'nightly' must be a mapping.") == 1
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly' must be a mapping.\n"
+        "\tHINT: Set the schedule entry to a dict with task, cron, and"
+        " optional queue/args/kwargs.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_missing_task_no_queue_error(
@@ -254,8 +344,18 @@ def test_pg_cron_missing_task_no_queue_error(
             "schedule": {"nightly": {"cron": "0 2 * * *"}},
         },
     )
-    assert "could not be imported" in out
-    assert "is not declared" not in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': task '' could not be imported: ImportError(\" doesn't"
+        ' look like a module path")\n'
+        "\tHINT: Ensure the task path is importable and points to a"
+        " @task-decorated function.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_unimportable_task_no_queue_error(
@@ -271,8 +371,19 @@ def test_pg_cron_unimportable_task_no_queue_error(
             "schedule": {"nightly": {"task": "tests.tasks.nope", "cron": "0 2 * * *"}},
         },
     )
-    assert "could not be imported" in out
-    assert "is not declared" not in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': task 'tests.tasks.nope' could not be imported:"
+        ' ImportError(\'Module "tests.tasks" does not define a "nope"'
+        " attribute/class')\n"
+        "\tHINT: Ensure the task path is importable and points to a"
+        " @task-decorated function.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_non_task_no_queue_error(
@@ -290,8 +401,16 @@ def test_pg_cron_non_task_no_queue_error(
             },
         },
     )
-    assert "is not a Django task" in out
-    assert "is not declared" not in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': 'tests.tasks.Payload' is not a Django task.\n"
+        "\tHINT: The path must point to a Django @task-decorated callable.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 @pytest.mark.parametrize("cron", ["", 300])
@@ -310,8 +429,17 @@ def test_pg_cron_structurally_absent_cron_rejected(
             "schedule": {"nightly": {"task": "tests.tasks.add", "cron": cron}},
         },
     )
-    assert "absurd.E007" in out
-    assert "cron must be a non-empty string." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': cron must be a non-empty string.\n"
+        "\tHINT: Set cron to a non-empty schedule string; the pg_cron app"
+        " checks its grammar.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_trailing_newline_name_rejected(
@@ -332,8 +460,18 @@ def test_pg_cron_trailing_newline_name_rejected(
             },
         },
     )
-    assert "absurd.E007" in out
-    assert "Schedule name contains characters other than [A-Za-z0-9_-]." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly\\n': Schedule name contains characters other than"
+        " [A-Za-z0-9_-].\n"
+        "\tHINT: Schedule names must match [A-Za-z0-9_-]+ when using the"
+        " pg_cron scheduler.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_empty_string_queue_resolves_via_effective_queue(
@@ -360,7 +498,17 @@ def test_pg_cron_empty_string_queue_resolves_via_effective_queue(
             },
         },
     )
-    assert out.count("queue '' is not declared") == 1
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': queue '' is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_valid_five_field_cron_no_error(
@@ -397,8 +545,17 @@ def test_pg_cron_non_string_name_yields_e007_not_typeerror(
             "schedule": {5: {"task": "tests.tasks.add", "cron": "0 2 * * *"}},
         },
     )
-    assert "absurd.E007" in out
-    assert "TypeError" not in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 5:"
+        " Schedule name contains characters other than [A-Za-z0-9_-].\n"
+        "\tHINT: Schedule names must match [A-Za-z0-9_-]+ when using the"
+        " pg_cron scheduler.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_cleanup_cron_grammar_is_checked(
@@ -409,8 +566,20 @@ def test_pg_cron_cleanup_cron_grammar_is_checked(
     # SCHEDULE entry: beat's 6-field form would otherwise reach sync, where pg_cron
     # accepts it and silently drops the sixth field.
     out = run_pg_cron_cleanup_check(settings, capsys, {"schedule": "*/30 * * * * *"})
-    assert "absurd.E010" in out
-    assert "Expected a 5-field cron expression; got 6 fields." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E010) django-absurd: invalid CLEANUP option. Expected a"
+        " 5-field cron expression; got 6 fields.\n"
+        "\tHINT: Use a 5-field cron expression, an interval such as"
+        " '30 seconds' (1-59), or one of"
+        " @hourly/@daily/@weekly/@monthly/@yearly/@annually/@midnight"
+        " (lowercase). The beat scheduler's 6-field leading-seconds form is"
+        " not pg_cron syntax.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 @pytest.mark.parametrize("cleanup", [{"schedule": 5}, {"schedule": "   "}])
@@ -422,7 +591,16 @@ def test_pg_cron_cleanup_defers_a_non_grammar_problem_to_core(
     # Core already reports shape/emptiness as absurd.E010; reporting it again from the
     # grammar check would show one field's problem twice.
     out = run_pg_cron_cleanup_check(settings, capsys, cleanup)
-    assert out.count("absurd.E010") == 1
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E010) django-absurd: invalid CLEANUP option.\n"
+        "\tHINT: Set CLEANUP to a dict with a single 'schedule' key:"
+        ' OPTIONS["CLEANUP"] = {"schedule": "<cron>"}.\n'
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_schedule_defers_an_empty_cron_to_core(
@@ -437,7 +615,17 @@ def test_pg_cron_schedule_defers_an_empty_cron_to_core(
             "schedule": {"s": {"task": "tests.tasks.add", "cron": "   "}},
         },
     )
-    assert out.count("absurd.E007") == 1
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 's':"
+        " cron must be a non-empty string.\n"
+        "\tHINT: Set cron to a non-empty schedule string; the pg_cron app"
+        " checks its grammar.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_queues_option_as_a_list_errors_without_crashing_the_schedule_check(
@@ -454,8 +642,18 @@ def test_queues_option_as_a_list_errors_without_crashing_the_schedule_check(
     }
     with pytest.raises(SystemCheckError) as excinfo:
         call_command("check", "django_absurd")
-    assert "absurd.E014" in str(excinfo.value)
-    assert (
-        "django-absurd: OPTIONS['QUEUES'] must be a mapping of queue name to"
-        " policy options." in str(excinfo.value)
+    assert str(excinfo.value) == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule 's':"
+        " queue 'default' is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "?: (absurd.E014) django-absurd: OPTIONS['QUEUES'] must be a mapping"
+        " of queue name to policy options.\n"
+        "\tHINT: Write OPTIONS['QUEUES'] = {'a': {}}, or declare names only"
+        " with the top-level QUEUES list.\n"
+        "\n"
+        "System check identified 2 issues (0 silenced)."
     )

--- a/tests/pg_cron/test_scheduler_app_checks.py
+++ b/tests/pg_cron/test_scheduler_app_checks.py
@@ -45,14 +45,17 @@ def test_pg_cron_app_before_core_warns(
     settings: Settings,
 ) -> None:
     out = run_check(capsys, settings, build_apps_with_pg_cron_first(settings))
-    assert "absurd.W003" in out
-    assert (
-        "django-absurd: 'django_absurd.pg_cron' is ordered before 'django_absurd'"
-        " in INSTALLED_APPS (its post_migrate cron reconcile runs before queue"
-        " provisioning)."
-    ) in out
-    assert (
-        "Place 'django_absurd.pg_cron' after 'django_absurd' in INSTALLED_APPS." in out
+    assert out == (
+        "System check identified some issues:\n"
+        "\n"
+        "WARNINGS:\n"
+        "?: (absurd.W003) django-absurd: 'django_absurd.pg_cron' is ordered"
+        " before 'django_absurd' in INSTALLED_APPS (its post_migrate cron"
+        " reconcile runs before queue provisioning).\n"
+        "\tHINT: Place 'django_absurd.pg_cron' after 'django_absurd' in"
+        " INSTALLED_APPS.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced).\n"
     )
 
 
@@ -79,8 +82,17 @@ def test_pg_cron_schedule_error_reported(
             }
         },
     )
-    assert "absurd.E007" in out
-    assert "queue 'ghost' is not declared." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E007) django-absurd: invalid SCHEDULE entry. Schedule"
+        " 'nightly': queue 'ghost' is not declared.\n"
+        "\tHINT: Declare the queue under OPTIONS['QUEUES'] or correct the"
+        " queue name.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
+    )
 
 
 def test_pg_cron_app_config_path_before_core_warns(
@@ -98,14 +110,17 @@ def test_pg_cron_app_config_path_before_core_warns(
         ],
     ]
     out = run_check(capsys, settings, installed_apps=apps_with_config_path_first)
-    assert "absurd.W003" in out
-    assert (
-        "django-absurd: 'django_absurd.pg_cron' is ordered before 'django_absurd'"
-        " in INSTALLED_APPS (its post_migrate cron reconcile runs before queue"
-        " provisioning)."
-    ) in out
-    assert (
-        "Place 'django_absurd.pg_cron' after 'django_absurd' in INSTALLED_APPS." in out
+    assert out == (
+        "System check identified some issues:\n"
+        "\n"
+        "WARNINGS:\n"
+        "?: (absurd.W003) django-absurd: 'django_absurd.pg_cron' is ordered"
+        " before 'django_absurd' in INSTALLED_APPS (its post_migrate cron"
+        " reconcile runs before queue provisioning).\n"
+        "\tHINT: Place 'django_absurd.pg_cron' after 'django_absurd' in"
+        " INSTALLED_APPS.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced).\n"
     )
 
 
@@ -123,10 +138,20 @@ def test_pg_cron_installed_without_an_absurd_backend_is_reported(
     with pytest.raises(SystemCheckError) as exc_info:
         call_command("check", "django_absurd")
     out = str(exc_info.value)
-    assert "absurd.E013" in out
-    assert (
-        "django-absurd: 'django_absurd.pg_cron' is installed, but no AbsurdBackend is"
-        " configured, so a schedule would save without ever being scheduled." in out
+    assert out == (
+        "SystemCheckError: System check identified some issues:\n"
+        "\n"
+        "ERRORS:\n"
+        "?: (absurd.E013) django-absurd: 'django_absurd.pg_cron' is"
+        " installed, but no AbsurdBackend is configured, so a schedule would"
+        " save without ever being scheduled.\n"
+        "\tHINT: Point a TASKS entry at"
+        " django_absurd.backends.AbsurdBackend, or remove"
+        " 'django_absurd.pg_cron' from INSTALLED_APPS. To keep the app"
+        " installed with another backend deliberately (a dev or CI settings"
+        " module), add 'absurd.E013' to SILENCED_SYSTEM_CHECKS.\n"
+        "\n"
+        "System check identified 1 issue (0 silenced)."
     )
 
 


### PR DESCRIPTION
Finishes what #217 started: every system-check test now asserts the entire command output by equality, not a substring of it. 113 substring assertions across six files collapse into one equality assertion per test, and two tests in `test_central_checks.py` that asserted nothing at all get one.

Files get longer (+618/-183) — a literal carrying the message, `HINT:` and the issue-count footer is longer than the substring it replaces, even after collapsing several assertions into one. That is the trade: the assertion pins the id, the message, the hint, the rendering order and the issue count together, and cannot pass vacuously if a check id is deleted.

Two defects the sweep uncovered, both invisible to a substring:

- `test_queues_option_as_a_list_errors_without_crashing_the_schedule_check` raises **two** issues (`absurd.E007` and `absurd.E014`); only E014 was ever checked.
- `@task` validates `queue_name` against the live `settings.TASKS`, so whichever test first triggered `import tests.tasks` decided whether `tasks.routed`'s queue was valid — a test that narrowed QUEUES got `InvalidTask` in place of its own subject. Undetectable before, because the masking error carries the same `absurd.E007` id as the real one. Fixed by importing the shared task fixtures at collection, per-suite: `tests/multidb` replaces `TASKS` with a backend declaring no QUEUES, where those tasks cannot be decorated at all.

Every converted file passes in isolation (`-n0`), which is new — `test_scheduler_checks.py` had two tests already failing alone on main.
