### PR TITLE
docs: show a durable step in both quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ python manage.py absurd_worker
 That's the whole loop. The `"default"` queue is declared for you, so `migrate`
 provisions it without any `QUEUES` setting of your own.
 
+Wrap work in steps and a retry resumes instead of redoing:
+
+```python
+from django_absurd import get_absurd_context
+
+
+@task
+def pay_for_order(order_id: int, amount: int) -> None:
+    # Absurd's workflow context — steps, sleep, events.
+    context = get_absurd_context()
+
+    def process_payment():
+        return stripe.charges.create(amount=amount)
+
+    # Checkpointed under "process-payment": Absurd stores the result.
+    charge = context.step("process-payment", process_payment)
+    # If this raises, the retry replays the task but reuses the charge above.
+    context.step("send-receipt", lambda: send_receipt(order_id, charge))
+```
+
 ## Documentation
 
 - **[Documentation](https://lincolnloop.github.io/django-absurd/)** — tasks, workflows,

--- a/cliff.toml
+++ b/cliff.toml
@@ -73,6 +73,9 @@ commit_parsers = [
   # as the ci type skip further down. Checking scope only after `^fix`/`^feat` had
   # already claimed the commit first.
   {field = "scope", pattern = "^ci$", skip = true},
+  # Same shape for bench: benchmarks/ is a dev harness, absent from the wheel, so a
+  # fix there is invisible to users no matter which type carries it.
+  {field = "scope", pattern = "^bench$", skip = true},
   {message = "^feat", group = "0 -- Features"},
   {message = "^fix", group = "1 -- Bug fixes"},
   # Its own section: folding a revert into Bug fixes would misreport what happened.

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -81,6 +81,27 @@ That's the whole loop. The task runs on the [worker](workers.md) and its result 
 stored in Postgres — [fetch it later](tasks.md#read-the-result) with
 `add.get_result(result.id)`.
 
+Wrap work in [steps](workflows.md#steps) and a [retry](tasks.md#retries-spawn-options)
+resumes instead of redoing:
+
+```python
+from django_absurd import get_absurd_context
+
+
+@task
+def pay_for_order(order_id: int, amount: int) -> None:
+    # Absurd's workflow context — steps, sleep, events.
+    context = get_absurd_context()
+
+    def process_payment():
+        return stripe.charges.create(amount=amount)
+
+    # Checkpointed under "process-payment": Absurd stores the result.
+    charge = context.step("process-payment", process_payment)
+    # If this raises, the retry replays the task but reuses the charge above.
+    context.step("send-receipt", lambda: send_receipt(order_id, charge))
+```
+
 ## Next
 
 - **[Tasks](tasks.md)** — enqueue with retries and other options, and read results.


### PR DESCRIPTION
Quickstarts stopped at enqueue-and-run — same as Django's own database backend. Adds a checkpointed-step example to README and docs/web/index.md.

Also skips `bench`-scoped commits in the changelog; `benchmarks/` isn't in the wheel.