### PR TITLE
fix(bench): refuse DEBUG runs and mark windows with the rows' clock

### DIFF
--- a/benchmarks/CLAUDE.md
+++ b/benchmarks/CLAUDE.md
@@ -48,6 +48,22 @@ the default batch; and its `latency_under_load` calibrated from `workers_5` rath
 went to seven. An `a` row beside a `b` row is two experiments, not one measurement
 repeated. Read the `Calibrated from` line first, always.
 
+**A noisy ladder picks a slow winner, and four stages then measure it.**
+`clean-20260904T151738Z` is the case: `concurrency_8` cv 15.5% and `concurrency_16` cv
+11.9%, both unstable, so the pick settled on `concurrency=4 batch_size=8` where
+neighbouring runs picked 16/32. Measured faithfully at that configuration downstream —
+`workers_10` 1,944.0 against 4,593.1/4,661.5, `async_dispatch` 527.8 against
+1,098.1/1,179.0, `checkpoint_cost`'s `flat` 829.1 against 1,297.2. The box was not 2.4x
+slower; the harness mis-calibrated and then measured that correctly. Nothing flagged the
+run: it exited 0 and every number inside it was self-consistent, which is why a marked
+calibration row is grounds to DISCARD the run rather than to note a caveat beside it.
+`pick_best_measurement` prefers a valid, stable rung and falls back to the whole set
+instead of refusing, deliberately — aborting a forty-minute run on a mark would cost
+more than it saves, so the reading is what has to catch this. A ratio between two arms
+of one run survives a bad calibration where an absolute rate does not: `size_vs_depth`
+read 345.0/187.5/192.8 under that calibration against 375.2/201.0/203.5 under a good
+one.
+
 Load is sampled on each side of every rep. Median of every `load_before`/`load_after`
 sample: `warmup` 2.68, `c2` 3.39, `b` 3.40, `a` 5.11. It does not account for a whole
 run reading low — `c2` and `b` sat at 3.39 and 3.40 and still disagreed by up to 18% on

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -226,8 +226,9 @@ reference machine.
 
 `PGPORT` picks the server and `SAMPLE_DATABASE` the database on it. It is a database of
 its own because the harness's default is `db_bench`'s, which a real run empties. The
-script also sets `DEBUG=1`, which is what serves the admin's own CSS — leave `DEBUG`
-unset for anything you intend to time.
+script also sets `DEBUG=1`, which is what serves the admin's own CSS. `python -m stages`
+refuses to run while it is on: the children inherit the whole environment, so a shell
+that exported it once would measure every rate through the debug cursor.
 
 **The data is synthetic, and no number taken on it is a property of django-absurd.**
 Every task is a copy of one of six templates, so the ages are uniform, the payloads are

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -109,6 +109,15 @@ something was wrong with it, marked in place:
   about the system, not a broken measurement.
 - `?` — fewer than two valid reps, so the spread was never measured at all.
 
+Four stages run at a configuration an earlier stage picked — `process_scaling`,
+`poll_interval` and `checkpoint_cost` inherit `worker_knobs`' winning row, and
+`latency_under_load` inherits `process_scaling`'s. Each prints a `Calibrated from` line
+naming the row it took and ending in that row's standing. **Read it before the numbers
+under it, and discard the whole run unless it says `valid and stable`.** Anything else —
+`unstable`, `invalid`, `dispersion unmeasured` — means those stages measured a
+configuration that did not repeat, and nothing else in the report says so: the run still
+exits cleanly and its tables still agree with each other.
+
 Under each saturation table is a commit-budget line saying what limited that row:
 `client-bound` is our Python, `connection-bound` is Postgres, `unresolved` means the
 calibration could not tell.

--- a/benchmarks/analysis.py
+++ b/benchmarks/analysis.py
@@ -303,8 +303,10 @@ def count_client_backends() -> int:
 
 
 def capture_database_now() -> dt.datetime:
+    # `clock_timestamp()`, not `now()`: the rows this mark is compared against carry
+    # `absurd.current_time()`, and `now()` is the calling transaction's START.
     with connections[resolve_absurd_database()].cursor() as cursor:
-        cursor.execute("select now()")
+        cursor.execute("select clock_timestamp()")
         return t.cast("dt.datetime", cursor.fetchone()[0])
 
 

--- a/benchmarks/stages.py
+++ b/benchmarks/stages.py
@@ -8,6 +8,7 @@ import typing as t
 from pathlib import Path
 
 import django
+from django.conf import settings
 from django.utils.module_loading import import_string
 
 import analysis
@@ -174,6 +175,15 @@ class InvalidSizeError(Exception):
             f"{flag} {value:g} is below {floor:g}, which leaves a stage nothing to "
             f"measure — no worker to spawn, no task to drain, or no window to divide "
             f"by. Every number it recorded would describe work that never happened."
+        )
+
+
+class MeasuringUnderDebugError(Exception):
+    def __init__(self) -> None:
+        super().__init__(
+            "DEBUG is on, so every query would run through Django's debug cursor and "
+            "no rate measured under it compares with one measured without it. Unset "
+            "DEBUG — it is there to serve the seeded admin, not to measure."
         )
 
 
@@ -1222,9 +1232,11 @@ def main(argv: list[str] | None = None) -> None:
     django.setup()
     # All three are the caller's to fix, so they print as errors rather than crashing.
     try:
+        refuse_measuring_under_debug()
         run_stages(stages, build_stage_options(args))
     except (
         InvalidSizeError,
+        MeasuringUnderDebugError,
         MissingStageError,
         UncalibratableStageError,
     ) as exc:
@@ -1256,6 +1268,17 @@ def build_stage_options(args: argparse.Namespace) -> StageOptions:
         durable_seconds=args.durable_seconds,
         max_workers=args.max_workers,
     )
+
+
+def refuse_measuring_under_debug() -> None:
+    """Refuse rather than record it: the host block reads config off the SERVER.
+
+    A debug cursor is the harness's own process, so nothing in a results file could
+    speak for it, and every rate in the run would be incomparable rather than merely
+    annotated.
+    """
+    if settings.DEBUG:
+        raise MeasuringUnderDebugError
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/test_analysis.py
+++ b/tests/benchmarks/test_analysis.py
@@ -1,0 +1,26 @@
+import pytest
+from django.db import connections, transaction
+
+import analysis
+from django_absurd.queues import resolve_absurd_database
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def test_the_mark_sorts_after_rows_stamped_before_it() -> None:
+    """A mark taken after a row must sort after it, transaction or no transaction.
+
+    `enqueue_at` defaults to `absurd.current_time()`, which is `clock_timestamp()` —
+    real time, advancing inside a transaction. A mark reading `now()` would be that
+    transaction's START, so on a connection already in one it can predate rows written
+    before it and admit them to a window meant to exclude them. Read here rather than
+    through an enqueue because enqueueing is deferred to commit, which would stamp the
+    row after the mark and pass either way.
+    """
+    with transaction.atomic(using=resolve_absurd_database()):
+        with connections[resolve_absurd_database()].cursor() as cursor:
+            cursor.execute("select absurd.current_time()")
+            stamped = cursor.fetchone()[0]
+        mark = analysis.capture_database_now()
+
+    assert mark > stamped

--- a/tests/benchmarks/test_cli.py
+++ b/tests/benchmarks/test_cli.py
@@ -6,6 +6,7 @@ import typing as t
 import pytest
 from django.core.management import call_command
 from django.db import connections
+from pytest_django import Settings
 
 import analysis
 import stages
@@ -630,6 +631,33 @@ def test_refuses_a_size_that_leaves_a_stage_nothing_to_measure(
             f"{flag} {value} is below {floor}, which leaves a stage nothing to "
             "measure — no worker to spawn, no task to drain, or no window to divide "
             "by. Every number it recorded would describe work that never happened.\n"
+        ),
+    )
+
+
+def test_refuses_to_measure_while_debug_is_on(
+    capsys: pytest.CaptureFixture[str],
+    settings: Settings,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Refused before anything runs, because no results file would record it.
+
+    `benchmarks/settings.py` reads `DEBUG` from the environment so the seeded admin can
+    be browsed, and `build_worker_env` hands the children the whole environment — so a
+    shell that exported it once measures every rate through the debug cursor, and the
+    host block has no field that says which cursor a run got.
+    """
+    settings.DEBUG = True
+
+    with pytest.raises(SystemExit) as exit_info:
+        stages.main(["process_scaling", "--results-dir", str(tmp_path)])
+
+    assert (exit_info.value.code, capsys.readouterr().err) == (
+        1,
+        (
+            "DEBUG is on, so every query would run through Django's debug cursor and "
+            "no rate measured under it compares with one measured without it. Unset "
+            "DEBUG — it is there to serve the seeded admin, not to measure.\n"
         ),
     )
 


### PR DESCRIPTION
Three odds and ends on the harness.

- `python -m stages` refuses to run while `DEBUG` is on. The worker children inherit the whole environment, so a shell that exported it once measured every rate through Django's debug cursor, and nothing in a results file said which cursor a run got.
- Window marks read `clock_timestamp()` — the clock `enqueue_at` and `completed_at` actually carry. `now()` is the calling transaction's START, measured here 22 ms earlier than a row stamped before it, which is enough to admit a whole ballast into a window meant to exclude it.
- `benchmarks/README.md` and `CLAUDE.md`: discard a run whose `Calibrated from` line does not end `valid and stable`, with the 2.4x mis-calibration cascade recorded as the evidence.
