### PR TITLE
chore: prepare v1.0.0b1

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -44,28 +44,30 @@ reasoning, then ask** — present the change summary, map it to candidate versio
 let the human choose. Surface disagreement (e.g. "these look like breaking changes, so
 I'd lean beta over another alpha — your call").
 
-**Where we are:** pre-1.0, the `0.1.0` line, shipping **alpha** pre-releases (`v0.1.0a1`
-→ `a2` → … → `a5`). The history: `git tag --list 'v*' | sort -V`, or the section
-headings in `CHANGELOG.md`.
+**Where we are:** the `1.0.0` line, shipping **beta** pre-releases. The `0.1.0` alpha
+series (`v0.1.0a1` → … → `a8`) is closed; `v1.0.0b1` opened the beta and jumped the
+target line at the same time. The history: `git tag --list 'v*' | sort -V`, or the
+section headings in `CHANGELOG.md`.
 
 **PEP 440 pre-release suffixes** (what `pip` does):
 
 - `aN` (alpha), `bN` (beta), `rcN` (release candidate) — all install only with
   `pip install --pre`. Tag each with the GitHub **"pre-release"** flag.
-- no suffix (`v0.1.0`) — the real release; installs by default.
+- no suffix (`v1.0.0`) — the real release; installs by default.
 
 **How to reason about the next number (present these, let the human pick):**
 
-- **Another alpha** (`a(N+1)`) — still iterating toward `0.1.0`; API/behavior still
-  moving. The default during this phase.
-- **Move to beta / rc** (`b1` / `rc1`) — feature-set for `0.1.0` is settling; you want
-  wider testing without more API churn. A deliberate phase change — confirm intent.
-- **Bump the target line** (`0.2.0aN`, etc.) — only if scope grew enough that `0.1.0` no
-  longer names it.
-- **Semantic versioning** governs the target line. Pre-1.0 (`0.x`): the API is unstable,
-  so a `0.MINOR` bump may include breaking changes; `0.x.PATCH` is for fixes. Post-1.0:
-  MAJOR = breaking, MINOR = backward-compatible features, PATCH = fixes. The first
-  stable cut is `v0.1.0` (no suffix) — a separate, explicit decision (see Guardrails).
+- **Another beta** (`b(N+1)`) — the 1.0.0 feature set is settled but feedback is still
+  arriving and the API may still need a correction. The default during this phase.
+- **Move to rc** (`rc1`) — nothing left you expect to change; the cut is a formality
+  pending a final soak. A deliberate phase change — confirm intent.
+- **The stable cut** (`v1.0.0`, no suffix) — see Guardrails; its own explicit decision.
+- **Back to alpha, or a new target line** (`1.1.0aN`, `2.0.0aN`) — only if scope grew
+  enough that `1.0.0` no longer names what is shipping.
+- **Semantic versioning** governs the target line, and from `1.0.0` onward it binds:
+  MAJOR = breaking, MINOR = backward-compatible features, PATCH = fixes. The 0.x licence
+  to break things in a minor bump is gone, so a breaking change after `v1.0.0` is
+  `v2.0.0` — price that in before agreeing to one.
 
 ## Steps
 
@@ -95,8 +97,8 @@ headings in `CHANGELOG.md`.
 
    ```bash
    git fetch origin
-   git checkout -b changelog-v0.1.0aN origin/main
-   uv run git-cliff --unreleased --tag v0.1.0aN --prepend CHANGELOG.md
+   git checkout -b changelog-v1.0.0bN origin/main
+   uv run git-cliff --unreleased --tag v1.0.0bN --prepend CHANGELOG.md
    ```
 
    `--tag` supplies the heading for a tag that does not exist yet. `--prepend` inserts
@@ -123,23 +125,17 @@ headings in `CHANGELOG.md`.
      printed one. Rerun with `-vv` to see which. Anything that isn't a pre-mandate
      Renovate subject is user-visible work that would otherwise be omitted permanently:
      once the tag lands, that commit is below the next release's range boundary and no
-     later run will ever see it. Add an entry by hand.
-
-     _One-time, for the first release cut this way:_ the range reaches back before
-     conventional commits were mandated (~#131), so this warning covers 13 commits.
-     Twelve are Renovate; the thirteenth,
-     `Cross-database pg_cron scheduling (restore xdist + test isolation) (#107)`, is
-     real runtime work in `django_absurd/pg_cron/` and **must** get a hand-written
-     entry. Afterwards the warning should be rare — treat any occurrence as something to
-     look at, not as routine.
+     later run will ever see it. Add an entry by hand. Every range now sits well after
+     conventional commits were mandated, so the warning should be rare — treat any
+     occurrence as something to look at, not as routine.
 
    Then, with the section final (prettier reflows the generated one-line bullets, so run
    this last):
 
    ```bash
    uv run pre-commit run --all-files
-   git commit -am "chore: changelog for v0.1.0aN"
-   git push -u origin changelog-v0.1.0aN && gh pr create --fill
+   git commit -am "chore: changelog for v1.0.0bN"
+   git push -u origin changelog-v1.0.0bN && gh pr create --fill
    ```
 
    `chore:` is deliberate — `--fill` makes this subject the PR title, squash-merge makes
@@ -153,7 +149,7 @@ headings in `CHANGELOG.md`.
    **That merge is the last time `--prepend` runs for this version.** Everything after
    it — a missed commit found in step 5, a wording change asked for at GATE 2 — is a
    hand-edit PR against the top section of `CHANGELOG.md`. Re-running the prepend would
-   render the identical range a second time and stack a duplicate `## [v0.1.0aN]`
+   render the identical range a second time and stack a duplicate `## [v1.0.0bN]`
    section above the merged one, because the tag still does not exist and the range has
    not moved. Steps 5 and 6 both send you back here; both mean the hand edit, neither
    means the command.
@@ -200,8 +196,8 @@ headings in `CHANGELOG.md`.
 7. **Create the release** (creates the tag AND triggers `publish.yml`):
 
    ```bash
-   gh release create v0.1.0aN --target main --prerelease \
-     --title v0.1.0aN --notes-file /tmp/release-notes.md
+   gh release create v1.0.0bN --target main --prerelease \
+     --title v1.0.0bN --notes-file /tmp/release-notes.md
    ```
 
    Use `--prerelease` for any `a`/`b`/`rc`; omit it only for a final release.
@@ -230,9 +226,11 @@ headings in `CHANGELOG.md`.
   project).
 - The `pypi` environment restricts deployments to `v*` tags and requires a reviewer
   (`marcgibbons`).
-- **First stable (non-pre) `v0.1.0`** is its own deliberate decision — confirm the API
-  is ready, and first ensure README + LICENSE + license metadata are in place (twine
-  warns on a missing long_description for pre-releases today).
+- **First stable (non-pre) `v1.0.0`** is its own deliberate decision — confirm the API
+  is ready. Packaging metadata is not a blocker: README, LICENSE, the MIT license
+  expression and the `long_description` all ship, and `uvx twine check --strict dist/*`
+  passed on both artifacts at the `v1.0.0b1` cut. Re-run that check rather than assuming
+  it still holds.
 - A mistaken release: you can delete the GitHub release + its tag, but a published PyPI
   version is permanent — yank it, never reuse the number; cut the next pre-release
   instead.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -96,7 +96,12 @@ A change triggers a doc pass if it touches any of:
 
 1. **README.md** — does the quickstart still reflect the happy path? If a step changed
    (e.g. a command became optional), fix it. If you're tempted to _add_ explanation, put
-   it in AGENTS.md and link instead.
+   it in AGENTS.md and link instead. **Every link in this file must be absolute:** it is
+   the published PyPI description, where a relative link resolves against pypi.org and
+   arrives dead. `twine check --strict` passes anyway — it checks that the description
+   renders, not that its links resolve — so nothing but review catches one. Introduce
+   the package by what it does, never by what it replaces; naming other projects to
+   define this one dates fast and sells against them instead of describing this.
 2. **AGENTS.md** — update the relevant section (Tasks / Workflows / Cron jobs / Workers
    / Cleanup / Monitoring / Testing / Configuration / Database setup). This is where
    completeness lives, and it must **stand alone**: it ships inside the installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@ Never `git cliff -o`: it discards every hand edit, and no regeneration can repro
 
 # Changelog
 
+## [1.0.0b1](https://github.com/lincolnloop/django-absurd/compare/v0.1.0a8...v1.0.0b1) - 2026-08-21
+
+**First beta, and the first release on the 1.0 line.** The alpha series is over: the
+feature set for 1.0 is settled and the API is not expected to move again before it. This
+is still a pre-release, so `pip install --pre` / `uv add --prerelease allow` is still
+how you get it — but the reason has changed. Alpha meant "this may be reshaped"; beta
+means "this is what 1.0 will be, please tell us where it's wrong." Feedback on the
+public surface is the point of this release, and now is the cheap time to give it:
+[open an issue](https://github.com/lincolnloop/django-absurd/issues).
+
+**`absurd_flush` now clears pg_cron state too.** With `django_absurd.pg_cron` installed,
+a flush unschedules every pg_cron job the package owns — the schedule lanes and the
+`OPTIONS["CLEANUP"]` job — and deletes every `ScheduledTask` row, before dropping the
+queues rather than after. Previously they survived and fired at queues that no longer
+existed. This deletes **admin-authored** schedules, which no earlier release did: the
+confirmation prompt names it, but `--noinput` does it silently, so check any automation
+that flushes unattended. Restore settings-declared schedules with
+`manage.py absurd_sync_crons`; admin-authored ones are gone. The command now also prints
+the commands needed to re-provision.
+
+### Breaking changes
+
+- absurd_flush clears the pg_cron state django-absurd owns
+  ([#233](https://github.com/lincolnloop/django-absurd/pull/233)) — admin-authored
+  schedules are deleted along with the settings-declared ones and the cleanup job.
+
+### Bug fixes
+
+- absurd_flush surfaces a failed queue drop instead of reporting success
+  ([#233](https://github.com/lincolnloop/django-absurd/pull/233)) — a drop that failed
+  could print `Dropped N queue(s)` regardless.
+- Stop reporting a torn install as an absent schema
+  ([#230](https://github.com/lincolnloop/django-absurd/pull/230)) — a schema present but
+  missing a relation no longer advises `migrate`, which could not fix it.
+
+### Documentation
+
+- Document the grants a non-superuser pg_cron role needs
+  ([#224](https://github.com/lincolnloop/django-absurd/pull/224))
+
 ## [0.1.0a8](https://github.com/lincolnloop/django-absurd/compare/v0.1.0a7...v0.1.0a8) - 2026-08-19
 
 **Partitioned queues are refused, not experimental.** Declaring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ the commands needed to re-provision.
 
 - Document the grants a non-superuser pg_cron role needs
   ([#224](https://github.com/lincolnloop/django-absurd/pull/224))
+- Fix the dead `examples/` and `LICENSE` links on the PyPI project page — PyPI resolves
+  a README's relative links against pypi.org, not the repository
+  ([#236](https://github.com/lincolnloop/django-absurd/pull/236))
 
 ## [0.1.0a8](https://github.com/lincolnloop/django-absurd/compare/v0.1.0a7...v0.1.0a8) - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ workflow engine, into Django's
 [Tasks](https://docs.djangoproject.com/en/6.0/topics/tasks/) framework, reusing your
 existing database connection.
 
-> **Alpha.** APIs and behavior may change between releases.
+> **Beta.** The API is settling ahead of 1.0; behavior may still change.
 
 ## Install
 
@@ -14,9 +14,9 @@ existing database connection.
 uv add django-absurd --prerelease allow    # or: pip install --pre django-absurd
 ```
 
-Only pre-releases are published during alpha, hence the flags. Needs Python 3.12+,
-Django 6.0+, and PostgreSQL on the **psycopg (v3)** driver — Absurd reuses Django's
-connection, so psycopg2 won't work.
+Only pre-releases are published before 1.0, hence the flags. Needs Python 3.12+, Django
+6.0+, and PostgreSQL on the **psycopg (v3)** driver — Absurd reuses Django's connection,
+so psycopg2 won't work.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@
 [![License](https://img.shields.io/pypi/l/django-absurd.svg)](https://github.com/lincolnloop/django-absurd/blob/main/LICENSE)
 <!-- prettier-ignore-end -->
 
-Run background tasks in Django on **Postgres** — no separate broker, no Redis, no
-Celery. Plugs [Absurd](https://earendil-works.github.io/absurd/), a Postgres-native
-workflow engine, into Django's
-[Tasks](https://docs.djangoproject.com/en/6.0/topics/tasks/) framework, reusing your
-existing database connection.
+Run background tasks and durable workflows in Django on **Postgres**. Plugs
+[Absurd](https://earendil-works.github.io/absurd/), a Postgres-native workflow engine,
+into Django's [Tasks](https://docs.djangoproject.com/en/6.0/topics/tasks/) framework,
+reusing the database connection your project already has.
 
 > **Beta.** The API is settling ahead of 1.0; behavior may still change.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # django-absurd
 
+<!-- prettier-ignore-start -->
+[![CI](https://github.com/lincolnloop/django-absurd/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/lincolnloop/django-absurd/actions/workflows/test.yml?query=branch%3Amain+event%3Apush)
+[![Coverage](https://img.shields.io/codecov/c/github/lincolnloop/django-absurd.svg)](https://codecov.io/gh/lincolnloop/django-absurd)
+[![PyPI](https://img.shields.io/pypi/v/django-absurd.svg)](https://pypi.org/project/django-absurd/)
+[![Python versions](https://img.shields.io/pypi/pyversions/django-absurd.svg)](https://pypi.org/project/django-absurd/)
+[![Django versions](https://img.shields.io/pypi/frameworkversions/django/django-absurd.svg)](https://pypi.org/project/django-absurd/)
+[![License](https://img.shields.io/pypi/l/django-absurd.svg)](https://github.com/lincolnloop/django-absurd/blob/main/LICENSE)
+<!-- prettier-ignore-end -->
+
 Run background tasks in Django on **Postgres** — no separate broker, no Redis, no
 Celery. Plugs [Absurd](https://earendil-works.github.io/absurd/), a Postgres-native
 workflow engine, into Django's
@@ -61,9 +70,10 @@ provisions it without any `QUEUES` setting of your own.
 
 - **[Documentation](https://lincolnloop.github.io/django-absurd/)** — tasks, workflows,
   cron jobs, workers, cleanup, monitoring, testing, and configuration.
-- **[Runnable examples](examples/)** — three dockerized nanodjango demos (`web`
-  enqueue+result, `beat`, and `pg_cron`), each with one `docker compose up`.
+- **[Runnable examples](https://github.com/lincolnloop/django-absurd/tree/main/examples)**
+  — three dockerized nanodjango demos (`web` enqueue+result, `beat`, and `pg_cron`),
+  each with one `docker compose up`.
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](https://github.com/lincolnloop/django-absurd/blob/main/LICENSE).

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -1343,4 +1343,4 @@ Django cannot detect. Verify the versions line up first.
 
 ---
 
-Alpha software: APIs may change between versions.
+Beta software: the API is settling ahead of 1.0 and behavior may still change.

--- a/django_absurd/AGENTS.md
+++ b/django_absurd/AGENTS.md
@@ -3,8 +3,7 @@
 django-absurd plugs [Absurd](https://earendil-works.github.io/absurd/), a
 Postgres-native workflow engine, into Django's
 [Tasks framework](https://docs.djangoproject.com/en/6.0/topics/tasks/), reusing Django's
-database connection and shipping Absurd's schema as Django migrations — no separate
-broker.
+database connection and shipping Absurd's schema as Django migrations.
 
 Ships inside the installed package (`site-packages/django_absurd/AGENTS.md`), complete
 on its own. Same material with navigation:

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -53,6 +53,13 @@ replaced upstream by a function that falls back to what Postgres has built in, w
 what makes the package installable by an ordinary application role on a locked-down
 deployment.
 
+Whether that schema is installed is asked directly, never inferred from a failure. A
+schema that is present but missing a single relation raises the same error as one that
+was never installed, and only the second is fixed by running migrations — so classifying
+off the error tells an operator holding a half-applied install to do the one thing that
+cannot help them. The question is asked on the same connection that is about to do the
+work, so the answer cannot disagree with what that connection goes on to see.
+
 ### Queue provisioning: `migrate` or the command, never a runtime seam
 
 Provisioning per-queue tables from the declared queue list has been redesigned three
@@ -671,9 +678,17 @@ leaving the schema, functions, and migration history intact — the migration sy
 the sole owner of the schema, and since migrations do not run backwards, a reset that
 also removed the schema would leave no supported way to get it back. It follows the
 framework's own destructive-command convention (confirm interactively, skip with a
-no-input flag) so the safety model is one users already know. Dropping a queue removes
-only that queue's own maintenance jobs and data; user-defined recurring schedules live
-elsewhere and survive, so a reset never silently cancels recurring work.
+no-input flag) so the safety model is one users already know.
+
+That reset also clears the recurring schedules this package owns, and clears them before
+dropping the queues rather than after: a schedule left behind fires at a queue that no
+longer exists, and one that fires in the gap between the two steps spawns into the same
+hole. It costs the operator every hand-authored schedule, which is why the confirmation
+says so outright — the alternative, leaving them to fail on each fire, was the earlier
+behaviour and read as a bug every time it happened. The queue drop refuses to be
+tolerant here even though the identical operation is deliberately tolerant during test
+teardown, where a run that provisioned nothing must not fail on the way out; an operator
+needs the database's own error, not a success line naming queues that are still there.
 
 ## Admin & ORM introspection
 

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -883,6 +883,12 @@ The release body is sliced out of the checked-in file rather than out of the gen
 output, so there is one artifact to edit and hand-written prose reaches the published
 notes without a second step.
 
+The repository's front page doubles as the package's published description, so a link
+written relative to the repository resolves against the index host instead and arrives
+dead for every visitor who never sees the repository. The packaging metadata check does
+not catch this — it verifies the description renders, not that its links point anywhere
+— so links in that file are absolute by rule rather than by review.
+
 ## Deliberately not doing (yet)
 
 Task **priority** is unsupported because Absurd has no notion of it — we won't fake it

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -14,9 +14,9 @@ workflow engine, into Django's built-in
 [Tasks framework](https://docs.djangoproject.com/en/6.0/topics/tasks/) and reuses your
 existing database connection.
 
-!!! warning "Alpha"
+!!! warning "Beta"
 
-    APIs and behavior may change between releases.
+    The API is settling ahead of 1.0; behavior may still change.
 
 ## Install
 
@@ -32,7 +32,7 @@ existing database connection.
     pip install --pre django-absurd
     ```
 
-Only pre-releases are published during alpha, hence the flags. Needs Python **3.12+**,
+Only pre-releases are published before 1.0, hence the flags. Needs Python **3.12+**,
 Django **6.0+**, and PostgreSQL on the **psycopg (v3)** driver — Absurd reuses Django's
 connection, so psycopg2 won't work.
 

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -8,11 +8,11 @@ icon: lucide/rocket
 
 # django-absurd
 
-Run background tasks in Django on **Postgres** — no separate broker, no Redis, no
-Celery. It plugs [Absurd](https://earendil-works.github.io/absurd/), a Postgres-native
-workflow engine, into Django's built-in
-[Tasks framework](https://docs.djangoproject.com/en/6.0/topics/tasks/) and reuses your
-existing database connection.
+Run background tasks and durable workflows in Django on **Postgres**. It plugs
+[Absurd](https://earendil-works.github.io/absurd/), a Postgres-native workflow engine,
+into Django's built-in
+[Tasks framework](https://docs.djangoproject.com/en/6.0/topics/tasks/) and reuses the
+database connection your project already has.
 
 !!! warning "Beta"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,8 +33,8 @@ its own compose database:
 
 ```bash
 cd examples/web        # or: cd examples/beat, cd examples/pg_cron
-docker compose up -d db
-docker compose run --rm app pytest
+docker compose up -d --build --wait db
+docker compose run --rm --build app sh -c "cd /app && pytest"
 ```
 
 **pg_cron** runs the same way — no special setup. The extension lives on the central

--- a/examples/beat/README.md
+++ b/examples/beat/README.md
@@ -25,6 +25,9 @@ Tear down: `docker compose down -v`
 
 ## Test
 
+Runs in the demo's own Docker stack, the way CI runs it:
+
 ```
-uv run pytest
+docker compose up -d --build --wait db
+docker compose run --rm --build app sh -c "cd /app && pytest"
 ```

--- a/examples/pg_cron/README.md
+++ b/examples/pg_cron/README.md
@@ -36,6 +36,6 @@ This suite is only meaningful **in-stack** — a host run reaches the repo's pla
 database on 5432, which has no `pg_cron` extension:
 
 ```
-docker compose up -d --build db
+docker compose up -d --build --wait db
 docker compose run --rm --build app sh -c "cd /app && pytest"
 ```

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -29,6 +29,9 @@ Tear down: `docker compose down -v`
 
 ## Test
 
+Runs in the demo's own Docker stack, the way CI runs it:
+
 ```
-uv run pytest
+docker compose up -d --build --wait db
+docker compose run --rm --build app sh -c "cd /app && pytest"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ authors = [
   {name = "Lincoln Loop", email = "info@lincolnloop.com"},
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Environment :: Web Environment",
   "Framework :: Django",
   "Framework :: Django :: 6.0",


### PR DESCRIPTION
Changelog section for `v1.0.0b1`, plus the docs sync the phase change needs (five "alpha" claims, `Development Status` → `4 - Beta`).

Two findings from the sync, unrelated to the release:

- `examples/web` and `examples/beat` documented their suites as `uv run pytest` — not what CI runs, and not what `examples/README.md` says. All four now carry CI's in-stack form; verified by running `examples/web` that way.
- `WHY.md` claimed a reset never cancels recurring work, which #233 reversed. Replaced, and added why schema presence is asked rather than inferred from a failure.

Second commit corrects the release skill: it described the project as pre-1.0 on the `0.1.0` line, and claimed twine warns on a missing `long_description` (it doesn't — README, LICENSE, MIT expression and `long_description` all ship, `twine check --strict` passes).

git-cliff's `Requirements` entry for the examples' `DATABASE_URL` change is deliberately dropped — it touched no package dependency, so listing it there would imply the library's requirements moved.
