### PR TITLE
perf: build the admin state filter from static choices

### DIFF
--- a/django_absurd/admin.py
+++ b/django_absurd/admin.py
@@ -244,9 +244,6 @@ def build_entity_admin(
     list_filter: list[type[ListFilter] | str] = [AbsurdQueueListFilter]
     if spec.has_state:
         list_filter.append("state")
-    if spec.has_status:
-        list_filter.append("status")
-
     list_display = spec.list_display
     search_fields = spec.search_fields
     readonly_fields: tuple[str, ...] = ()

--- a/django_absurd/admin_views.py
+++ b/django_absurd/admin_views.py
@@ -6,6 +6,7 @@ from django.apps.registry import Apps
 from django.db import connections, models, transaction
 from django.db.utils import OperationalError, ProgrammingError
 
+from django_absurd.choices import TaskState
 from django_absurd.exceptions import (
     ADMIN_VIEW_READONLY_MSG,
     QueueReadOnlyError,
@@ -25,7 +26,6 @@ class EntitySpec:
     natural_key_sql: psycopg.sql.Composable
     columns: tuple[tuple[str, str], ...]
     has_state: bool
-    has_status: bool
     list_display: tuple[str, ...]
     search_fields: tuple[str, ...]
 
@@ -56,7 +56,6 @@ ADMIN_ENTITY_SPECS: tuple[EntitySpec, ...] = (
             ("idempotency_key", "text"),
         ),
         has_state=True,
-        has_status=False,
         list_display=(
             "natural_key",
             "queue",
@@ -93,7 +92,6 @@ ADMIN_ENTITY_SPECS: tuple[EntitySpec, ...] = (
             ("created_at", "timestamptz"),
         ),
         has_state=True,
-        has_status=False,
         list_display=(
             "natural_key",
             "queue",
@@ -121,7 +119,6 @@ ADMIN_ENTITY_SPECS: tuple[EntitySpec, ...] = (
             ("updated_at", "timestamptz"),
         ),
         has_state=False,
-        has_status=True,
         list_display=("natural_key", "queue", "task_id", "checkpoint_name", "status"),
         search_fields=("task__task_id", "checkpoint_name"),
     ),
@@ -138,7 +135,6 @@ ADMIN_ENTITY_SPECS: tuple[EntitySpec, ...] = (
             ("emitted_at", "timestamptz"),
         ),
         has_state=False,
-        has_status=False,
         list_display=("natural_key", "queue", "event_name", "emitted_at"),
         search_fields=("event_name",),
     ),
@@ -158,7 +154,6 @@ ADMIN_ENTITY_SPECS: tuple[EntitySpec, ...] = (
             ("created_at", "timestamptz"),
         ),
         has_state=False,
-        has_status=False,
         list_display=("natural_key", "queue", "task_id", "run_id", "step_name"),
         search_fields=("task__task_id", "run_id", "step_name"),
     ),
@@ -307,6 +302,10 @@ def build_model_field(
             null=True,
             related_name="waits",
         )
+    # Sourcing the choices statically keeps Django on ChoicesFieldListFilter; a bare
+    # name picks AllValuesFieldListFilter, which SELECT DISTINCTs the whole view.
+    if spec.has_state and col_name == "state":
+        return col_name, models.TextField(null=True, choices=TaskState)
     return col_name, make_field(col_type)
 
 

--- a/django_absurd/choices.py
+++ b/django_absurd/choices.py
@@ -1,0 +1,18 @@
+from django.db import models
+
+
+class TaskState(models.TextChoices):
+    """The states a task or run row can hold.
+
+    Mirrors the CHECK on ``t_<queue>.state`` and ``r_<queue>.state``,
+    ``django_absurd/migrations/0001_initial_0_5_0.sql:233`` and ``:250``. Each label
+    repeats its value because a bare member would title-case it, and the admin shows
+    the string Postgres stores.
+    """
+
+    PENDING = "pending", "pending"
+    RUNNING = "running", "running"
+    SLEEPING = "sleeping", "sleeping"
+    COMPLETED = "completed", "completed"
+    FAILED = "failed", "failed"
+    CANCELLED = "cancelled", "cancelled"

--- a/tests/core/test_admin/test_run.py
+++ b/tests/core/test_admin/test_run.py
@@ -9,7 +9,12 @@ from django.urls import reverse, reverse_lazy
 from django_absurd.models import Run
 from django_absurd.test import AbsurdTestRuntime
 from tests import tasks
-from tests.core.test_admin.utils import parse_html, result_rows, seed_mixed
+from tests.core.test_admin.utils import (
+    extract_filter_choices,
+    parse_html,
+    result_rows,
+    seed_mixed,
+)
 
 if t.TYPE_CHECKING:
     from bs4 import Tag
@@ -133,3 +138,19 @@ def test_detail_shows_failure_reason(
     assert failure is not None
     text = failure.get_text()
     assert "boom" in text or "ValueError" in text
+
+
+def test_state_filter_lists_all_states_with_no_rows(
+    admin_user: User, client: Client
+) -> None:
+    client.force_login(admin_user)
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
+    assert extract_filter_choices(soup, "state") == {
+        "pending",
+        "running",
+        "sleeping",
+        "completed",
+        "failed",
+        "cancelled",
+    }

--- a/tests/core/test_admin/test_task.py
+++ b/tests/core/test_admin/test_task.py
@@ -13,7 +13,13 @@ from django_absurd.admin_views import ADMIN_ENTITY_SPECS, build_admin_model
 from django_absurd.queues import get_absurd_client
 from django_absurd.test import AbsurdTestRuntime
 from tests import atasks, tasks, utils
-from tests.core.test_admin.utils import parse_html, result_rows, seed, seed_mixed
+from tests.core.test_admin.utils import (
+    extract_filter_choices,
+    parse_html,
+    result_rows,
+    seed,
+    seed_mixed,
+)
 
 if t.TYPE_CHECKING:
     from bs4 import ResultSet, Tag
@@ -303,3 +309,19 @@ def test_changelist_degrades_when_view_dropped(
     resp = client.get(CHANGELIST)
     assert resp.status_code == 200
     assert result_rows(parse_html(resp)) == []
+
+
+def test_state_filter_lists_all_states_with_no_rows(
+    admin_user: User, client: Client
+) -> None:
+    client.force_login(admin_user)
+    resp = client.get(CHANGELIST)
+    soup = parse_html(resp)
+    assert extract_filter_choices(soup, "state") == {
+        "pending",
+        "running",
+        "sleeping",
+        "completed",
+        "failed",
+        "cancelled",
+    }

--- a/tests/core/test_admin/utils.py
+++ b/tests/core/test_admin/utils.py
@@ -2,6 +2,7 @@
 
 import importlib
 import typing as t
+import urllib.parse
 
 from bs4 import BeautifulSoup, ResultSet, Tag
 from django.conf import settings
@@ -50,3 +51,22 @@ def seed_mixed() -> tuple[
     worker.drain_queue("default")
     pending = tasks.add.enqueue(5, 6)  # enqueued after the drain → never claimed
     return completed, failed, pending
+
+
+def extract_filter_choices(soup: BeautifulSoup, param: str) -> set[str]:
+    """Labels the changelist sidebar offers for one filter parameter.
+
+    Keyed off the querystring rather than the link text so the "All" entry drops
+    out without matching a translated string.
+    """
+    links = soup.select(f'#changelist-filter details[data-filter-title="{param}"] a')
+    return {
+        a.get_text(strip=True)
+        for a in links
+        if names_param(t.cast("str", a.get("href", "")), param)
+    }
+
+
+def names_param(href: str, param: str) -> bool:
+    keys = urllib.parse.parse_qs(urllib.parse.urlparse(href).query)
+    return any(k == param or k.startswith(f"{param}__") for k in keys)


### PR DESCRIPTION
Closes #241.

`AllValuesFieldListFilter` sourced the state dropdown from `queryset.distinct()`, so every changelist render scanned the union view — 393 ms of a 1576 ms runs changelist at 2M tasks / 3M runs. Static `TaskState` choices move Django to `ChoicesFieldListFilter`.

Behaviour: the dropdown now lists all six states always, not just those present in the data. The checkpoint `status` filter is dropped — the schema writes one value, so it could never narrow anything.
