### PR TITLE
chore: move test Postgres off the default 5432/5434 ports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
       PGUSER: postgres
       PGPASSWORD: postgres
       PGDATABASE: postgres
-      PGPORT: "5432"
-      PGPORT_PGCRON: "5434"
+      PGPORT: "5442"
+      PGPORT_PGCRON: "5443"
       # Worker count for tox's `-n auto`; a runner has more cores than the suites
       # profitably use, and 2 is enough to keep the parallel path exercised.
       PYTEST_XDIST_AUTO_NUM_WORKERS: "2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,9 @@ writing or editing any test file. Running the suites:
   `pytest.toml` and settings; invoke explicitly (a bare `uv run pytest` at repo root
   collects nothing and exits code 5 — intentional):
   - `uv run pytest tests/core` — core django-absurd; `django_absurd.pg_cron` NOT
-    installed; plain `db` service (`PGPORT`, default 5432).
+    installed; plain `db` service (`PGPORT`, default 5442).
   - `uv run pytest tests/pg_cron` — pg_cron app installed; requires the `db_pg_cron`
-    service (`PGPORT_PGCRON`, default 5434); an ORDINARY test DB (`test_absurd_pg_cron`)
+    service (`PGPORT_PGCRON`, default 5443); an ORDINARY test DB (`test_absurd_pg_cron`)
     with no extension — the central `cron.database_name` on that server is `postgres`, a
     different database entirely, and jobs reach it cross-database.
   - `uv run pytest tests/multidb` — multi-DB router suite; plain `db`.

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     ports:
-      - "${PGPORT:-5432}:5432"
+      - "${PGPORT:-5442}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 5s
@@ -29,7 +29,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     ports:
-      - "${PGPORT_PGCRON:-5434}:5432"
+      - "${PGPORT_PGCRON:-5443}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 5s

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -186,7 +186,7 @@ Measured on this repo; the point is to spend the slow gate once, not per edit.
   to its file. The catalog row outlives the per-test flush, so the second `--reuse-db`
   run of that file reports nothing created. Passes alone, fails on repeat.
 - **A deadlock/duplicate-key storm across unrelated tests means a concurrent run**, not
-  a code defect — suites from a worktree reach this checkout's Postgres on 5432. Confirm
+  a code defect — suites from a worktree reach this checkout's Postgres on 5442. Confirm
   nothing else is running before bisecting.
 
 ### When an agent runs the gates

--- a/tests/multidb/settings.py
+++ b/tests/multidb/settings.py
@@ -21,7 +21,7 @@ pg = {
     "USER": os.environ.get("PGUSER", "postgres"),
     "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
     "HOST": os.environ.get("PGHOST", "localhost"),
-    "PORT": os.environ.get("PGPORT", "5432"),
+    "PORT": os.environ.get("PGPORT", "5442"),
     "NAME": os.environ.get("PGDATABASE", "postgres"),
 }
 DATABASES = {

--- a/tests/pg_cron/settings.py
+++ b/tests/pg_cron/settings.py
@@ -6,7 +6,7 @@ from tests.settings import *  # noqa: F403
 INSTALLED_APPS = [*INSTALLED_APPS, "django_absurd.pg_cron"]  # noqa: F405
 
 DATABASES["default"]["HOST"] = os.environ.get("PGHOST", "localhost")  # noqa: F405
-DATABASES["default"]["PORT"] = os.environ.get("PGPORT_PGCRON", "5434")  # noqa: F405
+DATABASES["default"]["PORT"] = os.environ.get("PGPORT_PGCRON", "5443")  # noqa: F405
 # An ORDINARY test DB — NOT db_pg_cron's cron.database_name (the central `postgres`
 # DB). The app/test DB holds no extension; jobs are scheduled cross-database into it
 # from the central catalog, so the topology here is truly central != app.

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -42,7 +42,7 @@ DATABASES = {
         "USER": os.environ.get("PGUSER", "postgres"),
         "PASSWORD": os.environ.get("PGPASSWORD", "postgres"),
         "HOST": os.environ.get("PGHOST", "localhost"),
-        "PORT": os.environ.get("PGPORT", "5432"),
+        "PORT": os.environ.get("PGPORT", "5442"),
         "TEST": {"NAME": "absurd_test_core"},
     },
     "sqlite": {


### PR DESCRIPTION
5432 collides with a developer's own Postgres. Defaults now 5442 (`db`) / 5443 (`db_pg_cron`); `PGPORT` / `PGPORT_PGCRON` still override.

After pulling: `docker compose up -d db db_pg_cron` to rebind.