### PR TITLE
fix(benchmarks): keep an interrupted probe from poisoning its connection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,10 @@ jobs:
           report_type: test_results
           flags: ${{ matrix.env }}
           fail_ci_if_error: true
-          files: junit-core.xml,junit-pg_cron.xml,junit-multidb.xml,junit-benchmarks.xml
+          # `tests/benchmarks` is a `dev`-only suite, so only that env writes its file.
+          files:
+            junit-core.xml,junit-pg_cron.xml,junit-multidb.xml${{ matrix.env == 'dev'
+            && ',junit-benchmarks.xml' || '' }}
 
   examples:
     name: examples/${{ matrix.example }} pytest suite

--- a/benchmarks/CLAUDE.md
+++ b/benchmarks/CLAUDE.md
@@ -64,7 +64,7 @@ the macOS indexer suppressed.
 Per `noop_sync` task (empty body), worker side, across the 204 `noop_sync` saturation
 reps of `warmup`, `a`, `b` and `c2`:
 
-    commits per task     1.72 - 3.01   varies with SHAPE, not just with batching
+    commits per task     1.72 - 3.01   part shape, part ramp; the split is open
     row updates          ~4            ~2 on r_bench, ~2 on t_bench
     backends per worker  2             SDK connection + Django ORM, at ANY --concurrency
 
@@ -298,31 +298,51 @@ curve. What it does change is the experiment — the medians move by more than h
 is depth and not precision — at four times the tasks and up to ten times the wall clock.
 **Rejected.**
 
-A short drain is not a fleet getting going, either. Worker startup is outside the
-measured window by construction: `start_workers` waits for each child's readiness line
-and `measure_phase` opens afterwards, and the p10-p90 trim then drops the first tenth of
-the completions. Over the concurrency ladder's 60 reps slice 0 sits at 0.60-1.09 of its
-rep's median slice, and the SHORT rungs show no deficit to explain — `concurrency_16`
-and `batch_32` (4.0-5.1 s) read 0.78-1.10 while `concurrency_1` (13.1-15.7 s) reads
-0.60-0.93. Dropping slice 0 moves a rep's fitted drift by a median 0.9 points across
-those 60 reps and at most 7.4. A short drain here is a shallower queue, not a ramp.
+A short drain is not a fleet getting going, either — at one process. `start_workers`
+waits for that child's readiness line before `measure_phase` opens, and the p10-p90 trim
+then drops the first tenth of the completions. Over the concurrency ladder's 60 reps
+slice 0 sits at 0.60-1.09 of its rep's median slice, and the SHORT rungs show no deficit
+to explain — `concurrency_16` and `batch_32` (4.0-5.1 s) read 0.78-1.10 while
+`concurrency_1` (13.1-15.7 s) reads 0.60-0.93. Dropping slice 0 moves a rep's fitted
+drift by a median 0.9 points across those 60 reps and at most 7.4. A short drain here is
+a shallower queue, not a ramp.
 
-**Where a ramp IS in the window: the multi-process arms.** `split_8` (8x1, 5,000 tasks,
-1.5-2.0 s) reads slice 0 at 0.21-0.24 of its median and climbs from 479-523 to
-2,286-2,714 tasks/s across its own drain, while the pooled arm of the same pair (1x8,
-5.5-6.1 s) sits at 0.95-1.05. The contamination tracks the PROCESS COUNT and not the
-window length: eight fresh interpreters warming their claim path up inside a two-second
-drain. `split_8` publishes 1,920-2,055 tasks/s against its own median slices of
+### Where a ramp IS in the window: the multi-process arms
+
+**Above one process the fleet starts inside the measured drain.** `start_workers` spawns
+children one at a time, blocking on each one's readiness line, and the preload is
+already in the queue — so worker 0 claims for the whole stagger before the last child
+exists. A child's interpreter and Django startup times at 0.20 s, putting roughly 1.5 s
+of staggered start inside an eight-process arm and 2 s inside a ten-process one.
+
+`split_8` (8x1, 5,000 tasks, 1.5-2.0 s) reads slice 0 at 0.21-0.24 of its median and
+climbs from 479-523 to 2,286-2,714 tasks/s across its own drain, while the pooled arm of
+the same pair (1x8, 5.5-6.1 s) sits at 0.95-1.05. The contamination tracks the PROCESS
+COUNT and not the window length, and the pooled arm is what rules out a warm-up
+explanation: one interpreter warms its claim path as much as eight do, and it shows no
+deficit. `split_8` publishes 1,920-2,055 tasks/s against its own median slices of
 2,060-2,253, so it understates by 7-15% and `pooled_vs_split`'s split/pooled ratio is
 understated with it — the direction of that ratio is not in doubt either way, and it
 would only grow. (All four runs, 12 reps.)
 
+**`commits_per_task` and `calls_per_task` take the same defect the other way up.** Both
+divide a phase-window delta — `xact_commit`, and `pg_stat_statements` — by `n_runs`,
+which `analyze_saturation` counts over the WHOLE drain (`window = true`). Tasks finished
+before the phase opened are in the denominator and their commits are not, so both counts
+read low above one process, by the share of the drain that ran during the stagger. What
+that costs in practice is not established: the measured `commits_per_task` column falls
+from 2.13 at one, two and five processes to 1.88 at ten, which is the right direction,
+but a bias proportional to the stagger would have moved the two- and five-process rungs
+too and it did not. Treat the spread across process counts as unresolved rather than as
+shape.
+
 That is a real defect and a bigger constant is the wrong fix for it: it would dilute the
-warm-up only by measuring a deeper queue for both arms of a pair, at four times the
-cost, while degrading every single-process rung it touches. What it wants is a windowed
-analysis — a saturation rep capturing the database clock the way a rate rep already
-does, and counting completions from there — which moves every saturation figure in this
-file and is not done here.
+stagger only by measuring a deeper queue for both arms of a pair, at four times the
+cost, while degrading every single-process rung it touches. Two things would: spawning
+the children concurrently rather than one at a time, and a windowed analysis — a
+saturation rep capturing the database clock the way a rate rep already does, and
+counting both completions and runs from there. The second moves every saturation figure
+in this file. Neither is done here.
 
 ## Storage: two regimes on a volume, and none on RAM
 
@@ -763,9 +783,13 @@ order:
    one file's opening and closing probes says the same about that file. Re-run rather
    than reading on.
 2. **the structural counts** — `commits_per_task` per measurement, each statement's
-   `calls_per_task` in `statement_stats`, `shape_connections`. These are exact and
-   portable, so movement in them is the change itself and is worth chasing; a claim path
-   that grew a statement shows here and nowhere else.
+   `calls_per_task` in `statement_stats`, `shape_connections`. Counts rather than
+   timings, so a claim path that grew a statement shows here at a magnitude no
+   throughput number could resolve, and nowhere else. `shape_connections` is exact. The
+   two per-task counts are exact at ONE worker process and read low above it
+   ([the multi-process arms](#where-a-ramp-is-in-the-window-the-multi-process-arms)), so
+   compare them at the SAME process count — where the bias is common to both runs — and
+   do not read a difference between rungs of `process_scaling` as shape.
 3. **the `options` and `calibration` blocks.** Same flags, or the runs measured
    different experiments — a deeper queue is slower, so a saturation rate does not
    compare across `--tasks`. And a stage that calibrates inherits the winning rung, so a

--- a/benchmarks/CLAUDE.md
+++ b/benchmarks/CLAUDE.md
@@ -213,11 +213,13 @@ and below three-quarters of it, and a p50 measured above the knee is a function 
 window length rather than of the system.
 
 Two hazards live in those rows. A rung whose drain outruns `RATE_TIMEOUT_S` raises
-`MeasurementTimeoutError`, which reaches no handler: the invocation dies there and every
-stage file it wrote is missing its closing commit ceiling. And 60 s diverges where 20 s
-does not — the fleet completed 2,741-2,954/s inside a 20 s probe and collapsed at a
-comparable offer held for 60 — so a rate the ramp absorbed is not a rate a rung will;
-[the guard](#the-guard-a-backlog-that-grew-measured-nothing) catches that on the rung.
+`MeasurementTimeoutError`, which reaches no handler and takes the invocation with it —
+the stages that finished keep their files and their closing ceiling
+([the results files](#the-results-files)), and everything after that rung is unmeasured.
+And 60 s diverges where 20 s does not — the fleet completed 2,741-2,954/s inside a 20 s
+probe and collapsed at a comparable offer held for 60 — so a rate the ramp absorbed is
+not a rate a rung will; [the guard](#the-guard-a-backlog-that-grew-measured-nothing)
+catches that on the rung.
 
 **What the rungs actually exercise.** Both post-change runs:
 
@@ -482,6 +484,14 @@ than two seconds the host napped mid-phase, the rep is thrown away and the measu
 is marked invalid. A wall clock stepping BACKWARDS is an NTP correction, not a nap, and
 is tolerated.
 
+**A drain waits on the queue AND on the fleet.** A queue polled by itself cannot tell a
+slow drain from an absent one, so a rung whose workers died would sit out its whole
+`timeout_s` — 900 s in saturation — and then report the timeout as the failure, with the
+crash that caused it printed underneath as an afterthought. Any child exit ends the
+wait, a clean one included: a worker that returned 0 has stopped claiming as thoroughly
+as one that died. `stop_workers` then raises the children's own crash over that refusal
+on the way out, so what a reader sees first is the failure and not its symptom.
+
 **The summary rep is the unluckier middle, and which one that is depends on the
 metric.** `pick_median_rep` sorts the valid reps by the ranking key and, at an even rep
 count, takes the WORSE of the two middles — the lower throughput, the lower enqueue
@@ -669,9 +679,27 @@ The probe loops server-side, a `do` block committing single-row inserts timed wi
 the server's fsync. It writes to a real table it creates and drops rather than a
 temporary one, since a temp table is not WAL-logged and a probe against one skips the
 WAL the run itself pays for (84,000/s against 953/s on a disk, measured side by side).
-Any of the three blocks can be `null`: the probe was refused, the run went ahead
-regardless, and the report says the calibration is missing rather than dropping the
-line.
+
+**A block that holds no rate says which of two things happened**, in the `valid`/`error`
+vocabulary a rep already uses. `"the server refused the probe: ..."` is an answer about
+the server — it was asked, and the message it gave is the reader's first clue.
+`"the run ended before this probe was taken"` is not about the server at all: the run
+was interrupted mid-wait, killed, or died at a stage, and nothing here is evidence about
+what that machine could commit. Reading the second as the first is how an interrupted
+run comes to look like a server that cannot commit, so the report prints the reason
+beside every missing rate and calibrates against neither. A run whose probe was refused
+goes ahead regardless — an uncalibrated number that says it is uncalibrated beats no
+number.
+
+Every file carries the closing block from its FIRST write, holding the never-taken
+reason until a probe replaces it, so a run killed outright still says what it never did.
+A stage that raises is not that case: its session is intact where an interrupted wait's
+is not, so the closing probe is still taken and written into the files the finished
+stages left — 75 minutes of measurement must not lose its calibration to the stage that
+died. The probe issues nothing from a `finally`, either: a statement sent after an
+interrupted wait raises over the interruption, and what reaches the caller is then a
+database error where a timeout happened, on a session stuck mid-command for everything
+that follows.
 
 **A calibration that disagrees with itself softens every bound-verdict under it**, and
 it can disagree two ways. Within one probe: `range_low` and `range_high` come off the

--- a/benchmarks/CLAUDE.md
+++ b/benchmarks/CLAUDE.md
@@ -8,12 +8,26 @@ what a human does.
 
 ## How to read every number in this file
 
-All figures are from the tmpfs runs with the macOS indexer suppressed, on one 14-core
-laptop at `--max-workers 10 --reps 3`. Runs `warmup` and `b` are the clean pair (per-rep
-load medians 2.54 and 3.38); run `a` ran at load 6.70 with peaks to 15.01 while the
-indexer held 1-1.4 cores, and reads 6-10% low. The offer-rate and queue-depth figures
-come from three later runs on the same server in the same session — two of
-`latency_under_load` after it was changed, and one `worker_knobs` at `--tasks 20000`.
+Every figure names the run it came from, and one quoted from several runs is a range
+across them. All of them are tmpfs runs with the macOS indexer suppressed, on one
+14-core laptop at `--max-workers 10 --reps 3`: four complete runs — `warmup`, `a`, `b`,
+`c2` — plus `c`, which recorded `worker_knobs` alone. The offer-rate figures come from
+two later `latency_under_load` runs (`after1`, `after2`) and the depth figures from one
+`worker_knobs` at `--tasks 20000`, same server, same session.
+
+**Runs with different calibration points did not measure the same configuration.** `a`'s
+`worker_knobs` winner was `batch_32`, so every stage downstream of it ran
+`--concurrency 16 --batch-size 32` where `warmup`, `b` and `c2` ran concurrency 16 with
+the default batch; and its `latency_under_load` calibrated from `workers_5` rather than
+`workers_7`, so its rate rungs were offered to five workers where the other three runs'
+went to seven. An `a` row beside a `b` row is two experiments, not one measurement
+repeated. Read the `Calibrated from` line first, always.
+
+Load is sampled on each side of every rep. Median of every `load_before`/`load_after`
+sample: `warmup` 2.68, `c2` 3.39, `b` 3.40, `a` 5.11. It does not account for a whole
+run reading low — `c2` and `b` sat at 3.39 and 3.40 and still disagreed by up to 18% on
+individual rungs. Measure on a quiet machine regardless: the macOS indexer alone was
+measured at 1-1.4 cores sustained.
 
 **Every ceiling proposed during this work turned out to be the measurement environment
 rather than Absurd: disk fsync, then one connection's commit rate, then CPU. The harness
@@ -26,83 +40,109 @@ they are labelled, and their levels mean nothing now.
 
 ## Repeatability: rank things, do not confirm small changes
 
-Three full runs of one commit, 25 shared saturation measurements:
+Runs `warmup`, `b` and `c2` — one commit, one calibration point — over the 25 saturation
+measurements they share:
 
     median CV      4.7%      (14 of 25 under 5%)
     mean CV        5.1%
     worst CV      12.5%
 
-The clean pair alone: median run-to-run ratio 0.987, CV of ratios 4.7%, ratios spanning
-0.88-1.15. On the disk volume the same comparison read median ratio 1.20, CV 31.7%,
-ratios 0.02-1.71 — so the storage change is what bought repeatability.
+`b` against `warmup` over the same 25: median ratio 0.98, CV of ratios 3.7%, ratios
+spanning 0.88-1.08.
 
-**4.7% is not a precision guarantee for a single measurement.** The third run sits
-systematically BELOW the other two on several of them (`workers_1` 1,066 against
-1,211/1,306; `async_dispatch` 888 against 1,137/1,071), which is a mild between-run bias
-and not pure scatter. Treat a difference under ~12% as noise.
+**4.7% is not a precision guarantee for a single measurement.** `c2` sits systematically
+BELOW the other two on several of them (`workers_1` 1,066 against 1,211/1,306;
+`async_dispatch` 888 against 1,137/1,071; 8-20% low on `concurrency_2`, `concurrency_4`
+and `batch_32`) at the same per-rep load as `b`, so there is a between-run bias on top
+of scatter. Treat a difference under ~12% as noise.
 
-Two conditions produced it and both matter: the data directory on tmpfs, and the macOS
-indexer suppressed. `latency_under_load`'s upper rungs used to be the exception, at CVs
-of 160%+; they were over-offered rather than noisy, and now repeat at 0.6-3.7% —
-[a drain rate is not an arrival rate](#a-drain-rate-is-not-an-arrival-rate).
+Two conditions produced these figures and both matter: the data directory on tmpfs, and
+the macOS indexer suppressed.
 
 ## Overhead, itemised
 
-Per `noop_sync` task (empty body), worker side:
+Per `noop_sync` task (empty body), worker side, across the 204 `noop_sync` saturation
+reps of `warmup`, `a`, `b` and `c2`:
 
-    commits per task     1.85 - 2.67   varies with SHAPE, not just with batching
+    commits per task     1.72 - 3.01   varies with SHAPE, not just with batching
     row updates          ~4            ~2 on r_bench, ~2 on t_bench
     backends per worker  2             SDK connection + Django ORM, at ANY --concurrency
 
-From `pg_stat_statements` with `track=all`, top-level rows only:
+From `pg_stat_statements` with `track=all`, at `worker_knobs` `concurrency_1` — the only
+shape where the client remainder is exact
+([the measurement model](#the-measurement-model)). Each figure is a range over the
+median rep of the five saved runs:
 
-    wall 2.82 ms/task = server 1.64 ms + client 1.18 ms
+    wall 2.82 - 3.14 ms/task = server 1.57 - 1.77 ms + client 1.16 - 1.48 ms
 
-    1.00 calls/task  1.4718 ms  claim_task            (top level)
-    1.00 calls/task  0.9058 ms    candidate CTE       (nested)
-    1.00 calls/task  0.2684 ms    cancellation scan   (nested)
-    1.00 calls/task  0.0990 ms  complete_run          (top level)
+    1.00 calls/task  1.41 - 1.56 ms  claim_task            (top level)
+    1.00 calls/task  0.84 - 0.92 ms    candidate CTE       (nested)
+    1.00 calls/task  0.27 - 0.30 ms    cancellation scan   (nested)
+    1.00 calls/task  0.09 - 0.12 ms  complete_run          (top level)
 
-- WAL durability was 71% of a full run's active backend time on the volume, which is why
-  every rate here is read against a commit ceiling rather than on its own.
-- Claiming costs ~15x completing. All per-task database cost is acquiring work.
-- 42% of a task's wall time is client-side Python. That is what a GIL serialises, and it
-  is the mechanism behind processes beating in-process concurrency.
-- The cancellation scan is 18% of the claim, on every claim.
+- WAL durability was 71% of a full run's active backend time on the volume (disk-era),
+  which is why every rate here is read against a commit ceiling rather than on its own.
+- Claiming costs 13-16x completing. All per-task database cost is acquiring work.
+- The cancellation scan is 18-19% of the claim, on every claim.
+- **40-47% of a task's wall time is outside the server, and what serialises it is not
+  established.** `client_ms_per_task` is wall minus server, so it holds our Python, the
+  SDK's and the round-trip waits — and a round trip releases the GIL. Two mechanisms fit
+  every figure here: the GIL, or the single claim connection a worker process owns. Both
+  predict processes beating in-process concurrency.
 
-## Throughput: 4,441 tasks/s, and no knee on either axis
+## Throughput: both axes were still buying at the top of the sweep
 
-    shape    tasks/s   commits/task
-    10x16    4,441.7   1.85          <- best measured
-     7x16    4,182.3   2.03
-     5x16    3,727.7   2.13
-     2x16    2,292.8   2.13
-     8x1     2,028.3   2.67
+    shape    tasks/s              backlog   commits/task
+    10x16    4,008.5 - 4,441.7    20,000    1.72 - 1.88
+     7x16    4,052.1 - 4,231.4    14,000    1.96 - 2.07
+     5x16    3,623.1 - 3,727.7    10,000    2.13
+     2x16    2,074.6 - 2,292.8     4,000    2.13
+     1x16    1,066.1 - 1,306.3     4,000    2.13
+     8x1     1,924.4 - 2,028.3     5,000    2.35 - 2.69
 
-Both axes still paid at the top of the sweep:
+`process_scaling` rungs over `warmup`, `b` and `c2`; `8x1` is `pooled_vs_split`'s
+`split_8`. **`--tasks` belongs beside every rate in that table.**
+`build_process_scaling_measurements` sizes the preload as `max(4000, 2000 * count)`, so
+the ladder's rungs drain 4,000 to 20,000 tasks, and four times the backlog costs 40-58%
+of the throughput on its own
+([Queue depth costs throughput](#queue-depth-costs-throughput)). No rate in that table
+compares with the rate above it.
 
-    concurrency at 1 process:     1->16 gives 360.6 -> 1,231.1 tasks/s   (3.4x)
-    processes at concurrency 16:  1->10 gives 1,211.5 -> 4,441.7         (3.7x)
-    diagonal at equal total:      4x1 beats 1x4 by 2.08x; 8x1 beats 1x8 by 2.24x
+    concurrency at 1 process, all 5,000 tasks:  1->16 gives 333-361 -> 1,096-1,231
+                                                tasks/s, 3.0-3.7x over four runs
+    diagonal at equal total, 5,000 both arms:   4x1 beats 1x4 by 1.95-2.28x
+                                                8x1 beats 1x8 by 2.17-2.29x
 
-10x16 is 160 concurrent tasks on 14 cores and still the top cell, still climbing. In
-particular in-process concurrency does NOT saturate around 3x: 3.4x at concurrency 16
-with no rung flattening.
+Those two comparisons hold one depth each, so both are measurements: in-process
+concurrency does not saturate around 3x, and processes beat threads at the same total.
+The process axis has no multiple — its raw 1->10 quotients read 3.3-3.8x across
+`warmup`, `b` and `c2`, each dividing a 20,000-task rung by a 4,000-task one, and the
+deeper rung is the slower-reading one, so 3.3x is a LOWER BOUND. The report's
+`T(N)/(N x T(1))` block prints each rung's backlog and marks itself `CONFOUNDED` for the
+same reason.
 
-Advice that survives: scale with PROCESSES, concurrency around 16, batch the claims.
+Advice: scale with PROCESSES, concurrency around 16, batch the claims.
+
+**Future work: run the ladder at one depth.** A fixed preload across every rung, sized
+for the fastest one, is what makes the process axis a measurement.
 
 ## Queue depth costs throughput
 
-    within-rep drift, 46 reps across two runs: median +13.3%, positive in 37 of 46
+Throughput RISES as a backlog drains. Within-rep drift — the least-squares trend over a
+rep's `profile_slices`, read as total fractional change across the drain — over the 150
+saturation reps of `warmup` and `b`:
 
-Throughput RISES as the queue drains. This was the original hypothesis; it was recorded
-as refuted off a single disk run whose sign was inverted by storage noise, and it is
-confirmed on RAM across two runs. Nothing cumulative can make a drain faster, which is
-what makes the sign readable at all.
+    median +15.7%, positive in 120 of 150
+
+The magnitude moves with the definition and the rep set — the same trend over just those
+runs' 48 `worker_knobs` reps reads +19.3% in 36 of 48, last-slice-over-first +17.7% over
+the 150 — so quote one only with both beside it. The SIGN is what nothing cumulative
+could produce: accumulated state cannot make a drain faster.
 
 Consequence: a saturation measurement averages a curve, so its single number depends on
-the starting depth and is not comparable across `--tasks` values. `profile_slices` is
-what makes that visible.
+the starting depth and does not compare across `--tasks` values. `profile_slices` makes
+the curve visible; the report's `backlog` column makes the depth visible beside the
+rate.
 
 **How much depth costs, measured directly.** The whole `worker_knobs` concurrency ladder
 at `--tasks 20000` against the four baseline runs at 5,000, same machine, same session:
@@ -114,80 +154,94 @@ at `--tasks 20000` against the four baseline runs at 5,000, same machine, same s
     concurrency_8    809-913             415.7     0.47
     concurrency_16   1,096-1,231         716.4     0.60
 
-Four times the backlog costs 40-58% of the throughput on every rung — an order of
-magnitude more than the +13.3% within-rep drift, because the drift is measured over the
-part of the drain that is left rather than across two starting depths. The within-rep
-drift grows to match: at 20,000 the first slice reads 0.46 of the median slice, against
-0.79-1.01 at 5,000, so a rep at that size climbs by more than 2x across its own drain.
+Four times the backlog costs 40-58% of the throughput on every rung. The within-rep
+drift grows with depth with it: the same fitted trend reads a median +19% over the
+ladder's 60 reps at 5,000 and +46% over its 15 reps at 20,000, while slice 0 reads
+0.60-1.09 of its rep's median slice at 5,000 against 0.46-0.93 at 20,000.
 
 That is why `--tasks` is a comparability key and not a size knob, and it is the measured
 answer to raising `SATURATION_TASKS`:
-[the window is long enough already](#saturation_tasks-stays-at-5000).
+[the window is long enough already](#saturation_tasks-stays-at-5000). It is also why
+`process_scaling`, which sizes its own preload from the worker count, reports no scaling
+multiple:
+[both axes were still buying](#throughput-both-axes-were-still-buying-at-the-top-of-the-sweep).
 
 ## A drain rate is not an arrival rate
 
 A saturated fleet has work waiting at every claim; a paced one has to keep up in real
 time, claim polls that find nothing included. So the two rates are different quantities
-and the drain one is the larger — which is what `latency_under_load` used to get wrong.
-Its rungs were fractions of the `process_scaling` drain ceiling, and from `rate_50pct`
-up they offered more than the fleet could absorb. Four runs on RAM, 7 workers x
-concurrency 16, whose drain rate measured 4,182-4,231 tasks/s:
-
-    rung          offered/s      p50 latency      throughput/s    cv
-    rate_25pct    1,013-1,058    15-18 ms         1,013-1,057     3-65%
-    rate_50pct    2,026-2,116    30 ms - 2.6 s    1,314-2,093     2-167%
-    rate_75pct    3,039-3,174    35-86 SECONDS    529-718         10-18%
-
-The 75% rung is the shape of the error. Offered 3,100/s, the same fleet that drains
-4,200/s completed 620 — a seventh of it — because a queue that deep is a different
-workload: the tables are 150,000 rows of unfinished work, the producer is competing for
-the cores, and every claim scans more. Its p50 is then a function of how long the window
-was, not of the system. The 50% rung sat right on the knee and came out bimodal: reps at
-31 ms beside reps at 1.3-2.6 s in the same measurement, which is where the 167% CV came
-from.
-
-It also aborted runs. Three of those four never recorded a `rate_90pct` row: the drain
-after that offer outran `RATE_TIMEOUT_S`, and `MeasurementTimeoutError` reaches no
-handler, so the invocation died there — which is why every stage file in those three
-runs is missing its closing commit ceiling.
-
-**So the stage measures the arrival rate itself.** A ramp offers for 20 s at a time,
-climbing from a tenth of the drain ceiling by half again a step, and stops at the first
-offer the fleet did not absorb; the highest one it did absorb is the working point, and
-the rungs are fractions of THAT. The whole ramp is recorded probe by probe under
+and the drain one is the larger, and `latency_under_load` measures its own arrival rate
+rather than taking fractions of a drain rate. A ramp offers for 20 s at a time, climbing
+from a tenth of the drain ceiling by half again a step, and stops at the first offer
+that did not come off cleanly; the highest one that did is the working point, and the
+rungs are fractions of THAT. The whole ramp is recorded probe by probe under
 `sustainable_rate`, because a working point nothing can see is a number a reader cannot
-argue with. On this server it found 2,142 tasks/s sustainable and 3,213 refused against
-a 4,231 drain rate — the knee is around half the drain rate, which is exactly why the
-old 50% rung was the bimodal one. What the rungs read after the change:
+argue with.
 
-    rung          offered/s   p50 latency   cv     marks
-    rate_25pct        535.5      9.7 ms     3.6%   none
-    rate_50pct      1,070.7     15.3 ms     0.6%   none
-    rate_75pct      1,605.7     23.1 ms     3.7%   none
-    rate_90pct      1,926.7     29.9 ms     1.8%   none
+**The ramp stops at the lower of two limits and does not say which.** The producer runs
+on the same box as the workers, so a probe fails either because the fleet fell behind or
+because the enqueue loop never made the offer. On this server, both at once: `after1`
+and `after2` absorbed 2,142.1/s and refused 3,213.2/s, and the refused probe tripped
+both guards in both runs.
 
-A monotonic latency curve against offered load, which is what the stage is for, and the
-first run of it with nothing marked. It cost ~15 minutes against 17-24, because the
-rungs that took the longest were the ones carrying no information.
+    run      target/s   producer achieved/s   deadlines missed   fleet completed/s   backlog growth
+    after1    3,213.2               2,894.8   61,225 / 64,264              2,741.2   4,472 / 30,300
+    after2    3,213.2               3,016.4   60,961 / 64,264              2,954.3   2,614 / 31,511
 
-**At a matched offer rate the new rungs reproduce the old ones.** 1,071/s reads 15.3 ms
-here against 15.2-15.9 ms at 1,046-1,058/s before, and 1,606/s reads 23.1 ms against
-22.1 ms at 1,433/s. The change removed rows, not signal.
+`offered_ok` false — the producer delivered 90-94% of its target — AND `backlog_grew`
+true under what it did deliver. So 2,142/s is the highest offer this rig got through
+cleanly, and it bounds the two sides jointly. The report prints `achieved/s` and
+`producer kept up` beside every probe, and its offer-rate line names both limits.
 
-**And the stage now repeats.** A second run of it, back to back, absorbed and refused
-the same probes and read 10.5/16.1/24.0/28.8 ms against 9.7/15.3/23.1/29.9 — ratios of
-0.96-1.08, inside the rig's own 12% floor, every row unmarked in both. Both runs read
-the same `stage_process_scaling.json` back, though, so what repeated is which offer the
-fleet absorbed and not the drain ceiling the ramp climbs from: a run whose
-`process_scaling` lands 12% elsewhere probes 12% elsewhere too, and its rung rates move
-with it. That is what makes `sustainable_rate` the first thing to compare between two of
-these reports.
+**The fleet's own knee is measured by over-offering it, which the ramp cannot do.**
+Three runs at 7 workers x concurrency 16 — `warmup`, `b`, `c2`, whose `workers_7` drain
+rates measured 4,052-4,231 tasks/s — offered fractions of that drain rate for 60 s a
+rung:
 
-**The knee is bracketed, never resolved.** Probes are 1.5x apart, so the ramp says the
-rate is between 2,142 and 3,213 tasks/s and nothing here refines it; the working point
-is deliberately the low end of that bracket. And a probe offers for 20 s while a rung
-offers for 60, so a rate that only diverges over a longer window survives the ramp — the
-guard below is what catches that, on the rung itself.
+    rung          offered/s      p50 (medians)   throughput/s (medians)   cv
+    rate_25pct    1,013-1,058    15-18 ms        1,013-1,057              3-65%
+    rate_50pct    2,026-2,116    30-34 ms        1,982-2,084              2-167%
+    rate_75pct    3,039-3,174    39-68 SECONDS   619-718                  10-18%
+
+Medians throughout, so one column cannot be read against another's endpoints. At
+2,026-2,116/s the fleet kept up in seven of nine reps and went bimodal in two — 29-34 ms
+beside 1.30 s and 2.61 s in the same measurement, which is the 167% CV. At 3,039-3,174/s
+it collapsed to 619-718/s while the producer delivered its full offer in seven of nine:
+`warmup`'s first rep offered 188,203 tasks over 60 s, delivered 3,136/s of them, and its
+trimmed window completed 619/s. So the knee is at or a little above half the drain rate
+and below three-quarters of it, and a p50 measured above the knee is a function of the
+window length rather than of the system.
+
+Two hazards live in those rows. A rung whose drain outruns `RATE_TIMEOUT_S` raises
+`MeasurementTimeoutError`, which reaches no handler: the invocation dies there and every
+stage file it wrote is missing its closing commit ceiling. And 60 s diverges where 20 s
+does not — the fleet completed 2,741-2,954/s inside a 20 s probe and collapsed at a
+comparable offer held for 60 — so a rate the ramp absorbed is not a rate a rung will;
+[the guard](#the-guard-a-backlog-that-grew-measured-nothing) catches that on the rung.
+
+**What the rungs actually exercise.** Both post-change runs:
+
+    rung          offered/s   p50 (after1 / after2)   cv (after1 / after2)   marks
+    rate_25pct        535.5   9.7 / 10.5 ms           3.6% / 3.5%            none
+    rate_50pct      1,071.1   15.3 / 16.1 ms          0.6% / 3.4%            none
+    rate_75pct      1,606.6   23.1 / 24.0 ms          3.7% / 0.9%            none
+    rate_90pct      1,927.9   29.9 / 28.8 ms          1.8% / 2.9%            none
+
+A monotonic latency curve against offered load, which is what the stage is for, at 14.2
+minutes of measured phase per run, ramp included. **The top rung asks the fleet for
+1,927.9/s, so a change that only shows above about 2,100/s — where these runs put the
+knee — is invisible to this stage.**
+
+Back to back, the two runs absorbed and refused the same probes and their rungs agree to
+0.96-1.08 — inside the rig's own 12% floor. Both read the same
+`stage_process_scaling.json` back, though, so what repeats is which offer got through
+and not the drain ceiling the ramp climbs from: a run whose `process_scaling` lands 12%
+elsewhere probes 12% elsewhere too, and its rung rates move with it. That is what makes
+`sustainable_rate` the first thing to compare between two of these reports.
+
+**The knee is bracketed, never resolved.** Probes are 1.5x apart, so the ramp puts the
+working point between 2,142 and 3,213 tasks/s and nothing here refines it; it is
+deliberately the low end of that bracket.
 
 **A ramp whose first probe diverges does not abort the stage.** It measures at that
 lowest rate, records `sustained: false`, and the marks on the rungs become the finding.
@@ -202,18 +256,19 @@ more than 5% of the tasks offered between those two points is `invalid`: it meas
 climb towards a rate rather than the rate.
 
 A share and not a count, because one threshold has to cover a five-task smoke offer and
-a 120,000-task one. In steady state the backlog is one Little's-law-worth of in-flight
-work at each end, so the growth cancels to a fraction of a percent — under 0.2% at 160
-concurrent tasks over a 60-second offer — while a fleet absorbing 95% of its offer reads
-5% and the refused 3,213/s probe read 4,472 tasks of growth on 64,000 offered. Under 8
-tasks of growth the share is not consulted, so a smoke-sized offer cannot trip it on
-scheduling jitter.
+a 120,000-task one. **The denominator is `offered_after_midpoint`, the tasks offered
+between the two readings — half the window, not the whole offer.** In steady state the
+backlog is one Little's-law-worth of in-flight work at each end, so the growth cancels
+to a fraction of a percent — under 0.2% at 160 concurrent tasks over a 60-second offer —
+while a fleet absorbing 95% of its offer reads 5%. The refused 3,213/s probe read 4,472
+tasks of growth against the 30,300 offered after its midpoint, 14.8%, and 2,614 against
+31,511, 8.3%, in the second run.
 
-5% rather than tighter, on evidence: `rate_90pct` above ended two of its three reps with
-backlogs of 1,149 and 2,345 tasks against ~52 at the midpoint, 2-4% of the offer, and
-all three reps still agreed on the p50 within 1.8% — the rep with no spike at all read
-30.6 ms against 29.5 and 29.9. A 2% limit would have thrown that measurement away for a
-transient that demonstrably did not reach the number.
+5% rather than tighter, on evidence: `after1`'s `rate_90pct` ended two of its three reps
+with backlogs of 1,149 and 2,345 tasks against 46 and 52 at the midpoint — 1.9% and 4.0%
+of the ~57,800 offered after the midpoint — and all three reps still agreed on the p50
+within 1.8%: the rep with no spike at all read 30.6 ms against 29.5 and 29.9. A 2% limit
+would throw that measurement away for a transient that does not reach the number.
 
 The blind spot is the other side of the same threshold: a fleet absorbing 96% of its
 offer diverges slowly and this guard will not say so. That is part of why the top rung
@@ -222,40 +277,43 @@ is 90% of a measured knee rather than 100%.
 ## `SATURATION_TASKS` stays at 5,000
 
 5,000 was sized when `concurrency_1` drained 67 tasks/s, which made a 75-second window.
-On RAM the same rung drains 360/s, so the window is now ~14 s and the fastest rung using
-the constant is 4.5 s — short enough to ask whether what it measures is mostly the fleet
-getting going. Tested by running the whole ladder at `--tasks 20000` and comparing it
-with the four baseline runs:
+On RAM the same rung drains 333-361/s, so the window is now 13-16 s and the fastest rung
+using the constant is 4 s — short enough to ask whether what it measures is mostly the
+fleet getting going. Tested by running the whole ladder at `--tasks 20000` and comparing
+it with the four baseline runs. Everything below is the concurrency ladder's five rungs,
+3 reps each — 60 reps at 5,000 against 15 at 20,000:
 
     what moved            5,000 (4 runs)     20,000
     medians               (the table above)  0.42-0.60x
     cross-rep cv          0.7-7.3%           1.9-4.5%
-    within-rep profile_cv 5.6-11.0%          10.9-22.4%
-    slowest rep           14.7 s             148.1 s
+    within-rep profile_cv 2.6-16.9%          8.7-29.0%
+    slowest rep           15.7 s             148.1 s
 
-So a longer window does not tighten anything: every CV at 20,000 lands inside the
-bracket the same rungs already spanned at 5,000, and the within-rep profile gets noisier
-because the drain now crosses more of the depth curve. What it does change is the
-experiment — the medians move by more than half, which is depth and not precision — at
-four times the tasks and up to ten times the wall clock. **Rejected.**
+So a longer window does not tighten anything: the cross-rep CV at 20,000 lands inside
+the bracket the same rungs already spanned at 5,000, and the within-rep profile gets
+NOISIER — its whole band moves up — because the drain now crosses more of the depth
+curve. What it does change is the experiment — the medians move by more than half, which
+is depth and not precision — at four times the tasks and up to ten times the wall clock.
+**Rejected.**
 
-The premise behind the question is also wrong for these rungs. Worker startup is outside
-the measured window by construction: `start_workers` waits for each child's readiness
-line and `measure_phase` opens afterwards, and the p10-p90 trim then drops the first
-tenth of the completions. The data agrees — slice 0 sits at 0.79-1.01 of the median
-slice across every single-process rung, and the SHORTEST drains show the LEAST deficit
-(`concurrency_16` and `batch_32`, 4.5 s, read 1.00-1.07) while the longest shows the
-most (`concurrency_1`, 14.7 s, reads 0.79-0.90). Dropping slice 0 moves a rep's fitted
-drift by under 3 points. A short drain here is not a ramp; it is a shallower queue.
+A short drain is not a fleet getting going, either. Worker startup is outside the
+measured window by construction: `start_workers` waits for each child's readiness line
+and `measure_phase` opens afterwards, and the p10-p90 trim then drops the first tenth of
+the completions. Over the concurrency ladder's 60 reps slice 0 sits at 0.60-1.09 of its
+rep's median slice, and the SHORT rungs show no deficit to explain — `concurrency_16`
+and `batch_32` (4.0-5.1 s) read 0.78-1.10 while `concurrency_1` (13.1-15.7 s) reads
+0.60-0.93. Dropping slice 0 moves a rep's fitted drift by a median 0.9 points across
+those 60 reps and at most 7.4. A short drain here is a shallower queue, not a ramp.
 
 **Where a ramp IS in the window: the multi-process arms.** `split_8` (8x1, 5,000 tasks,
-2.0 s) reads slice 0 at 0.22-0.23 of its median and climbs 482 → 2,440 tasks/s across
-its own drain, while the pooled arm of the same pair (1x8, 6.1 s) sits flat at
-0.97-0.99. The contamination tracks the PROCESS COUNT and not the window length: eight
-fresh interpreters warming their claim path up inside a two-second drain. `split_8`
-publishes 1,924-2,028 tasks/s against settled slices of 2,300-2,500, so it understates
-by ~17%, and `pooled_vs_split`'s split/pooled ratio is understated with it — its
-direction is not in doubt either way, and it would only grow.
+1.5-2.0 s) reads slice 0 at 0.21-0.24 of its median and climbs from 479-523 to
+2,286-2,714 tasks/s across its own drain, while the pooled arm of the same pair (1x8,
+5.5-6.1 s) sits at 0.95-1.05. The contamination tracks the PROCESS COUNT and not the
+window length: eight fresh interpreters warming their claim path up inside a two-second
+drain. `split_8` publishes 1,920-2,055 tasks/s against its own median slices of
+2,060-2,253, so it understates by 7-15% and `pooled_vs_split`'s split/pooled ratio is
+understated with it — the direction of that ratio is not in doubt either way, and it
+would only grow. (All four runs, 12 reps.)
 
 That is a real defect and a bigger constant is the wrong fix for it: it would dilute the
 warm-up only by measuring a deeper queue for both arms of a pair, at four times the
@@ -274,11 +332,21 @@ Ten arms each, interleaved so the media alternate, one configuration throughout:
 The volume was the single largest source of irreproducibility here: its durable commit
 rate sits in one of two regimes about 3.5x apart and nothing the harness controls
 selects between them. RAM is not better storage; it is storage taken out of the
-measurement. At 56,659 commits/s and ~2.5 commits per task the database could sustain
-~22,000 tasks/s against the ~4,400 this rig actually reaches, so the commit ceiling
-stops constraining anything and its own spread stops reaching the numbers below it. The
-runs themselves recorded 200,000-240,000 commits/s. `synchronous_commit=on` and
-`fsync=on` are unchanged: the durability request is the same one, only the medium moved.
+measurement.
+
+**A run's own probe is the figure to use, and the interleaved arms above are not it.**
+Those arms are one connection alternating media without the per-session warm-up a
+results file's probe does, and their tmpfs median is 56,659 c/s. The five saved runs'
+opening probes — warmed, on the session that then times — recorded 203,804-240,964
+durable commits/s (cv 3.7-14.6%) and 512,453-617,208 non-durable; `a`'s closing probe
+read 307,377. Every commit-budget verdict in a report is read against the in-run
+figures; the interleaved arms establish the ratio between the media and nothing else.
+
+Either way the ceiling stops constraining: at 203,804 c/s and the 1.72-3.01 commits per
+task measured here the database could sustain 68,000-118,000 tasks/s against the
+4,000-4,400 this rig reaches, so neither the ceiling nor its spread reaches the numbers
+below it. `synchronous_commit=on` and `fsync=on` are unchanged: the durability request
+is the same one, only the medium moved.
 
 A stage took ~14 minutes on the volume and ~4-5 minutes on RAM.
 
@@ -414,6 +482,12 @@ than two seconds the host napped mid-phase, the rep is thrown away and the measu
 is marked invalid. A wall clock stepping BACKWARDS is an NTP correction, not a nap, and
 is tolerated.
 
+**The summary rep is the unluckier middle, and which one that is depends on the
+metric.** `pick_median_rep` sorts the valid reps by the ranking key and, at an even rep
+count, takes the WORSE of the two middles — the lower throughput, the lower enqueue
+rate, the HIGHER end-to-end p50 — because a measurement must not be summarized by its
+luckiest rep, and the metric is what says which one that is.
+
 **Marking is the honesty mechanism, and nothing is suppressed.** Every rep votes, not
 just the median one: a rep that under-offered has a LOWER latency, so it sorts away from
 the median and would never be looked at. Two unrelated things can be wrong, so two
@@ -443,8 +517,14 @@ repeat sit at 1.0-3.4%, ones that genuinely lurch at 25-50%, and 10% is the gap 
 them. `spread` and the endpoints (`range_low`, `range_high`) are still recorded and the
 report prints the endpoints, because `209-501` is what a reader wants to see — they have
 simply stopped being the trigger. A `spread_floor` guards the test in the ranking key's
-own units: reps within 150 ms of each other are not called unstable however far apart
-they read relatively — reps of 67/89/173 ms read as a 119% spread.
+own units: reps closer together than the floor are not called unstable however far apart
+they read relatively. Saturation mode sets none — a throughput's relative and absolute
+dispersion say the same thing — and the rate stages set `RATE_SPREAD_FLOOR_S`, 10 ms.
+**A floor has to sit BELOW the measurements it guards, or it disables the mark instead
+of steadying it:** `latency_under_load`'s rungs read p50s of 9-30 ms and `poll_0.05`
+39-42 ms, so no combination of their reps clears a floor set anywhere near a tenth of a
+second. At 10 ms a rung that lurches still marks, and a 10% CV on reps milliseconds
+apart does not.
 
 Fewer than two valid reps is an unknown dispersion rather than a zero: `spread` and `cv`
 record `null` and the row is marked `?`, so a measurement that measured nothing cannot
@@ -572,10 +652,12 @@ a median with its dispersion and never as a scalar. Eight volume-era trials spre
 `synchronous_commit = off` held to 5%; two warmed opening probes, one per run, read
 1,984/s and 615/s. Nothing here selects between those two regimes. The two probes are
 also sized differently on purpose — `DURABLE_PROBE_COMMITS` 300 against
-`NONDURABLE_PROBE_COMMITS` 5,000 — because the non-durable rate reached ~370,000
-commits/s on the same stack, where 300 commits would be timing under a millisecond. A
-round read straight after a run once came back at 719/s: that was a cold session, not a
-depressed server, and it is why all three probes warm.
+`NONDURABLE_PROBE_COMMITS` 5,000 — because the non-durable rate reached 512,000-617,000
+commits/s across the five saved runs, where 300 commits would be timing under a
+millisecond. (On tmpfs the durable count is barely out of that regime either:
+[Storage](#storage-two-regimes-on-a-volume-and-none-on-ram).) A round read straight
+after a run once came back at 719/s: that was a cold session, not a depressed server,
+and it is why all three probes warm.
 
 The opening probe runs before the first measurement and the closing one after the last.
 The closing probe is not the opening one repeated: a run leaves behind the bloat and the
@@ -666,11 +748,13 @@ order:
    changed places is a finding; a rung that changed by 10% and kept its place is not.
 
 **The floor: a difference under about 12% is not evidence of anything.** Three runs of
-identical code gave a median CV of 4.7% and a worst of 12.5%, and the third sat
+identical code gave a median CV of 4.7% and a worst of 12.5%, and one of them sat
 systematically below the other two, so there is between-run bias on top of scatter. Only
 a delta clearing that floor on SEVERAL measurements at once, in one direction, is a
-change. Check `load_before`/`load_after` too: a run at load 6.7 measured 6-10% low
-against one at 2.5.
+change. `load_before`/`load_after` are worth reading but will not explain such a delta:
+the two runs whose per-rep load medians were 3.39 and 3.40 still disagreed by up to 18%
+on individual rungs. A whole run's numbers moving together is usually the working point
+it inherited — read the `calibration` block first.
 
 Two `latency_under_load` reports compare rung for rung only if their ramps found the
 same rate: the rungs are fractions of a MEASURED offer rate, so a run whose knee moved

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,9 +87,10 @@ says outright that rates off that server are only for comparing configurations. 
 it is the commit ceiling: what a single connection to this server could commit per
 second, measured before the first stage and again after the last.
 
-Then one table per stage, one row per configuration, with the rate and the spread across
-repeats. Every measurement appears even when something was wrong with it, marked in
-place:
+Then one table per stage, one row per configuration, with the rate, the `backlog` it
+preloaded and the spread across repeats. Two rows with different backlogs are two
+different experiments — a deeper queue is slower. Every measurement appears even when
+something was wrong with it, marked in place:
 
 - `!` **invalid** — a rep measured something other than what was asked (a redelivery, a
   task that never finished, a window too short to divide by, an offer the producer could
@@ -105,54 +106,53 @@ calibration could not tell.
 
 ## What it found
 
-Measured on one 14-core laptop with the server's data directory in RAM. Read the ratios,
-not the rates.
+Measured on one 14-core laptop with the data directory in RAM, over four runs of one
+commit; every range below is across those runs. Read the directions, not the rates.
+[`CLAUDE.md`](CLAUDE.md) names the run behind each figure.
 
 - **Scale with worker processes, keep `--concurrency` around 16, and batch the claims.**
-  The best cell measured was 10 processes x 16 concurrency at 4,441 tasks/s. Neither
-  axis had flattened out there: concurrency 1 -> 16 at one process bought 3.4x (360.6 ->
-  1,231.1 tasks/s), and processes 1 -> 10 at concurrency 16 bought 3.7x (1,211.5 ->
-  4,441.7).
-- **Processes beat threads at the same total.** 4 processes x 1 beat 1 x 4 concurrency
-  by 2.08x, and 8 x 1 beat 1 x 8 by 2.24x. The reason is that 42% of a task's wall time
-  is client-side Python (2.82 ms per task = 1.64 ms server + 1.18 ms client), which is
-  what a GIL serialises.
+  Neither axis had flattened at the top of the sweep: concurrency 1 -> 16 at one process
+  bought 3.0-3.7x, all of it at one queue depth. More processes always bought more, but
+  `process_scaling` preloads 2,000 tasks per worker, so its rungs drained 4,000 to
+  20,000 tasks and no multiple can be read off that ladder.
+- **Processes beat threads at the same total.** 4 x 1 beat 1 x 4 by 1.95-2.28x and 8 x 1
+  beat 1 x 8 by 2.17-2.29x, both arms of each pair at the same depth. 40-47% of a task's
+  wall time is outside the server (2.82-3.14 ms per task = 1.57-1.77 server + 1.16-1.48
+  client); what serialises it — the GIL, or the one claim connection a worker process
+  owns — is not established.
 - **All of the per-task database cost is acquiring work, not finishing it.** Claiming a
-  task costs about 15x completing one (1.47 ms against 0.099 ms), and 18% of every claim
-  is a scan for cancellations.
-- **A queue that is deeper is slower.** Throughput rises as a backlog drains — within a
-  measurement, by a median 13.3%, in 37 of 46 repeats. So a saturation number averages a
-  curve and cannot be compared across different `--tasks` values.
+  task costs 13-16x completing one (1.41-1.56 ms against 0.09-0.12 ms), and 18-19% of
+  every claim is a scan for cancellations.
+- **A queue that is deeper is slower.** Throughput rises as a backlog drains, a fitted
+  median +15.7% within a rep over 150 reps, so a saturation number averages a curve and
+  does not compare across `--tasks` values.
 
 ## Caveats that change what you can do with a number
 
 **Absolute rates are not publishable, at all** — not across runs, and not as a property
-of django-absurd. `db_bench` keeps its data directory in RAM, so every rate here was
-measured against a server with no disk under it, and no production Postgres runs that
-way. A row read against another row in the same file is a comparison; the same row
-quoted on its own is a number about RAM. Publishable figures need real storage under a
-real filesystem, which nothing in this directory can provide.
+of django-absurd. `db_bench` keeps its data directory in RAM, and no production Postgres
+runs that way. A row read against another row in the same file is a comparison; the same
+row quoted on its own is a number about RAM. Publishable figures need real storage,
+which nothing in this directory can provide.
 
 **Every ceiling this work proposed turned out to be the measurement environment rather
 than Absurd** — disk fsync first, then a single connection's commit rate, then CPU. The
-harness has not found Absurd's limit; it has only ever found its own. Read every figure
-above with that in mind.
+harness has not found Absurd's limit; it has only ever found its own.
 
 **Repeats are good enough to rank things, not to confirm a small change.** Three runs of
-the same commit, 25 shared measurements: median CV 4.7%, mean 5.1%, worst 12.5%. The
-third run also sat systematically below the other two on several measurements, so part
-of that is a between-run bias rather than scatter. A difference smaller than about 12%
-is not evidence of anything.
+the same commit, 25 shared measurements: median CV 4.7%, mean 5.1%, worst 12.5%, one run
+systematically below the other two. Under about 12% is not evidence of anything, and a
+whole run reading low is usually the working point it inherited, not the machine.
 
 **Measure on a quiet machine on AC power.** The macOS indexer alone was worth 1-1.4
-cores sustained and moved measurements 6-10%. It ruins the saturation stages, which
-drive the box to its limit, and barely reaches the paced ones — so a run on a machine
-you are also using is worth reading for its rate stages and worth distrusting for the
-rest.
+cores sustained. It spoils the saturation stages, which drive the box to its limit, and
+barely reaches the paced ones.
 
-**`latency_under_load` measures the offer rate it then uses.** Its rungs are fractions
-of whatever rate its own ramp found the fleet could absorb, so read the `Offer rate:`
-line under its table first — two runs' rows only compare if their ramps agreed.
+**`latency_under_load` measures the offer rate it then uses, and stops at the lower of
+two limits.** Its rungs are fractions of whatever rate its own ramp got through cleanly,
+and a probe fails when the fleet falls behind OR when the producer — on the same box —
+never delivers the offer. Read the `Offer rate:` line and the ramp's `producer kept up`
+column first; two runs' rows only compare if their ramps agreed.
 
 ## Files
 

--- a/benchmarks/analysis.py
+++ b/benchmarks/analysis.py
@@ -41,6 +41,13 @@ PROBE_WARM_UP_COMMITS = 1200
 # Timed rounds kept. The durable rate is a distribution and not a constant, so the
 # ceiling is recorded as a median with its own dispersion beside it.
 PROBE_TIMED_ROUNDS = 5
+# What a ceiling block holds until a probe replaces it, so a run cut short — killed,
+# interrupted mid-wait, or dead at a stage — records that it never took one. A server
+# that refused a probe is a different fact and gets a different block.
+UNPROBED_COMMIT_CEILING = {
+    "valid": False,
+    "error": "the run ended before this probe was taken",
+}
 
 # Completions per profile slice. Equal-COUNT rather than equal-time, so a slow
 # measurement's slices are not noisier for purely statistical reasons.
@@ -268,8 +275,8 @@ def measure_idle_commit_rate(seconds: float) -> float:
     return (read_xact_commit() - before) / seconds
 
 
-def measure_commit_ceiling(*, durable: bool) -> dict[str, float] | None:
-    """What one WARM session commits per second, as a distribution, or ``None``.
+def measure_commit_ceiling(*, durable: bool) -> dict[str, t.Any]:
+    """What one WARM session commits per second, as a distribution, or why it is not.
 
     The ceiling every throughput in a run is read against: near it, a per-connection
     task rate is a property of Postgres on this disk rather than of Absurd.
@@ -279,8 +286,8 @@ def measure_commit_ceiling(*, durable: bool) -> dict[str, float] | None:
     bound-verdict widens on. ONE session, because a worker opens one claim connection
     whatever its ``--concurrency`` — see `benchmarks/CLAUDE.md`.
 
-    Calibration, not measurement: a run that cannot have its ceiling records that it
-    has none and carries on.
+    Calibration, not measurement: a run whose server refuses the probe records the
+    refusal in a rep's own ``valid``/``error`` vocabulary and carries on.
     """
     commits = DURABLE_PROBE_COMMITS if durable else NONDURABLE_PROBE_COMMITS
     table = psycopg.sql.Identifier(COMMIT_PROBE_TABLE)
@@ -288,53 +295,67 @@ def measure_commit_ceiling(*, durable: bool) -> dict[str, float] | None:
         commits=psycopg.sql.Literal(commits), table=table
     )
     warm_up_rounds = math.ceil(PROBE_WARM_UP_COMMITS / commits)
+    connection = connections[resolve_absurd_database()]
     try:
-        with connections[resolve_absurd_database()].cursor() as cursor:
-            # Outside the try/finally on purpose: a name already taken belongs to
-            # someone else, and the cleanup must never drop a table it did not create.
+        with connection.cursor() as cursor:
+            # A name already taken belongs to someone else, and the cleanup below must
+            # never drop a table it did not create.
             cursor.execute(
                 psycopg.sql.SQL(
                     "create table {table} (n int, elapsed_s float8)"
                 ).format(table=table)
             )
-            try:
-                if not durable:
-                    cursor.execute("set synchronous_commit = off")
-                rates = []
-                for _ in range(warm_up_rounds + PROBE_TIMED_ROUNDS):
-                    # Emptied first so the row read back is this round's own elapsed
-                    # and never a slower earlier round's.
-                    cursor.execute(
-                        psycopg.sql.SQL("truncate {table}").format(table=table)
-                    )
-                    cursor.execute(probe)
-                    cursor.execute(
-                        psycopg.sql.SQL("select max(elapsed_s) from {table}").format(
-                            table=table
-                        )
-                    )
-                    rates.append(commits / float(cursor.fetchone()[0]))
-                # Warmed on this cursor's own connection: the climb is per connection,
-                # so a session warmed anywhere else leaves this one paying for it.
-                return summarize_commit_rates(rates[warm_up_rounds:])
-            finally:
-                # Reset unconditionally: a no-op for the durable probe, and a branch
-                # here would be one more way to leave the session altered.
-                cursor.execute("reset synchronous_commit")
+            if not durable:
+                cursor.execute("set synchronous_commit = off")
+            rates = []
+            for _ in range(warm_up_rounds + PROBE_TIMED_ROUNDS):
+                # Emptied first so the row read back is this round's own elapsed
+                # and never a slower earlier round's.
+                cursor.execute(psycopg.sql.SQL("truncate {table}").format(table=table))
+                cursor.execute(probe)
                 cursor.execute(
-                    psycopg.sql.SQL("drop table {table}").format(table=table)
+                    psycopg.sql.SQL("select max(elapsed_s) from {table}").format(
+                        table=table
+                    )
                 )
-    except db.Error:
-        return None
+                rates.append(commits / float(cursor.fetchone()[0]))
+            # Cleanup on the way out of a probe that finished, never from a `finally`:
+            # a statement issued after an interrupted wait raises over the interruption
+            # and hands the rest of the process a session stuck mid-command.
+            cursor.execute("reset synchronous_commit")
+            cursor.execute(psycopg.sql.SQL("drop table {table}").format(table=table))
+    except db.Error as exc:
+        return describe_refused_probe(exc)
+    except BaseException:
+        # An interrupted wait leaves the session mid-command, where every later
+        # statement reads `another command is already in progress`. Nothing can be
+        # issued on it, so it is dropped rather than reset, and the interruption goes
+        # on untouched.
+        connection.close()
+        raise
+    # Warmed on that session itself: the climb is per connection, so a session warmed
+    # anywhere else leaves this one paying for it.
+    return summarize_commit_rates(rates[warm_up_rounds:])
 
 
-def summarize_commit_rates(rates: list[float]) -> dict[str, float]:
+def describe_refused_probe(exc: db.Error) -> dict[str, t.Any]:
+    """A probe the server was asked for and would not give, and what it said.
+
+    Distinct from `UNPROBED_COMMIT_CEILING`: one is a server that answered no, the
+    other is a run that never asked, and a reader deciding whether to trust a rate
+    needs to tell them apart.
+    """
+    return {"valid": False, "error": f"the server refused the probe: {exc}"}
+
+
+def summarize_commit_rates(rates: list[float]) -> dict[str, t.Any]:
     """One probe's timed rounds, in the vocabulary a measurement's reps already use.
 
     The endpoints ride along with the CV because a percentage is what a reader has to
     un-reduce to see what was measured.
     """
     return {
+        "valid": True,
         "median_per_s": statistics.median(rates),
         "cv": statistics.stdev(rates) / statistics.fmean(rates),
         "range_low": min(rates),

--- a/benchmarks/analysis.py
+++ b/benchmarks/analysis.py
@@ -26,7 +26,11 @@ BACKLOG_GROWTH_FLOOR_TASKS = 8
 # The table the commit-ceiling probe commits into. A REAL table, not a temporary one:
 # a temp table is not WAL-logged, so the probe would report memory speed as durable.
 COMMIT_PROBE_TABLE = "benchmark_commit_ceiling_probe"
-# Commits per timed round: ~0.15 s at the rate a warmed session sustains.
+# Commits per timed round. Sized on the volume, where ~2,000 commits/s made this a
+# 0.15 s round; on tmpfs a warmed session commits 204,000-241,000/s, so the same round
+# times 1.2-1.5 ms — the regime the count below exists to stay out of. Unchanged
+# anyway: every ceiling in `CLAUDE.md` was measured at 300, and re-sizing it makes none
+# of them comparable.
 DURABLE_PROBE_COMMITS = 300
 # The same window with fsync out of the way, where the durable count above would
 # be timing under a millisecond.

--- a/benchmarks/measurement.py
+++ b/benchmarks/measurement.py
@@ -16,6 +16,16 @@ DRAIN_POLL_INTERVAL_S = 0.5
 LOWER_IS_BETTER_RANKING_KEYS = frozenset({"end_to_end_p50_s"})
 
 
+class WorkerExitedError(Exception):
+    def __init__(self, name: str, exited: int, workers: int) -> None:
+        super().__init__(
+            f"Measurement '{name}' lost {exited} of its {workers} worker process(es) "
+            f"while the queue was still draining, so what is left cannot drain it. "
+            f"Refused here rather than at the drain timeout, which the fleet would "
+            f"otherwise burn in full before anything said the workers were gone."
+        )
+
+
 class MeasurementTimeoutError(Exception):
     def __init__(self, name: str, timeout_s: float) -> None:
         super().__init__(
@@ -88,7 +98,7 @@ def run_saturation_rep(spec: MeasurementSpec) -> dict[str, t.Any]:
     commits_before = analysis.read_xact_commit()
     try:
         with host.measure_phase() as phase:
-            wait_until_drained(spec)
+            wait_until_drained(spec, procs)
     finally:
         runner.stop_workers(procs)
     # Read once the workers have exited, since a live backend flushes its transaction
@@ -128,7 +138,7 @@ def run_rate_rep(spec: MeasurementSpec) -> dict[str, t.Any]:
                 kwargs=spec.task_kwargs,
             )
             window_end = analysis.capture_database_now()
-            wait_until_drained(spec)
+            wait_until_drained(spec, procs)
     finally:
         runner.stop_workers(procs)
     # No commits per task and no statement stats: the completed-run count comes off the
@@ -140,9 +150,19 @@ def run_rate_rep(spec: MeasurementSpec) -> dict[str, t.Any]:
     }
 
 
-def wait_until_drained(spec: MeasurementSpec) -> None:
+def wait_until_drained(spec: MeasurementSpec, workers: list[runner.Worker]) -> None:
+    """Poll the queue until it is empty — and the fleet, which is the other way out.
+
+    A queue polled alone cannot tell a slow drain from an absent one, so a rung whose
+    workers died waits out its whole timeout and then reports the timeout as the
+    failure. The children's own exit is what `stop_workers` raises over this on the
+    way out, so the crash stays the cause.
+    """
     deadline = time.monotonic() + spec.timeout_s
     while analysis.count_unfinished_tasks(spec.worker.queue) > 0:
+        exited = runner.count_exited_workers(workers)
+        if exited:
+            raise WorkerExitedError(spec.name, exited, len(workers))
         if time.monotonic() > deadline:
             raise MeasurementTimeoutError(spec.name, spec.timeout_s)
         time.sleep(DRAIN_POLL_INTERVAL_S)

--- a/benchmarks/measurement.py
+++ b/benchmarks/measurement.py
@@ -10,6 +10,10 @@ import runner
 from django_absurd.flush import truncate_queue_tables
 
 DRAIN_POLL_INTERVAL_S = 0.5
+# Ranking keys a SMALLER value is the better measurement of. Everything else here is
+# a rate, where bigger is better; only an end-to-end latency runs the other way, and
+# which way it runs is what says which of two middle reps is the unlucky one.
+LOWER_IS_BETTER_RANKING_KEYS = frozenset({"end_to_end_p50_s"})
 
 
 class MeasurementTimeoutError(Exception):
@@ -153,9 +157,7 @@ def summarize_reps(
     valid = sorted(
         (rep for rep in reps if rep["valid"]), key=lambda rep: rep[ranking_key]
     )
-    # Lower of the two middles at an even rep count: the upper one is the BEST rep,
-    # and a measurement must not be summarized by its luckiest one.
-    median: dict[str, t.Any] = valid[(len(valid) - 1) // 2] if valid else {}
+    median = pick_median_rep(valid, ranking_key)
     absolute_spread = measure_absolute_spread(valid, ranking_key)
     cv = measure_cv(valid, ranking_key)
     low, high = measure_rep_range(valid, ranking_key)
@@ -175,6 +177,23 @@ def summarize_reps(
         "unstable": is_measurement_unstable(spec, cv, absolute_spread),
         "host": host.collect_host_context(),
     }
+
+
+def pick_median_rep(
+    valid: list[dict[str, t.Any]], ranking_key: str
+) -> dict[str, t.Any]:
+    """The middle rep of reps already sorted ascending, resolving an even count
+    towards the WORSE of the two middles.
+
+    Which middle that is depends on the metric, and taking the lower one both times
+    summarized a rate measurement by its LUCKIEST rep: a throughput and an enqueue
+    rate are better high, an end-to-end latency is better low.
+    """
+    if not valid:
+        return {}
+    if ranking_key in LOWER_IS_BETTER_RANKING_KEYS:
+        return valid[len(valid) // 2]
+    return valid[(len(valid) - 1) // 2]
 
 
 def measure_spread(

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -6,10 +6,10 @@ from pathlib import Path
 DEFAULT_RESULTS_DIR = Path(__file__).resolve().parent / "results"
 
 TABLE_HEADER = (
-    "| measurement | mode | workers | concurrency | batch | poll | tasks/s "
+    "| measurement | mode | backlog | workers | concurrency | batch | poll | tasks/s "
     "| e2e p50 s | e2e p90 s | e2e p99 s | rep range | spread | cv | notes |"
 )
-TABLE_RULE = "| " + " | ".join(["---"] * 14) + " |"
+TABLE_RULE = "| " + " | ".join(["---"] * 15) + " |"
 PRODUCER_TABLE_HEADER = (
     "| mode | enqueues | enqueues/s | enqueue p50 s | enqueue p99 s "
     "| rep range | spread | cv | notes |"
@@ -27,6 +27,15 @@ MARK_LEGEND = (
         "and disagreed, beyond the measurement's CV limit. `?` — fewer than two "
         "valid reps, so dispersion was never measured. A marked measurement stays "
         "in every table and in every number derived below one."
+    ),
+    "",
+    (
+        "`backlog` is the `--tasks` depth a saturation rep preloaded and then drained, "
+        "blank in rate mode, which preloads nothing. Throughput RISES as a backlog "
+        "drains, so a saturation rate averages a curve whose starting depth is in this "
+        "column: two rows with different backlogs are two different experiments, and "
+        "anything derived across them carries a depth penalty as well as whatever it "
+        "meant to measure."
     ),
     "",
     (
@@ -378,6 +387,9 @@ def render_measurement_row(entry: dict[str, t.Any]) -> str:
         [
             spec["name"],
             spec["mode"],
+            # The depth a rate row never had: it starts on an empty queue and is
+            # sized by its offer, so a `0` here would read as a measured zero.
+            "" if paced else str(spec["tasks"]),
             str(spec["workers"]),
             str(worker["concurrency"]),
             "default" if worker["batch_size"] is None else str(worker["batch_size"]),
@@ -408,15 +420,20 @@ def render_rate_ramp(stage: dict[str, t.Any]) -> list[str]:
         describe_sustainable_rate(ramp),
         "",
         (
-            "| offered/s | offer s | absorbed | e2e p50 s | backlog at midpoint "
-            "| backlog at end |"
+            "| offered/s | offer s | achieved/s | producer kept up | absorbed "
+            "| e2e p50 s | backlog at midpoint | backlog at end |"
         ),
-        "| " + " | ".join(["---"] * 6) + " |",
+        "| " + " | ".join(["---"] * 8) + " |",
         *[
             render_row(
                 [
                     f"{probe['rate_per_s']:.1f}",
                     f"{ramp['offer_seconds']:g}",
+                    # What the producer managed against what it aimed at, because a
+                    # probe the enqueue side never delivered says nothing about the
+                    # fleet — and `absorbed` alone cannot tell the two apart.
+                    f"{probe['rep'].get('achieved_rate_per_s', 0.0):.1f}",
+                    "yes" if probe["rep"].get("offered_ok", True) else "no",
                     "yes" if probe["sustained"] else "no",
                     f"{probe['rep'].get('end_to_end_p50_s', 0.0):.4f}",
                     str(probe["rep"].get("backlog_mid", 0)),
@@ -429,11 +446,13 @@ def render_rate_ramp(stage: dict[str, t.Any]) -> list[str]:
 
 
 def describe_sustainable_rate(ramp: dict[str, t.Any]) -> str:
-    """What the ramp settled on, and why it is not the drain rate beside it.
+    """What the ramp settled on, and the two limits it cannot tell apart.
 
     A fleet draining a backlog has work waiting at every claim; a paced one has to keep
-    up in real time. So the two rates are different quantities and the drain one is the
-    larger, which is what taking fractions of it got wrong.
+    up in real time, so the two rates are different quantities and the drain one is the
+    larger — which is why the rungs are fractions of the ramp's rate and not of it. The
+    ramp stops at the first offer that did not come off cleanly, and the producer runs
+    on the same box as the workers, so that offer bounds whichever ran out first.
     """
     drain = (
         f"The drain rate this stage calibrated from was "
@@ -447,22 +466,35 @@ def describe_sustainable_rate(ramp: dict[str, t.Any]) -> str:
             f"an unproven rate and the marks on them are the finding. {drain}"
         )
     return (
-        f"Offer rate: {ramp['rate_per_s']:.1f}/s, the highest offer the fleet "
-        f"absorbed; {describe_rate_bracket(ramp)} The rows above offer fractions of "
-        f"it. {drain}"
+        f"Offer rate: {ramp['rate_per_s']:.1f}/s, the highest offer this ramp got "
+        f"through cleanly — the LOWER of the fleet's knee and the producer's own "
+        f"ceiling, and the ramp does not say which of the two it found. "
+        f"{describe_rate_bracket(ramp)} The rows above offer fractions of it. {drain}"
     )
 
 
 def describe_rate_bracket(ramp: dict[str, t.Any]) -> str:
-    """Where the knee is, which is between two probes and never at one of them."""
+    """What the first refusal bounds — which is the fleet only if the producer kept
+    up in it, and the enqueue side otherwise."""
     if ramp["bracket_high_per_s"] is None:
         return (
-            "the ramp ran out of climb below the drain rate without finding an offer "
+            "The ramp ran out of climb below the drain rate without finding an offer "
             "it could not, so the knee is at or above the top of the ramp."
         )
+    refused = next(probe for probe in ramp["probes"] if not probe["sustained"])
+    rep = refused["rep"]
+    if rep.get("offered_ok", True):
+        return (
+            f"It refused {ramp['bracket_high_per_s']:.1f}/s with the producer still "
+            f"delivering its target, so that refusal is the FLEET's and the knee is "
+            f"between the two; nothing here refines it."
+        )
     return (
-        f"it refused {ramp['bracket_high_per_s']:.1f}/s, so the knee is between the "
-        f"two and nothing here refines it."
+        f"It refused {ramp['bracket_high_per_s']:.1f}/s, but the producer itself only "
+        f"achieved {rep.get('achieved_rate_per_s', 0.0):.1f}/s there, so that "
+        f"refusal bounds the ENQUEUE side and not the fleet — which completed "
+        f"{rep.get('throughput_per_s', 0.0):.1f}/s inside the same probe. The fleet's "
+        f"own knee is somewhere above that, unmeasured."
     )
 
 
@@ -781,8 +813,35 @@ def build_scaling_efficiency_lines(measurements: list[dict[str, t.Any]]) -> list
     for entry in measurements:
         workers = entry["spec"]["workers"]
         efficiency = describe_quotient(entry, single, THROUGHPUT_KEY, workers, "")
-        lines.append(f"- {workers} worker(s): {efficiency}")
-    return lines
+        backlog = entry["spec"]["tasks"]
+        lines.append(f"- {workers} worker(s): {efficiency}, backlog {backlog}")
+    return lines + describe_depth_confound(measurements, single)
+
+
+def describe_depth_confound(
+    measurements: list[dict[str, t.Any]], single: dict[str, t.Any]
+) -> list[str]:
+    """Said under the efficiencies when the rungs they divide drained different
+    depths, because the quotient then carries a depth penalty as well as the scaling.
+
+    The direction is knowable even though the size is not: a deeper backlog is
+    slower, and every rung above one worker is the deeper one, so each figure is a
+    floor rather than an estimate.
+    """
+    depths = {entry["spec"]["tasks"] for entry in measurements}
+    if len(depths) < 2:
+        return []
+    return [
+        "",
+        (
+            f"CONFOUNDED: these rungs drained different backlogs "
+            f"({min(depths)} to {max(depths)}, against {single['spec']['tasks']} at "
+            f"one worker) and a deeper backlog is slower, so each efficiency divides "
+            f"a deeper measurement by a shallower one. Read them as lower bounds on "
+            f"the scaling, not as measurements of it; only a ladder run at one depth "
+            f"would separate the two."
+        ),
+    ]
 
 
 def build_pooled_vs_split_lines(measurements: list[dict[str, t.Any]]) -> list[str]:

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -146,25 +146,42 @@ def describe_commit_ceiling(stages: list[dict[str, t.Any]]) -> str:
 
 def format_commit_ceiling(stage: dict[str, t.Any]) -> str:
     durable = stage.get("commit_ceiling_durable")
-    if durable is None:
-        return (
-            "not measured, so nothing below says whether a throughput is this "
-            "connection's number or Absurd's"
-        )
     nondurable = stage.get("commit_ceiling_nondurable")
     after = stage.get("commit_ceiling_durable_after")
+    measured = read_measured_probe(durable)
+    if measured is None:
+        return (
+            f"{format_commit_rate(durable)}, so nothing below says whether a "
+            f"throughput is this connection's number or Absurd's"
+        )
     return (
         f"durable {format_commit_rate(durable)}, "
         f"after the run {format_commit_rate(after)}, "
         f"non-durable {format_commit_rate(nondurable)}, "
-        f"{describe_durability_cost(durable, nondurable)}"
+        f"{describe_durability_cost(measured, nondurable)}"
     )
 
 
-def format_commit_rate(ceiling: dict[str, float] | None) -> str:
-    """A probe's median, with the spread that says how much of it to believe."""
+def read_measured_probe(ceiling: dict[str, t.Any] | None) -> dict[str, t.Any] | None:
+    """A probe's rates, or ``None`` where it recorded a reason instead of measuring.
+
+    Every reader of a ceiling block goes through this, so a run whose probe was
+    refused and one whose probe was never taken cannot be read as calibrated, and the
+    reason each gave stays available to print.
+    """
+    if ceiling is None or not ceiling["valid"]:
+        return None
+    return ceiling
+
+
+def format_commit_rate(ceiling: dict[str, t.Any] | None) -> str:
+    """A probe's median with the spread that says how much of it to believe, or what
+    happened instead — a server that refused it and a run that never took it are two
+    different reasons a rate is missing."""
     if ceiling is None:
         return "not measured"
+    if not ceiling["valid"]:
+        return f"not measured: {ceiling['error']}"
     return (
         f"{ceiling['median_per_s']:.0f} "
         f"(cv {ceiling['cv']:.0%}, {ceiling['range_low']:.0f}-"
@@ -173,12 +190,13 @@ def format_commit_rate(ceiling: dict[str, float] | None) -> str:
 
 
 def describe_durability_cost(
-    durable: dict[str, float], nondurable: dict[str, float] | None
+    durable: dict[str, t.Any], nondurable: dict[str, t.Any] | None
 ) -> str:
     """What fsync costs, as the multiple the same server reaches without it."""
-    if nondurable is None:
+    measured = read_measured_probe(nondurable)
+    if measured is None:
         return "ratio not measured"
-    return f"{nondurable['median_per_s'] / durable['median_per_s']:.0f}x without fsync"
+    return f"{measured['median_per_s'] / durable['median_per_s']:.0f}x without fsync"
 
 
 def describe_storage_medium(contexts: list[dict[str, t.Any]]) -> list[str]:
@@ -628,8 +646,8 @@ def build_commit_budget_lines(stage: dict[str, t.Any]) -> list[str]:
     measurements = select_saturation_measurements(stage)
     if not any(entry["median"].get("commits_per_task") for entry in measurements):
         return []
-    opening = stage.get("commit_ceiling_durable")
-    closing = stage.get("commit_ceiling_durable_after")
+    opening = read_measured_probe(stage.get("commit_ceiling_durable"))
+    closing = read_measured_probe(stage.get("commit_ceiling_durable_after"))
     return [
         "",
         (
@@ -643,8 +661,8 @@ def build_commit_budget_lines(stage: dict[str, t.Any]) -> list[str]:
 
 def describe_commit_budget(
     entry: dict[str, t.Any],
-    opening: dict[str, float] | None,
-    closing: dict[str, float] | None,
+    opening: dict[str, t.Any] | None,
+    closing: dict[str, t.Any] | None,
 ) -> str:
     """One row's commit rate, as a band across every durable probe the run recorded.
 
@@ -680,7 +698,7 @@ def describe_commit_budget(
     )
 
 
-def describe_band_probes(closing: dict[str, float] | None) -> str:
+def describe_band_probes(closing: dict[str, t.Any] | None) -> str:
     """Which probes the band came from, since a wide band has two different causes.
 
     A reader comparing two reports has to tell a band widened by mid-run drift from

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -54,6 +54,15 @@ def start_workers(spec: WorkerSpec, count: int) -> list[Worker]:
     return started
 
 
+def count_exited_workers(workers: list[Worker]) -> int:
+    """How many children are no longer running, whatever their exit code.
+
+    Any exit at all, not just a crashing one: a worker that returned 0 mid-measurement
+    has stopped claiming exactly as thoroughly as one that died.
+    """
+    return sum(worker.proc.poll() is not None for worker in workers)
+
+
 def stop_workers(workers: list[Worker]) -> None:
     """SIGTERM every worker, reap it, then report any that had already died."""
     crashed = [worker for worker in workers if worker.proc.poll() not in (None, 0)]

--- a/benchmarks/stages.py
+++ b/benchmarks/stages.py
@@ -166,7 +166,7 @@ class StageOptions:
     max_workers: int | None = None
     # Not a flag: the machine's own commit ceiling, carried into every stage file this
     # run writes. Mutable because the closing probe lands after those files exist.
-    commit_ceiling: dict[str, dict[str, float] | None] = dataclasses.field(
+    commit_ceiling: dict[str, dict[str, t.Any]] = dataclasses.field(
         default_factory=dict
     )
 
@@ -183,27 +183,42 @@ def run_stages(stage_names: list[str], options: StageOptions) -> None:
         {
             "commit_ceiling_durable": analysis.measure_commit_ceiling(durable=True),
             "commit_ceiling_nondurable": analysis.measure_commit_ceiling(durable=False),
+            # Every file carries this from its first write, so a run killed at any
+            # point says it never took a closing probe rather than reading as a run
+            # whose server refused one.
+            "commit_ceiling_durable_after": analysis.UNPROBED_COMMIT_CEILING,
         }
     )
-    for name in ordered:
-        run_stage(name, options)
+    try:
+        for name in ordered:
+            run_stage(name, options)
+    except Exception:
+        # A stage that raised leaves its session intact, unlike an interrupted wait,
+        # so the stages that did finish still get the ceiling they were read against.
+        record_closing_commit_ceiling(ordered, options)
+        raise
+    record_closing_commit_ceiling(ordered, options)
+
+
+def record_closing_commit_ceiling(
+    stage_names: list[str], options: StageOptions
+) -> None:
+    """Probe the ceiling once more and write it into the files this invocation wrote.
+
+    Last, because the closing probe does not exist until the stages are over — and it
+    says whether the ceiling those stages were read against still held.
+    """
     options.commit_ceiling["commit_ceiling_durable_after"] = (
         analysis.measure_commit_ceiling(durable=True)
     )
-    record_commit_ceiling(ordered, options)
-
-
-def record_commit_ceiling(stage_names: list[str], options: StageOptions) -> None:
-    """Write the after-the-run ceiling into the files this invocation already wrote.
-
-    Last, because the closing probe does not exist until the last stage is done; a run
-    killed before then leaves the field null.
-    """
     for name in stage_names:
         path = options.results_dir / f"stage_{name}.json"
-        write_results_file(
-            path, {**json.loads(path.read_text()), **options.commit_ceiling}
-        )
+        # A stage that raised before writing anything has no file to update, and a
+        # FileNotFoundError raised here would replace the failure that got us here.
+        if path.exists():
+            write_results_file(
+                path, {**json.loads(path.read_text()), **options.commit_ceiling}
+            )
 
 
 def order_by_dependency(stage_names: list[str]) -> list[str]:
@@ -807,8 +822,8 @@ def write_stage_file(
         {
             "stage": stage,
             "options": resolve_options(options),
-            # The three keys always, at null until a probe fills them: omitting them
-            # would read as a file written before the ceiling was ever recorded.
+            # The three keys always: omitting one would read as a file written
+            # before the ceiling was ever recorded.
             **dict.fromkeys(COMMIT_CEILING_KEYS),
             **options.commit_ceiling,
             "measurements": recorded,

--- a/benchmarks/stages.py
+++ b/benchmarks/stages.py
@@ -59,8 +59,9 @@ STAGE_DESCRIPTIONS = {
 
 # The depth every rung sharing a table is measured at, so `--tasks` is a comparability
 # key rather than a size: 20,000 was measured and REFUSED — it moves the medians
-# 0.42-0.60x on depth alone, tightens no CV, and costs up to 10x the wall clock. See
-# `benchmarks/CLAUDE.md`.
+# 0.42-0.60x on depth alone, leaves the cross-rep CV inside the bracket 5,000 already
+# spanned while making the within-rep profile noisier, and costs up to 10x the wall
+# clock. See `benchmarks/CLAUDE.md`.
 SATURATION_TASKS = 5000
 SATURATION_TIMEOUT_S = 900.0
 # Read back off the measurement default rather than restated, so a results file
@@ -86,7 +87,11 @@ RATE_RAMP_STEP = 1.5
 RATE_RAMP_SECONDS = 20.0
 # Reps this close are not called unstable however far apart they read relatively: a
 # rate measurement ranks on a latency, which every relative dispersion divides by.
-RATE_SPREAD_FLOOR_S = 0.15
+# 10 ms and not the 150 ms this started at: `latency_under_load`'s rungs measure p50s of
+# 9-30 ms and `poll_0.05` 39-42 ms, so a floor above their whole healthy range put `~`
+# out of reach of every one of them and an unmarked rate table said nothing. Under the
+# smallest rung's own p50, so a rep that genuinely lurched still clears it.
+RATE_SPREAD_FLOOR_S = 0.010
 IDLE_PROBE_SECONDS = 30.0
 # A rate is divided by its own window, so a zero-length one has nothing to report.
 SMALLEST_MEASURABLE_DURATION_S = 0.001
@@ -556,6 +561,14 @@ def build_async_dispatch_measurements(
 def build_process_scaling_measurements(
     winner: runner.WorkerSpec, max_workers: int
 ) -> list[measurement.MeasurementSpec]:
+    """The worker ladder, each rung preloaded with 2,000 tasks per worker.
+
+    Sized per rung so a ten-worker fleet still has a drain long enough to trim, which
+    CONFOUNDS the ladder: its rungs run at 4,000 to 20,000 tasks and a deeper backlog
+    is slower, so no rate here compares with the rate above it and the report marks
+    the scaling efficiency it derives. Fixing it means one depth for every rung — see
+    `benchmarks/CLAUDE.md`, which also records the direction the confound points.
+    """
     return [
         measurement.MeasurementSpec(
             name=f"workers_{count}",
@@ -871,7 +884,7 @@ def summarize_producer_reps(
     valid = sorted(
         (rep for rep in reps if rep["valid"]), key=lambda rep: rep["enqueues_per_s"]
     )
-    median: dict[str, t.Any] = valid[(len(valid) - 1) // 2] if valid else {}
+    median = measurement.pick_median_rep(valid, "enqueues_per_s")
     # The shared helpers rather than a second copy of the arithmetic, which needs
     # every dispersion guard fixed in two places.
     cv = measurement.measure_cv(valid, "enqueues_per_s")

--- a/docs/plans/2026-09-01-benchmarks-harness-rework.md
+++ b/docs/plans/2026-09-01-benchmarks-harness-rework.md
@@ -147,6 +147,14 @@ From `benchmarks/README.md` and, where they appear, the docs page being deleted:
   context stay. Do not replace it with a ratio against the flagged baseline.
 - "only the ratios travel" where stated generally
 
+A second pass over `benchmarks/CLAUDE.md` and `benchmarks/README.md` found the same
+failure inside the rework's own docs — figures that trace to no saved run, a scaling
+multiple divided across two queue depths, a producer-side refusal reported as the
+fleet's. Retracted claim by claim in
+[the spec](../specs/2026-09-01-benchmarks-harness-rework.md#retracted-in-review-and-why);
+the reference docs state only the current position, with the run behind each figure
+named.
+
 Not a deletion in the harness README, which keeps the number under the provenance stamp.
 It does NOT go in the user guide: the same branch marks that whole regime as unbacked by
 anything in the repo, so citing one of its numbers as guidance two files away

--- a/docs/specs/2026-09-01-benchmarks-harness-rework.md
+++ b/docs/specs/2026-09-01-benchmarks-harness-rework.md
@@ -173,6 +173,60 @@ seed. It reuses the measurement core — host context, suspension guard, reps, m
 flags — and not the stage-runner shell. That reuse is what makes it one harness; sharing
 a CLI is not.
 
+## Retracted in review, and why
+
+The rework's own reference docs failed the rule above. Each claim below was in
+`benchmarks/CLAUDE.md` or `benchmarks/README.md`; each is now deleted or replaced by
+what the recorded runs support. Kept here for the reasoning, not for the wording.
+
+- **"processes 1 -> 10 at concurrency 16 bought 3.7x" and "the best cell measured was
+  4,441 tasks/s".** `build_process_scaling_measurements` sizes the preload as
+  `max(4000, 2000 * count)`, so the ladder's rungs run at 4,000 to 20,000 tasks — and
+  the same document's own measurement puts 4x the depth at 40-58% of the throughput. The
+  multiple and the ceiling both mixed process scaling with a depth penalty. Withdrawn:
+  the direction survives, the confound points conservative, so the quotients are lower
+  bounds. Equal-depth re-measurement is the fix and is not done.
+- **"2,142 sustainable, so the knee is around half the drain rate", attributed to the
+  fleet.** The refused 3,213/s probe recorded `offered_ok` false — the producer achieved
+  2,895 and 3,016/s and missed 61k of 64k deadlines — as well as `backlog_grew`. A ramp
+  probe bounds whichever of the fleet and the producer ran out first, and both run on
+  one box. The knee figure itself survives on different evidence: the over-offered
+  rungs, where the producer DID deliver, collapse between 2,116 and 3,039/s offered.
+- **"run `a` reads 6-10% low" attributed to load and the macOS indexer.** `a`'s
+  `worker_knobs` winner was `batch_32` where the others picked `concurrency_16`, so
+  every downstream stage ran a different worker config, and its rate stage calibrated
+  from `workers_5`. Its overall deficit against the clean pair is 2%, while `c2` — at
+  the same load as `b` — reads 8-20% low on several rungs. The load attribution is
+  withdrawn; the indexer stays as a measured hazard (1-1.4 cores) with no percentage
+  attached.
+- **The old `latency_under_load` before/after table's provenance.** It said "four runs,
+  7 workers x concurrency 16, drain 4,182-4,231"; run `a` ran five workers and `c2`'s
+  drain was 4,052, and its throughput column mixed per-rep endpoints with medians.
+- **Itemised per-task costs as single figures** (2.82 ms = 1.64 server + 1.18 client;
+  `claim_task` 1.4718 ms). No saved run produces that decomposition. Replaced by ranges
+  over the five runs' median reps.
+- **"42% is what a GIL serialises."** `client_ms_per_task` is wall minus server time, so
+  it includes round-trip waits, where the GIL is released. The single claim connection
+  per worker process is an equally good fit and nothing measured separates them.
+- **"46 reps, median +13.3%, 37 of 46"** for within-rep drift. Not reproducible from any
+  stated rep set; five reasonable definitions span +8% to +22%. Replaced by one
+  definition with its rep set named.
+- **Two irreconciled tmpfs commit ceilings** (56,659 c/s interleaved against
+  200,000-240,000 in-run). Different measurements — the interleaved arms skip the
+  per-session warm-up — and only the in-run probe is what a report's verdicts are read
+  against.
+- **Cherry-picked slice-0 and dispersion ranges** (0.46 from one rep, "0.79-1.01 across
+  every single-process rung", "profile_cv 5.6-11.0%"). Replaced by the full ranges.
+
+Two guards were wrong rather than overstated, and were fixed:
+
+- `summarize_reps` took the lower of two middle reps in every mode. In rate mode the
+  ranking key is end-to-end p50, where lower is better, so an even `--reps` reported the
+  measurement by its LUCKIEST rep. `pick_median_rep` now resolves towards the worse
+  middle per metric.
+- `RATE_SPREAD_FLOOR_S` was 150 ms while the rate rungs read p50s of 9-42 ms, so `~`
+  could never fire on any of them and an unmarked rate table said nothing. Now 10 ms.
+
 ## What survives from `loadtest/`
 
 Kept: the admin probe and its seeder (the ordering decision in #142 is made and

--- a/docs/web/tasks.md
+++ b/docs/web/tasks.md
@@ -26,22 +26,6 @@ module. `async def` works the same — `await send_report.aenqueue(42)`.
 - Delivery is **at-least-once** — keep handlers idempotent. See
   [runs & retries](workers.md#runs-retries).
 
-### Enqueue in bulk
-
-```python
-from django.db import transaction
-
-with transaction.atomic():
-    for order in batch:
-        process_order.enqueue(order.id)
-```
-
-Each `enqueue()` is its own round trip, so a bare loop commits once per task; one
-transaction amortises that across the batch. The trade is the rule above at batch scale
-— a rollback drops every enqueue in the block together, and workers see none of them
-until it commits. Chunk a few hundred at a time and retry a failed chunk, rather than
-wrapping the whole batch in one transaction.
-
 ## Read the result
 
 ```python

--- a/docs/web/workers.md
+++ b/docs/web/workers.md
@@ -31,16 +31,6 @@ dropped from under a running worker fails on its next claim, with the same messa
 | `--beat`          | off            | Also run the [beat scheduler](cron-jobs.md#application-side-beat). |
 
 - **One worker per queue.** `--queue` takes a single name; run a process per queue.
-- **`--concurrency`** — default `1`. Runs in flight per worker; also the sync
-  thread-pool size. Raise it when tasks wait — on the database, an HTTP call, a sleep.
-  The overlap is partial, and thins out as it rises: each run still pays for its own
-  claim and completion, and those do not overlap away.
-- **`--batch-size`** — defaults to `--concurrency`. A claim never fetches more than the
-  worker has free, so this only bites at `--concurrency 1`, where a bigger batch means
-  fewer claims. Setting it to 1 costs a round trip per task and buys nothing.
-- **`--poll-interval`** — default `0.25`. Applies only when a worker is idle; a busy one
-  reclaims immediately. Lower it for latency on quiet queues, raise it to stop idle
-  workers polling so often.
 - A run that makes no progress within `--claim-timeout` is re-claimed and replayed from
   its last [checkpoint](workflows.md#steps) — see [long steps](workflows.md#long-steps).
 - Run **exactly one** `--beat` across your fleet; there is no leader election.

--- a/docs/web/workflows.md
+++ b/docs/web/workflows.md
@@ -53,10 +53,6 @@ context **inside** a running task — `get_absurd_context()` when sync,
 - Async `fn` must return an awaitable — an `async def`, not a lambda.
 - Results go through `json.dumps`: no sets, custom classes, or `datetime`, and `tuple`
   returns as `list`.
-- **Each step is a durable write, and it is not cheap.** A 4-step workflow cost 4.55x a
-  flat task doing the same trivial work (8-core laptop, Postgres on the same box).
-  Checkpoint at boundaries worth not repeating — an external charge, a slow import — not
-  at every line.
 
 →
 [Absurd: Concepts — Steps (Checkpoints)](https://earendil-works.github.io/absurd/concepts/#steps-checkpoints)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,10 @@ skip_covered = true
 
 [tool.coverage.run]
 branch = true
-patch = ["subprocess"]
+# `_exit` beside `subprocess`: a benchmark worker child is killed mid-task by
+# `os._exit`, which skips the hook the child's own coverage data is written from, and
+# the line that killed it would read as never executed.
+patch = ["subprocess", "_exit"]
 plugins = [
   "django_coverage_plugin",
 ]

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,20 @@
+import typing as t
+
+import pytest
+from django.db import connections
+
+
+@pytest.fixture(autouse=True)
+def _drop_connections_between_tests() -> t.Iterator[None]:
+    """Hand no test a session an earlier one left mid-command.
+
+    This suite is the only one that can be interrupted inside a wait: its tests run
+    real probes and real drains, and the suite's own `pytest-timeout` alarm fires
+    inside them. An interrupted wait leaves that connection stuck on
+    `another command is already in progress`, and under `--reuse-db` the next test on
+    the same worker inherits it — one timeout then reads as a whole worker's worth of
+    unrelated failures. Closing costs a reconnect per test and bounds the damage to
+    the test that was interrupted.
+    """
+    yield
+    connections.close_all()

--- a/tests/benchmarks/test_cli.py
+++ b/tests/benchmarks/test_cli.py
@@ -129,6 +129,7 @@ def test_records_the_commit_ceiling_this_machine_was_measured_against(
     result = utils.read_stage(tmp_path, "producer_ceiling")
     durable = result["commit_ceiling_durable"]
     assert {
+        "measured": durable["valid"],
         "durable": durable["median_per_s"] > 0,
         "durable_after": result["commit_ceiling_durable_after"]["median_per_s"] > 0,
         "measured_its_own_dispersion": durable["cv"] >= 0,
@@ -140,6 +141,7 @@ def test_records_the_commit_ceiling_this_machine_was_measured_against(
             > durable["median_per_s"]
         ),
     } == {
+        "measured": True,
         "durable": True,
         "durable_after": True,
         "measured_its_own_dispersion": True,
@@ -148,14 +150,16 @@ def test_records_the_commit_ceiling_this_machine_was_measured_against(
     }
 
 
-def test_records_no_commit_ceiling_when_the_probe_was_refused(
+def test_records_what_the_server_said_when_the_probe_was_refused(
     tmp_path: pathlib.Path,
 ) -> None:
-    """A run nobody could calibrate still runs; it records that it has no ceiling.
+    """A run nobody could calibrate still runs; it records why it has no ceiling.
 
     Refusing to measure because a calibration probe failed would be worse than
-    reporting an uncalibrated number and saying so, which is what the null here and
-    the report's header line together do.
+    reporting an uncalibrated number and saying so, which is what these blocks and the
+    report's header line together do. What they say is that the server was ASKED and
+    said no — a run that ended before a probe was ever taken records the other thing,
+    and a reader deciding whether to trust a rate has to tell them apart.
     """
     with utils.hold_the_commit_probe_table():
         stages.main(
@@ -177,10 +181,72 @@ def test_records_no_commit_ceiling_when_the_probe_was_refused(
         "commit_ceiling_durable_after": result["commit_ceiling_durable_after"],
         "measured_anyway": result["measurements"][0]["median"]["enqueues_per_s"] > 0,
     } == {
-        "commit_ceiling_durable": None,
-        "commit_ceiling_nondurable": None,
-        "commit_ceiling_durable_after": None,
+        "commit_ceiling_durable": {
+            "valid": False,
+            "error": (
+                "the server refused the probe: relation "
+                '"benchmark_commit_ceiling_probe" already exists'
+            ),
+        },
+        "commit_ceiling_nondurable": {
+            "valid": False,
+            "error": (
+                "the server refused the probe: relation "
+                '"benchmark_commit_ceiling_probe" already exists'
+            ),
+        },
+        "commit_ceiling_durable_after": {
+            "valid": False,
+            "error": (
+                "the server refused the probe: relation "
+                '"benchmark_commit_ceiling_probe" already exists'
+            ),
+        },
         "measured_anyway": True,
+    }
+
+
+def test_a_run_that_died_still_records_the_ceiling_its_stages_were_read_against(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A stage that raises must not take the finished stages' calibration with it.
+
+    The closing probe is what says whether the ceiling those stages were read against
+    still held, and it lands after the last stage — so an invocation that dies at a
+    later one has to take it anyway, or 75 minutes of measurement bands against the
+    opening probe alone for the sake of the stage that failed. The stage that never
+    wrote a file is skipped rather than being an error of its own.
+
+    latency_under_load reads `stage_process_scaling.json` back off disk, and there is
+    none here, so it raises after producer_ceiling has finished and written its own.
+    """
+    with pytest.raises(SystemExit) as exit_info:
+        stages.main(
+            [
+                "producer_ceiling",
+                "latency_under_load",
+                "--reps",
+                "1",
+                "--tasks",
+                "10",
+                "--results-dir",
+                str(tmp_path),
+            ]
+        )
+
+    result = utils.read_stage(tmp_path, "producer_ceiling")
+    assert {
+        "exit_code": exit_info.value.code,
+        "kept_its_measurements": len(result["measurements"]),
+        "closing_probe_measured": result["commit_ceiling_durable_after"]["valid"],
+        "wrote_the_stage_that_never_ran": (
+            tmp_path / "stage_latency_under_load.json"
+        ).exists(),
+    } == {
+        "exit_code": 1,
+        "kept_its_measurements": 3,
+        "closing_probe_measured": True,
+        "wrote_the_stage_that_never_ran": False,
     }
 
 
@@ -467,6 +533,13 @@ def test_refuses_a_size_that_leaves_a_stage_nothing_to_measure(
     )
 
 
+# Four stages in one body, where every other test here drives one: the suite's own
+# 120 s alarm is sized for a single stage, and firing it mid-drain would fail the test
+# for its length rather than for anything it asserts. Raised rather than split because
+# what is under test IS the chain — each stage reads the previous one back off disk,
+# so splitting it either re-runs worker_knobs per test or moves the same 70 seconds
+# into one test's fixture setup, where the same alarm still covers it.
+@pytest.mark.timeout(600)
 def test_runs_every_calibrated_stage_from_its_prerequisite(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/benchmarks/test_report.py
+++ b/tests/benchmarks/test_report.py
@@ -154,6 +154,13 @@ HEADER = (
     "so dispersion was never measured. A marked measurement stays in every table and "
     "in every number derived below one.\n"
     "\n"
+    "`backlog` is the `--tasks` depth a saturation rep preloaded and then drained, "
+    "blank in rate mode, which preloads nothing. Throughput RISES as a backlog "
+    "drains, so a saturation rate averages a curve whose starting depth is in this "
+    "column: two rows with different backlogs are two different experiments, and "
+    "anything derived across them carries a depth penalty as well as whatever it "
+    "meant to measure.\n"
+    "\n"
     "`rep range`, `spread` and `cv` are over the metric the reps were ranked on: "
     "tasks/s in saturation mode, end-to-end p50 s in rate mode, enqueues/s in "
     "producer mode. `spread` is `(max - min) / median`, shown because the endpoints "
@@ -162,10 +169,10 @@ HEADER = (
 )
 
 MEASUREMENT_TABLE_HEAD = (
-    "| measurement | mode | workers | concurrency | batch | poll | tasks/s "
+    "| measurement | mode | backlog | workers | concurrency | batch | poll | tasks/s "
     "| e2e p50 s | e2e p90 s | e2e p99 s | rep range | spread | cv | notes |\n"
     "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- "
-    "| --- | --- |\n"
+    "| --- | --- | --- |\n"
 )
 
 
@@ -193,6 +200,9 @@ def build_measurement(
         "name": name,
         "mode": "saturation",
         "workers": 1,
+        # The depth a rung preloaded, which the table prints because a saturation rate
+        # averages the drain of it and two different ones are two experiments.
+        "tasks": 5000,
         "task_path": "tasks.noop_sync",
         "worker": {"concurrency": 1, "batch_size": None, "poll_interval": 0.25},
         **spec,
@@ -260,7 +270,9 @@ def build_rate_ramp(**overrides: t.Any) -> dict[str, t.Any]:
     """The ramp a rate stage records, the way `stages.measure_sustainable_rate` does.
 
     Three probes climbing towards the drain rate: two the fleet absorbed and the one it
-    did not, whose backlog doubled across its own offer window.
+    did not, whose backlog doubled across its own offer window. The refused one has
+    the producer delivering its whole target, which is what makes the refusal the
+    fleet's — the other case is `build_producer_bound_ramp`.
     """
     return {
         "drain_ceiling_per_s": 4200.0,
@@ -273,6 +285,9 @@ def build_rate_ramp(**overrides: t.Any) -> dict[str, t.Any]:
                 "rate_per_s": 933.3,
                 "sustained": True,
                 "rep": {
+                    "achieved_rate_per_s": 933.2,
+                    "offered_ok": True,
+                    "throughput_per_s": 933.0,
                     "end_to_end_p50_s": 0.014,
                     "backlog_mid": 30,
                     "backlog_end": 26,
@@ -282,6 +297,9 @@ def build_rate_ramp(**overrides: t.Any) -> dict[str, t.Any]:
                 "rate_per_s": 1400.0,
                 "sustained": True,
                 "rep": {
+                    "achieved_rate_per_s": 1399.8,
+                    "offered_ok": True,
+                    "throughput_per_s": 1399.1,
                     "end_to_end_p50_s": 0.018,
                     "backlog_mid": 42,
                     "backlog_end": 39,
@@ -291,6 +309,9 @@ def build_rate_ramp(**overrides: t.Any) -> dict[str, t.Any]:
                 "rate_per_s": 2100.0,
                 "sustained": False,
                 "rep": {
+                    "achieved_rate_per_s": 2099.6,
+                    "offered_ok": True,
+                    "throughput_per_s": 1704.0,
                     "end_to_end_p50_s": 8.4,
                     "backlog_mid": 24000,
                     "backlog_end": 51000,
@@ -299,6 +320,22 @@ def build_rate_ramp(**overrides: t.Any) -> dict[str, t.Any]:
         ],
         **overrides,
     }
+
+
+def build_producer_bound_ramp() -> dict[str, t.Any]:
+    """The same ramp, refused by an offer the PRODUCER never delivered.
+
+    Both sides run on one box, so the enqueue loop misses its own deadlines before the
+    fleet runs out — which is what the recorded ramps did. The rep is otherwise the
+    refused probe's: a backlog that grew, on an offer nobody made in full.
+    """
+    ramp = build_rate_ramp()
+    ramp["probes"][-1]["rep"] |= {
+        "achieved_rate_per_s": 1890.0,
+        "offered_ok": False,
+        "throughput_per_s": 1804.0,
+    }
+    return ramp
 
 
 def build_pooled_vs_split_entries() -> list[dict[str, t.Any]]:
@@ -354,9 +391,9 @@ def test_renders_stage_tables_from_result_files(
         "## Worker knobs\n"
         "\n"
         + MEASUREMENT_TABLE_HEAD
-        + "| concurrency_1 | saturation | 1 | 1 | default | 0.25 "
+        + "| concurrency_1 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 412.5 |  |  |  | 412.5-412.5 | 4.0% | 2.0% |  |\n"
-        "| concurrency_2 | saturation | 1 | 2 | 4 | 0.25 "
+        "| concurrency_2 | saturation | 5000 | 1 | 2 | 4 | 0.25 "
         "| 800.0 |  |  |  | 614-990 | 47.0% | 31.0% | ~ |\n"
         "\n"
         "Throughput relative to `concurrency_1`:\n"
@@ -425,9 +462,9 @@ def test_derives_from_an_invalid_measurement_rather_than_dropping_it(
         "## Worker knobs\n"
         "\n"
         + MEASUREMENT_TABLE_HEAD
-        + "| concurrency_1 | saturation | 1 | 1 | default | 0.25 "
+        + "| concurrency_1 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 412.5 |  |  |  | 0-500 | 4.0% | 2.0% | ! |\n"
-        "| concurrency_2 | saturation | 1 | 1 | default | 0.25 "
+        "| concurrency_2 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 825.0 |  |  |  | 825-825 | 4.0% | 2.0% |  |\n"
         "\n"
         "Throughput relative to `concurrency_1`:\n"
@@ -460,7 +497,7 @@ def test_marks_a_measurement_whose_dispersion_was_never_measured(
         "## Worker knobs\n"
         "\n"
         + MEASUREMENT_TABLE_HEAD
-        + "| concurrency_1 | saturation | 1 | 1 | default | 0.25 "
+        + "| concurrency_1 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 412.5 |  |  |  | 412.5-412.5 | n/a | n/a | ? |\n"
         "\n"
         "Throughput relative to `concurrency_1`:\n"
@@ -492,9 +529,9 @@ def test_leaves_latency_columns_empty_for_a_saturation_measurement(
         "## Worker knobs\n"
         "\n"
         + MEASUREMENT_TABLE_HEAD
-        + "| concurrency_1 | saturation | 1 | 1 | default | 0.25 "
+        + "| concurrency_1 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 412.5 |  |  |  | 412.5-412.5 | 4.0% | 2.0% |  |\n"
-        "| rate_25pct | rate | 1 | 1 | default | 0.25 "
+        "| rate_25pct | rate |  | 1 | 1 | default | 0.25 "
         "| 90.0 | 0.0120 | 0.0300 | 0.0500 | 0.012-0.012 | 4.0% | 2.0% |  |\n"
         "\n"
         "Throughput relative to `concurrency_1`:\n"
@@ -535,9 +572,9 @@ def test_renders_a_measurement_whose_every_rep_was_refused(
         "## Worker knobs\n"
         "\n"
         + MEASUREMENT_TABLE_HEAD
-        + "| concurrency_1 | saturation | 1 | 1 | default | 0.25 "
+        + "| concurrency_1 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 0.0 |  |  |  | n/a | n/a | n/a | ! ? |\n"
-        "| concurrency_2 | saturation | 1 | 1 | default | 0.25 "
+        "| concurrency_2 | saturation | 5000 | 1 | 1 | default | 0.25 "
         "| 800.0 |  |  |  | 800-800 | 4.0% | 2.0% |  |\n"
         "\n"
         "Reference measurement measured nothing; nothing derived.\n"
@@ -703,22 +740,61 @@ def test_reports_mixed_options_when_stages_were_run_at_different_sizes(
 def test_renders_scaling_efficiency_for_process_scaling(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
-    """The single-worker rung is the divisor, so its own spread widens every rung."""
+    """The single-worker rung is the divisor, so its own spread widens every rung.
+
+    Each rung's backlog prints with its efficiency: the ladder sizes its preload from
+    the worker count, so the divisor is usually the shallowest rung in the stage.
+    """
     entries = [
         build_measurement(
             "workers_1",
-            {"workers": 1},
+            {"tasks": 4000, "workers": 1},
             {"throughput_per_s": 100.0},
             {"range_high": 110.0, "range_low": 90.0},
         ),
-        build_measurement("workers_2", {"workers": 2}, {"throughput_per_s": 180.0}),
+        build_measurement(
+            "workers_2", {"tasks": 4000, "workers": 2}, {"throughput_per_s": 180.0}
+        ),
     ]
 
     assert (
         "Scaling efficiency `T(N) / (N x T(1))`:\n"
         "\n"
-        "- 1 worker(s): 1.00 (reps 0.82-1.22)\n"
-        "- 2 worker(s): 0.90 (reps 0.82-1.00)\n"
+        "- 1 worker(s): 1.00 (reps 0.82-1.22), backlog 4000\n"
+        "- 2 worker(s): 0.90 (reps 0.82-1.00), backlog 4000\n"
+    ) in render(capsys, tmp_path, "process_scaling", entries)
+
+
+def test_says_a_scaling_ladder_measured_at_two_depths_confounded_itself(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """The ladder sizes its preload from the worker count, so its rungs drain
+    different depths and the efficiency divides one depth by another.
+
+    A deeper backlog is slower and the deeper rung is always the numerator, so the
+    direction is known even though the size is not — which makes every figure a lower
+    bound rather than a measurement, and it has to say so where it is read.
+    """
+    entries = [
+        build_measurement(
+            "workers_1", {"tasks": 4000, "workers": 1}, {"throughput_per_s": 100.0}
+        ),
+        build_measurement(
+            "workers_5", {"tasks": 10000, "workers": 5}, {"throughput_per_s": 300.0}
+        ),
+    ]
+
+    assert (
+        "Scaling efficiency `T(N) / (N x T(1))`:\n"
+        "\n"
+        "- 1 worker(s): 1.00, backlog 4000\n"
+        "- 5 worker(s): 0.60, backlog 10000\n"
+        "\n"
+        "CONFOUNDED: these rungs drained different backlogs (4000 to 10000, against "
+        "4000 at one worker) and a deeper backlog is slower, so each efficiency "
+        "divides a deeper measurement by a shallower one. Read them as lower bounds "
+        "on the scaling, not as measurements of it; only a ladder run at one depth "
+        "would separate the two.\n"
     ) in render(capsys, tmp_path, "process_scaling", entries)
 
 
@@ -1246,7 +1322,8 @@ def test_renders_the_ramp_that_measured_a_rate_stage_its_offer_rate(
 
     The two rates in the block are different quantities: the fleet drained 4200/s off
     a backlog and absorbed 1400/s as it arrived, which is why fractions of the drain
-    rate over-offered. Each probe's backlogs are what the verdict was read off.
+    rate over-offered. Each probe carries what the producer actually delivered beside
+    the verdict, because a refusal only bounds the fleet if the offer was made in full.
     """
     entries = [build_measurement("rate_25pct", {"mode": "rate"}, {})]
 
@@ -1259,19 +1336,51 @@ def test_renders_the_ramp_that_measured_a_rate_stage_its_offer_rate(
     )
 
     assert (
-        "Offer rate: 1400.0/s, the highest offer the fleet absorbed; it refused "
-        "2100.0/s, so the knee is between the two and nothing here refines it. The "
-        "rows above offer fractions of it. The drain rate this stage calibrated from "
-        "was 4200.0/s, which is what the fleet completes with a backlog already "
-        "waiting rather than what it can absorb as it arrives.\n"
+        "Offer rate: 1400.0/s, the highest offer this ramp got through cleanly — the "
+        "LOWER of the fleet's knee and the producer's own ceiling, and the ramp does "
+        "not say which of the two it found. It refused 2100.0/s with the producer "
+        "still delivering its target, so that refusal is the FLEET's and the knee is "
+        "between the two; nothing here refines it. The rows above offer fractions of "
+        "it. The drain rate this stage calibrated from was 4200.0/s, which is what "
+        "the fleet completes with a backlog already waiting rather than what it can "
+        "absorb as it arrives.\n"
         "\n"
-        "| offered/s | offer s | absorbed | e2e p50 s | backlog at midpoint "
-        "| backlog at end |\n"
-        "| --- | --- | --- | --- | --- | --- |\n"
-        "| 933.3 | 20 | yes | 0.0140 | 30 | 26 |\n"
-        "| 1400.0 | 20 | yes | 0.0180 | 42 | 39 |\n"
-        "| 2100.0 | 20 | no | 8.4000 | 24000 | 51000 |\n"
+        "| offered/s | offer s | achieved/s | producer kept up | absorbed "
+        "| e2e p50 s | backlog at midpoint | backlog at end |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        "| 933.3 | 20 | 933.2 | yes | yes | 0.0140 | 30 | 26 |\n"
+        "| 1400.0 | 20 | 1399.8 | yes | yes | 0.0180 | 42 | 39 |\n"
+        "| 2100.0 | 20 | 2099.6 | yes | no | 8.4000 | 24000 | 51000 |\n"
     ) in rendered
+
+
+def test_says_a_ramp_stopped_by_the_producer_bounds_the_enqueue_side(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """The refusal that reads as the fleet's limit and is not.
+
+    Producer and workers share the box, so the enqueue loop can miss its own deadlines
+    before the fleet runs out — and `absorbed` alone cannot tell that apart from a
+    fleet that fell behind. The rate the fleet DID complete in the refused probe is
+    printed with it, because it is a floor on the fleet the ramp never reached.
+    """
+    entries = [build_measurement("rate_25pct", {"mode": "rate"}, {})]
+
+    rendered = render(
+        capsys,
+        tmp_path,
+        "latency_under_load",
+        entries,
+        sustainable_rate=build_producer_bound_ramp(),
+    )
+
+    assert (
+        "It refused 2100.0/s, but the producer itself only achieved 1890.0/s there, "
+        "so that refusal bounds the ENQUEUE side and not the fleet — which completed "
+        "1804.0/s inside the same probe. The fleet's own knee is somewhere above "
+        "that, unmeasured."
+    ) in rendered
+    assert "| 2100.0 | 20 | 1890.0 | no | no | 8.4000 | 24000 | 51000 |\n" in rendered
 
 
 def test_says_a_ramp_that_ran_out_of_ceiling_never_found_the_knee(
@@ -1294,9 +1403,11 @@ def test_says_a_ramp_that_ran_out_of_ceiling_never_found_the_knee(
     )
 
     assert (
-        "Offer rate: 1400.0/s, the highest offer the fleet absorbed; the ramp ran out "
-        "of climb below the drain rate without finding an offer it could not, so the "
-        "knee is at or above the top of the ramp."
+        "Offer rate: 1400.0/s, the highest offer this ramp got through cleanly — the "
+        "LOWER of the fleet's knee and the producer's own ceiling, and the ramp does "
+        "not say which of the two it found. The ramp ran out of climb below the drain "
+        "rate without finding an offer it could not, so the knee is at or above the "
+        "top of the ramp."
     ) in rendered
 
 

--- a/tests/benchmarks/test_report.py
+++ b/tests/benchmarks/test_report.py
@@ -40,18 +40,21 @@ OPTIONS = {
 # has to carry that.
 COMMIT_CEILING = {
     "commit_ceiling_durable": {
+        "valid": True,
         "median_per_s": 2016.0,
         "cv": 0.279,
         "range_low": 1600.0,
         "range_high": 2262.0,
     },
     "commit_ceiling_nondurable": {
+        "valid": True,
         "median_per_s": 367723.0,
         "cv": 0.052,
         "range_low": 324000.0,
         "range_high": 380000.0,
     },
     "commit_ceiling_durable_after": {
+        "valid": True,
         "median_per_s": 1904.0,
         "cv": 0.114,
         "range_low": 1700.0,
@@ -1043,6 +1046,7 @@ def test_softens_the_bound_verdict_when_the_calibration_disagrees_with_itself(
         "worker_knobs",
         entries,
         commit_ceiling_durable={
+            "valid": True,
             "median_per_s": 2000.0,
             "cv": 0.012,
             "range_low": 1950.0,
@@ -1060,6 +1064,7 @@ def test_softens_the_bound_verdict_when_the_calibration_disagrees_with_itself(
         "worker_knobs",
         entries,
         commit_ceiling_durable={
+            "valid": True,
             "median_per_s": 2000.0,
             "cv": 0.136,
             "range_low": 1500.0,
@@ -1089,12 +1094,14 @@ def test_bands_the_bound_verdict_across_both_durable_probes(
     ]
     drifted = {
         "commit_ceiling_durable": {
+            "valid": True,
             "median_per_s": 615.0,
             "cv": 0.136,
             "range_low": 465.0,
             "range_high": 673.0,
         },
         "commit_ceiling_durable_after": {
+            "valid": True,
             "median_per_s": 2100.0,
             "cv": 0.024,
             "range_low": 2030.0,
@@ -1136,6 +1143,7 @@ def test_bands_against_the_opening_probe_when_the_run_recorded_no_closing_one(
         "worker_knobs",
         entries,
         commit_ceiling_durable={
+            "valid": True,
             "median_per_s": 615.0,
             "cv": 0.136,
             "range_low": 465.0,
@@ -1188,7 +1196,7 @@ def test_says_where_each_measurement_spent_its_time_per_task(
 def test_says_the_commit_ceiling_is_missing_rather_than_omitting_it(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
-    """A run whose calibration probe was refused still runs and still reports.
+    """A file carrying no ceiling blocks at all still renders, uncalibrated.
 
     What it must not do is read like a calibrated one: the header says the ceiling is
     missing and every commit budget under it says it has nothing to be measured
@@ -1213,6 +1221,44 @@ def test_says_the_commit_ceiling_is_missing_rather_than_omitting_it(
         "- `concurrency_1`: 532 commits/s per worker connection (150.0 x 3.55 / 1), "
         "against no ceiling — nothing here says what bound it\n"
     ) in rendered
+
+
+def test_tells_a_refused_probe_apart_from_one_the_run_never_took(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Two ways a ceiling can be missing, and only one of them is about the server.
+
+    A refused probe was asked for and answered: the server would not give a rate, and
+    what it said is the reader's first clue. A run cut short — interrupted mid-wait,
+    killed, dead at a stage — never asked, so nothing about its server is in evidence.
+    Reading the second as the first is how an interrupted run comes to look like a
+    server that cannot commit, so the block carries the reason and the header prints
+    it.
+    """
+    entries = [build_measurement("concurrency_1", {}, {})]
+
+    assert (
+        "- commit ceiling (commits/s, one connection): durable 2016 (cv 28%, "
+        "1600-2262), after the run not measured: the run ended before this probe was "
+        "taken, non-durable not measured: the server refused the probe: relation "
+        '"benchmark_commit_ceiling_probe" already exists, ratio not measured\n'
+    ) in render(
+        capsys,
+        tmp_path,
+        "worker_knobs",
+        entries,
+        commit_ceiling_durable_after={
+            "valid": False,
+            "error": "the run ended before this probe was taken",
+        },
+        commit_ceiling_nondurable={
+            "valid": False,
+            "error": (
+                "the server refused the probe: relation "
+                '"benchmark_commit_ceiling_probe" already exists'
+            ),
+        },
+    )
 
 
 def test_says_which_halves_of_the_commit_ceiling_were_measured(

--- a/tests/benchmarks/test_smoke.py
+++ b/tests/benchmarks/test_smoke.py
@@ -476,6 +476,53 @@ def test_saturation_measurement_records_every_dispersion_of_its_reps() -> None:
     }
 
 
+def test_saturation_measurement_of_two_reps_reports_the_slower_one() -> None:
+    """An even rep count has two middles, and the summary takes the unlucky one.
+
+    Whichever way two real reps land, the measurement reports the LOWER throughput of
+    the pair — asserted as the low endpoint rather than as a level, since which rep is
+    faster is not something a test can arrange.
+    """
+    spec = measurement.MeasurementSpec(
+        name="smoke-two-reps-saturation",
+        mode="saturation",
+        task_path="tasks.noop_sync",
+        tasks=int(MEASURABLE_TASKS),
+        workers=1,
+        worker=runner.WorkerSpec(concurrency=1, poll_interval=0.05),
+        reps=2,
+        timeout_s=60,
+    )
+
+    result = measurement.run_measurement(spec)
+
+    assert (result["median"]["throughput_per_s"] == result["range_low"]) is True
+
+
+def test_rate_measurement_of_two_reps_reports_the_slower_one() -> None:
+    """The same rule, on the metric that runs the other way.
+
+    A rate measurement ranks on end-to-end p50, where LOW is the lucky rep, so the
+    unlucky middle is the high endpoint — the opposite index from a saturation
+    measurement, and taking the low one both times published the better rep.
+    """
+    spec = measurement.MeasurementSpec(
+        name="smoke-two-reps-rate",
+        mode="rate",
+        task_path="tasks.noop_sync",
+        rate_per_s=ABSORBABLE_RATE_PER_S,
+        duration_s=2.0,
+        workers=1,
+        worker=runner.WorkerSpec(concurrency=1, poll_interval=0.05),
+        reps=2,
+        timeout_s=120,
+    )
+
+    result = measurement.run_measurement(spec)
+
+    assert (result["median"]["end_to_end_p50_s"] == result["range_high"]) is True
+
+
 def test_saturation_rep_records_what_its_tasks_cost_in_commits() -> None:
     """A task rate is a commit rate in disguise, and this is the exchange rate.
 

--- a/tests/benchmarks/test_smoke.py
+++ b/tests/benchmarks/test_smoke.py
@@ -686,10 +686,10 @@ def test_commit_ceiling_probe_times_a_warmed_session_not_a_cold_one() -> None:
     committed = analysis.read_xact_commit() - committed_before
     # An unmeasured ceiling has no timed window at all, which the dict below reports as
     # the whole call rather than dividing by None.
-    timed_s = timed_commits / ceiling["median_per_s"] if ceiling else elapsed_s
+    timed_s = timed_commits / ceiling["median_per_s"] if ceiling["valid"] else elapsed_s
 
     assert {
-        "measured": ceiling is not None,
+        "measured": ceiling["valid"],
         "committed_its_warm_up_rounds_too": (
             committed >= analysis.PROBE_WARM_UP_COMMITS + timed_commits
         ),
@@ -699,6 +699,71 @@ def test_commit_ceiling_probe_times_a_warmed_session_not_a_cold_one() -> None:
         "committed_its_warm_up_rounds_too": True,
         "timed_only_the_rounds_it_kept": True,
     }
+
+
+def test_an_interrupted_commit_probe_leaves_the_session_usable() -> None:
+    """A probe abandoned mid-wait must cost the process nothing but the probe.
+
+    A signal delivered while psycopg waits on the socket leaves the session stuck
+    mid-command, where every later statement reads `another command is already in
+    progress`. Issuing the probe's own cleanup there raises over the interruption and
+    hands that session on, so one interrupted probe becomes every later failure in the
+    process — which is how a single 120 s test alarm took 57 unrelated tests down with
+    it. The session is dropped instead, and the interruption travels on untouched.
+
+    The alarm is the real mechanism rather than a simulation of it: `pytest-timeout`
+    raises from a SIGALRM handler exactly like this, and a BaseException that is not a
+    KeyboardInterrupt is what psycopg declines to cancel the query for.
+    """
+    with pytest.raises(utils.ProbeInterrupted), utils.interrupt_after(0.2):
+        analysis.measure_commit_ceiling(durable=True)
+
+    with connections[resolve_absurd_database()].cursor() as cursor:
+        cursor.execute("select 1")
+        answered = cursor.fetchone()
+        # The probe's own table outlives the interruption, and a later probe on this
+        # database would read a name it does not own as a refusal.
+        cursor.execute(f"drop table if exists {analysis.COMMIT_PROBE_TABLE}")
+
+    assert answered == (1,)
+
+
+def test_saturation_measurement_refuses_a_fleet_that_died_mid_drain() -> None:
+    """A queue polled alone cannot tell a slow drain from an absent fleet.
+
+    The task ends its own worker, so nothing is left to claim and the backlog never
+    moves again. Waiting that out would burn the whole timeout — 900 s for the
+    saturation stages — and then report the timeout as the failure, with the crash that
+    caused it printed underneath. The children's exit is what the measurement is
+    refused on, and the crash is what it is refused with.
+    """
+    spec = measurement.MeasurementSpec(
+        name="smoke-dead-fleet",
+        mode="saturation",
+        task_path="tests.benchmarks.utils.kill_the_worker_that_claimed_it",
+        tasks=1,
+        workers=1,
+        worker=runner.WorkerSpec(concurrency=1, poll_interval=0.05),
+        reps=1,
+        timeout_s=120.0,
+    )
+    started = time.monotonic()
+
+    with pytest.raises(RuntimeError) as error_info:
+        measurement.run_measurement(spec)
+
+    assert str(error_info.value).startswith(
+        f"1 absurd_worker child(ren) exited before the measurement finished (codes "
+        f"[{utils.WORKER_EXIT_CODE}]); it measured a worker count it never had. "
+        f"Last output:"
+    )
+    assert str(error_info.value.__context__) == (
+        "Measurement 'smoke-dead-fleet' lost 1 of its 1 worker process(es) while the "
+        "queue was still draining, so what is left cannot drain it. Refused here "
+        "rather than at the drain timeout, which the fleet would otherwise burn in "
+        "full before anything said the workers were gone."
+    )
+    assert (time.monotonic() - started < 30.0) is True
 
 
 def test_saturation_rep_records_no_statement_stats_where_nothing_counted_them() -> None:

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -1,10 +1,13 @@
 import contextlib
 import datetime as dt
 import json
+import os
 import pathlib
 import re
+import signal
 import threading
 import time
+import types
 import typing as t
 
 import time_machine
@@ -18,6 +21,20 @@ from django_absurd.queues import resolve_absurd_database
 
 NAP_SECONDS = 30.0
 NAP_INTERVAL_S = 0.02
+# Exit code the fixture task below leaves behind, distinctive enough that a test can
+# assert the harness reported the child's own status rather than a generic failure.
+WORKER_EXIT_CODE = 9
+
+
+class ProbeInterrupted(BaseException):
+    """What `interrupt_after` raises: an interruption, not an error.
+
+    A BaseException and deliberately NOT a KeyboardInterrupt, because that is the shape
+    the harness actually meets. `pytest-timeout`'s alarm raises pytest's `Failed`, which
+    derives from BaseException, and psycopg only cancels the running query for a
+    KeyboardInterrupt — so anything else leaves the session mid-command, which is the
+    state under test.
+    """
 
 
 def read_stage(results_dir: pathlib.Path, stage: str) -> dict[str, t.Any]:
@@ -163,3 +180,38 @@ def fail_on_its_only_attempt() -> t.Never:
     its own ever completing — the shape that shrinks a measurement's sample silently."""
     msg = "benchmark fixture: this task always fails"
     raise RuntimeError(msg)
+
+
+@contextlib.contextmanager
+def interrupt_after(seconds: float) -> t.Iterator[None]:
+    """Interrupt this thread mid-body with a real signal, the way a timeout alarm does.
+
+    A test cannot ask psycopg to abandon a wait; the only thing that does is a signal
+    delivered while it is waiting, which is exactly what fires here. The suite's own
+    timeout uses the same alarm, so both the handler and the pending timer are put
+    back on the way out.
+    """
+    previous_handler = signal.signal(signal.SIGALRM, raise_probe_interrupted)
+    previous_delay, previous_interval = signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, previous_delay, previous_interval)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+def raise_probe_interrupted(signum: int, frame: types.FrameType | None) -> t.Never:
+    msg = "the wait was interrupted from outside the process"
+    raise ProbeInterrupted(msg)
+
+
+@task(queue_name="bench")
+@absurd_params(max_attempts=1)
+def kill_the_worker_that_claimed_it() -> t.Never:
+    """Ends its own worker process mid-task, leaving the queue with nobody to drain it.
+
+    `os._exit` rather than an exception or a signal: a task that raises is retried and
+    a SIGTERM is what a stopping worker gets anyway, while this is the shape a fleet
+    dies in — a child gone, its claim never completed, and a queue that no longer moves.
+    """
+    os._exit(WORKER_EXIT_CODE)

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,11 @@ commands =
     !mypy: pytest tests/core -m "not packaging" -n auto {posargs}
     !mypy: pytest tests/pg_cron -n auto {posargs}
     !mypy: pytest tests/multidb -n auto {posargs}
-    !mypy: pytest tests/benchmarks -n auto {posargs}
     mypy: mypy .
 
+# `tests/benchmarks` runs here and nowhere else in the matrix: `benchmarks/` ships in
+# no wheel and imports nothing version-sensitive, so a second Python or Django buys no
+# signal for the minutes it costs.
 [testenv:dev]
 runner = uv-venv-lock-runner
 commands =


### PR DESCRIPTION
Stacked on #257. Fixes the CI failure on #262's merged head.

## Fixed

- **The commit-ceiling probe poisoned its connection when interrupted.** Cleanup ran from a `finally`, so a pytest-timeout alarm inside `cursor.execute(probe)` left the session mid-command; the `reset` that followed raised over the interruption and `except db.Error` swallowed it as a ceiling of `None`. The test passed, the connection stayed broken, and `--reuse-db` handed it on — 30 failures and 27 errors from one slow test. In a real run the same path reports an interruption as a server that refused the probe.
- A run cut short lost the closing ceiling probe, so its finished stages recorded no ceiling to be read against.
- `wait_until_drained` polled the queue alone, so a fleet that died mid-drain burned the full timeout and then blamed the timeout.

A missing ceiling now says which of three things happened: measured, refused by the server, or never taken.

## Corrected

`benchmarks/CLAUDE.md` claimed worker startup was outside the measured window, and made `commits_per_task` and `calls_per_task` step 2 of its bisection procedure as "exact and portable". `start_workers` spawns children one at a time, blocking on each readiness line, so above one process the fleet starts inside the drain; both counts divide a phase-window delta by runs counted over the whole drain. Exact at one process, low above it by an amount not established. The measurement fix is not in this PR.

## Also

`tests/benchmarks` runs in the `dev` tox env only — `benchmarks/` ships in no wheel and imports nothing version-sensitive.
