### PR TITLE
docs: correct the per-worker backend count in the benchmarks docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Start Postgres services
-        run: docker compose up -d --build --wait db db_pg_cron
+        # A mypy env reads the tree and never connects, and `tests/benchmarks` installs
+        # no `django_absurd.pg_cron`, so neither pays for the extension image.
+        if: ${{ !contains(matrix.env, 'mypy') }}
+        run: >-
+          docker compose up -d --build --wait
+          ${{ matrix.env == 'benchmarks' && 'db' || 'db db_pg_cron' }}
       - name: Run tox
         run: uvx --with tox-uv tox -e "${{ matrix.env }}"
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - py312-django61
           - py314-django61
           - dev
+          - benchmarks
           - py312-django61-mypy
           - py314-django61-mypy
     env:
@@ -62,10 +63,10 @@ jobs:
           report_type: test_results
           flags: ${{ matrix.env }}
           fail_ci_if_error: true
-          # `tests/benchmarks` is a `dev`-only suite, so only that env writes its file.
-          files:
-            junit-core.xml,junit-pg_cron.xml,junit-multidb.xml${{ matrix.env == 'dev'
-            && ',junit-benchmarks.xml' || '' }}
+          # The `benchmarks` env runs that suite and nothing else; every other env
+          # runs the other three and never writes its file.
+          files: ${{ matrix.env == 'benchmarks' && 'junit-benchmarks.xml' ||
+            'junit-core.xml,junit-pg_cron.xml,junit-multidb.xml' }}
 
   examples:
     name: examples/${{ matrix.example }} pytest suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           - py312-django61
           - py314-django61
           - dev
-          - benchmarks
+          - bench_harness
           - py312-django61-mypy
           - py314-django61-mypy
     env:
@@ -45,12 +45,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Start Postgres services
-        # A mypy env reads the tree and never connects, and `tests/benchmarks` installs
-        # no `django_absurd.pg_cron`, so neither pays for the extension image.
+        # A mypy env reads the tree and never connects, and `bench_harness` installs no
+        # `django_absurd.pg_cron`, so neither pays for the extension image.
         if: ${{ !contains(matrix.env, 'mypy') }}
         run: >-
           docker compose up -d --build --wait
-          ${{ matrix.env == 'benchmarks' && 'db' || 'db db_pg_cron' }}
+          ${{ matrix.env == 'bench_harness' && 'db' || 'db db_pg_cron' }}
       - name: Run tox
         run: uvx --with tox-uv tox -e "${{ matrix.env }}"
       - name: Upload coverage to Codecov
@@ -68,9 +68,9 @@ jobs:
           report_type: test_results
           flags: ${{ matrix.env }}
           fail_ci_if_error: true
-          # The `benchmarks` env runs that suite and nothing else; every other env
-          # runs the other three and never writes its file.
-          files: ${{ matrix.env == 'benchmarks' && 'junit-benchmarks.xml' ||
+          # `bench_harness` runs that suite and nothing else; every other env runs the
+          # other three and never writes its file.
+          files: ${{ matrix.env == 'bench_harness' && 'junit-benchmarks.xml' ||
             'junit-core.xml,junit-pg_cron.xml,junit-multidb.xml' }}
 
   examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,12 @@ writing or editing any test file. Running the suites:
   both in a worktree — published ports are host-global, so a compose project name does
   not keep a worktree off the main checkout's 5442/5443.
 - **The two gates to run before a commit** — not five separate commands:
-  - `uvx --with tox-uv tox -e dev` — all four suites against the dev env only. Reach for
-    the bare `uvx --with tox-uv tox` (full Python×Django matrix + min-max mypy) only
-    when a change could plausibly break on another version, not while iterating.
+  - `uvx --with tox-uv tox -e dev,benchmarks` — all four suites at one Python and one
+    Django. `tests/benchmarks` has an env of its own so CI runs it as a parallel job, so
+    naming both envs is what covers everything; the order matters for coverage, below.
+    Reach for the bare `uvx --with tox-uv tox` (full Python×Django matrix + min-max
+    mypy) only when a change could plausibly break on another version, not while
+    iterating.
   - `uv run pre-commit run --all-files` — owns ruff-check, ruff-format, **mypy**, and
     prettier. Never invoke `ruff` or `mypy` directly; pre-commit already runs them, and
     a hand-rolled invocation drifts from the hook's flags and exclusions.
@@ -136,17 +139,19 @@ writing or editing any test file. Running the suites:
 - **The combined coverage number only exists after all four suites run in order.**
   `tests/core` passes `--cov` (no append, truncating `.coverage`); the rest append. So a
   suite run alone leaves `.coverage` holding a partial picture, and `coverage.xml` is
-  overwritten by whichever suite ran last. Read a total only after a full `tox -e dev`;
-  a single-suite percentage means nothing on its own.
+  overwritten by whichever suite ran last. Read a total only after a full
+  `tox -e dev,benchmarks`, in that order — `dev` runs `tests/core` first, so it is the
+  run that truncates. A single-suite percentage means nothing on its own, and
+  `benchmarks` alone leaves `.coverage` holding that suite only.
 - **Every tox test env runs the suites under `pytest-xdist`** (`-n auto` on each
   `pytest` command line, mypy envs excluded), so parallel safety is exercised on every
   push instead of only when someone remembers to pass `-n`. Worker count is xdist's own
   `PYTEST_XDIST_AUTO_NUM_WORKERS`, which applies to `auto` only: CI pins it to 2 in
   `test.yml`, and unset it takes every core. **Pin it in your environment too** —
   `tests/multidb` creates a pair of databases per worker, and an unpinned `auto` on a
-  many-core box times that out. `tox -e dev -- -n0` gives a serial baseline for telling
-  a real failure from an xdist-only one. A bare `uv run pytest <path>` is unaffected —
-  `-n` is in no suite's `addopts`, so pass it there yourself.
+  many-core box times that out. `tox -e dev,benchmarks -- -n0` gives a serial baseline
+  for telling a real failure from an xdist-only one. A bare `uv run pytest <path>` is
+  unaffected — `-n` is in no suite's `addopts`, so pass it there yourself.
 - Each suite runs with `--reuse-db` (addopts); add `--create-db` to rebuild after a
   migration change — including `tests/pg_cron`: its test DB is an ordinary one that
   pg_cron's launcher holds no session on (the launcher only ever connects to the central

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,12 +120,12 @@ writing or editing any test file. Running the suites:
   both in a worktree — published ports are host-global, so a compose project name does
   not keep a worktree off the main checkout's 5442/5443.
 - **The two gates to run before a commit** — not five separate commands:
-  - `uvx --with tox-uv tox -e dev,benchmarks` — all four suites at one Python and one
-    Django. `tests/benchmarks` has an env of its own so CI runs it as a parallel job, so
-    naming both envs is what covers everything; the order matters for coverage, below.
-    Reach for the bare `uvx --with tox-uv tox` (full Python×Django matrix + min-max
-    mypy) only when a change could plausibly break on another version, not while
-    iterating.
+  - `uvx --with tox-uv tox -e dev,bench_harness` — all four suites at one Python and one
+    Django. `tests/benchmarks` has an env of its own, `bench_harness`, so CI runs it as
+    a parallel job; naming both envs is what covers everything, and the order matters
+    for coverage, below. Reach for the bare `uvx --with tox-uv tox` (full Python×Django
+    matrix + min-max mypy) only when a change could plausibly break on another version,
+    not while iterating.
   - `uv run pre-commit run --all-files` — owns ruff-check, ruff-format, **mypy**, and
     prettier. Never invoke `ruff` or `mypy` directly; pre-commit already runs them, and
     a hand-rolled invocation drifts from the hook's flags and exclusions.
@@ -140,8 +140,8 @@ writing or editing any test file. Running the suites:
   `tests/core` passes `--cov` (no append, truncating `.coverage`); the rest append. So a
   suite run alone leaves `.coverage` holding a partial picture, and `coverage.xml` is
   overwritten by whichever suite ran last. Read a total only after a full
-  `tox -e dev,benchmarks`, in that order — `dev` runs `tests/core` first, so it is the
-  run that truncates. A single-suite percentage means nothing on its own, and
+  `tox -e dev,bench_harness`, in that order — `dev` runs `tests/core` first, so it is
+  the run that truncates. A single-suite percentage means nothing on its own, and
   `benchmarks` alone leaves `.coverage` holding that suite only.
 - **Every tox test env runs the suites under `pytest-xdist`** (`-n auto` on each
   `pytest` command line, mypy envs excluded), so parallel safety is exercised on every
@@ -149,9 +149,10 @@ writing or editing any test file. Running the suites:
   `PYTEST_XDIST_AUTO_NUM_WORKERS`, which applies to `auto` only: CI pins it to 2 in
   `test.yml`, and unset it takes every core. **Pin it in your environment too** —
   `tests/multidb` creates a pair of databases per worker, and an unpinned `auto` on a
-  many-core box times that out. `tox -e dev,benchmarks -- -n0` gives a serial baseline
-  for telling a real failure from an xdist-only one. A bare `uv run pytest <path>` is
-  unaffected — `-n` is in no suite's `addopts`, so pass it there yourself.
+  many-core box times that out. `tox -e dev,bench_harness -- -n0` gives a serial
+  baseline for telling a real failure from an xdist-only one. A bare
+  `uv run pytest <path>` is unaffected — `-n` is in no suite's `addopts`, so pass it
+  there yourself.
 - Each suite runs with `--reuse-db` (addopts); add `--create-db` to rebuild after a
   migration change — including `tests/pg_cron`: its test DB is an ordinary one that
   pg_cron's launcher holds no session on (the launcher only ever connects to the central

--- a/benchmarks/CLAUDE.md
+++ b/benchmarks/CLAUDE.md
@@ -66,7 +66,18 @@ reps of `warmup`, `a`, `b` and `c2`:
 
     commits per task     1.72 - 3.01   part shape, part ramp; the split is open
     row updates          ~4            ~2 on r_bench, ~2 on t_bench
-    backends per worker  2             SDK connection + Django ORM, at ANY --concurrency
+    backends per worker  2             SDK connection + Django ORM, for a body that
+                                       touches no ORM itself
+
+**That 2 holds only for task bodies that do not touch the ORM**, which is every workload
+in `tasks.py`. Django's connections are thread-local and `open_worker_runtime` runs sync
+bodies on a `ThreadPoolExecutor(max_workers=options.concurrency)`, so a body doing ORM
+work opens a third backend per busy thread and holds it for the body's whole duration —
+up to `C + 2` per process, 126 at the 7 x 16 this file recommends, against a
+`BENCH_MAX_CONNECTIONS` of 100 and a stock `max_connections` of 100. Nothing here
+measured that: `measure_shape_connections` counts backends across starting a fleet and
+runs no task, so it observes worker STARTUP connections and cannot see a body-opened
+one.
 
 From `pg_stat_statements` with `track=all`, at `worker_knobs` `concurrency_1` — the only
 shape where the client remainder is exact
@@ -417,16 +428,15 @@ cumulative state or a per-run latch. A sawtooth is contention, and neither.
 it covers claim, completion and the driver's drain polling and excludes the preload.
 Throughput times that is the commit rate the run asked of the database, and the report
 prints it under each saturation table — divided by the worker count first, because **the
-ceiling is one connection's**. A worker process opens exactly two backends whatever its
-`--concurrency` (the SDK's connection and Django's), so its claim traffic funnels
-through one connection however many threads are behind it, while the box has several
-times that capacity spread across more of them; concurrent backends share an fsync
-through group commit, so that scaling is sublinear (measured once on the volume in its
-fast regime: 1,953 c/s at one connection, 4,748 at four, 13,238 at sixteen — read the
-shape, not the levels, and note that a single-connection ceiling is a per-run
-measurement rather than a constant of the machine). Comparing a fleet's total against
-one connection's ceiling would call an eight-process measurement saturated while each of
-its connections idled.
+ceiling is one connection's**. A worker process's claims all ride the SDK's one
+connection however many threads are behind it — so its claim traffic funnels through a
+single backend whatever its `--concurrency`, while the box has several times that
+capacity spread across more of them; concurrent backends share an fsync through group
+commit, so that scaling is sublinear (measured once on the volume in its fast regime:
+1,953 c/s at one connection, 4,748 at four, 13,238 at sixteen — read the shape, not the
+levels, and note that a single-connection ceiling is a per-run measurement rather than a
+constant of the machine). Comparing a fleet's total against one connection's ceiling
+would call an eight-process measurement saturated while each of its connections idled.
 
 So a row is **connection-bound** when its per-connection commit rate is near the ceiling
 — that number belongs to Postgres and moves on another machine — and **client-bound**
@@ -632,8 +642,10 @@ matter:
   concurrency on two backends and `4x1` reaches it on eight, so the shapes differ in
   connection count as well as in claim path, and the report says so above the ratio
   rather than leaving it to be read as the claim path alone. Measured per shape as a
-  delta across starting the fleet, so the day a pooled worker opens a connection per
-  slot the same line will say the comparison is clean.
+  delta across starting the fleet, before any rep runs, so what it counts is what a
+  WORKER opens at startup: the day a pooled worker opens a connection per slot the same
+  line will say so. A connection a task BODY opens is invisible to it —
+  `measure_shape_connections` never enqueues or runs a task.
 
 ## The results files
 
@@ -768,6 +780,33 @@ and whether it was marked. The choice prefers a rung that measured what was aske
 repeated, so when most rungs are marked it lands on the slowest survivor and every
 number in the later stage was measured at it — which the report prints under that
 stage's heading.
+
+## Which findings survive the durable regime
+
+Everything here measures nano-tasks at saturation. django-absurd is mostly used for
+durable agent tool calls — seconds to minutes per task, checkpointed, often suspended —
+so most of the above answers a question that workload does not ask. A claim costing
+1.41-1.56 ms is the whole story at 4,000 tasks/s and rounding error at 4 tasks/s.
+
+Carries over:
+
+- **What a `ctx.step` costs.** A checkpoint per tool call IS the durable shape. The
+  `checkpoint_cost` stage measures it and **no finding for it is written up in this
+  file** — the most durable-relevant number the harness produces is the one nobody
+  recorded. Fix that before quoting anything else here at a durable workload.
+- **The connection budget, `C + 2` backends per process once a body touches the ORM**
+  ([Overhead](#overhead-itemised)). Not a throughput fact, and it binds precisely when
+  holds are long: a durable body holds its thread, and its connection, for minutes.
+- **`r_bench` bloats and `t_bench` does not** (10,000 dead tuples against 5,000 live).
+  Retries and suspensions make run rows, so a durable workload compounds this.
+- **Table size costing throughput.** A durable workload accumulates history by design,
+  which turns retention into a throughput concern rather than housekeeping.
+
+Does not carry over: peak tasks/s, the process x concurrency sweep, `--batch-size`, the
+producer ceiling. Those answer how fast a flood of trivial tasks drains.
+
+Not measured at all: a task that sleeps for minutes, checkpoints repeatedly, and
+suspends. No stage exercises that shape, so nothing here bounds it.
 
 ## Comparing two runs: refactors, version bumps, bisection
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -65,13 +65,20 @@ The defaults need about 5 GB free in the Docker VM (1 GB of shared buffers plus 
 tmpfs). Set any of these in the shell that starts `db_bench`, then restart it and re-run
 `migrate`:
 
-| variable                | default | change it when                                             |
-| ----------------------- | ------- | ---------------------------------------------------------- |
-| `BENCH_SHARED_BUFFERS`  | `1GB`   | the Docker VM has under ~4 GB free — try `256MB`           |
-| `BENCH_MAX_CONNECTIONS` | `100`   | you run over ~40 worker processes (2 server backends each) |
-| `BENCH_TMPFS_SIZE`      | `4g`    | the VM is small — `512m` covers a single stage             |
-| `BENCH_CPUS`            | unset   | you want the server pinned to N cores; unset = no limit    |
-| `BENCH_MEMORY`          | unset   | you want the server's memory capped; unset = no limit      |
+| variable                | default | change it when                                          |
+| ----------------------- | ------- | ------------------------------------------------------- |
+| `BENCH_SHARED_BUFFERS`  | `1GB`   | the Docker VM has under ~4 GB free — try `256MB`        |
+| `BENCH_MAX_CONNECTIONS` | `100`   | you run over ~40 worker processes (2 backends each)     |
+| `BENCH_TMPFS_SIZE`      | `4g`    | the VM is small — `512m` covers a single stage          |
+| `BENCH_CPUS`            | unset   | you want the server pinned to N cores; unset = no limit |
+| `BENCH_MEMORY`          | unset   | you want the server's memory capped; unset = no limit   |
+
+**Two backends per worker process is the count for task bodies like the ones here, which
+touch no ORM.** Django's connections are thread-local and a worker runs sync bodies on a
+thread pool sized to `--concurrency`, so a body that queries the ORM opens one more per
+busy thread and holds it while the body runs: budget `--concurrency + 2` per process for
+that workload — 126 connections at 7 processes running the concurrency 16 recommended
+below.
 
 Too small a tmpfs does not fail at startup: the run dies partway through on a Postgres
 write error, so raise it if a long run aborts. Every value above is recorded in the
@@ -143,6 +150,13 @@ harness has not found Absurd's limit; it has only ever found its own.
 the same commit, 25 shared measurements: median CV 4.7%, mean 5.1%, worst 12.5%, one run
 systematically below the other two. Under about 12% is not evidence of anything, and a
 whole run reading low is usually the working point it inherited, not the machine.
+
+**Every workload here is a nano-task.** The five bodies are two no-ops, two sleeps and a
+4-step workflow, driven at the highest rate a fleet will take. django-absurd is mostly
+used for durable agent tool calls and long-running work — seconds to minutes per task,
+checkpointed, often suspended — where a 1.5 ms claim amortises into nothing. These
+tables rank configurations for THIS regime; they do not characterise that one.
+[`CLAUDE.md`](CLAUDE.md) says which findings carry over.
 
 **Measure on a quiet machine on AC power.** The macOS indexer alone was worth 1-1.4
 cores sustained. It spoils the saturation stages, which drive the box to its limit, and

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -238,3 +238,22 @@ commit where it last lived — recoverable from git any time.
   declaration door and delete the handling rather than carry it, and the reasoning that
   no cheap correct fix existed for the lapsed-window wedge) →
   [view @6c1b4f2](https://github.com/lincolnloop/django-absurd/blob/6c1b4f29233f5ab40e023d6cd279dd3b2586cde8/docs/plans/2026-08-18-refuse-partitioned-queues.md)
+
+## Archived branches
+
+Unlike everything above, this one never reached `origin/main`, so nothing in main's
+history reaches its commits and no `blob/<main sha>` link can be written for it. The tag
+is what keeps it: delete the branch without it and the commits become unreachable.
+
+- 2026-08-02 — `loadtest/`, the first load harness, superseded by
+  [`benchmarks/`](../benchmarks/README.md) but not replaced in full. Archived at
+  [`3b4ac82`](https://github.com/lincolnloop/django-absurd/tree/3b4ac82bad087a3a24d40be81aebfd350f65646f/loadtest)
+  on branch `worktree-load-test-harness`. It measured four things `benchmarks/` cannot:
+  the **admin changelist at volume** (`load_admin`, with `EXPLAIN (ANALYZE, BUFFERS)`
+  and per-request query counts — the instrument behind
+  [#142](https://github.com/lincolnloop/django-absurd/issues/142)); a **million-row
+  seeded corpus** (`load_seed`, against a persistent volume, where `benchmarks/`
+  truncates before every rep on a RAM disk); **mixed-duration backlogs with slot
+  occupancy** (`load_barrier`, whose uniform-duration control is what identified the
+  batch boundary recorded in [`UPSTREAM.md`](UPSTREAM.md)); and a **multi-queue
+  topology** with failure/retry and event/wait workloads.

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ env_list =
     py312-django60
     py3{12,14}-django61
     dev
+    benchmarks
     py312-django61-mypy
     py314-django61-mypy
 
@@ -29,13 +30,17 @@ commands =
     !mypy: pytest tests/multidb -n auto {posargs}
     mypy: mypy .
 
-# `tests/benchmarks` runs here and nowhere else in the matrix: `benchmarks/` ships in
-# no wheel and imports nothing version-sensitive, so a second Python or Django buys no
-# signal for the minutes it costs.
 [testenv:dev]
 runner = uv-venv-lock-runner
 commands =
     pytest tests/core -n auto {posargs}
     pytest tests/pg_cron -n auto {posargs}
     pytest tests/multidb -n auto {posargs}
+
+# `tests/benchmarks` has an env to itself so CI runs it as a job of its own alongside the
+# rest of the matrix. One Python and one Django is all the signal there is: `benchmarks/`
+# ships in no wheel and imports nothing version-sensitive.
+[testenv:benchmarks]
+runner = uv-venv-lock-runner
+commands =
     pytest tests/benchmarks -n auto {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ env_list =
     py312-django60
     py3{12,14}-django61
     dev
-    benchmarks
+    bench_harness
     py312-django61-mypy
     py314-django61-mypy
 
@@ -38,9 +38,11 @@ commands =
     pytest tests/multidb -n auto {posargs}
 
 # `tests/benchmarks` has an env to itself so CI runs it as a job of its own alongside the
-# rest of the matrix. One Python and one Django is all the signal there is: `benchmarks/`
-# ships in no wheel and imports nothing version-sensitive.
-[testenv:benchmarks]
+# rest of the matrix. Named for the harness, not for benchmarking: it exercises
+# `benchmarks/` at a handful of tasks per stage and measures nothing. One Python and one
+# Django is all the signal there is — `benchmarks/` ships in no wheel and imports nothing
+# version-sensitive.
+[testenv:bench_harness]
 runner = uv-venv-lock-runner
 commands =
     pytest tests/benchmarks -n auto {posargs}


### PR DESCRIPTION
`benchmarks/CLAUDE.md` and `README.md` claimed a worker opens exactly two server backends at any `--concurrency`. True only for task bodies that touch no ORM (every workload in `benchmarks/tasks.py`).

`worker.py:274` runs sync bodies on a `ThreadPoolExecutor(max_workers=concurrency)` and Django connections are thread-local, so an ORM-touching body opens up to `C + 2` per process — 126 at the recommended 7 x 16, against `BENCH_MAX_CONNECTIONS` 100. `stages.py:722` never runs a task, so the shape probe can only see worker-startup connections.

Also adds a durable-regime caveat to both files and archives `loadtest/` in `docs/HISTORY.md`.
