### PR TITLE
docs: document the grants a non-superuser pg_cron role needs

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -554,8 +554,9 @@ existing workers run the tasks; a settings-only change needs no new migration fi
   `"*/30 * * * * *"` would silently schedule `"*/30 * * * *"` — a cadence you did not
   write, reported as valid. `@reboot` and `@restart` are refused too: neither is a
   recurring cadence.
-- **Timezone is the `cron.timezone` GUC, default GMT** — not Django's `TIME_ZONE`. Set
-  it to match if yours is not UTC.
+- **Timezone is the `cron.timezone` GUC** (Grand Unified Configuration — Postgres's term
+  for a server setting), **default GMT** — not Django's `TIME_ZONE`. Set it to match if
+  yours is not UTC.
 - **To stop a job, remove it from `SCHEDULE`.** Every reconcile re-arms settings-owned
   jobs, so disabling one directly in `cron.job` does not survive the next deploy.
 - `absurd.W003` if the app is ordered before `"django_absurd"`, which would run its
@@ -661,6 +662,7 @@ the Absurd one. A migration cannot do any of it.
   execute rights.
 
   ```sql
+  GRANT CONNECT ON DATABASE <central_database> TO <scheduling_role>;
   GRANT USAGE ON SCHEMA cron TO <scheduling_role>;
   GRANT EXECUTE ON FUNCTION
       cron.schedule_in_database(text, text, text, text, text, boolean)
@@ -668,11 +670,27 @@ the Absurd one. A migration cannot do any of it.
   GRANT EXECUTE ON FUNCTION
       cron.alter_job(bigint, text, text, text, text, boolean)
       TO <scheduling_role>;
+  GRANT EXECUTE ON FUNCTION cron.unschedule(bigint) TO <scheduling_role>;
   ```
+
+  `CONNECT` is needed even though none of your tables live there: the central connection
+  reuses the app's own credentials and swaps only the database name.
 
   The `alter_job` grant is required, not optional: `schedule_in_database`'s `active`
   argument only takes effect when it first creates a job, so disabling an
   already-scheduled job needs an explicit `alter_job` call.
+
+- **A scheduling role that isn't a superuser needs one grant more**, or `migrate` fails:
+
+  ```sql
+  GRANT pg_read_all_settings TO <scheduling_role>;
+  ```
+
+  Discovering the central database means reading the `cron.database_name` GUC, which
+  pg_cron marks superuser-only. Without it the failure is
+  `permission denied to examine "cron.database_name"`. This is not specific to managed
+  Postgres — it applies on any server; local setups miss it only because they connect as
+  `postgres`.
 
 - Managed Postgres (RDS, Cloud SQL, Azure) exposes these as parameter-group flags.
 - `python manage.py check --database default` reports `absurd.E012` when that central

--- a/docs/web/cron-jobs.md
+++ b/docs/web/cron-jobs.md
@@ -91,8 +91,9 @@ into [pg_cron](https://github.com/citusdata/pg_cron) jobs and your existing
 - **Beat's 6-field form and `#` are refused**, though pg_cron accepts them: its parser
   reads five fields and takes the rest as the command, so `"*/30 * * * * *"` would
   schedule `"*/30 * * * *"` — a cadence you didn't write, reported as valid.
-- **Timezone is the `cron.timezone` GUC, default GMT** — not Django's `TIME_ZONE`. Set
-  it to match if yours is non-UTC.
+- **Timezone is the `cron.timezone` GUC** (Grand Unified Configuration — Postgres's term
+  for a server setting), **default GMT** — not Django's `TIME_ZONE`. Set it to match if
+  yours is non-UTC.
 - **To stop a job, remove it from `SCHEDULE`.** Every reconcile re-arms settings-owned
   jobs, so disabling one directly in `cron.job` doesn't survive the next deploy.
 - `absurd.W003` if the app is ordered before `"django_absurd"`.
@@ -169,6 +170,7 @@ the Absurd one. See [pg_cron's own docs](https://github.com/citusdata/pg_cron).
   `schedule_in_database` only applies `active` on first create:
 
   ```sql
+  GRANT CONNECT ON DATABASE <central_database> TO <scheduling_role>;
   GRANT USAGE ON SCHEMA cron TO <scheduling_role>;
   GRANT EXECUTE ON FUNCTION
       cron.schedule_in_database(text, text, text, text, text, boolean)
@@ -176,7 +178,22 @@ the Absurd one. See [pg_cron's own docs](https://github.com/citusdata/pg_cron).
   GRANT EXECUTE ON FUNCTION
       cron.alter_job(bigint, text, text, text, text, boolean)
       TO <scheduling_role>;
+  GRANT EXECUTE ON FUNCTION cron.unschedule(bigint) TO <scheduling_role>;
   ```
+
+  `CONNECT` applies even though none of your tables live there — the central connection
+  reuses the app's own credentials and swaps only the database name.
+
+- **A scheduling role that isn't a superuser needs one grant more**, or `migrate` fails:
+
+  ```sql
+  GRANT pg_read_all_settings TO <scheduling_role>;
+  ```
+
+  Finding the central database means reading the `cron.database_name` GUC, which pg_cron
+  marks superuser-only. Without it: `permission denied to examine "cron.database_name"`.
+  Not specific to managed Postgres — it applies on any server; local setups miss it only
+  because they connect as `postgres`.
 
 Managed Postgres (RDS, Cloud SQL, Azure) exposes these as parameter-group flags.
 `manage.py check` reports `absurd.E012` if the central database is unreachable or


### PR DESCRIPTION
The pg_cron grant list was missing three, and a deploy hits them in this order:

- `GRANT CONNECT ON DATABASE <central>` — the central connection reuses the app's own credentials and swaps only the database name, so the role connects somewhere none of its tables live.
- `GRANT EXECUTE ON FUNCTION cron.unschedule(bigint)` — never documented, though every prune and teardown calls it.
- `GRANT pg_read_all_settings` — needed to read `cron.database_name`.

Reported from an RDS deploy as RDS-specific, but reproduced here on plain `postgres:18` + pg_cron 1.6: pg_cron marks `cron.database_name` superuser-only on any server. Local setups miss it only because they connect as `postgres`. Documented as applying to any non-superuser role rather than to RDS.

Docs only — no code change. Today's failure already names the parameter and the required role in its `DETAIL` line, and `post_migrate` already logs it with a traceback, so documenting the grants is the fix rather than reshaping the error.
