### PR TITLE
feat!: absurd_flush clears the pg_cron state django-absurd owns

### DIFF
--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -873,14 +873,19 @@ python manage.py absurd_flush            # prompts, then drops on 'yes'
 python manage.py absurd_flush --noinput  # drops without prompting
 ```
 
-**Destructive: this deletes all task history.** It removes every queue — its per-queue
-tables and registry entry — along with all tasks, runs, and events in them. It does not
+**Destructive: this deletes all task history, and every admin-authored schedule.** It
+removes every queue — its per-queue tables and registry entry — along with all tasks,
+runs, and events in them, then prints the commands to re-provision. It does not
 uninstall Absurd: the schema, migrations, and functions stay, so you never re-`migrate`,
 only re-provision the queues with `migrate` or `absurd_sync_queues`.
 
-- Scheduled jobs survive the flush and **error on each fire** until the queues exist
-  again, so re-provision promptly. The `OPTIONS["CLEANUP"]` job is the exception: it
-  survives and runs harmlessly, finding no eligible rows.
+- With `django_absurd.pg_cron` installed the flush also unschedules every pg_cron job
+  django-absurd owns — the schedule lanes and the `OPTIONS["CLEANUP"]` job — and deletes
+  every `ScheduledTask` row, so nothing fires at a queue that no longer exists.
+  `absurd_sync_crons` brings the settings-declared schedules back; admin-authored ones
+  are gone for good.
+- On the beat process instead, schedules live in settings, so beat keeps enqueuing and
+  **errors on each fire** until the queues exist again — re-provision promptly.
 - Per-queue Absurd maintenance jobs from `absurdctl cron --enable <queue>` are dropped
   with their queue.
 

--- a/django_absurd/flush.py
+++ b/django_absurd/flush.py
@@ -113,12 +113,17 @@ def clear_queues(*, drop_schema: bool) -> None:
         return  # absurd schema not present (unmigrated / schema-absent)
 
 
-def teardown_owned_pg_cron_jobs() -> None:
-    # Scoped clear (drop_schema=False) — the existing, already-tested
-    # teardown_crons(include_admin=True), never a hand-rolled parallel implementation.
+def teardown_owned_pg_cron_jobs() -> int:
+    """Unschedule every pg_cron job django-absurd owns and delete every schedule row,
+    admin-authored included. Returns the number of rows deleted.
+
+    Shared by the post-test flush and ``absurd_flush``.
+    """
+    # The existing, already-tested teardown_crons(include_admin=True), never a
+    # hand-rolled parallel implementation.
     from django_absurd.pg_cron.reconcile import teardown_crons  # noqa: PLC0415
 
-    teardown_crons(include_admin=True)
+    return teardown_crons(include_admin=True)
 
 
 def truncate_queue_tables(queue: str) -> None:

--- a/django_absurd/flush.py
+++ b/django_absurd/flush.py
@@ -91,26 +91,35 @@ def reset_fake_now(alias: str) -> None:
 
 
 def clear_queues(*, drop_schema: bool) -> None:
-    """Drop (``drop_schema=True``) or truncate (``drop_schema=False``) every queue's
-    tables. Queue-only — never touches pg_cron. No-op on an unreachable database, an
-    unmigrated/absent schema, or a partial one — a queue whose catalog row survives
-    but one of its own tables does not.
+    """``clear_provisioned_queues``, made a no-op on an unreachable database, an
+    unmigrated/absent schema, or a partial one — a queue whose catalog row survives but
+    one of its own tables does not. The form post-test cleanup needs: a test that never
+    provisioned anything must not fail in teardown.
     """
-    try:
-        names = list_provisioned_queues()
-        client = get_absurd_client()
-        for name in names:
-            if drop_schema:
-                client.drop_queue(name)
-            else:
-                truncate_queue_tables(name)
-    except (
+    with contextlib.suppress(
         OperationalError,
         ProgrammingError,
         ImproperlyConfigured,
         SchemaNotInstalledError,
     ):
-        return  # absurd schema not present (unmigrated / schema-absent)
+        clear_provisioned_queues(drop_schema=drop_schema)
+
+
+def clear_provisioned_queues(*, drop_schema: bool) -> list[str]:
+    """Drop (``drop_schema=True``) or truncate (``drop_schema=False``) every provisioned
+    queue's tables, returning the names cleared. Queue-only — never touches pg_cron.
+
+    Raises, unlike ``clear_queues``: an operator running ``absurd_flush`` needs the
+    Postgres error, not a silent success line naming queues that are still there.
+    """
+    names = list_provisioned_queues()
+    client = get_absurd_client()
+    for name in names:
+        if drop_schema:
+            client.drop_queue(name)
+        else:
+            truncate_queue_tables(name)
+    return names
 
 
 def teardown_owned_pg_cron_jobs() -> int:

--- a/django_absurd/management/commands/absurd_flush.py
+++ b/django_absurd/management/commands/absurd_flush.py
@@ -1,16 +1,23 @@
+from django.apps import apps
 from django.core.management.base import CommandParser
 
-from django_absurd.backends import get_absurd_backends
+from django_absurd.backends import PG_CRON_APP_NAME, get_absurd_backends
 from django_absurd.exceptions import BackendNotConfiguredError
-from django_absurd.flush import clear_queues
+from django_absurd.flush import clear_queues, teardown_owned_pg_cron_jobs
 from django_absurd.management.base import AbsurdCommand
 from django_absurd.queues import list_provisioned_queues
+
+PG_CRON_WARNING = (
+    "This will also UNSCHEDULE django-absurd's pg_cron jobs and delete ALL"
+    " schedule rows, including admin-authored ones."
+)
 
 
 class Command(AbsurdCommand):
     help = (
-        "Drop ALL Absurd queues and their data (the schema and functions are kept)."
-        " Destructive."
+        "Drop ALL Absurd queues and their data, and — with django_absurd.pg_cron"
+        " installed — unschedule every pg_cron job django-absurd owns (the schema and"
+        " functions are kept). Destructive."
     )
 
     def add_arguments(self, parser: CommandParser) -> None:
@@ -26,14 +33,20 @@ class Command(AbsurdCommand):
         if not get_absurd_backends():
             raise BackendNotConfiguredError
         queues = list_provisioned_queues()
-        if not queues:
+        pg_cron_installed = apps.is_installed(PG_CRON_APP_NAME)
+        # With pg_cron installed there is always state to clear even at zero queues —
+        # the CLEANUP job is invisible to this count and outlives every queue.
+        if not queues and not pg_cron_installed:
             self.stdout.write("No queues to flush.")
             return
         names = ", ".join(queues)
         if options["interactive"]:
-            self.stdout.write(
-                f"This will DROP {len(queues)} queue(s) and ALL their data: {names}"
-            )
+            if queues:
+                self.stdout.write(
+                    f"This will DROP {len(queues)} queue(s) and ALL their data: {names}"
+                )
+            if pg_cron_installed:
+                self.stdout.write(PG_CRON_WARNING)
             try:
                 confirm = input("Type 'yes' to continue, or 'no' to cancel: ")
             except EOFError:  # non-interactive (CI, docker exec -T) — cancel
@@ -43,5 +56,17 @@ class Command(AbsurdCommand):
         if confirm != "yes":
             self.stdout.write("Flush cancelled.")
             return
-        clear_queues(drop_schema=True)
-        self.stdout.write(f"Dropped {len(queues)} queue(s): {names}")
+        commands = ["manage.py absurd_sync_queues"]
+        if pg_cron_installed:
+            # Before the queues go, not after: a job firing in the window between
+            # would spawn into a queue that no longer exists.
+            removed = teardown_owned_pg_cron_jobs()
+            commands.append("manage.py absurd_sync_crons")
+            self.stdout.write(
+                "Unscheduled django-absurd's pg_cron jobs and removed"
+                f" {removed} schedule row(s)."
+            )
+        if queues:
+            clear_queues(drop_schema=True)
+            self.stdout.write(f"Dropped {len(queues)} queue(s): {names}")
+        self.stdout.write(f"Re-provision with: {', '.join(commands)}")

--- a/django_absurd/management/commands/absurd_flush.py
+++ b/django_absurd/management/commands/absurd_flush.py
@@ -3,13 +3,13 @@ from django.core.management.base import CommandParser
 
 from django_absurd.backends import PG_CRON_APP_NAME, get_absurd_backends
 from django_absurd.exceptions import BackendNotConfiguredError
-from django_absurd.flush import clear_queues, teardown_owned_pg_cron_jobs
+from django_absurd.flush import clear_provisioned_queues, teardown_owned_pg_cron_jobs
 from django_absurd.management.base import AbsurdCommand
 from django_absurd.queues import list_provisioned_queues
 
 PG_CRON_WARNING = (
-    "This will also UNSCHEDULE django-absurd's pg_cron jobs and delete ALL"
-    " schedule rows, including admin-authored ones."
+    "This will UNSCHEDULE django-absurd's pg_cron jobs and delete ALL schedule rows,"
+    " including admin-authored ones."
 )
 
 
@@ -34,8 +34,8 @@ class Command(AbsurdCommand):
             raise BackendNotConfiguredError
         queues = list_provisioned_queues()
         pg_cron_installed = apps.is_installed(PG_CRON_APP_NAME)
-        # With pg_cron installed there is always state to clear even at zero queues —
-        # the CLEANUP job is invisible to this count and outlives every queue.
+        # Zero queues is not nothing to do under pg_cron: the CLEANUP job is invisible
+        # to this count and outlives every queue.
         if not queues and not pg_cron_installed:
             self.stdout.write("No queues to flush.")
             return
@@ -67,6 +67,8 @@ class Command(AbsurdCommand):
                 f" {removed} schedule row(s)."
             )
         if queues:
-            clear_queues(drop_schema=True)
-            self.stdout.write(f"Dropped {len(queues)} queue(s): {names}")
+            # Reported off what came back, not off the pre-prompt listing: the two can
+            # differ, and only the first is what actually went.
+            dropped = clear_provisioned_queues(drop_schema=True)
+            self.stdout.write(f"Dropped {len(dropped)} queue(s): {', '.join(dropped)}")
         self.stdout.write(f"Re-provision with: {', '.join(commands)}")

--- a/docs/web/cleanup.md
+++ b/docs/web/cleanup.md
@@ -95,9 +95,9 @@ exists. `absurd_sync_crons` brings the settings-declared schedules back;
     admin-authored schedule. Re-provision your declared queues afterward with `migrate`
     or `absurd_sync_queues`.
 
-    On the [beat process](cron-jobs.md#application-side-beat) instead, schedules live in settings, so
-    beat keeps enqueuing and **errors on each fire** until the queues exist again —
-    re-provision promptly.
+    On the [beat process](cron-jobs.md#application-side-beat) instead, schedules live
+    in settings, so beat keeps enqueuing and **errors on each fire** until the queues
+    exist again — re-provision promptly.
 
     Per-queue Absurd maintenance jobs from `absurdctl cron --enable <queue>` are dropped
     with their queue.

--- a/docs/web/cleanup.md
+++ b/docs/web/cleanup.md
@@ -79,18 +79,25 @@ python manage.py absurd_flush            # prompts, then drops on 'yes'
 python manage.py absurd_flush --noinput  # drops without prompting
 ```
 
-Removes every queue — tables, registry entry, and all tasks, runs, and events in them.
-It does **not** uninstall Absurd: the schema, migrations, and functions stay, so you
-only re-provision the queues, never re-`migrate`.
+Removes every queue — tables, registry entry, and all tasks, runs, and events in them —
+then prints the commands to re-provision. It does **not** uninstall Absurd: the schema,
+migrations, and functions stay, so you never re-`migrate`.
+
+With [`django_absurd.pg_cron`](cron-jobs.md) installed the flush also unschedules every
+pg_cron job django-absurd owns — the schedule lanes and the `OPTIONS["CLEANUP"]` job —
+and deletes every `ScheduledTask` row, so nothing fires at a queue that no longer
+exists. `absurd_sync_crons` brings the settings-declared schedules back;
+[admin-authored](cron-jobs.md#author-schedules-in-the-admin) ones are gone for good.
 
 !!! warning "Destructive"
 
-    This permanently deletes all task history across every queue. Re-provision your
-    declared queues afterward with `migrate` or `absurd_sync_queues`.
+    This permanently deletes all task history across every queue, and every
+    admin-authored schedule. Re-provision your declared queues afterward with `migrate`
+    or `absurd_sync_queues`.
 
-    Scheduled jobs survive the flush and **error on each fire** until the queues exist
-    again — re-provision promptly. The `OPTIONS["CLEANUP"]` job is the exception: it
-    survives and runs harmlessly, finding no eligible rows.
+    On the [beat process](cron-jobs.md#application-side-beat) instead, schedules live in settings, so
+    beat keeps enqueuing and **errors on each fire** until the queues exist again —
+    re-provision promptly.
 
     Per-queue Absurd maintenance jobs from `absurdctl cron --enable <queue>` are dropped
     with their queue.

--- a/tests/core/test_cleanup.py
+++ b/tests/core/test_cleanup.py
@@ -1,10 +1,6 @@
-import collections.abc
-import contextlib
 import datetime as dt
-import io
 import logging
 import re
-import sys
 import typing as t
 
 import psycopg.errors
@@ -91,17 +87,6 @@ def parse_cleanup_line(line: str) -> QueueCleanup:
         "tasks_deleted": int(match[2]),
         "events_deleted": int(match[3]),
     }
-
-
-@contextlib.contextmanager
-def answer(text: str) -> collections.abc.Iterator[None]:
-    """Feed a line to the next input() prompt via a real stdin (no mock)."""
-    original = sys.stdin
-    sys.stdin = io.StringIO(text)
-    try:
-        yield
-    finally:
-        sys.stdin = original
 
 
 def test_cleanup_deletes_aged_terminal_tasks(
@@ -249,7 +234,10 @@ def test_flush_noinput_drops_all_queues(
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
     call_command("absurd_flush", "--noinput")
-    assert capsys.readouterr().out == "Dropped 2 queue(s): default, other\n"
+    assert capsys.readouterr().out == (
+        "Dropped 2 queue(s): default, other\n"
+        "Re-provision with: manage.py absurd_sync_queues\n"
+    )
     assert get_absurd_client().list_queues() == []
 
 
@@ -259,12 +247,13 @@ def test_flush_interactive_yes_drops_all_queues(
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
-    with answer("yes\n"):
+    with utils.answer("yes\n"):
         call_command("absurd_flush")
     assert capsys.readouterr().out == (
         "This will DROP 2 queue(s) and ALL their data: default, other\n"
         "Type 'yes' to continue, or 'no' to cancel: "
         "Dropped 2 queue(s): default, other\n"
+        "Re-provision with: manage.py absurd_sync_queues\n"
     )
     assert get_absurd_client().list_queues() == []
 
@@ -275,7 +264,7 @@ def test_flush_interactive_no_keeps_queues(
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
-    with answer("no\n"):
+    with utils.answer("no\n"):
         call_command("absurd_flush")
     assert capsys.readouterr().out == (
         "This will DROP 2 queue(s) and ALL their data: default, other\n"
@@ -291,7 +280,7 @@ def test_flush_non_interactive_eof_keeps_queues(
 ) -> None:
     sync_queue(settings, names=("default", "other"))
     capsys.readouterr()  # discard sync output
-    with answer(""):  # empty stdin → input() raises EOFError
+    with utils.answer(""):  # empty stdin → input() raises EOFError
         call_command("absurd_flush")
     assert capsys.readouterr().out == (
         "This will DROP 2 queue(s) and ALL their data: default, other\n"

--- a/tests/pg_cron/test_cleanup_schedule.py
+++ b/tests/pg_cron/test_cleanup_schedule.py
@@ -72,7 +72,7 @@ def test_sync_unschedules_cleanup_job_when_cleanup_dropped(
     assert fetch_cleanup_lane() == []
 
 
-def test_cleanup_job_survives_absurd_flush_command(
+def test_absurd_flush_command_removes_cleanup_job(
     settings: Settings,
 ) -> None:
     settings.TASKS = build_cleanup_tasks("17 * * * *")
@@ -83,9 +83,7 @@ def test_cleanup_job_survives_absurd_flush_command(
 
     call_command("absurd_flush", "--noinput")
 
-    assert fetch_cleanup_lane() == [
-        (build_cleanup_jobname(), "17 * * * *", CLEANUP_COMMAND, True)
-    ]
+    assert fetch_cleanup_lane() == []
 
 
 def test_teardown_removes_cleanup_job(

--- a/tests/pg_cron/test_flush_scoped.py
+++ b/tests/pg_cron/test_flush_scoped.py
@@ -1,11 +1,15 @@
 import pytest
+from django.core.management import call_command
 from django.db import connections
 from pytest_django import Settings
 
 from django_absurd.flush import flush_absurd_state
 from django_absurd.pg_cron import catalog
 from django_absurd.pg_cron.choices import Source
+from django_absurd.pg_cron.models import ScheduledTask
+from django_absurd.queues import list_provisioned_queues
 from tests.pg_cron import utils
+from tests.utils import answer
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -30,3 +34,65 @@ def test_flush_only_removes_this_database_jobs(settings: Settings) -> None:
         assert utils.is_control_job_present("other_db_name") is True
     finally:
         utils.remove_control_job("other_db_name")
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_flush_command_removes_owned_pg_cron_jobs_and_rows(
+    capsys: pytest.CaptureFixture[str],
+    settings: Settings,
+) -> None:
+    settings.TASKS = utils.build_pg_cron_tasks(
+        {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    )
+    ScheduledTask.objects.create(
+        name="admin-job",
+        source=Source.ADMIN,
+        task="tests.tasks.add",
+        cron="0 4 * * *",
+    )
+    call_command("absurd_sync_crons")
+    call_command("absurd_sync_queues")
+    assert utils.fetch_managed_jobs(utils.fetch_live_database()) != []
+    capsys.readouterr()  # discard sync output
+
+    with answer("yes\n"):
+        call_command("absurd_flush")
+
+    assert capsys.readouterr().out == (
+        "This will DROP 3 queue(s) and ALL their data: default, other, reports\n"
+        "This will also UNSCHEDULE django-absurd's pg_cron jobs and delete ALL"
+        " schedule rows, including admin-authored ones.\n"
+        "Type 'yes' to continue, or 'no' to cancel: "
+        "Unscheduled django-absurd's pg_cron jobs and removed 2 schedule row(s).\n"
+        "Dropped 3 queue(s): default, other, reports\n"
+        "Re-provision with: manage.py absurd_sync_queues,"
+        " manage.py absurd_sync_crons\n"
+    )
+    assert utils.fetch_managed_jobs(utils.fetch_live_database()) == []
+    assert ScheduledTask.objects.exists() is False
+
+
+@pytest.mark.usefixtures("_isolate_queues")
+def test_flush_command_clears_pg_cron_state_with_no_queues_provisioned(
+    capsys: pytest.CaptureFixture[str],
+    settings: Settings,
+) -> None:
+    settings.TASKS = utils.build_pg_cron_tasks(
+        {"nightly": {"task": "tests.tasks.add", "cron": "0 2 * * *"}}
+    )
+    call_command("absurd_sync_crons")
+    assert list_provisioned_queues() == []
+    capsys.readouterr()  # discard sync output
+
+    with answer("yes\n"):
+        call_command("absurd_flush")
+
+    assert capsys.readouterr().out == (
+        "This will also UNSCHEDULE django-absurd's pg_cron jobs and delete ALL"
+        " schedule rows, including admin-authored ones.\n"
+        "Type 'yes' to continue, or 'no' to cancel: "
+        "Unscheduled django-absurd's pg_cron jobs and removed 1 schedule row(s).\n"
+        "Re-provision with: manage.py absurd_sync_queues,"
+        " manage.py absurd_sync_crons\n"
+    )
+    assert utils.fetch_managed_jobs(utils.fetch_live_database()) == []

--- a/tests/pg_cron/test_flush_scoped.py
+++ b/tests/pg_cron/test_flush_scoped.py
@@ -49,6 +49,7 @@ def test_flush_command_removes_owned_pg_cron_jobs_and_rows(
         source=Source.ADMIN,
         task="tests.tasks.add",
         cron="0 4 * * *",
+        queue="default",
     )
     call_command("absurd_sync_crons")
     call_command("absurd_sync_queues")
@@ -60,8 +61,8 @@ def test_flush_command_removes_owned_pg_cron_jobs_and_rows(
 
     assert capsys.readouterr().out == (
         "This will DROP 3 queue(s) and ALL their data: default, other, reports\n"
-        "This will also UNSCHEDULE django-absurd's pg_cron jobs and delete ALL"
-        " schedule rows, including admin-authored ones.\n"
+        "This will UNSCHEDULE django-absurd's pg_cron jobs and delete ALL schedule"
+        " rows, including admin-authored ones.\n"
         "Type 'yes' to continue, or 'no' to cancel: "
         "Unscheduled django-absurd's pg_cron jobs and removed 2 schedule row(s).\n"
         "Dropped 3 queue(s): default, other, reports\n"
@@ -88,8 +89,8 @@ def test_flush_command_clears_pg_cron_state_with_no_queues_provisioned(
         call_command("absurd_flush")
 
     assert capsys.readouterr().out == (
-        "This will also UNSCHEDULE django-absurd's pg_cron jobs and delete ALL"
-        " schedule rows, including admin-authored ones.\n"
+        "This will UNSCHEDULE django-absurd's pg_cron jobs and delete ALL schedule"
+        " rows, including admin-authored ones.\n"
         "Type 'yes' to continue, or 'no' to cancel: "
         "Unscheduled django-absurd's pg_cron jobs and removed 1 schedule row(s).\n"
         "Re-provision with: manage.py absurd_sync_queues,"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 import contextlib
+import io
 import os
 import signal
+import sys
 import threading
 import time
 import typing as t
@@ -326,3 +328,14 @@ def connect_receiver(
         yield
     finally:
         signal.disconnect(receiver, sender=sender)
+
+
+@contextlib.contextmanager
+def answer(text: str) -> t.Iterator[None]:
+    """Feed a line to the next input() prompt via a real stdin (no mock)."""
+    original = sys.stdin
+    sys.stdin = io.StringIO(text)
+    try:
+        yield
+    finally:
+        sys.stdin = original


### PR DESCRIPTION
`absurd_flush` left every pg_cron job and `ScheduledTask` row behind, so schedules kept firing at queues that no longer existed. It now unschedules the schedule lanes and the `OPTIONS["CLEANUP"]` job and deletes every schedule row before dropping the queues, and prints the commands to re-provision.

BREAKING CHANGE: with `django_absurd.pg_cron` installed, `absurd_flush` also deletes admin-authored schedules. The prompt says so; `--noinput` does it silently.

Also splits the error-swallowing out of `clear_queues` so the command can no longer report `Dropped N queue(s)` on a drop that failed.

Closes #94
