### PR TITLE
build(examples): configure the database from DATABASE_URL

### DIFF
--- a/examples/beat/app.py
+++ b/examples/beat/app.py
@@ -10,6 +10,7 @@ it and logs 'tock ⏰'. Watch Tasks/Runs fill in the admin.
 import logging
 import os
 
+import dj_database_url
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.tasks import task
@@ -18,15 +19,14 @@ from nanodjango import Django
 app = Django(
     ADMIN_URL="admin/",
     EXTRA_APPS=["django_absurd"],
+    # Managed platforms inject DATABASE_URL and rotate the credentials inside it, so
+    # PG* vars would go stale.
     DATABASES={
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("PGDATABASE", "postgres"),
-            "USER": os.environ.get("PGUSER", "postgres"),
-            "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
-            "HOST": os.environ.get("PGHOST", "localhost"),
-            "PORT": os.environ.get("PGPORT", "5432"),
-        }
+        "default": dj_database_url.parse(
+            os.environ.get(
+                "DATABASE_URL", "postgres://postgres:postgres@localhost:5432/postgres"
+            )
+        )
     },
     TASKS={
         "default": {

--- a/examples/beat/compose.yaml
+++ b/examples/beat/compose.yaml
@@ -24,11 +24,7 @@ services:
       db:
         condition: service_healthy
     environment: &env
-      - PGHOST=db
-      - PGPORT=5432
-      - PGUSER=postgres
-      - PGPASSWORD=postgres
-      - PGDATABASE=postgres
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
     volumes: &mounts
       - ./:/app
       - ../../django_absurd:/src/django_absurd

--- a/examples/beat/pyproject.toml
+++ b/examples/beat/pyproject.toml
@@ -7,6 +7,7 @@ dev = [
 
 [project]
 dependencies = [
+  "dj-database-url==3.1.2",
   "django-absurd",
   "django==6.1",
   "nanodjango==0.16.3",

--- a/examples/beat/uv.lock
+++ b/examples/beat/uv.lock
@@ -127,6 +127,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dj-database-url"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/f6/00b625e9d371b980aa261011d0dc906a16444cb688f94215e0dc86996eb5/dj_database_url-3.1.2.tar.gz", hash = "sha256:63c20e4bbaa51690dfd4c8d189521f6bf6bc9da9fcdb23d95d2ee8ee87f9ec62", size = 11490, upload-time = "2026-02-19T15:30:23.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/a9/57c66006373381f1d3e5bd94216f1d371228a89f443d3030e010f73dd198/dj_database_url-3.1.2-py3-none-any.whl", hash = "sha256:544e015fee3efa5127a1eb1cca465f4ace578265b3671fe61d0ed7dbafb5ec8a", size = 8953, upload-time = "2026-02-19T15:30:39.37Z" },
+]
+
+[[package]]
 name = "django"
 version = "6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -186,6 +198,7 @@ name = "django-absurd-example-beat"
 version = "0"
 source = { virtual = "." }
 dependencies = [
+    { name = "dj-database-url" },
     { name = "django" },
     { name = "django-absurd" },
     { name = "nanodjango" },
@@ -201,6 +214,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dj-database-url", specifier = "==3.1.2" },
     { name = "django", specifier = "==6.1" },
     { name = "django-absurd", editable = "../../" },
     { name = "nanodjango", specifier = "==0.16.3" },

--- a/examples/pg_cron/app.py
+++ b/examples/pg_cron/app.py
@@ -13,6 +13,7 @@ cross-database. Watch Tasks/Runs in the admin.
 import logging
 import os
 
+import dj_database_url
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.tasks import task
@@ -21,15 +22,15 @@ from nanodjango import Django
 app = Django(
     ADMIN_URL="admin/",
     EXTRA_APPS=["django_absurd", "django_absurd.pg_cron"],  # pg_cron app AFTER core
+    # Managed platforms inject DATABASE_URL and rotate the credentials inside it, so
+    # PG* vars would go stale. The `demo` database is this example's own, not the
+    # central pg_cron catalog.
     DATABASES={
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("PGDATABASE", "demo"),
-            "USER": os.environ.get("PGUSER", "postgres"),
-            "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
-            "HOST": os.environ.get("PGHOST", "localhost"),
-            "PORT": os.environ.get("PGPORT", "5432"),
-        }
+        "default": dj_database_url.parse(
+            os.environ.get(
+                "DATABASE_URL", "postgres://postgres:postgres@localhost:5432/demo"
+            )
+        )
     },
     TASKS={
         "default": {

--- a/examples/pg_cron/compose.yaml
+++ b/examples/pg_cron/compose.yaml
@@ -38,11 +38,7 @@ services:
       db:
         condition: service_healthy
     environment: &env
-      - PGHOST=db
-      - PGPORT=5432
-      - PGUSER=postgres
-      - PGPASSWORD=postgres
-      - PGDATABASE=demo
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/demo
     volumes: &mounts
       - ./:/app
       - ../../django_absurd:/src/django_absurd

--- a/examples/pg_cron/pyproject.toml
+++ b/examples/pg_cron/pyproject.toml
@@ -7,6 +7,7 @@ dev = [
 
 [project]
 dependencies = [
+  "dj-database-url==3.1.2",
   "django-absurd",
   "django==6.1",
   "nanodjango==0.16.3",

--- a/examples/pg_cron/uv.lock
+++ b/examples/pg_cron/uv.lock
@@ -127,6 +127,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dj-database-url"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/f6/00b625e9d371b980aa261011d0dc906a16444cb688f94215e0dc86996eb5/dj_database_url-3.1.2.tar.gz", hash = "sha256:63c20e4bbaa51690dfd4c8d189521f6bf6bc9da9fcdb23d95d2ee8ee87f9ec62", size = 11490, upload-time = "2026-02-19T15:30:23.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/a9/57c66006373381f1d3e5bd94216f1d371228a89f443d3030e010f73dd198/dj_database_url-3.1.2-py3-none-any.whl", hash = "sha256:544e015fee3efa5127a1eb1cca465f4ace578265b3671fe61d0ed7dbafb5ec8a", size = 8953, upload-time = "2026-02-19T15:30:39.37Z" },
+]
+
+[[package]]
 name = "django"
 version = "6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -186,6 +198,7 @@ name = "django-absurd-example-pg-cron"
 version = "0"
 source = { virtual = "." }
 dependencies = [
+    { name = "dj-database-url" },
     { name = "django" },
     { name = "django-absurd" },
     { name = "nanodjango" },
@@ -201,6 +214,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dj-database-url", specifier = "==3.1.2" },
     { name = "django", specifier = "==6.1" },
     { name = "django-absurd", editable = "../../" },
     { name = "nanodjango", specifier = "==0.16.3" },

--- a/examples/web/app.py
+++ b/examples/web/app.py
@@ -23,6 +23,7 @@ import os
 import pprint
 from urllib.parse import quote as url_quote
 
+import dj_database_url
 from django import forms
 from django.contrib.admin.utils import quote
 from django.http import HttpRequest, HttpResponse
@@ -40,15 +41,14 @@ from django_absurd import emit_event, get_absurd_context
 app = Django(
     ADMIN_URL="admin/",
     EXTRA_APPS=["django_absurd"],
+    # Managed platforms inject DATABASE_URL and rotate the credentials inside it, so
+    # PG* vars would go stale.
     DATABASES={
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("PGDATABASE", "postgres"),
-            "USER": os.environ.get("PGUSER", "postgres"),
-            "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
-            "HOST": os.environ.get("PGHOST", "localhost"),
-            "PORT": os.environ.get("PGPORT", "5432"),
-        }
+        "default": dj_database_url.parse(
+            os.environ.get(
+                "DATABASE_URL", "postgres://postgres:postgres@localhost:5432/postgres"
+            )
+        )
     },
     TASKS={
         "default": {

--- a/examples/web/compose.yaml
+++ b/examples/web/compose.yaml
@@ -24,11 +24,7 @@ services:
       db:
         condition: service_healthy
     environment: &env
-      - PGHOST=db
-      - PGPORT=5432
-      - PGUSER=postgres
-      - PGPASSWORD=postgres
-      - PGDATABASE=postgres
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
     volumes: &mounts
       - ./:/app
       - ../../django_absurd:/src/django_absurd

--- a/examples/web/pyproject.toml
+++ b/examples/web/pyproject.toml
@@ -9,6 +9,7 @@ dev = [
 
 [project]
 dependencies = [
+  "dj-database-url==3.1.2",
   "django-absurd",
   "django==6.1",
   "nanodjango==0.16.3",

--- a/examples/web/uv.lock
+++ b/examples/web/uv.lock
@@ -127,6 +127,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dj-database-url"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/f6/00b625e9d371b980aa261011d0dc906a16444cb688f94215e0dc86996eb5/dj_database_url-3.1.2.tar.gz", hash = "sha256:63c20e4bbaa51690dfd4c8d189521f6bf6bc9da9fcdb23d95d2ee8ee87f9ec62", size = 11490, upload-time = "2026-02-19T15:30:23.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/a9/57c66006373381f1d3e5bd94216f1d371228a89f443d3030e010f73dd198/dj_database_url-3.1.2-py3-none-any.whl", hash = "sha256:544e015fee3efa5127a1eb1cca465f4ace578265b3671fe61d0ed7dbafb5ec8a", size = 8953, upload-time = "2026-02-19T15:30:39.37Z" },
+]
+
+[[package]]
 name = "django"
 version = "6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -186,6 +198,7 @@ name = "django-absurd-example-web"
 version = "0"
 source = { virtual = "." }
 dependencies = [
+    { name = "dj-database-url" },
     { name = "django" },
     { name = "django-absurd" },
     { name = "nanodjango" },
@@ -202,6 +215,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dj-database-url", specifier = "==3.1.2" },
     { name = "django", specifier = "==6.1" },
     { name = "django-absurd", editable = "../../" },
     { name = "nanodjango", specifier = "==0.16.3" },


### PR DESCRIPTION
Closes #196.

The demos read five `PG*` vars. Every managed platform injects one `DATABASE_URL` instead and rotates the credentials inside it, so hand-setting the `PG*` vars isn't even a workaround — they go stale. Per the report on #196, that was the single biggest friction in getting a demo onto a real platform.

One env var for the database now, via `dj-database-url`. Each demo defaults to exactly what its own `PG*` vars resolved to before, so `docker compose up` and a bare local run behave as they did. `APP_PORT` is untouched — a published port, not app config — so the host web port stays settable without editing a URL.

Examples only; no change to the package.

Note the pg_cron demo keeps `demo` rather than `postgres`: its app database is deliberately not the central pg_cron catalog, which is what that demo exists to show. Verified after the change — `cron.job` holds `_dj:demo:s:ping` bound to `demo`, `cron.job_run_details` reports `succeeded`, and the worker runs the resulting task.
