### PR TITLE
test(benchmarks): assert what the harness measures, not that it ran

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,9 @@ writing or editing any test file. Running the suites:
   settings connect to — so one value keeps them consistent. Set it whenever a system
   Postgres already owns 5432: otherwise `tests/core` runs against that server, and a
   system cluster with pg_cron installed makes `test_central_connection.py`'s "no
-  pg_cron" assertion never fire. `PGPORT_PGCRON` does the same for `db_pg_cron`.
+  pg_cron" assertion never fire. `PGPORT_PGCRON` does the same for `db_pg_cron`. Export
+  both in a worktree — published ports are host-global, so a compose project name does
+  not keep a worktree off the main checkout's 5442/5443.
 - **The two gates to run before a commit** — not five separate commands:
   - `uvx --with tox-uv tox -e dev` — all four suites against the dev env only. Reach for
     the bare `uvx --with tox-uv tox` (full Python×Django matrix + min-max mypy) only

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -198,8 +198,9 @@ Measured on this repo; the point is to spend the slow gate once, not per edit.
   to its file. The catalog row outlives the per-test flush, so the second `--reuse-db`
   run of that file reports nothing created. Passes alone, fails on repeat.
 - **A deadlock/duplicate-key storm across unrelated tests means a concurrent run**, not
-  a code defect — suites from a worktree reach this checkout's Postgres on 5442. Confirm
-  nothing else is running before bisecting.
+  a code defect — suites from a worktree reach this checkout's Postgres on 5442 unless
+  it exported its own `PGPORT`/`PGPORT_PGCRON`. Confirm nothing else is running before
+  bisecting.
 
 ### When an agent runs the gates
 

--- a/tests/benchmarks/test_cli.py
+++ b/tests/benchmarks/test_cli.py
@@ -1,4 +1,6 @@
+import json
 import pathlib
+import typing as t
 
 import pytest
 from django.db import connections
@@ -300,6 +302,94 @@ def test_records_which_measurement_became_the_working_point(
             "unstable": False,
         }
     ] * 2
+
+
+def test_calibrates_from_the_fastest_rung_no_mark_disqualified(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The working point is an argmax over the rungs a mark left in the running.
+
+    A marked rung measured something other than what it was asked to, so calibrating
+    on one aims every later stage at a number the run itself refused — and the rung
+    that a mark disqualifies is often the FASTEST, because measuring less than it was
+    asked to is exactly what makes it look fast. The two clean rungs differ in
+    throughput so that picking either end of them is a different answer.
+    """
+    (tmp_path / "stage_worker_knobs.json").write_text(
+        json.dumps(
+            {
+                "measurements": [
+                    build_recorded_rung("invalid_c8", 900.0, 8, invalid=True),
+                    build_recorded_rung("unstable_c16", 800.0, 16, unstable=True),
+                    build_recorded_rung("clean_c2", 500.0, 2),
+                    build_recorded_rung("clean_c32", 100.0, 32),
+                ]
+            }
+        )
+    )
+
+    stages.main(
+        [
+            "checkpoint_cost",
+            "--reps",
+            "1",
+            "--tasks",
+            "8",
+            "--results-dir",
+            str(tmp_path),
+        ]
+    )
+
+    recorded = utils.read_stage(tmp_path, "checkpoint_cost")
+    assert {
+        "calibration": recorded["calibration"],
+        "concurrency_each_measurement_ran_at": [
+            entry["spec"]["worker"]["concurrency"] for entry in recorded["measurements"]
+        ],
+    } == {
+        "calibration": {
+            "stage": "worker_knobs",
+            "measurement": "clean_c2",
+            "throughput_per_s": 500.0,
+            "cv": 0.02,
+            "invalid": False,
+            "unstable": False,
+        },
+        "concurrency_each_measurement_ran_at": [2, 2],
+    }
+
+
+def build_recorded_rung(
+    name: str,
+    throughput_per_s: float,
+    concurrency: int,
+    *,
+    invalid: bool = False,
+    unstable: bool = False,
+) -> dict[str, t.Any]:
+    """One rung of a recorded stage file, as much of one as a reader of it needs.
+
+    Written rather than measured because the marks are the input: a real ladder is
+    marked by what the machine did during it, and this stage picks between rungs on
+    marks it cannot be asked to produce on demand.
+    """
+    return {
+        "spec": {
+            "name": name,
+            "workers": 1,
+            "worker": {
+                "concurrency": concurrency,
+                "batch_size": None,
+                "poll_interval": 0.05,
+                "claim_timeout": 120,
+                "queue": "bench",
+            },
+        },
+        "median": {"throughput_per_s": throughput_per_s},
+        "cv": 0.02,
+        "invalid": invalid,
+        "unstable": unstable,
+    }
 
 
 def test_runs_a_saturation_stage_at_the_size_it_was_asked_for(

--- a/tests/benchmarks/test_metrics.py
+++ b/tests/benchmarks/test_metrics.py
@@ -1,0 +1,154 @@
+import datetime as dt
+
+import pytest
+
+import analysis
+from django_absurd.flush import truncate_queue_tables
+from tests.benchmarks import utils
+
+# Where the hand-timed rows below are placed. Arbitrary, and fixed: every metric is a
+# difference between two of these columns, so only the offsets matter.
+EPOCH = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
+
+# Completion second, queue wait, execution, and the worker that claimed it. The three
+# latency families are deliberately three different distributions, and the completion
+# seconds are a fourth, so reading a percentile off the wrong column cannot land on
+# the right number by accident.
+SATURATION_ROWS = (
+    (0, 2.0, 0.1, "bench-0"),
+    (1, 0.4, 0.2, "bench-0"),
+    (2, 1.2, 0.3, "bench-0"),
+    (3, 0.6, 0.4, "bench-0"),
+    (4, 1.8, 0.5, "bench-0"),
+    (5, 0.2, 0.6, "bench-0"),
+    (6, 1.4, 0.7, "bench-0"),
+    (7, 0.8, 0.8, "bench-1"),
+    (8, 1.6, 0.9, "bench-1"),
+    (9, 1.0, 1.0, "bench-1"),
+    (10, 2.2, 1.1, "bench-1"),
+)
+# The one task that was redelivered, which puts a second run row in the table without
+# putting a second completion in it.
+REDELIVERED_COMPLETION_SECOND = 3
+
+# Arrival second, queue wait, execution, and the worker that claimed it, offered over
+# a hundred-second window. The two rows claimed by `bench-2` arrive outside the
+# trimmed middle of it, and the three slowest rows complete outside it — so trimming
+# on the wrong column keeps a different set of rows, not a different slice of one.
+RATE_ROWS = (
+    (5, 8.0, 5.0, "bench-2"),
+    (15, 3.0, 10.0, "bench-0"),
+    (25, 1.0, 12.0, "bench-0"),
+    (35, 5.0, 8.0, "bench-0"),
+    (45, 2.0, 11.0, "bench-0"),
+    (55, 6.0, 7.0, "bench-0"),
+    (65, 4.0, 36.0, "bench-1"),
+    (75, 9.0, 28.0, "bench-1"),
+    (85, 7.0, 30.0, "bench-1"),
+    (95, 10.0, 30.0, "bench-2"),
+)
+RATE_WINDOW_SECONDS = 100.0
+
+
+def test_saturation_metrics_are_the_columns_the_rows_were_timed_on() -> None:
+    """Every number a drain reports, against rows whose every timestamp was chosen.
+
+    Queue wait is `started_at - enqueue_at`, execution is `completed_at - started_at`
+    and end-to-end is the pair of them, so a swapped column reads a different
+    distribution; throughput is 0.8 tasks over the p10..p90 COMPLETION span, so a
+    dropped trim factor or a span taken off the wrong column reads a different rate.
+    """
+    truncate_queue_tables("bench")
+    for completed_second, queue_wait, execution, claimed_by in SATURATION_ROWS:
+        completed_at = EPOCH + dt.timedelta(seconds=completed_second)
+        started_at = completed_at - dt.timedelta(seconds=execution)
+        utils.insert_hand_timed_task(
+            "bench",
+            started_at - dt.timedelta(seconds=queue_wait),
+            started_at,
+            completed_at,
+            claimed_by,
+            redelivered=completed_second == REDELIVERED_COMPLETION_SECOND,
+        )
+
+    assert analysis.analyze_saturation("bench") == {
+        "n_tasks": 11,
+        "n_runs": 11,
+        # The failed first attempt of the redelivered task, which no state filters out.
+        "total_runs": 12,
+        "total_tasks": 11,
+        "max_attempt": 2,
+        "extra_runs": 1,
+        "degenerate_window": False,
+        # 0.8 * 11 completions over the 1 s..9 s trimmed completion span.
+        "throughput_per_s": pytest.approx(1.1),
+        "fairness": {"bench-0": 7, "bench-1": 4},
+        "fairness_ratio": pytest.approx(4 / 7),
+        "queue_wait_p50_s": pytest.approx(1.2),
+        "queue_wait_p90_s": pytest.approx(2.0),
+        "queue_wait_p99_s": pytest.approx(2.18),
+        "execution_p50_s": pytest.approx(0.6),
+        "execution_p90_s": pytest.approx(1.0),
+        "execution_p99_s": pytest.approx(1.09),
+        "end_to_end_p50_s": pytest.approx(2.0),
+        "end_to_end_p90_s": pytest.approx(2.5),
+        "end_to_end_p99_s": pytest.approx(3.22),
+        # Eleven completions is a twentieth of one profile slice, so the drain has no
+        # shape to report.
+        "profile_slices": None,
+        "profile_median_per_s": None,
+        "profile_cv": None,
+    }
+
+
+def test_rate_metrics_trim_the_offer_window_on_when_a_task_arrived() -> None:
+    """A rate experiment is defined by arrival, so its middle 80% is 80% of the offer.
+
+    Trimmed on `enqueue_at`, the rows measured are the eight that ARRIVED between 10 s
+    and 90 s; trimmed on completion instead it would be the six that FINISHED in that
+    span, which is a different sample with different percentiles and a different
+    count. The backlog either side of the midpoint is counted over the whole window,
+    untrimmed, because it is a level rather than a rate.
+    """
+    truncate_queue_tables("bench")
+    for enqueue_second, queue_wait, execution, claimed_by in RATE_ROWS:
+        enqueue_at = EPOCH + dt.timedelta(seconds=enqueue_second)
+        started_at = enqueue_at + dt.timedelta(seconds=queue_wait)
+        utils.insert_hand_timed_task(
+            "bench",
+            enqueue_at,
+            started_at,
+            started_at + dt.timedelta(seconds=execution),
+            claimed_by,
+        )
+
+    assert analysis.analyze_rate(
+        "bench", EPOCH, EPOCH + dt.timedelta(seconds=RATE_WINDOW_SECONDS)
+    ) == {
+        "n_tasks": 8,
+        "n_runs": 8,
+        "total_runs": 8,
+        "total_tasks": 8,
+        "max_attempt": 1,
+        "extra_runs": 0,
+        "degenerate_window": False,
+        # 0.8 * 8 completions over the 35 s..115 s trimmed completion span.
+        "throughput_per_s": pytest.approx(0.08),
+        "fairness": {"bench-0": 5, "bench-1": 3},
+        "fairness_ratio": pytest.approx(3 / 5),
+        "queue_wait_p50_s": pytest.approx(4.5),
+        "queue_wait_p90_s": pytest.approx(7.6),
+        "queue_wait_p99_s": pytest.approx(8.86),
+        "execution_p50_s": pytest.approx(11.5),
+        "execution_p90_s": pytest.approx(31.8),
+        "execution_p99_s": pytest.approx(35.58),
+        "end_to_end_p50_s": pytest.approx(13.0),
+        "end_to_end_p90_s": pytest.approx(37.9),
+        "end_to_end_p99_s": pytest.approx(39.79),
+        # Five arrivals against four completions at the midpoint, ten against six at
+        # the end.
+        "backlog_mid": 1,
+        "backlog_end": 4,
+        "offered_after_midpoint": 5,
+        "backlog_grew": False,
+    }

--- a/tests/benchmarks/test_smoke.py
+++ b/tests/benchmarks/test_smoke.py
@@ -1,3 +1,4 @@
+import dataclasses
 import pathlib
 import time
 import typing as t
@@ -7,6 +8,7 @@ from django.db import connections
 
 import analysis
 import measurement
+import producer
 import runner
 import stages
 from django_absurd.queues import resolve_absurd_database
@@ -31,6 +33,20 @@ UNABSORBABLE_RATE_PER_S = 800.0
 # A drain ceiling whose lowest ramp probe — a tenth of it — is already the rate above,
 # so a ramp anchored to it cannot absorb even its first offer.
 UNABSORBABLE_CEILING_PER_S = UNABSORBABLE_RATE_PER_S / stages.RATE_RAMP_START_FRACTION
+# A drain ceiling a ramp of TWO workers climbs THROUGH rather than up to, with its
+# rungs at 90/s..683/s. Two workers rather than one because only the ends of the climb
+# are load-bearing and a lone worker holds neither reliably: 45/s each leaves the
+# bottom rung absorbed while one of them stalls, and the pair's knee was measured at
+# 456-683/s, under the top rung. A rung between them refusing early only shortens the
+# climb, which the assertions allow for.
+RAMP_CEILING_PER_S = 900.0
+RAMP_WORKERS = 2
+# Two offers for ONE producer thread, either side of what a round trip to Postgres
+# allows it: an enqueue takes milliseconds, so two a second leave it idling and three
+# thousand a second are beyond it however long it is given. The windows differ only in
+# what they cost — the second one is 900 enqueues, and every one of them is late.
+DELIVERABLE_OFFER = (2.0, 2.0)
+UNDELIVERABLE_OFFER = (3000.0, 0.3)
 
 # One phase's statement counters as `pg_stat_statements` hands them over, either side
 # of it. Cumulative, so the figures per task are the difference: the claim and its
@@ -279,6 +295,53 @@ def test_rate_ramp_that_absorbed_nothing_measures_at_the_lowest_rate_it_probed(
     }
 
 
+def test_rate_ramp_measures_at_the_highest_offer_it_absorbed(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The working point is the last rate that came off cleanly, not the one that
+    stopped the climb.
+
+    The ramp stops at the first refusal, so the refused rate is the one nearest to
+    hand and measuring there offers the rungs below a rate this fleet has just been
+    shown not to absorb. It is kept as the bracket instead: the knee is between the
+    two, which is only a bracket at all because the two are different numbers.
+
+    Called directly, and at a ceiling of its own: a stage reads that number off
+    `stage_process_scaling.json`, where it is whatever the machine measured, and a
+    ramp that absorbs or refuses everything it probes cannot show which end it
+    measured at.
+    """
+    ramp = stages.measure_sustainable_rate(
+        runner.WorkerSpec(concurrency=1, poll_interval=0.05),
+        RAMP_WORKERS,
+        RAMP_CEILING_PER_S,
+        stages.StageOptions(results_dir=tmp_path, duration_s=2.0),
+    )
+
+    absorbed = [probe["rate_per_s"] for probe in ramp["probes"] if probe["sustained"]]
+    refused = [
+        probe["rate_per_s"] for probe in ramp["probes"] if not probe["sustained"]
+    ]
+    assert {
+        "climbed_before_it_refused": len(absorbed) >= 1,
+        "stopped_at_the_first_refusal": [probe["sustained"] for probe in ramp["probes"]]
+        == [True] * len(absorbed) + [False],
+    } == {"climbed_before_it_refused": True, "stopped_at_the_first_refusal": True}
+    assert {
+        "rate_per_s": ramp["rate_per_s"],
+        "bracket_high_per_s": ramp["bracket_high_per_s"],
+        "sustained": ramp["sustained"],
+        "measured_below_the_offer_it_refused": (
+            ramp["rate_per_s"] < ramp["bracket_high_per_s"]
+        ),
+    } == {
+        "rate_per_s": max(absorbed),
+        "bracket_high_per_s": min(refused),
+        "sustained": True,
+        "measured_below_the_offer_it_refused": True,
+    }
+
+
 def test_backlog_growth_is_read_as_a_share_of_the_offer_it_grew_under() -> None:
     """The rule the guard turns on, at the two boundaries no real offer can hold still.
 
@@ -310,6 +373,61 @@ def test_backlog_growth_is_read_as_a_share_of_the_offer_it_grew_under() -> None:
             "backlog_grew": False,
         },
     }
+
+
+def test_rate_producer_marks_an_offer_it_could_not_keep_up_with() -> None:
+    """A rate the producer never delivered is not a rate the fleet was offered.
+
+    The enqueue side runs on the same box as the workers, so a rung can fall over
+    because the producer ran out of thread rather than because the fleet ran out of
+    capacity — and the two want opposite conclusions. The offer carries its own
+    verdict so a measurement reading it is refused rather than published as a fleet
+    result, and so a report can attribute the refusal to the right side.
+
+    Each arm is assembled into a rep the way `measurement.run_rate_rep` does, because
+    the flag only means anything through the rules that mark a rep.
+    """
+    delivered, starved = (
+        producer.run_rate_producer(
+            "tasks.noop_sync", rate_per_s, offer_seconds, threads=1
+        )
+        for rate_per_s, offer_seconds in (DELIVERABLE_OFFER, UNDELIVERABLE_OFFER)
+    )
+
+    assert [
+        {
+            "offered": offer.offered,
+            "offered_ok": offer.offered_ok,
+            "fell_short_of_the_rate_it_aimed_at": (
+                offer.achieved_rate_per_s < rate_per_s
+            ),
+            "missed_every_deadline_after_the_first": (
+                offer.missed_deadline_count == offer.offered - 1
+            ),
+            "rep_invalid": measurement.is_rep_invalid(
+                {"valid": True, **dataclasses.asdict(offer)}
+            ),
+        }
+        for offer, (rate_per_s, _) in (
+            (delivered, DELIVERABLE_OFFER),
+            (starved, UNDELIVERABLE_OFFER),
+        )
+    ] == [
+        {
+            "offered": 4,
+            "offered_ok": True,
+            "fell_short_of_the_rate_it_aimed_at": False,
+            "missed_every_deadline_after_the_first": False,
+            "rep_invalid": False,
+        },
+        {
+            "offered": 900,
+            "offered_ok": False,
+            "fell_short_of_the_rate_it_aimed_at": True,
+            "missed_every_deadline_after_the_first": True,
+            "rep_invalid": True,
+        },
+    ]
 
 
 def test_saturation_measurement_invalidates_a_task_that_outlived_its_claim_lease() -> (

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -9,7 +9,9 @@ import threading
 import time
 import types
 import typing as t
+import uuid
 
+import psycopg.sql
 import time_machine
 from absurd_sdk import RetryStrategy
 from django.db import connections
@@ -215,3 +217,60 @@ def kill_the_worker_that_claimed_it() -> t.Never:
     dies in — a child gone, its claim never completed, and a queue that no longer moves.
     """
     os._exit(WORKER_EXIT_CODE)
+
+
+def insert_hand_timed_task(
+    queue: str,
+    enqueue_at: dt.datetime,
+    started_at: dt.datetime,
+    completed_at: dt.datetime,
+    claimed_by: str,
+    *,
+    redelivered: bool = False,
+) -> None:
+    """One task and its completed run, at timestamps the caller chose itself.
+
+    Written straight into Absurd's own tables: every metric is defined on these
+    columns, and a real drain only produces timestamps nothing can predict, so a
+    number a test can compute by hand has to be timed by hand.
+
+    ``redelivered`` adds the failed first attempt in front of the completed one, which
+    is what a run count that no state filters is there to notice.
+    """
+    task_id = uuid.uuid4()
+    attempt = 2 if redelivered else 1
+    with connections[resolve_absurd_database()].cursor() as cursor:
+        cursor.execute(
+            psycopg.sql.SQL(
+                "insert into {tasks} "
+                "(task_id, task_name, params, enqueue_at, state, attempts) "
+                "values (%s, 'tasks.noop_sync', '{{}}', %s, 'completed', %s)"
+            ).format(tasks=psycopg.sql.Identifier("absurd", f"t_{queue}")),
+            [task_id, enqueue_at, attempt],
+        )
+        if redelivered:
+            cursor.execute(
+                psycopg.sql.SQL(
+                    "insert into {runs} "
+                    "(run_id, task_id, attempt, state, claimed_by, available_at) "
+                    "values (%s, %s, 1, 'failed', %s, %s)"
+                ).format(runs=psycopg.sql.Identifier("absurd", f"r_{queue}")),
+                [uuid.uuid4(), task_id, claimed_by, enqueue_at],
+            )
+        cursor.execute(
+            psycopg.sql.SQL(
+                "insert into {runs} "
+                "(run_id, task_id, attempt, state, claimed_by, available_at, "
+                "started_at, completed_at) "
+                "values (%s, %s, %s, 'completed', %s, %s, %s, %s)"
+            ).format(runs=psycopg.sql.Identifier("absurd", f"r_{queue}")),
+            [
+                uuid.uuid4(),
+                task_id,
+                attempt,
+                claimed_by,
+                enqueue_at,
+                started_at,
+                completed_at,
+            ],
+        )


### PR DESCRIPTION
Stacked on #257. The suite drove every path in `benchmarks/` at 100% branch coverage and constrained almost none of them — nine mutations to production code passed all 102 tests. That is the blind spot that let `latency_under_load` offer every rung above the knee for a whole session with every required check green.

Eight of the nine now die against a named test. No mocks — every test drives real code against a real database.

| mutation | killed by |
| --- | --- |
| ramp working point `max(sustained, …)` → `probes[-1]` (the *refused* rate) | `test_rate_ramp_measures_at_the_highest_offer_it_absorbed` |
| `pick_best_measurement` `max` → `min` | `test_calibrates_from_the_fastest_rung_no_mark_disqualified` |
| `pick_best_measurement` marked-rung filter deleted | same |
| `COMPLETED_RUNS_SQL` `started_at` → `completed_at` | both `test_metrics.py` tests |
| trim percentiles on `started_at`, not `completed_at` | both `test_metrics.py` tests |
| `build_metrics` drops the `0.8` trim factor | both `test_metrics.py` tests |
| `analyze_rate` trims on `completed_at`, not `enqueue_at` | `test_rate_metrics_trim_the_offer_window_on_when_a_task_arrived` |
| `producer.offered_ok = True` unconditionally | `test_rate_producer_marks_an_offer_it_could_not_keep_up_with` |

`test_metrics.py` inserts rows into `absurd.t_bench`/`absurd.r_bench` with every timestamp chosen, then asserts `analyze_saturation`/`analyze_rate` as whole dicts of hand-computed values. The three latency families get three different distributions and the completion seconds a fourth, so a swapped column cannot land on a correct number by accident; the rate rows are placed so trimming on the wrong column keeps a different *set* of rows rather than a different slice of one.

**The ninth mutation gets no test, deliberately.** Dividing commits by `n_tasks` instead of `n_runs` is semantically equivalent: `complete_run` raises unless the run is still `running`, so a task can never own two completed runs and the divisors are always equal inside a live rep. Measured to confirm — a rep that lost its claim lease reported `n_runs` 1, `n_tasks` 1, `total_runs` 5, `total_tasks` 3.

Also records the worktree port override in `CLAUDE.md` and `tests/CLAUDE.md`: published ports are host-global, so a compose project name does not keep a worktree off the main checkout's 5442/5443.

107 tests; `benchmarks/` and `tests/benchmarks/` at 100% statement and branch. No production code changed.
