### PR TITLE
fix: stop reporting a torn install as an absent schema

### DIFF
--- a/django_absurd/queues.py
+++ b/django_absurd/queues.py
@@ -43,6 +43,10 @@ INTERVAL_OPTION_KEYS = frozenset(
 # never across servers or versions.
 PROVISION_LOCK_KEY = zlib.crc32(b"django_absurd.provision")
 
+# Shared by the sync and async schema probes below: the connection plumbing cannot be,
+# but the question must be, or the two doors could classify one database differently.
+SCHEMA_ABSENT_SQL = "select to_regnamespace('absurd') is null"
+
 
 @dataclass
 class SyncResult:
@@ -87,15 +91,12 @@ def get_absurd_client(using: str | None = None) -> Absurd:
 
 
 def list_provisioned_queues(using: str | None = None) -> list[str]:
-    client = get_absurd_client(using)
-    try:
-        return sorted(client.list_queues())
-    except (
-        psycopg.errors.InvalidSchemaName,
-        psycopg.errors.UndefinedFunction,
-        psycopg.errors.UndefinedTable,
-    ) as exc:
-        raise SchemaNotInstalledError from exc
+    alias = using or resolve_absurd_database()
+    # Asked before the read, not classified off it: a present schema missing only one
+    # relation raises the same error as an absent one, and only the first is what
+    # SchemaNotInstalledError's "run migrate" advice can fix.
+    require_installed_schema(alias)
+    return sorted(get_absurd_client(alias).list_queues())
 
 
 def names_a_queue_table(exc: psycopg.errors.UndefinedTable, queue: str) -> bool:
@@ -220,8 +221,24 @@ def require_installed_schema(using: str) -> None:
     declaring no queues reads no queue at all and still rebuilds views off that table.
     """
     with connections[using].cursor() as cursor:
-        cursor.execute("select to_regnamespace('absurd') is null")
+        cursor.execute(SCHEMA_ABSENT_SQL)
         if cursor.fetchone()[0]:
+            raise SchemaNotInstalledError
+
+
+async def arequire_installed_schema(
+    conn: "psycopg.AsyncConnection[t.Any]",
+) -> None:
+    """``require_installed_schema``, asked on a worker's own async connection.
+
+    A twin body, not a shared one: a worker holds a raw async connection, and asking on
+    the connection it is about to use cannot disagree with what that connection sees.
+    Only the plumbing differs — the query itself is shared.
+    """
+    async with conn.cursor() as cursor:
+        await cursor.execute(SCHEMA_ABSENT_SQL)
+        row = t.cast("tuple[bool]", await cursor.fetchone())
+        if row[0]:
             raise SchemaNotInstalledError
 
 

--- a/django_absurd/worker.py
+++ b/django_absurd/worker.py
@@ -42,7 +42,6 @@ from django_absurd.deferred import DEFER_NAME_SUFFIX, build_deferred_handler
 from django_absurd.exceptions import (
     QueueNotDeclaredError,
     QueueNotProvisionedError,
-    SchemaNotInstalledError,
 )
 from django_absurd.hooks import (
     log_before_spawn,
@@ -50,7 +49,11 @@ from django_absurd.hooks import (
     read_sdk_claimed_task,
 )
 from django_absurd.management.base import resolve_backend
-from django_absurd.queues import afind_missing_queue_tables, names_a_queue_table
+from django_absurd.queues import (
+    afind_missing_queue_tables,
+    arequire_installed_schema,
+    names_a_queue_table,
+)
 from django_absurd.scheduler import run_beat
 
 logger = logging.getLogger(__name__)
@@ -307,15 +310,11 @@ async def aworker_client(
             ),
         )
         client._registry = LazyTaskRegistry(queue, backend)  # noqa: SLF001 -- SDK has no public fallback-resolver hook; install lazy import_string resolution
-        try:
-            # Probes for the schema-absent guard; raises if Absurd is not migrated.
-            provisioned = await client.list_queues()
-        except (
-            psycopg.errors.InvalidSchemaName,
-            psycopg.errors.UndefinedTable,
-            psycopg.errors.UndefinedFunction,
-        ) as err:
-            raise SchemaNotInstalledError from err
+        # Asked before the read, not classified off it: a present schema missing one
+        # relation raises the same error as an absent one, and only the first is what
+        # SchemaNotInstalledError's "run migrate" advice can fix.
+        await arequire_installed_schema(conn)
+        provisioned = await client.list_queues()
         # Both refusals belong before the banner: this is where "may this worker start"
         # is decided, and open_worker_runtime logs `worker started` one frame out.
         if queue not in provisioned:

--- a/tests/core/test_queue_sync.py
+++ b/tests/core/test_queue_sync.py
@@ -19,6 +19,7 @@ from django_absurd.models import Queue
 from django_absurd.queues import (
     PROVISION_LOCK_KEY,
     get_absurd_client,
+    list_provisioned_queues,
     resolve_absurd_database,
 )
 from tests import utils
@@ -470,3 +471,20 @@ def test_concurrent_sync_survives_the_admin_views_being_absent() -> None:
     with connection.cursor() as cur:
         cur.execute("SELECT count(*) FROM pg_views WHERE schemaname = 'absurd'")
         assert cur.fetchone() == (5,)
+
+
+def test_list_provisioned_queues_propagates_a_torn_install() -> None:
+    """Same door as the worker's, on Django's own connection: a present schema missing
+    only ``absurd.queues`` must not be reported as an absent one.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute("alter table absurd.queues rename to queues_hidden")
+    try:
+        with pytest.raises(psycopg.errors.UndefinedTable) as excinfo:
+            list_provisioned_queues()
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute("alter table absurd.queues_hidden rename to queues")
+    assert (
+        excinfo.value.diag.message_primary == 'relation "absurd.queues" does not exist'
+    )

--- a/tests/core/test_worker.py
+++ b/tests/core/test_worker.py
@@ -686,3 +686,26 @@ def test_run_worker_without_on_stop_requested_writes_nothing_to_stdout(
         signal.signal(signal.SIGTERM, previous_handler)
 
     assert capsys.readouterr().out == ""
+
+
+def test_worker_client_propagates_a_torn_install() -> None:
+    """Schema present, only ``absurd.queues`` gone. Relabelling that as absence names a
+    fix that replays no DDL — the migration is already recorded applied — so the advice
+    loops instead of resolving anything.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute("alter table absurd.queues rename to queues_hidden")
+
+    async def _enter() -> None:
+        async with contextlib.AsyncExitStack() as stack:
+            await stack.enter_async_context(aworker_client(backend(), "default"))
+
+    try:
+        with pytest.raises(psycopg.errors.UndefinedTable) as excinfo:
+            asyncio.run(_enter())
+    finally:
+        with connection.cursor() as cursor:
+            cursor.execute("alter table absurd.queues_hidden rename to queues")
+    assert (
+        excinfo.value.diag.message_primary == 'relation "absurd.queues" does not exist'
+    )


### PR DESCRIPTION
Closes #211.

With the schema present but `absurd.queues` missing — a partial restore, a manual drop — `absurd_worker` and `absurd_flush` reported:

```
CommandError: Absurd schema is not installed. Run: manage.py migrate
```

False, and inert: `migrate` replays no DDL once the migration is recorded applied, so the advice loops rather than resolving anything. Both doors classified the failure of `client.list_queues()`, and an absent schema raises the same `UndefinedTable` as a missing table, so the `except` could not tell them apart.

Both now probe `to_regnamespace('absurd')` ahead of the read and catch nothing, so every error the read raises surfaces as itself with its traceback — no psycopg type sits in `CONFIGURATION_ERRORS`. A genuinely absent schema still gets `SchemaNotInstalledError`, whose advice works.

Net −1 line in `worker.py`: removing the three-way `except` more than pays for the probe. The worker gets an async twin because a Django cursor in its loop raises `SynchronousOnlyOperation`, and because asking on the connection it is about to use cannot disagree with what that connection sees; only the plumbing differs, the query is shared as `SCHEMA_ABSENT_SQL`.

Two tests assert `diag.message_primary == 'relation "absurd.queues" does not exist'`, so reintroducing the relabelling fails loudly.
